### PR TITLE
Package.json engine fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         ".yalc/*"
     ],
     "engines": {
-        "yarn": "^1.18.0"
+        "yarn": ">=1.18.0"
     },
     "scripts": {
         "build": "cd shared/crypto && yarn build && cd ../structures && yarn build && cd ../utility && yarn build && cd ../..",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         ".yalc/*"
     ],
     "engines": {
-        "yarn": "1.18.0"
+        "yarn": "^1.18.0"
     },
     "scripts": {
         "build": "cd shared/crypto && yarn build && cd ../structures && yarn build && cd ../utility && yarn build && cd ../..",
@@ -91,5 +91,6 @@
     "resolutions": {
         "prosemirror-model": "1.9.1",
         "axios": "0.21.1"
-    }
+    },
+    "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,5 @@
     "resolutions": {
         "prosemirror-model": "1.9.1",
         "axios": "0.21.1"
-    },
-    "version": "0.0.0"
+    }
 }


### PR DESCRIPTION
I was not able to build the source with the latest version of yarn because of the engine field requirement was set to an older version of yarn, I suppose this was added to package.json to disallow the use of npm, as this will break some things according to the README. 

By requiring a minimum version of yarn later versions can be used as well.

If this was a conscious choice can someone explain me why we should use that specific version.