### PR TITLE
[Feature] Duplicate button for groups

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
@@ -6,106 +6,166 @@
         <span class="text">{{ organization.name }}</span>
       </button>
 
-      <input v-if="false" class="input search" placeholder="Zoeken">
+      <input v-if="false" class="input search" placeholder="Zoeken" />
     </div>
 
-    <a v-if="false" class="menu-button button heading" href="https://docs.stamhoofd.be" target="_blank">
+    <a
+      v-if="false"
+      class="menu-button button heading"
+      href="https://docs.stamhoofd.be"
+      target="_blank"
+    >
       <span class="icon info-filled" />
       <span>Documentatie</span>
     </a>
 
-    <a v-if="enableMemberModule" class="menu-button button heading" :href="registerUrl" target="_blank">
+    <a
+      v-if="enableMemberModule"
+      class="menu-button button heading"
+      :href="registerUrl"
+      target="_blank"
+    >
       <span class="icon external" />
       <span>Jouw inschrijvingspagina</span>
     </a>
 
-    <button v-if="whatsNewBadge" class="menu-button button heading" @click="manageWhatsNew()">
+    <button
+      v-if="whatsNewBadge"
+      class="menu-button button heading"
+      @click="manageWhatsNew()"
+    >
       <span class="icon gift" />
       <span>Wat is er nieuw?</span>
       <span v-if="whatsNewBadge" class="bubble">{{ whatsNewBadge }}</span>
     </button>
 
-    <button v-if="fullAccess && organization.privateMeta.requestKeysCount > 0" class="menu-button button heading" :class="{ selected: currentlySelected == 'keys' }" @click="manageKeys()">
+    <button
+      v-if="fullAccess && organization.privateMeta.requestKeysCount > 0"
+      class="menu-button button heading"
+      :class="{ selected: currentlySelected == 'keys' }"
+      @click="manageKeys()"
+    >
       <span class="icon key" />
       <span>Gebruikers goedkeuren</span>
-      <span class="bubble">{{ organization.privateMeta.requestKeysCount }}</span>
+      <span class="bubble">{{
+        organization.privateMeta.requestKeysCount
+      }}</span>
     </button>
 
     <template v-if="enableMemberModule">
       <div v-for="category in tree.categories">
         <div>
-          <button class="menu-button button heading" :class="{ selected: currentlySelected == 'category-'+category.id }" @click="openCategory(category)">
+          <button
+            class="menu-button button heading"
+            :class="{
+              selected: currentlySelected == 'category-' + category.id
+            }"
+            @click="openCategory(category)"
+          >
             <span class="icon group" />
             <span>{{ category.settings.name }}</span>
-            <span v-if="isCategoryDeactivated(category)" v-tooltip="'Deze categorie is onzichtbaar voor leden omdat activiteiten niet geactiveerd is'" class="icon error red right-icon" />
+            <span
+              v-if="isCategoryDeactivated(category)"
+              v-tooltip="
+                'Deze categorie is onzichtbaar voor leden omdat activiteiten niet geactiveerd is'
+              "
+              class="icon error red right-icon"
+            />
           </button>
 
           <button
-              v-for="group in category.groups"
-              :key="group.id"
-              class="menu-button button"
-              :class="{ selected: currentlySelected == 'group-'+group.id }"
-              @click="openGroup(group, category)"
+            v-for="group in category.groups"
+            :key="group.id"
+            class="menu-button button"
+            :class="{ selected: currentlySelected == 'group-' + group.id }"
+            @click="openGroup(group, category)"
           >
             <span>{{ group.settings.name }}</span>
           </button>
 
           <button
-              v-for="c in category.categories"
-              :key="c.id"
-              class="menu-button button"
-              :class="{ selected: currentlySelected == 'category-'+c.id }"
-              @click="openCategory(c)"
+            v-for="c in category.categories"
+            :key="c.id"
+            class="menu-button button"
+            :class="{ selected: currentlySelected == 'category-' + c.id }"
+            @click="openCategory(c)"
           >
             <span>{{ c.settings.name }}</span>
           </button>
         </div>
-        <hr>
+        <hr />
       </div>
     </template>
 
-
-    <div v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
+    <div
+      v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)"
+    >
       <button class="menu-button heading">
         <span class="icon basket" />
         <span>Verkopen</span>
-        <button v-if="canCreateWebshops" class="button text" @click="addWebshop()">
+        <button
+          v-if="canCreateWebshops"
+          class="button text"
+          @click="addWebshop()"
+        >
           <span class="icon add" />
           <span>Nieuw</span>
         </button>
       </button>
 
       <button
-          v-for="webshop in webshops"
-          :key="webshop.id"
-          class="menu-button button"
-          :class="{ selected: currentlySelected == 'webshop-'+webshop.id }"
-          @click="openWebshop(webshop)"
+        v-for="webshop in webshops"
+        :key="webshop.id"
+        class="menu-button button"
+        :class="{ selected: currentlySelected == 'webshop-' + webshop.id }"
+        @click="openWebshop(webshop)"
       >
         {{ webshop.meta.name }}
       </button>
     </div>
-    <hr v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
+    <hr
+      v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)"
+    />
 
-    <button v-if="canManagePayments" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-payments'}" @click="managePayments(true)">
+    <button
+      v-if="canManagePayments"
+      class="menu-button button heading"
+      :class="{ selected: currentlySelected == 'manage-payments' }"
+      @click="managePayments(true)"
+    >
       <span class="icon card" />
       <span>Overschrijvingen</span>
     </button>
 
     <div v-if="fullAccess">
-      <button class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-settings'}" @click="manageSettings(true)">
+      <button
+        class="menu-button button heading"
+        :class="{ selected: currentlySelected == 'manage-settings' }"
+        @click="manageSettings(true)"
+      >
         <span class="icon settings" />
         <span>Instellingen</span>
       </button>
 
-      <button v-if="isSGV" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-sgv-groepsadministratie'}" @click="openSyncScoutsEnGidsen(true)">
+      <button
+        v-if="isSGV"
+        class="menu-button button heading"
+        :class="{
+          selected: currentlySelected == 'manage-sgv-groepsadministratie'
+        }"
+        @click="openSyncScoutsEnGidsen(true)"
+      >
         <span class="icon sync" />
         <span>Groepsadministratie</span>
       </button>
     </div>
-    <hr v-if="fullAccess || canManagePayments">
+    <hr v-if="fullAccess || canManagePayments" />
     <div class="">
-      <button class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-account'}" @click="manageAccount(true)">
+      <button
+        class="menu-button button heading"
+        :class="{ selected: currentlySelected == 'manage-account' }"
+        @click="manageAccount(true)"
+      >
         <span class="icon user" />
         <span>Mijn account</span>
       </button>
@@ -119,12 +179,21 @@
 
 <script lang="ts">
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { ComponentWithProperties, HistoryManager } from "@simonbackx/vue-app-navigation";
+import {
+  ComponentWithProperties,
+  HistoryManager
+} from "@simonbackx/vue-app-navigation";
 import { NavigationMixin } from "@simonbackx/vue-app-navigation";
 import { NavigationController } from "@simonbackx/vue-app-navigation";
-import { CenteredMessage, Logo, Toast, ToastButton, TooltipDirective } from '@stamhoofd/components';
+import {
+  CenteredMessage,
+  Logo,
+  Toast,
+  ToastButton,
+  TooltipDirective
+} from "@stamhoofd/components";
 import { Sodium } from "@stamhoofd/crypto";
-import { Keychain, LoginHelper,SessionManager } from '@stamhoofd/networking';
+import { Keychain, LoginHelper, SessionManager } from "@stamhoofd/networking";
 import {
   Category,
   Group,
@@ -134,24 +203,24 @@ import {
   Permissions,
   UmbrellaOrganization,
   WebshopPreview
-} from '@stamhoofd/structures';
+} from "@stamhoofd/structures";
 import { Formatter } from "@stamhoofd/utility";
 import { Component, Mixins } from "vue-property-decorator";
 
 import { MemberManager } from "../../classes/MemberManager";
-import { OrganizationManager } from '../../classes/OrganizationManager';
-import { WhatsNewCount } from '../../classes/WhatsNewCount';
+import { OrganizationManager } from "../../classes/OrganizationManager";
+import { WhatsNewCount } from "../../classes/WhatsNewCount";
 import SignupModulesView from "../signup/SignupModulesView.vue";
-import AccountSettingsView from './account/AccountSettingsView.vue';
+import AccountSettingsView from "./account/AccountSettingsView.vue";
 import CategoryView from "./groups/CategoryView.vue";
 import GroupMembersView from "./groups/GroupMembersView.vue";
 import KeysView from "./keys/KeysView.vue";
-import NoKeyView from './NoKeyView.vue';
-import PaymentsView from './payments/PaymentsView.vue';
-import SettingsView from './settings/SettingsView.vue';
-import SGVGroepsadministratieView from './settings/SGVGroepsadministratieView.vue';
-import EditWebshopView from './webshop/EditWebshopView.vue';
-import WebshopView from './webshop/WebshopView.vue';
+import NoKeyView from "./NoKeyView.vue";
+import PaymentsView from "./payments/PaymentsView.vue";
+import SettingsView from "./settings/SettingsView.vue";
+import SGVGroepsadministratieView from "./settings/SGVGroepsadministratieView.vue";
+import EditWebshopView from "./webshop/EditWebshopView.vue";
+import WebshopView from "./webshop/WebshopView.vue";
 
 @Component({
   components: {
@@ -162,97 +231,129 @@ import WebshopView from './webshop/WebshopView.vue';
   }
 })
 export default class Menu extends Mixins(NavigationMixin) {
-  SessionManager = SessionManager // needed to make session reactive
-  currentlySelected: string | null = null
-  whatsNewBadge = ""
+  SessionManager = SessionManager; // needed to make session reactive
+  currentlySelected: string | null = null;
+  whatsNewBadge = "";
 
   get organization() {
-    return OrganizationManager.organization
+    return OrganizationManager.organization;
   }
 
   get registerUrl() {
     if (this.organization.registerDomain) {
-      return "https://"+this.organization.registerDomain
+      return "https://" + this.organization.registerDomain;
     }
 
-    return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
+    return (
+      "https://" +
+      this.organization.uri +
+      "." +
+      process.env.HOSTNAME_REGISTRATION
+    );
   }
 
   get isSGV() {
-    return this.organization.meta.type == OrganizationType.Youth && this.organization.meta.umbrellaOrganization == UmbrellaOrganization.ScoutsEnGidsenVlaanderen
+    return (
+      this.organization.meta.type == OrganizationType.Youth &&
+      this.organization.meta.umbrellaOrganization ==
+        UmbrellaOrganization.ScoutsEnGidsenVlaanderen
+    );
   }
 
   get tree() {
-    return this.organization.categoryTreeForPermissions(OrganizationManager.user.permissions ?? Permissions.create({}))
+    return this.organization.categoryTreeForPermissions(
+      OrganizationManager.user.permissions ?? Permissions.create({})
+    );
   }
 
   mounted() {
     const path = window.location.pathname;
     const parts = path.substring(1).split("/");
-    let didSet = false
+    let didSet = false;
 
-    if ((parts.length >= 1 && parts[0] == 'settings') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'mollie')) {
+    if (
+      (parts.length >= 1 && parts[0] == "settings") ||
+      (parts.length == 2 && parts[0] == "oauth" && parts[1] == "mollie")
+    ) {
       if (this.fullAccess) {
-        this.manageSettings(false)
-        didSet = true
+        this.manageSettings(false);
+        didSet = true;
       }
     }
 
-    if (parts.length >= 1 && parts[0] == 'transfers') {
+    if (parts.length >= 1 && parts[0] == "transfers") {
       if (this.canManagePayments) {
-        this.managePayments(false)
-        didSet = true
+        this.managePayments(false);
+        didSet = true;
       }
     }
 
-    if (parts.length >= 1 && parts[0] == 'account') {
-      this.manageAccount(false)
-      didSet = true
+    if (parts.length >= 1 && parts[0] == "account") {
+      this.manageAccount(false);
+      didSet = true;
     }
 
-    if ((parts.length >= 1 && parts[0] == 'scouts-en-gidsen-vlaanderen') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'sgv')) {
+    if (
+      (parts.length >= 1 && parts[0] == "scouts-en-gidsen-vlaanderen") ||
+      (parts.length == 2 && parts[0] == "oauth" && parts[1] == "sgv")
+    ) {
       if (this.fullAccess) {
-        this.openSyncScoutsEnGidsen(false)
-        didSet = true
+        this.openSyncScoutsEnGidsen(false);
+        didSet = true;
       }
     }
 
-    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "category") {
+    if (
+      !didSet &&
+      this.enableMemberModule &&
+      parts.length >= 2 &&
+      parts[0] == "category"
+    ) {
       for (const category of this.organization.meta.categories) {
         if (parts[1] == Formatter.slug(category.settings.name)) {
           if (parts[2] && parts[2] == "all") {
-            this.openCategoryMembers(category, false)
+            this.openCategoryMembers(category, false);
           } else {
-            this.openCategory(category, false)
+            this.openCategory(category, false);
           }
-          didSet = true
+          didSet = true;
           break;
         }
       }
     }
 
-    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
+    if (
+      !didSet &&
+      this.enableMemberModule &&
+      parts.length >= 2 &&
+      parts[0] == "groups"
+    ) {
       for (const group of this.organization.groups) {
         if (parts[1] == Formatter.slug(group.settings.name)) {
-          this.openGroup(group, false)
-          didSet = true
+          this.openGroup(group, false);
+          didSet = true;
           break;
         }
       }
     }
 
-    if (!didSet && this.enableWebshopModule && parts.length >= 2 && parts[0] == "webshops") {
+    if (
+      !didSet &&
+      this.enableWebshopModule &&
+      parts.length >= 2 &&
+      parts[0] == "webshops"
+    ) {
       for (const webshop of this.organization.webshops) {
         if (parts[1] == Formatter.slug(webshop.meta.name)) {
-          this.openWebshop(webshop, false)
-          didSet = true
+          this.openWebshop(webshop, false);
+          didSet = true;
           break;
         }
       }
     }
 
     if (!didSet) {
-      HistoryManager.setUrl("/")
+      HistoryManager.setUrl("/");
     }
 
     if (!didSet && !this.splitViewController?.shouldCollapse()) {
@@ -260,206 +361,311 @@ export default class Menu extends Mixins(NavigationMixin) {
       //this.openGroup(this.groups[0], false)
       //} else {
       if (this.fullAccess) {
-        this.manageSettings(false)
+        this.manageSettings(false);
       } else {
-        this.manageAccount(false)
+        this.manageAccount(false);
       }
       //}
     }
 
-    document.title = "Stamhoofd - "+OrganizationManager.organization.name
+    document.title = "Stamhoofd - " + OrganizationManager.organization.name;
 
     this.checkKey().catch(e => {
-      console.error(e)
-    })
+      console.error(e);
+    });
 
-    const currentCount = localStorage.getItem("what-is-new")
+    const currentCount = localStorage.getItem("what-is-new");
     if (currentCount) {
-      const c = parseInt(currentCount)
+      const c = parseInt(currentCount);
       if (!isNaN(c) && WhatsNewCount - c > 0) {
-        this.whatsNewBadge = (WhatsNewCount - c).toString()
+        this.whatsNewBadge = (WhatsNewCount - c).toString();
       }
     } else {
       localStorage.setItem("what-is-new", (WhatsNewCount as any).toString());
     }
 
     if (!didSet) {
-      if (!this.organization.meta.modules.useMembers && !this.organization.meta.modules.useWebshops) {
-        this.present(new ComponentWithProperties(SignupModulesView, { }).setDisplayStyle("popup").setAnimated(false))
+      if (
+        !this.organization.meta.modules.useMembers &&
+        !this.organization.meta.modules.useWebshops
+      ) {
+        this.present(
+          new ComponentWithProperties(SignupModulesView, {})
+            .setDisplayStyle("popup")
+            .setAnimated(false)
+        );
       }
     }
   }
 
   async checkKey() {
     // Check if public and private key matches
-    const user = SessionManager.currentSession!.user!
-    const privateKey = SessionManager.currentSession!.getUserPrivateKey()!
-    const publicKey = user.publicKey
+    const user = SessionManager.currentSession!.user!;
+    const privateKey = SessionManager.currentSession!.getUserPrivateKey()!;
+    const publicKey = user.publicKey;
 
-    if (!await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey)) {
-
+    if (
+      !(await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey))
+    ) {
       // Gather all keychain items, and check which ones are still valid
       // Oops! Error with public private key
-      await LoginHelper.fixPublicKey(SessionManager.currentSession!)
-      new Toast("We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.", "success green").setHide(15*1000).show()
-      MemberManager.callListeners("encryption", null)
+      await LoginHelper.fixPublicKey(SessionManager.currentSession!);
+      new Toast(
+        "We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.",
+        "success green"
+      )
+        .setHide(15 * 1000)
+        .show();
+      MemberManager.callListeners("encryption", null);
     }
-
 
     if (SessionManager.currentSession!.user!.incomingInvites.length > 0) {
       for (const invite of user.incomingInvites) {
         try {
-          const decryptedKeychainItems = await Sodium.unsealMessage(invite.keychainItems!, publicKey, privateKey)
-          await LoginHelper.addToKeychain(SessionManager.currentSession!, decryptedKeychainItems)
-          new Toast(invite.sender.firstName+" heeft een encryptiesleutel met jou gedeeld", "key green").setHide(15*1000).show()
+          const decryptedKeychainItems = await Sodium.unsealMessage(
+            invite.keychainItems!,
+            publicKey,
+            privateKey
+          );
+          await LoginHelper.addToKeychain(
+            SessionManager.currentSession!,
+            decryptedKeychainItems
+          );
+          new Toast(
+            invite.sender.firstName +
+              " heeft een encryptiesleutel met jou gedeeld",
+            "key green"
+          )
+            .setHide(15 * 1000)
+            .show();
         } catch (e) {
-          console.error(e)
-          new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
+          console.error(e);
+          new Toast(
+            invite.sender.firstName +
+              " wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.",
+            "error red"
+          )
+            .setHide(15 * 1000)
+            .show();
         }
 
         // Remove invite if succeeded
         await SessionManager.currentSession!.authenticatedServer.request({
           method: "POST",
-          path: "/invite/"+encodeURIComponent(invite.key)+"/trade"
-        })
+          path: "/invite/" + encodeURIComponent(invite.key) + "/trade"
+        });
       }
 
       // Reload all views
-      MemberManager.callListeners("encryption", null)
+      MemberManager.callListeners("encryption", null);
     }
 
     try {
-      const keychainItem = Keychain.getItem(OrganizationManager.organization.publicKey)
+      const keychainItem = Keychain.getItem(
+        OrganizationManager.organization.publicKey
+      );
       if (!keychainItem) {
-        throw new Error("Missing organization keychain")
+        throw new Error("Missing organization keychain");
       }
 
-      const session = SessionManager.currentSession!
-      await session.decryptKeychainItem(keychainItem)
-
+      const session = SessionManager.currentSession!;
+      await session.decryptKeychainItem(keychainItem);
     } catch (e) {
-      console.error(e)
+      console.error(e);
 
       // Show warnign instead
-      new Toast("Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.", "key-lost yellow").setHide(15*1000).setButton(new ToastButton("Meer info", () => {
-        this.present(new ComponentWithProperties(NoKeyView, {}).setDisplayStyle("popup"))
-      })).show()
+      new Toast(
+        "Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.",
+        "key-lost yellow"
+      )
+        .setHide(15 * 1000)
+        .setButton(
+          new ToastButton("Meer info", () => {
+            this.present(
+              new ComponentWithProperties(NoKeyView, {}).setDisplayStyle(
+                "popup"
+              )
+            );
+          })
+        )
+        .show();
     }
   }
 
   get webshops() {
-    return this.organization.webshops
+    return this.organization.webshops;
   }
 
   switchOrganization() {
-    SessionManager.deactivateSession()
+    SessionManager.deactivateSession();
   }
 
   openAll(animated = true) {
-    this.currentlySelected = "group-all"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
+    this.currentlySelected = "group-all";
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(GroupMembersView, {})
+      }).setAnimated(animated)
+    );
   }
 
   openGroup(group: Group, category: GroupCategoryTree, animated = true) {
-    this.currentlySelected = "group-"+group.id
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
-        group,
-        category
-      }) }).setAnimated(animated));
+    this.currentlySelected = "group-" + group.id;
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(GroupMembersView, {
+          group,
+          category
+        })
+      }).setAnimated(animated)
+    );
   }
 
   manageKeys(animated = true) {
-    this.currentlySelected = "keys"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(KeysView) }).setAnimated(animated));
+    this.currentlySelected = "keys";
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(KeysView)
+      }).setAnimated(animated)
+    );
   }
 
   openCategory(category: GroupCategory, animated = true) {
-    this.currentlySelected = "category-"+category.id
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(CategoryView, { category }) }).setAnimated(animated));
+    this.currentlySelected = "category-" + category.id;
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(CategoryView, { category })
+      }).setAnimated(animated)
+    );
   }
 
   openCategoryMembers(category: GroupCategory, animated = true) {
-    this.currentlySelected = "category-"+category.id
+    this.currentlySelected = "category-" + category.id;
 
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
-        category: GroupCategoryTree.build(category, this.organization.meta.categories, this.organization.groups)
-      }) }).setAnimated(animated));
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(GroupMembersView, {
+          category: GroupCategoryTree.build(
+            category,
+            this.organization.meta.categories,
+            this.organization.groups
+          )
+        })
+      }).setAnimated(animated)
+    );
   }
 
   openWebshop(webshop: WebshopPreview, animated = true) {
-    this.currentlySelected = "webshop-"+webshop.id
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(WebshopView, { preview: webshop }) }).setAnimated(animated));
+    this.currentlySelected = "webshop-" + webshop.id;
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(WebshopView, { preview: webshop })
+      }).setAnimated(animated)
+    );
   }
 
   managePayments(animated = true) {
-    this.currentlySelected = "manage-payments"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(PaymentsView, {}) }).setAnimated(animated));
+    this.currentlySelected = "manage-payments";
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(PaymentsView, {})
+      }).setAnimated(animated)
+    );
   }
 
   manageSettings(animated = true) {
-    this.currentlySelected = "manage-settings"
+    this.currentlySelected = "manage-settings";
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SettingsView, {}) }).setAnimated(animated));
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(SettingsView, {})
+      }).setAnimated(animated)
+    );
   }
 
   manageAccount(animated = true) {
-    this.currentlySelected = "manage-account"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(AccountSettingsView, {}) }).setAnimated(animated));
+    this.currentlySelected = "manage-account";
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(AccountSettingsView, {})
+      }).setAnimated(animated)
+    );
   }
 
   manageWhatsNew() {
-    this.whatsNewBadge = ""
+    this.whatsNewBadge = "";
 
-    window.open('https://www.stamhoofd.be/release-notes', '_blank');
+    window.open("https://www.stamhoofd.be/release-notes", "_blank");
     localStorage.setItem("what-is-new", WhatsNewCount.toString());
   }
 
   async logout() {
-    if (!await CenteredMessage.confirm("Ben je zeker dat je wilt uitloggen?", "Uitloggen")) {
+    if (
+      !(await CenteredMessage.confirm(
+        "Ben je zeker dat je wilt uitloggen?",
+        "Uitloggen"
+      ))
+    ) {
       return;
     }
-    SessionManager.logout()
+    SessionManager.logout();
   }
 
   openSyncScoutsEnGidsen(animated = true) {
-    this.currentlySelected = "manage-sgv-groepsadministratie"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SGVGroepsadministratieView, {}) }).setAnimated(animated));
+    this.currentlySelected = "manage-sgv-groepsadministratie";
+    this.showDetail(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(SGVGroepsadministratieView, {})
+      }).setAnimated(animated)
+    );
   }
 
   importMembers() {
-    new CenteredMessage("Binnenkort beschikbaar!", "Binnenkort kan je leden importeren via Excel of manueel.", "sync").addCloseButton().show()
+    new CenteredMessage(
+      "Binnenkort beschikbaar!",
+      "Binnenkort kan je leden importeren via Excel of manueel.",
+      "sync"
+    )
+      .addCloseButton()
+      .show();
   }
 
   addWebshop() {
-    this.present(new ComponentWithProperties(EditWebshopView, { }).setDisplayStyle("popup"))
+    this.present(
+      new ComponentWithProperties(EditWebshopView, {}).setDisplayStyle("popup")
+    );
   }
 
   get canCreateWebshops() {
-    return OrganizationManager.user.permissions?.canCreateWebshops(OrganizationManager.organization.privateMeta?.roles ?? [])
+    return OrganizationManager.user.permissions?.canCreateWebshops(
+      OrganizationManager.organization.privateMeta?.roles ?? []
+    );
   }
 
   get canManagePayments() {
-    return OrganizationManager.user.permissions?.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? [])
+    return OrganizationManager.user.permissions?.canManagePayments(
+      OrganizationManager.organization.privateMeta?.roles ?? []
+    );
   }
 
   get fullAccess() {
-    return SessionManager.currentSession!.user!.permissions!.hasFullAccess()
+    return SessionManager.currentSession!.user!.permissions!.hasFullAccess();
   }
 
   get fullReadAccess() {
-    return SessionManager.currentSession!.user!.permissions!.hasReadAccess()
+    return SessionManager.currentSession!.user!.permissions!.hasReadAccess();
   }
 
   get enableMemberModule() {
-    return this.organization.meta.modules.useMembers
+    return this.organization.meta.modules.useMembers;
   }
 
   get enableWebshopModule() {
-    return this.organization.meta.modules.useWebshops
+    return this.organization.meta.modules.useWebshops;
   }
 
   isCategoryDeactivated(category: GroupCategoryTree) {
-    return this.organization.isCategoryDeactivated(category)
+    return this.organization.isCategoryDeactivated(category);
   }
 }
 </script>

--- a/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
@@ -1,120 +1,120 @@
 <template>
-    <div class="st-menu">
-        <div class="padding-group">
-            <Logo />
-            <button id="organization-switcher" @click="switchOrganization">
-                <span class="text">{{ organization.name }}</span>
-            </button>
+  <div class="st-menu">
+    <div class="padding-group">
+      <Logo />
+      <button id="organization-switcher" @click="switchOrganization">
+        <span class="text">{{ organization.name }}</span>
+      </button>
 
-            <input v-if="false" class="input search" placeholder="Zoeken">
-        </div>
-
-        <a v-if="false" class="menu-button button heading" href="https://docs.stamhoofd.be" target="_blank">
-            <span class="icon info-filled" />
-            <span>Documentatie</span>
-        </a>
-
-        <a v-if="enableMemberModule" class="menu-button button heading" :href="registerUrl" target="_blank">
-            <span class="icon external" />
-            <span>Jouw inschrijvingspagina</span>
-        </a>
-
-        <button v-if="whatsNewBadge" class="menu-button button heading" @click="manageWhatsNew()">
-            <span class="icon gift" />
-            <span>Wat is er nieuw?</span>
-            <span v-if="whatsNewBadge" class="bubble">{{ whatsNewBadge }}</span>
-        </button>
-
-        <button v-if="fullAccess && organization.privateMeta.requestKeysCount > 0" class="menu-button button heading" :class="{ selected: currentlySelected == 'keys' }" @click="manageKeys()">
-            <span class="icon key" />
-            <span>Gebruikers goedkeuren</span>
-            <span class="bubble">{{ organization.privateMeta.requestKeysCount }}</span>
-        </button>
-
-        <template v-if="enableMemberModule">
-            <div v-for="category in tree.categories">
-                <div>
-                    <button class="menu-button button heading" :class="{ selected: currentlySelected == 'category-'+category.id }" @click="openCategory(category)">
-                        <span class="icon group" />
-                        <span>{{ category.settings.name }}</span>
-                        <span v-if="isCategoryDeactivated(category)" v-tooltip="'Deze categorie is onzichtbaar voor leden omdat activiteiten niet geactiveerd is'" class="icon error red right-icon" />
-                    </button>
-
-                    <button
-                        v-for="group in category.groups"
-                        :key="group.id"
-                        class="menu-button button"
-                        :class="{ selected: currentlySelected == 'group-'+group.id }"
-                        @click="openGroup(group)"
-                    >
-                        <span>{{ group.settings.name }}</span>
-                    </button>
-
-                    <button
-                        v-for="c in category.categories"
-                        :key="c.id"
-                        class="menu-button button"
-                        :class="{ selected: currentlySelected == 'category-'+c.id }"
-                        @click="openCategory(c)"
-                    >
-                        <span>{{ c.settings.name }}</span>
-                    </button>
-                </div>
-                <hr>
-            </div>
-        </template>
-    
-
-        <div v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
-            <button class="menu-button heading">
-                <span class="icon basket" />
-                <span>Verkopen</span>
-                <button v-if="canCreateWebshops" class="button text" @click="addWebshop()">
-                    <span class="icon add" />
-                    <span>Nieuw</span>
-                </button>
-            </button>
-
-            <button
-                v-for="webshop in webshops"
-                :key="webshop.id"
-                class="menu-button button"
-                :class="{ selected: currentlySelected == 'webshop-'+webshop.id }"
-                @click="openWebshop(webshop)"
-            >
-                {{ webshop.meta.name }}
-            </button>
-        </div>
-        <hr v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
-
-        <button v-if="canManagePayments" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-payments'}" @click="managePayments(true)"> 
-            <span class="icon card" />
-            <span>Overschrijvingen</span>
-        </button>
-
-        <div v-if="fullAccess">
-            <button class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-settings'}" @click="manageSettings(true)">
-                <span class="icon settings" />
-                <span>Instellingen</span>
-            </button>
-
-            <button v-if="isSGV" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-sgv-groepsadministratie'}" @click="openSyncScoutsEnGidsen(true)">
-                <span class="icon sync" />
-                <span>Groepsadministratie</span>
-            </button>
-        </div>
-        <hr v-if="fullAccess || canManagePayments">
-        <div class="">
-            <button class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-account'}" @click="manageAccount(true)">
-                <span class="icon user" />
-                <span>Mijn account</span>
-            </button>
-            <button class="menu-button button heading" @click="logout">
-                <span class="icon logout" />
-                <span>Uitloggen</span>
-            </button>
-        </div>
+      <input v-if="false" class="input search" placeholder="Zoeken">
     </div>
+
+    <a v-if="false" class="menu-button button heading" href="https://docs.stamhoofd.be" target="_blank">
+      <span class="icon info-filled" />
+      <span>Documentatie</span>
+    </a>
+
+    <a v-if="enableMemberModule" class="menu-button button heading" :href="registerUrl" target="_blank">
+      <span class="icon external" />
+      <span>Jouw inschrijvingspagina</span>
+    </a>
+
+    <button v-if="whatsNewBadge" class="menu-button button heading" @click="manageWhatsNew()">
+      <span class="icon gift" />
+      <span>Wat is er nieuw?</span>
+      <span v-if="whatsNewBadge" class="bubble">{{ whatsNewBadge }}</span>
+    </button>
+
+    <button v-if="fullAccess && organization.privateMeta.requestKeysCount > 0" class="menu-button button heading" :class="{ selected: currentlySelected == 'keys' }" @click="manageKeys()">
+      <span class="icon key" />
+      <span>Gebruikers goedkeuren</span>
+      <span class="bubble">{{ organization.privateMeta.requestKeysCount }}</span>
+    </button>
+
+    <template v-if="enableMemberModule">
+      <div v-for="category in tree.categories">
+        <div>
+          <button class="menu-button button heading" :class="{ selected: currentlySelected == 'category-'+category.id }" @click="openCategory(category)">
+            <span class="icon group" />
+            <span>{{ category.settings.name }}</span>
+            <span v-if="isCategoryDeactivated(category)" v-tooltip="'Deze categorie is onzichtbaar voor leden omdat activiteiten niet geactiveerd is'" class="icon error red right-icon" />
+          </button>
+
+          <button
+              v-for="group in category.groups"
+              :key="group.id"
+              class="menu-button button"
+              :class="{ selected: currentlySelected == 'group-'+group.id }"
+              @click="openGroup(group, category)"
+          >
+            <span>{{ group.settings.name }}</span>
+          </button>
+
+          <button
+              v-for="c in category.categories"
+              :key="c.id"
+              class="menu-button button"
+              :class="{ selected: currentlySelected == 'category-'+c.id }"
+              @click="openCategory(c)"
+          >
+            <span>{{ c.settings.name }}</span>
+          </button>
+        </div>
+        <hr>
+      </div>
+    </template>
+
+
+    <div v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
+      <button class="menu-button heading">
+        <span class="icon basket" />
+        <span>Verkopen</span>
+        <button v-if="canCreateWebshops" class="button text" @click="addWebshop()">
+          <span class="icon add" />
+          <span>Nieuw</span>
+        </button>
+      </button>
+
+      <button
+          v-for="webshop in webshops"
+          :key="webshop.id"
+          class="menu-button button"
+          :class="{ selected: currentlySelected == 'webshop-'+webshop.id }"
+          @click="openWebshop(webshop)"
+      >
+        {{ webshop.meta.name }}
+      </button>
+    </div>
+    <hr v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
+
+    <button v-if="canManagePayments" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-payments'}" @click="managePayments(true)">
+      <span class="icon card" />
+      <span>Overschrijvingen</span>
+    </button>
+
+    <div v-if="fullAccess">
+      <button class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-settings'}" @click="manageSettings(true)">
+        <span class="icon settings" />
+        <span>Instellingen</span>
+      </button>
+
+      <button v-if="isSGV" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-sgv-groepsadministratie'}" @click="openSyncScoutsEnGidsen(true)">
+        <span class="icon sync" />
+        <span>Groepsadministratie</span>
+      </button>
+    </div>
+    <hr v-if="fullAccess || canManagePayments">
+    <div class="">
+      <button class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-account'}" @click="manageAccount(true)">
+        <span class="icon user" />
+        <span>Mijn account</span>
+      </button>
+      <button class="menu-button button heading" @click="logout">
+        <span class="icon logout" />
+        <span>Uitloggen</span>
+      </button>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
@@ -125,7 +125,16 @@ import { NavigationController } from "@simonbackx/vue-app-navigation";
 import { CenteredMessage, Logo, Toast, ToastButton, TooltipDirective } from '@stamhoofd/components';
 import { Sodium } from "@stamhoofd/crypto";
 import { Keychain, LoginHelper,SessionManager } from '@stamhoofd/networking';
-import { Group, GroupCategory, GroupCategoryTree, OrganizationType, Permissions, UmbrellaOrganization, WebshopPreview } from '@stamhoofd/structures';
+import {
+  Category,
+  Group,
+  GroupCategory,
+  GroupCategoryTree,
+  OrganizationType,
+  Permissions,
+  UmbrellaOrganization,
+  WebshopPreview
+} from '@stamhoofd/structures';
 import { Formatter } from "@stamhoofd/utility";
 import { Component, Mixins } from "vue-property-decorator";
 
@@ -145,309 +154,312 @@ import EditWebshopView from './webshop/EditWebshopView.vue';
 import WebshopView from './webshop/WebshopView.vue';
 
 @Component({
-    components: {
-        Logo
-    },
-    directives: {
-        tooltip: TooltipDirective
-    }
+  components: {
+    Logo
+  },
+  directives: {
+    tooltip: TooltipDirective
+  }
 })
 export default class Menu extends Mixins(NavigationMixin) {
-    SessionManager = SessionManager // needed to make session reactive
-    currentlySelected: string | null = null
-    whatsNewBadge = ""
+  SessionManager = SessionManager // needed to make session reactive
+  currentlySelected: string | null = null
+  whatsNewBadge = ""
 
-    get organization() {
-        return OrganizationManager.organization
-    }
-    
-    get registerUrl() {
-        if (this.organization.registerDomain) {
-            return "https://"+this.organization.registerDomain
-        } 
+  get organization() {
+    return OrganizationManager.organization
+  }
 
-        return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
+  get registerUrl() {
+    if (this.organization.registerDomain) {
+      return "https://"+this.organization.registerDomain
     }
 
-    get isSGV() {
-        return this.organization.meta.type == OrganizationType.Youth && this.organization.meta.umbrellaOrganization == UmbrellaOrganization.ScoutsEnGidsenVlaanderen
+    return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
+  }
+
+  get isSGV() {
+    return this.organization.meta.type == OrganizationType.Youth && this.organization.meta.umbrellaOrganization == UmbrellaOrganization.ScoutsEnGidsenVlaanderen
+  }
+
+  get tree() {
+    return this.organization.categoryTreeForPermissions(OrganizationManager.user.permissions ?? Permissions.create({}))
+  }
+
+  mounted() {
+    const path = window.location.pathname;
+    const parts = path.substring(1).split("/");
+    let didSet = false
+
+    if ((parts.length >= 1 && parts[0] == 'settings') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'mollie')) {
+      if (this.fullAccess) {
+        this.manageSettings(false)
+        didSet = true
+      }
     }
 
-    get tree() {
-        return this.organization.categoryTreeForPermissions(OrganizationManager.user.permissions ?? Permissions.create({}))
+    if (parts.length >= 1 && parts[0] == 'transfers') {
+      if (this.canManagePayments) {
+        this.managePayments(false)
+        didSet = true
+      }
     }
 
-    mounted() {
-        const path = window.location.pathname;
-        const parts = path.substring(1).split("/");
-        let didSet = false
-
-        if ((parts.length >= 1 && parts[0] == 'settings') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'mollie')) {
-            if (this.fullAccess) {
-                this.manageSettings(false)
-                didSet = true
-            }
-        }
-
-        if (parts.length >= 1 && parts[0] == 'transfers') {
-            if (this.canManagePayments) {
-                this.managePayments(false)
-                didSet = true
-            }
-        }
-
-        if (parts.length >= 1 && parts[0] == 'account') {
-            this.manageAccount(false)
-            didSet = true
-        }
-
-        if ((parts.length >= 1 && parts[0] == 'scouts-en-gidsen-vlaanderen') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'sgv')) {
-            if (this.fullAccess) {
-                this.openSyncScoutsEnGidsen(false)
-                didSet = true
-            }
-        }
-
-        if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "category") {
-            for (const category of this.organization.meta.categories) {
-                if (parts[1] == Formatter.slug(category.settings.name)) {
-                    if (parts[2] && parts[2] == "all") {
-                        this.openCategoryMembers(category, false)
-                    } else {
-                        this.openCategory(category, false)
-                    }
-                    didSet = true
-                    break;
-                }
-            }
-        }
-
-        if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
-            for (const group of this.organization.groups) {
-                if (parts[1] == Formatter.slug(group.settings.name)) {
-                    this.openGroup(group, false)
-                    didSet = true
-                    break;
-                }
-            }
-        }
-
-        if (!didSet && this.enableWebshopModule && parts.length >= 2 && parts[0] == "webshops") {
-            for (const webshop of this.organization.webshops) {
-                if (parts[1] == Formatter.slug(webshop.meta.name)) {
-                    this.openWebshop(webshop, false)
-                    didSet = true
-                    break;
-                }
-            }
-        }
-
-        if (!didSet) {
-            HistoryManager.setUrl("/")
-        }
-        
-        if (!didSet && !this.splitViewController?.shouldCollapse()) {
-            //if (this.groups.length > 0) {
-                //this.openGroup(this.groups[0], false)
-            //} else {
-                if (this.fullAccess) {
-                    this.manageSettings(false)
-                } else {
-                    this.manageAccount(false)
-                }
-            //}
-        }
-
-        document.title = "Stamhoofd - "+OrganizationManager.organization.name
-
-        this.checkKey().catch(e => {
-            console.error(e)
-        })
-
-        const currentCount = localStorage.getItem("what-is-new")
-        if (currentCount) {
-            const c = parseInt(currentCount)
-            if (!isNaN(c) && WhatsNewCount - c > 0) {
-                this.whatsNewBadge = (WhatsNewCount - c).toString()
-            }
-        } else {
-            localStorage.setItem("what-is-new", (WhatsNewCount as any).toString());
-        }
-
-        if (!didSet) {
-            if (!this.organization.meta.modules.useMembers && !this.organization.meta.modules.useWebshops) {
-                this.present(new ComponentWithProperties(SignupModulesView, { }).setDisplayStyle("popup").setAnimated(false))
-            }
-        }
+    if (parts.length >= 1 && parts[0] == 'account') {
+      this.manageAccount(false)
+      didSet = true
     }
 
-    async checkKey() {
-        // Check if public and private key matches
-        const user = SessionManager.currentSession!.user!
-        const privateKey = SessionManager.currentSession!.getUserPrivateKey()!
-        const publicKey = user.publicKey
+    if ((parts.length >= 1 && parts[0] == 'scouts-en-gidsen-vlaanderen') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'sgv')) {
+      if (this.fullAccess) {
+        this.openSyncScoutsEnGidsen(false)
+        didSet = true
+      }
+    }
 
-        if (!await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey)) {
-
-            // Gather all keychain items, and check which ones are still valid
-            // Oops! Error with public private key
-            await LoginHelper.fixPublicKey(SessionManager.currentSession!)
-            new Toast("We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.", "success green").setHide(15*1000).show()
-            MemberManager.callListeners("encryption", null)
+    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "category") {
+      for (const category of this.organization.meta.categories) {
+        if (parts[1] == Formatter.slug(category.settings.name)) {
+          if (parts[2] && parts[2] == "all") {
+            this.openCategoryMembers(category, false)
+          } else {
+            this.openCategory(category, false)
+          }
+          didSet = true
+          break;
         }
+      }
+    }
 
-
-        if (SessionManager.currentSession!.user!.incomingInvites.length > 0) {
-            for (const invite of user.incomingInvites) {
-                try {
-                    const decryptedKeychainItems = await Sodium.unsealMessage(invite.keychainItems!, publicKey, privateKey)
-                    await LoginHelper.addToKeychain(SessionManager.currentSession!, decryptedKeychainItems)
-                    new Toast(invite.sender.firstName+" heeft een encryptiesleutel met jou gedeeld", "key green").setHide(15*1000).show()
-                } catch (e) {
-                    console.error(e)
-                    new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
-                }
-                
-                // Remove invite if succeeded
-                await SessionManager.currentSession!.authenticatedServer.request({
-                    method: "POST",
-                    path: "/invite/"+encodeURIComponent(invite.key)+"/trade"
-                })
-            }
-
-            // Reload all views
-            MemberManager.callListeners("encryption", null)
+    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
+      for (const group of this.organization.groups) {
+        if (parts[1] == Formatter.slug(group.settings.name)) {
+          this.openGroup(group, false)
+          didSet = true
+          break;
         }
+      }
+    }
 
+    if (!didSet && this.enableWebshopModule && parts.length >= 2 && parts[0] == "webshops") {
+      for (const webshop of this.organization.webshops) {
+        if (parts[1] == Formatter.slug(webshop.meta.name)) {
+          this.openWebshop(webshop, false)
+          didSet = true
+          break;
+        }
+      }
+    }
+
+    if (!didSet) {
+      HistoryManager.setUrl("/")
+    }
+
+    if (!didSet && !this.splitViewController?.shouldCollapse()) {
+      //if (this.groups.length > 0) {
+      //this.openGroup(this.groups[0], false)
+      //} else {
+      if (this.fullAccess) {
+        this.manageSettings(false)
+      } else {
+        this.manageAccount(false)
+      }
+      //}
+    }
+
+    document.title = "Stamhoofd - "+OrganizationManager.organization.name
+
+    this.checkKey().catch(e => {
+      console.error(e)
+    })
+
+    const currentCount = localStorage.getItem("what-is-new")
+    if (currentCount) {
+      const c = parseInt(currentCount)
+      if (!isNaN(c) && WhatsNewCount - c > 0) {
+        this.whatsNewBadge = (WhatsNewCount - c).toString()
+      }
+    } else {
+      localStorage.setItem("what-is-new", (WhatsNewCount as any).toString());
+    }
+
+    if (!didSet) {
+      if (!this.organization.meta.modules.useMembers && !this.organization.meta.modules.useWebshops) {
+        this.present(new ComponentWithProperties(SignupModulesView, { }).setDisplayStyle("popup").setAnimated(false))
+      }
+    }
+  }
+
+  async checkKey() {
+    // Check if public and private key matches
+    const user = SessionManager.currentSession!.user!
+    const privateKey = SessionManager.currentSession!.getUserPrivateKey()!
+    const publicKey = user.publicKey
+
+    if (!await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey)) {
+
+      // Gather all keychain items, and check which ones are still valid
+      // Oops! Error with public private key
+      await LoginHelper.fixPublicKey(SessionManager.currentSession!)
+      new Toast("We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.", "success green").setHide(15*1000).show()
+      MemberManager.callListeners("encryption", null)
+    }
+
+
+    if (SessionManager.currentSession!.user!.incomingInvites.length > 0) {
+      for (const invite of user.incomingInvites) {
         try {
-            const keychainItem = Keychain.getItem(OrganizationManager.organization.publicKey)
-            if (!keychainItem) {
-                throw new Error("Missing organization keychain")
-            }
-
-            const session = SessionManager.currentSession!
-            await session.decryptKeychainItem(keychainItem)
-
+          const decryptedKeychainItems = await Sodium.unsealMessage(invite.keychainItems!, publicKey, privateKey)
+          await LoginHelper.addToKeychain(SessionManager.currentSession!, decryptedKeychainItems)
+          new Toast(invite.sender.firstName+" heeft een encryptiesleutel met jou gedeeld", "key green").setHide(15*1000).show()
         } catch (e) {
-            console.error(e)
-
-            // Show warnign instead
-            new Toast("Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.", "key-lost yellow").setHide(15*1000).setButton(new ToastButton("Meer info", () => {
-                this.present(new ComponentWithProperties(NoKeyView, {}).setDisplayStyle("popup"))
-            })).show()
+          console.error(e)
+          new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
         }
+
+        // Remove invite if succeeded
+        await SessionManager.currentSession!.authenticatedServer.request({
+          method: "POST",
+          path: "/invite/"+encodeURIComponent(invite.key)+"/trade"
+        })
+      }
+
+      // Reload all views
+      MemberManager.callListeners("encryption", null)
     }
 
-    get webshops() {
-        return this.organization.webshops
+    try {
+      const keychainItem = Keychain.getItem(OrganizationManager.organization.publicKey)
+      if (!keychainItem) {
+        throw new Error("Missing organization keychain")
+      }
+
+      const session = SessionManager.currentSession!
+      await session.decryptKeychainItem(keychainItem)
+
+    } catch (e) {
+      console.error(e)
+
+      // Show warnign instead
+      new Toast("Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.", "key-lost yellow").setHide(15*1000).setButton(new ToastButton("Meer info", () => {
+        this.present(new ComponentWithProperties(NoKeyView, {}).setDisplayStyle("popup"))
+      })).show()
     }
+  }
 
-    switchOrganization() {
-        SessionManager.deactivateSession()
+  get webshops() {
+    return this.organization.webshops
+  }
+
+  switchOrganization() {
+    SessionManager.deactivateSession()
+  }
+
+  openAll(animated = true) {
+    this.currentlySelected = "group-all"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
+  }
+
+  openGroup(group: Group, category: GroupCategoryTree, animated = true) {
+    this.currentlySelected = "group-"+group.id
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
+        group,
+        category
+      }) }).setAnimated(animated));
+  }
+
+  manageKeys(animated = true) {
+    this.currentlySelected = "keys"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(KeysView) }).setAnimated(animated));
+  }
+
+  openCategory(category: GroupCategory, animated = true) {
+    this.currentlySelected = "category-"+category.id
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(CategoryView, { category }) }).setAnimated(animated));
+  }
+
+  openCategoryMembers(category: GroupCategory, animated = true) {
+    this.currentlySelected = "category-"+category.id
+
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
+        category: GroupCategoryTree.build(category, this.organization.meta.categories, this.organization.groups)
+      }) }).setAnimated(animated));
+  }
+
+  openWebshop(webshop: WebshopPreview, animated = true) {
+    this.currentlySelected = "webshop-"+webshop.id
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(WebshopView, { preview: webshop }) }).setAnimated(animated));
+  }
+
+  managePayments(animated = true) {
+    this.currentlySelected = "manage-payments"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(PaymentsView, {}) }).setAnimated(animated));
+  }
+
+  manageSettings(animated = true) {
+    this.currentlySelected = "manage-settings"
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SettingsView, {}) }).setAnimated(animated));
+  }
+
+  manageAccount(animated = true) {
+    this.currentlySelected = "manage-account"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(AccountSettingsView, {}) }).setAnimated(animated));
+  }
+
+  manageWhatsNew() {
+    this.whatsNewBadge = ""
+
+    window.open('https://www.stamhoofd.be/release-notes', '_blank');
+    localStorage.setItem("what-is-new", WhatsNewCount.toString());
+  }
+
+  async logout() {
+    if (!await CenteredMessage.confirm("Ben je zeker dat je wilt uitloggen?", "Uitloggen")) {
+      return;
     }
+    SessionManager.logout()
+  }
 
-    openAll(animated = true) {
-        this.currentlySelected = "group-all"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
-    }
+  openSyncScoutsEnGidsen(animated = true) {
+    this.currentlySelected = "manage-sgv-groepsadministratie"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SGVGroepsadministratieView, {}) }).setAnimated(animated));
+  }
 
-    openGroup(group: Group, animated = true) {
-        this.currentlySelected = "group-"+group.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group }) }).setAnimated(animated));
-    }
+  importMembers() {
+    new CenteredMessage("Binnenkort beschikbaar!", "Binnenkort kan je leden importeren via Excel of manueel.", "sync").addCloseButton().show()
+  }
 
-    manageKeys(animated = true) {
-        this.currentlySelected = "keys"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(KeysView) }).setAnimated(animated));
-    }
+  addWebshop() {
+    this.present(new ComponentWithProperties(EditWebshopView, { }).setDisplayStyle("popup"))
+  }
 
-    openCategory(category: GroupCategory, animated = true) {
-        this.currentlySelected = "category-"+category.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(CategoryView, { category }) }).setAnimated(animated));
-    }
+  get canCreateWebshops() {
+    return OrganizationManager.user.permissions?.canCreateWebshops(OrganizationManager.organization.privateMeta?.roles ?? [])
+  }
 
-    openCategoryMembers(category: GroupCategory, animated = true) {
-        this.currentlySelected = "category-"+category.id
+  get canManagePayments() {
+    return OrganizationManager.user.permissions?.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? [])
+  }
 
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
-            category: GroupCategoryTree.build(category, this.organization.meta.categories, this.organization.groups)
-        }) }).setAnimated(animated));
-    }
+  get fullAccess() {
+    return SessionManager.currentSession!.user!.permissions!.hasFullAccess()
+  }
 
-    openWebshop(webshop: WebshopPreview, animated = true) {
-        this.currentlySelected = "webshop-"+webshop.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(WebshopView, { preview: webshop }) }).setAnimated(animated));
-    }
+  get fullReadAccess() {
+    return SessionManager.currentSession!.user!.permissions!.hasReadAccess()
+  }
 
-    managePayments(animated = true) {
-        this.currentlySelected = "manage-payments"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(PaymentsView, {}) }).setAnimated(animated));
-    }
+  get enableMemberModule() {
+    return this.organization.meta.modules.useMembers
+  }
 
-    manageSettings(animated = true) {
-        this.currentlySelected = "manage-settings"
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SettingsView, {}) }).setAnimated(animated));
-    }
+  get enableWebshopModule() {
+    return this.organization.meta.modules.useWebshops
+  }
 
-    manageAccount(animated = true) {
-        this.currentlySelected = "manage-account"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(AccountSettingsView, {}) }).setAnimated(animated));
-    }
-
-    manageWhatsNew() {
-        this.whatsNewBadge = ""
-
-        window.open('https://www.stamhoofd.be/release-notes', '_blank');
-        localStorage.setItem("what-is-new", WhatsNewCount.toString());
-    }
-
-    async logout() {
-        if (!await CenteredMessage.confirm("Ben je zeker dat je wilt uitloggen?", "Uitloggen")) {
-            return;
-        }
-        SessionManager.logout()
-    }
-
-    openSyncScoutsEnGidsen(animated = true) {
-        this.currentlySelected = "manage-sgv-groepsadministratie"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SGVGroepsadministratieView, {}) }).setAnimated(animated));
-    }
-
-    importMembers() {
-        new CenteredMessage("Binnenkort beschikbaar!", "Binnenkort kan je leden importeren via Excel of manueel.", "sync").addCloseButton().show()
-    }
-
-    addWebshop() {
-        this.present(new ComponentWithProperties(EditWebshopView, { }).setDisplayStyle("popup"))
-    }
-
-    get canCreateWebshops() {
-        return OrganizationManager.user.permissions?.canCreateWebshops(OrganizationManager.organization.privateMeta?.roles ?? [])
-    }
-
-    get canManagePayments() {
-        return OrganizationManager.user.permissions?.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? [])
-    }
-
-    get fullAccess() {
-        return SessionManager.currentSession!.user!.permissions!.hasFullAccess()
-    }
-
-    get fullReadAccess() {
-        return SessionManager.currentSession!.user!.permissions!.hasReadAccess()
-    }
-
-    get enableMemberModule() {
-        return this.organization.meta.modules.useMembers
-    }
-
-    get enableWebshopModule() {
-        return this.organization.meta.modules.useWebshops
-    }
-
-    isCategoryDeactivated(category: GroupCategoryTree) {
-        return this.organization.isCategoryDeactivated(category)
-    }
+  isCategoryDeactivated(category: GroupCategoryTree) {
+    return this.organization.isCategoryDeactivated(category)
+  }
 }
 </script>

--- a/frontend/app/dashboard/src/views/dashboard/groups/CategoryView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/CategoryView.vue
@@ -16,14 +16,21 @@
       </h1>
 
       <p v-if="organization.isCategoryDeactivated(category)" class="error-box">
-        Deze categorie is niet zichtbaar voor leden omdat het activiteiten pakket niet is geactiveerd. Er kan dan maar één categorie in gebruik zijn. Via instellingen kunnen hoofdbeheerders pakketten activeren.
+        Deze categorie is niet zichtbaar voor leden omdat het activiteiten
+        pakket niet is geactiveerd. Er kan dan maar één categorie in gebruik
+        zijn. Via instellingen kunnen hoofdbeheerders pakketten activeren.
       </p>
 
       <STErrorsDefault :error-box="errorBox" />
 
       <template v-if="categories.length > 0">
         <STList>
-          <STListItem v-for="category in categories" :key="category.id" :selectable="true" @click="openCategory(category)">
+          <STListItem
+            v-for="category in categories"
+            :key="category.id"
+            :selectable="true"
+            @click="openCategory(category)"
+          >
             {{ category.settings.name }}
 
             <template slot="right">
@@ -33,18 +40,25 @@
         </STList>
       </template>
 
-
-
       <template v-else-if="groups.length > 0">
         <STList>
-          <STListItem v-if="groups.length > 1" :selectable="true" @click="openAll()">
+          <STListItem
+            v-if="groups.length > 1"
+            :selectable="true"
+            @click="openAll()"
+          >
             Alle leden
 
             <template slot="right">
               <span class="icon arrow-right-small gray" />
             </template>
           </STListItem>
-          <STListItem v-for="group in groups" :key="group.id" :selectable="true" @click="openGroup(group)">
+          <STListItem
+            v-for="group in groups"
+            :key="group.id"
+            :selectable="true"
+            @click="openGroup(group)"
+          >
             {{ group.settings.name }}
 
             <template slot="right">
@@ -54,11 +68,19 @@
         </STList>
       </template>
 
-      <p v-if="categories.length == 0 && groups.length == 0 && canCreate" class="info-box">
-        Deze inschrijvingscategorie is leeg, maak zelf inschrijvingsgroepen aan waarin leden kunnen inschrijven.
+      <p
+        v-if="categories.length == 0 && groups.length == 0 && canCreate"
+        class="info-box"
+      >
+        Deze inschrijvingscategorie is leeg, maak zelf inschrijvingsgroepen aan
+        waarin leden kunnen inschrijven.
       </p>
-      <p v-else-if="categories.length == 0 && groups.length == 0" class="info-box">
-        Deze inschrijvingscategorie is leeg. Vraag een hoofdbeheerder om groepen aan te maken.
+      <p
+        v-else-if="categories.length == 0 && groups.length == 0"
+        class="info-box"
+      >
+        Deze inschrijvingscategorie is leeg. Vraag een hoofdbeheerder om groepen
+        aan te maken.
       </p>
 
       <p v-if="categories.length == 0 && canCreate">
@@ -73,13 +95,39 @@
 
 <script lang="ts">
 import { AutoEncoderPatchType } from "@simonbackx/simple-encoding";
-import { ComponentWithProperties, HistoryManager, NavigationController, NavigationMixin } from "@simonbackx/vue-app-navigation";
-import { BackButton,ErrorBox, STErrorsDefault,STInputBox, STList, STListItem, STNavigationBar, STToolbar, Validator } from "@stamhoofd/components";
-import { Group, GroupCategory, GroupCategoryTree, GroupGenderType, GroupPrivateSettings, GroupSettings, Organization, OrganizationGenderType, OrganizationMetaData, Permissions } from "@stamhoofd/structures"
+import {
+  ComponentWithProperties,
+  HistoryManager,
+  NavigationController,
+  NavigationMixin
+} from "@simonbackx/vue-app-navigation";
+import {
+  BackButton,
+  ErrorBox,
+  STErrorsDefault,
+  STInputBox,
+  STList,
+  STListItem,
+  STNavigationBar,
+  STToolbar,
+  Validator
+} from "@stamhoofd/components";
+import {
+  Group,
+  GroupCategory,
+  GroupCategoryTree,
+  GroupGenderType,
+  GroupPrivateSettings,
+  GroupSettings,
+  Organization,
+  OrganizationGenderType,
+  OrganizationMetaData,
+  Permissions
+} from "@stamhoofd/structures";
 import { Formatter } from "@stamhoofd/utility";
-import { Component, Mixins,Prop } from "vue-property-decorator";
+import { Component, Mixins, Prop } from "vue-property-decorator";
 
-import { OrganizationManager } from '../../../classes/OrganizationManager';
+import { OrganizationManager } from "../../../classes/OrganizationManager";
 import EditCategoryGroupsView from "./EditCategoryGroupsView.vue";
 import EditGroupView from "./EditGroupView.vue";
 import GroupMembersView from "./GroupMembersView.vue";
@@ -93,82 +141,104 @@ import GroupMembersView from "./GroupMembersView.vue";
     STList,
     STListItem,
     BackButton
-  },
+  }
 })
 export default class CategoryView extends Mixins(NavigationMixin) {
-  errorBox: ErrorBox | null = null
-  validator = new Validator()
-  saving = false
+  errorBox: ErrorBox | null = null;
+  validator = new Validator();
+  saving = false;
 
   @Prop({ required: true })
-  category: GroupCategory
+  category: GroupCategory;
 
   mounted() {
-    HistoryManager.setUrl("/category/"+Formatter.slug(this.category.settings.name))
-    document.title = "Stamhoofd - "+ this.category.settings.name
+    HistoryManager.setUrl(
+      "/category/" + Formatter.slug(this.category.settings.name)
+    );
+    document.title = "Stamhoofd - " + this.category.settings.name;
   }
 
   get reactiveCategory() {
-    const c = this.organization.meta.categories.find(c => c.id === this.category.id)
+    const c = this.organization.meta.categories.find(
+      c => c.id === this.category.id
+    );
     if (c) {
-      return c
+      return c;
     }
-    return this.category
+    return this.category;
   }
 
   get tree() {
-    return GroupCategoryTree.build(this.reactiveCategory, this.organization.meta.categories, this.organization.groups, OrganizationManager.user.permissions)
+    return GroupCategoryTree.build(
+      this.reactiveCategory,
+      this.organization.meta.categories,
+      this.organization.groups,
+      OrganizationManager.user.permissions
+    );
   }
 
   get organization() {
-    return OrganizationManager.organization
+    return OrganizationManager.organization;
   }
 
   get isRoot() {
-    return this.category.id === this.organization.meta.rootCategoryId
+    return this.category.id === this.organization.meta.rootCategoryId;
   }
 
   get title() {
-    return this.isRoot ? 'Inschrijvingsgroepen' : this.name+''
+    return this.isRoot ? "Inschrijvingsgroepen" : this.name + "";
   }
 
   get name() {
-    return this.reactiveCategory.settings.name
+    return this.reactiveCategory.settings.name;
   }
 
   get canEdit() {
-    return OrganizationManager.user.permissions ? this.category.canEdit(OrganizationManager.user.permissions) : false
+    return OrganizationManager.user.permissions
+      ? this.category.canEdit(OrganizationManager.user.permissions)
+      : false;
   }
 
   get canCreate() {
-    return OrganizationManager.user.permissions ? this.category.canCreate(OrganizationManager.user.permissions, this.organization.meta.categories) : false
+    return OrganizationManager.user.permissions
+      ? this.category.canCreate(
+          OrganizationManager.user.permissions,
+          this.organization.meta.categories
+        )
+      : false;
   }
 
   get groups() {
-    return this.tree.groups
+    return this.tree.groups;
   }
 
   get categories() {
-    return this.tree.categories
+    return this.tree.categories;
   }
 
   openCategory(category: GroupCategory) {
-    this.show(new ComponentWithProperties(CategoryView, {
-      category
-    }))
+    this.show(
+      new ComponentWithProperties(CategoryView, {
+        category
+      })
+    );
   }
 
   openGroup(group: Group) {
-    this.show(new ComponentWithProperties(GroupMembersView, {
-      group: group,
-      category: this.category
-    }))
+    this.show(
+      new ComponentWithProperties(GroupMembersView, {
+        group: group,
+        category: this.category
+      })
+    );
   }
 
   openAll() {
-    this.show(new ComponentWithProperties(GroupMembersView, {
-      category: this.tree
-    }))
+    this.show(
+      new ComponentWithProperties(GroupMembersView, {
+        category: this.tree
+      })
+    );
   }
 
   createGroup() {
@@ -180,44 +250,50 @@ export default class CategoryView extends Mixins(NavigationMixin) {
         registrationStartDate: this.organization.meta.defaultStartDate,
         registrationEndDate: this.organization.meta.defaultEndDate,
         prices: this.organization.meta.defaultPrices,
-        genderType: this.organization.meta.genderType == OrganizationGenderType.Mixed ? GroupGenderType.Mixed : GroupGenderType.OnlyFemale
+        genderType:
+          this.organization.meta.genderType == OrganizationGenderType.Mixed
+            ? GroupGenderType.Mixed
+            : GroupGenderType.OnlyFemale
       }),
       privateSettings: GroupPrivateSettings.create({})
-    })
-    const meta = OrganizationMetaData.patch({})
+    });
+    const meta = OrganizationMetaData.patch({});
 
-    const me = GroupCategory.patch({ id: this.category.id })
-    me.groupIds.addPut(group.id)
-    meta.categories.addPatch(me)
+    const me = GroupCategory.patch({ id: this.category.id });
+    me.groupIds.addPut(group.id);
+    meta.categories.addPatch(me);
 
     const p = Organization.patch({
       id: this.organization.id,
       meta
-    })
+    });
 
-    p.groups.addPut(group)
+    p.groups.addPut(group);
 
-    this.present(new ComponentWithProperties(EditGroupView, {
-      group,
-      organization: this.organization.patch(p),
-      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
-        await OrganizationManager.patch(p.patch(patch))
-      }
-    }).setDisplayStyle("popup"))
+    this.present(
+      new ComponentWithProperties(EditGroupView, {
+        group,
+        organization: this.organization.patch(p),
+        saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+          await OrganizationManager.patch(p.patch(patch));
+        }
+      }).setDisplayStyle("popup")
+    );
   }
 
   editMe() {
-    this.present(new ComponentWithProperties(NavigationController, {
-      root: new ComponentWithProperties(EditCategoryGroupsView, {
-        category: this.category,
-        organization: this.organization,
-        saveHandler: async (patch) => {
-          patch.id = this.organization.id
-          await OrganizationManager.patch(patch)
-        }
-      })
-    }).setDisplayStyle("popup"))
+    this.present(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(EditCategoryGroupsView, {
+          category: this.category,
+          organization: this.organization,
+          saveHandler: async patch => {
+            patch.id = this.organization.id;
+            await OrganizationManager.patch(patch);
+          }
+        })
+      }).setDisplayStyle("popup")
+    );
   }
-
 }
 </script>

--- a/frontend/app/dashboard/src/views/dashboard/groups/CategoryView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/CategoryView.vue
@@ -1,74 +1,74 @@
 <template>
-    <div class="st-view background">
-        <STNavigationBar :title="title">
-            <BackButton v-if="canPop" slot="left" @click="pop" />
+  <div class="st-view background">
+    <STNavigationBar :title="title">
+      <BackButton v-if="canPop" slot="left" @click="pop" />
+      <template slot="right">
+        <button v-if="canEdit" class="button text" @click="editMe">
+          <span class="icon settings" />
+          <span>Wijzigen</span>
+        </button>
+      </template>
+    </STNavigationBar>
+
+    <main>
+      <h1>
+        {{ title }}
+      </h1>
+
+      <p v-if="organization.isCategoryDeactivated(category)" class="error-box">
+        Deze categorie is niet zichtbaar voor leden omdat het activiteiten pakket niet is geactiveerd. Er kan dan maar één categorie in gebruik zijn. Via instellingen kunnen hoofdbeheerders pakketten activeren.
+      </p>
+
+      <STErrorsDefault :error-box="errorBox" />
+
+      <template v-if="categories.length > 0">
+        <STList>
+          <STListItem v-for="category in categories" :key="category.id" :selectable="true" @click="openCategory(category)">
+            {{ category.settings.name }}
+
             <template slot="right">
-                <button v-if="canEdit" class="button text" @click="editMe">
-                    <span class="icon settings" />
-                    <span>Wijzigen</span>
-                </button>
+              <span class="icon arrow-right-small gray" />
             </template>
-        </STNavigationBar>
+          </STListItem>
+        </STList>
+      </template>
 
-        <main>
-            <h1>
-                {{ title }}
-            </h1>
 
-            <p v-if="organization.isCategoryDeactivated(category)" class="error-box">
-                Deze categorie is niet zichtbaar voor leden omdat het activiteiten pakket niet is geactiveerd. Er kan dan maar één categorie in gebruik zijn. Via instellingen kunnen hoofdbeheerders pakketten activeren.
-            </p>
-          
-            <STErrorsDefault :error-box="errorBox" />
 
-            <template v-if="categories.length > 0">
-                <STList>
-                    <STListItem v-for="category in categories" :key="category.id" :selectable="true" @click="openCategory(category)">
-                        {{ category.settings.name }}
+      <template v-else-if="groups.length > 0">
+        <STList>
+          <STListItem v-if="groups.length > 1" :selectable="true" @click="openAll()">
+            Alle leden
 
-                        <template slot="right">
-                            <span class="icon arrow-right-small gray" />
-                        </template>
-                    </STListItem>
-                </STList>
+            <template slot="right">
+              <span class="icon arrow-right-small gray" />
             </template>
+          </STListItem>
+          <STListItem v-for="group in groups" :key="group.id" :selectable="true" @click="openGroup(group)">
+            {{ group.settings.name }}
 
-            
-
-            <template v-else-if="groups.length > 0">
-                <STList>
-                    <STListItem v-if="groups.length > 1" :selectable="true" @click="openAll()">
-                        Alle leden
-
-                        <template slot="right">
-                            <span class="icon arrow-right-small gray" />
-                        </template>
-                    </STListItem>
-                    <STListItem v-for="group in groups" :key="group.id" :selectable="true" @click="openGroup(group)">
-                        {{ group.settings.name }}
-
-                        <template slot="right">
-                            <span class="icon arrow-right-small gray" />
-                        </template>
-                    </STListItem>
-                </STList>
+            <template slot="right">
+              <span class="icon arrow-right-small gray" />
             </template>
+          </STListItem>
+        </STList>
+      </template>
 
-            <p v-if="categories.length == 0 && groups.length == 0 && canCreate" class="info-box">
-                Deze inschrijvingscategorie is leeg, maak zelf inschrijvingsgroepen aan waarin leden kunnen inschrijven.
-            </p>
-            <p v-else-if="categories.length == 0 && groups.length == 0" class="info-box">
-                Deze inschrijvingscategorie is leeg. Vraag een hoofdbeheerder om groepen aan te maken.
-            </p>
+      <p v-if="categories.length == 0 && groups.length == 0 && canCreate" class="info-box">
+        Deze inschrijvingscategorie is leeg, maak zelf inschrijvingsgroepen aan waarin leden kunnen inschrijven.
+      </p>
+      <p v-else-if="categories.length == 0 && groups.length == 0" class="info-box">
+        Deze inschrijvingscategorie is leeg. Vraag een hoofdbeheerder om groepen aan te maken.
+      </p>
 
-            <p v-if="categories.length == 0 && canCreate">
-                <button class="button text" @click="createGroup">
-                    <span class="icon add" />
-                    <span>Nieuwe groep toevoegen</span>
-                </button>
-            </p>
-        </main>
-    </div>
+      <p v-if="categories.length == 0 && canCreate">
+        <button class="button text" @click="createGroup">
+          <span class="icon add" />
+          <span>Nieuwe groep toevoegen</span>
+        </button>
+      </p>
+    </main>
+  </div>
 </template>
 
 <script lang="ts">
@@ -85,138 +85,139 @@ import EditGroupView from "./EditGroupView.vue";
 import GroupMembersView from "./GroupMembersView.vue";
 
 @Component({
-    components: {
-        STNavigationBar,
-        STToolbar,
-        STInputBox,
-        STErrorsDefault,
-        STList,
-        STListItem,
-        BackButton
-    },
+  components: {
+    STNavigationBar,
+    STToolbar,
+    STInputBox,
+    STErrorsDefault,
+    STList,
+    STListItem,
+    BackButton
+  },
 })
 export default class CategoryView extends Mixins(NavigationMixin) {
-    errorBox: ErrorBox | null = null
-    validator = new Validator()
-    saving = false
+  errorBox: ErrorBox | null = null
+  validator = new Validator()
+  saving = false
 
-    @Prop({ required: true })
-    category: GroupCategory
+  @Prop({ required: true })
+  category: GroupCategory
 
-    mounted() {
-        HistoryManager.setUrl("/category/"+Formatter.slug(this.category.settings.name))    
-        document.title = "Stamhoofd - "+ this.category.settings.name
+  mounted() {
+    HistoryManager.setUrl("/category/"+Formatter.slug(this.category.settings.name))
+    document.title = "Stamhoofd - "+ this.category.settings.name
+  }
+
+  get reactiveCategory() {
+    const c = this.organization.meta.categories.find(c => c.id === this.category.id)
+    if (c) {
+      return c
     }
+    return this.category
+  }
 
-    get reactiveCategory() {
-        const c = this.organization.meta.categories.find(c => c.id === this.category.id)
-        if (c) {
-            return c
+  get tree() {
+    return GroupCategoryTree.build(this.reactiveCategory, this.organization.meta.categories, this.organization.groups, OrganizationManager.user.permissions)
+  }
+
+  get organization() {
+    return OrganizationManager.organization
+  }
+
+  get isRoot() {
+    return this.category.id === this.organization.meta.rootCategoryId
+  }
+
+  get title() {
+    return this.isRoot ? 'Inschrijvingsgroepen' : this.name+''
+  }
+
+  get name() {
+    return this.reactiveCategory.settings.name
+  }
+
+  get canEdit() {
+    return OrganizationManager.user.permissions ? this.category.canEdit(OrganizationManager.user.permissions) : false
+  }
+
+  get canCreate() {
+    return OrganizationManager.user.permissions ? this.category.canCreate(OrganizationManager.user.permissions, this.organization.meta.categories) : false
+  }
+
+  get groups() {
+    return this.tree.groups
+  }
+
+  get categories() {
+    return this.tree.categories
+  }
+
+  openCategory(category: GroupCategory) {
+    this.show(new ComponentWithProperties(CategoryView, {
+      category
+    }))
+  }
+
+  openGroup(group: Group) {
+    this.show(new ComponentWithProperties(GroupMembersView, {
+      group: group,
+      category: this.category
+    }))
+  }
+
+  openAll() {
+    this.show(new ComponentWithProperties(GroupMembersView, {
+      category: this.tree
+    }))
+  }
+
+  createGroup() {
+    const group = Group.create({
+      settings: GroupSettings.create({
+        name: "",
+        startDate: this.organization.meta.defaultStartDate,
+        endDate: this.organization.meta.defaultEndDate,
+        registrationStartDate: this.organization.meta.defaultStartDate,
+        registrationEndDate: this.organization.meta.defaultEndDate,
+        prices: this.organization.meta.defaultPrices,
+        genderType: this.organization.meta.genderType == OrganizationGenderType.Mixed ? GroupGenderType.Mixed : GroupGenderType.OnlyFemale
+      }),
+      privateSettings: GroupPrivateSettings.create({})
+    })
+    const meta = OrganizationMetaData.patch({})
+
+    const me = GroupCategory.patch({ id: this.category.id })
+    me.groupIds.addPut(group.id)
+    meta.categories.addPatch(me)
+
+    const p = Organization.patch({
+      id: this.organization.id,
+      meta
+    })
+
+    p.groups.addPut(group)
+
+    this.present(new ComponentWithProperties(EditGroupView, {
+      group,
+      organization: this.organization.patch(p),
+      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+        await OrganizationManager.patch(p.patch(patch))
+      }
+    }).setDisplayStyle("popup"))
+  }
+
+  editMe() {
+    this.present(new ComponentWithProperties(NavigationController, {
+      root: new ComponentWithProperties(EditCategoryGroupsView, {
+        category: this.category,
+        organization: this.organization,
+        saveHandler: async (patch) => {
+          patch.id = this.organization.id
+          await OrganizationManager.patch(patch)
         }
-        return this.category
-    }
+      })
+    }).setDisplayStyle("popup"))
+  }
 
-    get tree() {
-        return GroupCategoryTree.build(this.reactiveCategory, this.organization.meta.categories, this.organization.groups, OrganizationManager.user.permissions)
-    }
-
-    get organization() {
-        return OrganizationManager.organization
-    }
-
-    get isRoot() {
-        return this.category.id === this.organization.meta.rootCategoryId
-    }
-
-    get title() {
-        return this.isRoot ? 'Inschrijvingsgroepen' : this.name+''
-    }
-
-    get name() {
-        return this.reactiveCategory.settings.name
-    }
-
-    get canEdit() {
-        return OrganizationManager.user.permissions ? this.category.canEdit(OrganizationManager.user.permissions) : false
-    }
-
-    get canCreate() {
-        return OrganizationManager.user.permissions ? this.category.canCreate(OrganizationManager.user.permissions, this.organization.meta.categories) : false
-    }
-
-    get groups() {
-        return this.tree.groups
-    }
-
-    get categories() {
-        return this.tree.categories
-    }
-
-    openCategory(category: GroupCategory) {
-        this.show(new ComponentWithProperties(CategoryView, {
-            category
-        }))
-    }
-
-    openGroup(group: Group) {
-        this.show(new ComponentWithProperties(GroupMembersView, {
-            group
-        }))
-    }
-
-    openAll() {
-        this.show(new ComponentWithProperties(GroupMembersView, {
-            category: this.tree
-        }))
-    }
-
-    createGroup() {
-        const group = Group.create({
-            settings: GroupSettings.create({
-                name: "",
-                startDate: this.organization.meta.defaultStartDate,
-                endDate: this.organization.meta.defaultEndDate,
-                registrationStartDate: this.organization.meta.defaultStartDate,
-                registrationEndDate: this.organization.meta.defaultEndDate,
-                prices: this.organization.meta.defaultPrices,
-                genderType: this.organization.meta.genderType == OrganizationGenderType.Mixed ? GroupGenderType.Mixed : GroupGenderType.OnlyFemale
-            }),
-            privateSettings: GroupPrivateSettings.create({})
-        })
-        const meta = OrganizationMetaData.patch({})
-
-        const me = GroupCategory.patch({ id: this.category.id })
-        me.groupIds.addPut(group.id)
-        meta.categories.addPatch(me)
-
-        const p = Organization.patch({
-            id: this.organization.id,
-            meta
-        })
-
-        p.groups.addPut(group)
-        
-        this.present(new ComponentWithProperties(EditGroupView, { 
-            group, 
-            organization: this.organization.patch(p), 
-            saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
-                await OrganizationManager.patch(p.patch(patch))
-            }
-        }).setDisplayStyle("popup"))
-    }
-
-    editMe() {
-        this.present(new ComponentWithProperties(NavigationController, { 
-            root: new ComponentWithProperties(EditCategoryGroupsView, { 
-                category: this.category, 
-                organization: this.organization, 
-                saveHandler: async (patch) => {
-                    patch.id = this.organization.id
-                    await OrganizationManager.patch(patch)
-                }
-            })
-        }).setDisplayStyle("popup"))
-    }
-    
 }
 </script>

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
@@ -5,20 +5,37 @@
         <BackButton v-if="canPop" slot="left" @click="pop" />
         <STNavigationTitle v-else>
           <span class="icon-spacer">{{ title }}</span>
-          <span v-if="!loading && maxMembers" class="style-tag" :class="{ error: isFull}">{{ members.length }} / {{ maxMembers }}</span>
+          <span
+            v-if="!loading && maxMembers"
+            class="style-tag"
+            :class="{ error: isFull }"
+            >{{ members.length }} / {{ maxMembers }}</span
+          >
 
-          <button v-if="hasWaitingList" class="button text" @click="openWaitingList">
+          <button
+            v-if="hasWaitingList"
+            class="button text"
+            @click="openWaitingList"
+          >
             <span class="icon clock-small" />
             <span>Wachtlijst</span>
           </button>
 
-          <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
+          <button
+            v-if="group && hasFull"
+            class="button icon settings gray"
+            @click="modifyGroup"
+          />
 
           <button class="button text" @click="duplicateGroup">
             <span class="icon copy" />
           </button>
 
-          <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
+          <button
+            v-if="cycleOffset === 0 && !waitingList && canCreate"
+            class="button text"
+            @click="addMember"
+          >
             <span class="icon add" />
             <span>Nieuw</span>
           </button>
@@ -28,12 +45,25 @@
         <div />
       </template>
       <template #right>
-        <select v-if="!waitingList" v-model="selectedFilter" class="input hide-small">
-          <option v-for="(filter, index) in filters" :key="index" :value="index">
+        <select
+          v-if="!waitingList"
+          v-model="selectedFilter"
+          class="input hide-small"
+        >
+          <option
+            v-for="(filter, index) in filters"
+            :key="index"
+            :value="index"
+          >
             {{ filter.getName() }}
           </option>
         </select>
-        <input v-model="searchQuery" class="input search" placeholder="Zoeken" @input="searchQuery = $event.target.value">
+        <input
+          v-model="searchQuery"
+          class="input search"
+          placeholder="Zoeken"
+          @input="searchQuery = $event.target.value"
+        />
       </template>
     </STNavigationBar>
 
@@ -41,104 +71,153 @@
       <h1 v-if="canPop">
         <span class="icon-spacer">{{ title }}</span>
 
-        <button v-if="hasWaitingList" class="button text" @click="openWaitingList">
+        <button
+          v-if="hasWaitingList"
+          class="button text"
+          @click="openWaitingList"
+        >
           <span class="icon clock-small" />
           <span>Wachtlijst</span>
         </button>
 
-        <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
+        <button
+          v-if="group && hasFull"
+          class="button icon settings gray"
+          @click="modifyGroup"
+        />
 
         <button class="button text" @click="duplicateGroup">
           <span class="icon copy" />
         </button>
 
-        <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
+        <button
+          v-if="cycleOffset === 0 && !waitingList && canCreate"
+          class="button text"
+          @click="addMember"
+        >
           <span class="icon add" />
           <span>Nieuw</span>
         </button>
       </h1>
-      <span v-if="titleDescription" class="style-description title-description">{{ titleDescription }}</span>
+      <span
+        v-if="titleDescription"
+        class="style-description title-description"
+        >{{ titleDescription }}</span
+      >
 
       <BillingWarningBox filter-types="members" />
 
       <Spinner v-if="loading && sortedMembers.length == 0" class="center" />
       <table v-else class="data-table">
         <thead>
-        <tr>
-          <th class="prefix">
-            <Checkbox
-                v-model="selectAll"
-            />
-          </th>
-          <th @click="toggleSort('name')">
-            Naam
-            <span
+          <tr>
+            <th class="prefix">
+              <Checkbox v-model="selectAll" />
+            </th>
+            <th @click="toggleSort('name')">
+              Naam
+              <span
                 class="sort-arrow"
                 :class="{
-                                    up: sortBy == 'name' && sortDirection == 'ASC',
-                                    down: sortBy == 'name' && sortDirection == 'DESC',
-                                }"
-            />
-          </th>
-          <th class="hide-smartphone" @click="toggleSort('info')">
-            Leeftijd
-            <span
+                  up: sortBy == 'name' && sortDirection == 'ASC',
+                  down: sortBy == 'name' && sortDirection == 'DESC'
+                }"
+              />
+            </th>
+            <th class="hide-smartphone" @click="toggleSort('info')">
+              Leeftijd
+              <span
                 class="sort-arrow"
                 :class="{
-                                    up: sortBy == 'info' && sortDirection == 'ASC',
-                                    down: sortBy == 'info' && sortDirection == 'DESC',
-                                }"
-            />
-          </th>
-          <th class="hide-smartphone" @click="toggleSort('status')">
-            {{ waitingList ? "Op wachtlijst sinds" : "Status" }}
-            <span
+                  up: sortBy == 'info' && sortDirection == 'ASC',
+                  down: sortBy == 'info' && sortDirection == 'DESC'
+                }"
+              />
+            </th>
+            <th class="hide-smartphone" @click="toggleSort('status')">
+              {{ waitingList ? "Op wachtlijst sinds" : "Status" }}
+              <span
                 class="sort-arrow"
                 :class="{
-                                    up: sortBy == 'status' && sortDirection == 'ASC',
-                                    down: sortBy == 'status' && sortDirection == 'DESC',
-                                }"
-            />
-          </th>
-          <th>Acties</th>
-        </tr>
+                  up: sortBy == 'status' && sortDirection == 'ASC',
+                  down: sortBy == 'status' && sortDirection == 'DESC'
+                }"
+              />
+            </th>
+            <th>Acties</th>
+          </tr>
         </thead>
         <tbody>
-        <tr v-for="member in sortedMembers" :key="member.id" class="selectable" @click="showMember(member)" @contextmenu.prevent="showMemberContextMenu($event, member.member)">
-          <td class="prefix" @click.stop="">
-            <Checkbox v-model="member.selected" @change="onChanged(member)" />
-          </td>
-          <td>
-            <h2 class="style-title-list">
-              <div
+          <tr
+            v-for="member in sortedMembers"
+            :key="member.id"
+            class="selectable"
+            @click="showMember(member)"
+            @contextmenu.prevent="showMemberContextMenu($event, member.member)"
+          >
+            <td class="prefix" @click.stop="">
+              <Checkbox v-model="member.selected" @change="onChanged(member)" />
+            </td>
+            <td>
+              <h2 class="style-title-list">
+                <div
                   v-if="!waitingList && isNew(member.member)"
-                  v-tooltip="'Ingeschreven op ' + formatDate(registrationDate(member.member))"
+                  v-tooltip="
+                    'Ingeschreven op ' +
+                      formatDate(registrationDate(member.member))
+                  "
                   class="new-member-bubble"
-              />
-              {{ member.member.name }}
-              <span v-if="waitingList && canRegister(member.member)" v-tooltip="'Dit lid kan zich inschrijven via de uitnodiging'" class="style-tag warn">Toegelaten</span>
-            </h2>
-            <p v-if="!group" class="style-description-small">
-              {{ member.member.groups.map(g => g.settings.name ).join(", ") }}
-            </p>
-            <p v-if="member.member.details && !member.member.details.isPlaceholder" class="style-description-small only-smartphone">
+                />
+                {{ member.member.name }}
+                <span
+                  v-if="waitingList && canRegister(member.member)"
+                  v-tooltip="'Dit lid kan zich inschrijven via de uitnodiging'"
+                  class="style-tag warn"
+                  >Toegelaten</span
+                >
+              </h2>
+              <p v-if="!group" class="style-description-small">
+                {{ member.member.groups.map(g => g.settings.name).join(", ") }}
+              </p>
+              <p
+                v-if="
+                  member.member.details && !member.member.details.isPlaceholder
+                "
+                class="style-description-small only-smartphone"
+              >
+                {{ member.member.details.age }} jaar
+              </p>
+            </td>
+            <td
+              v-if="
+                member.member.details && !member.member.details.isPlaceholder
+              "
+              class="minor hide-smartphone"
+            >
               {{ member.member.details.age }} jaar
-            </p>
-          </td>
-          <td v-if="member.member.details && !member.member.details.isPlaceholder" class="minor hide-smartphone">
-            {{ member.member.details.age }} jaar
-          </td>
-          <td v-else class="minor hide-smartphone">
-            /
-          </td>
-          <td class="hide-smartphone member-description">
-            <p v-text="getMemberDescription(member.member)" />
-          </td>
-          <td>
-            <button v-if="!member.member.details || member.member.details.isPlaceholder" v-tooltip="'De sleutel om de gegevens van dit lid te bekijken ontbreekt'" class="button icon gray key-lost" />
-            <button class="button icon gray more" @click.stop="showMemberContextMenu($event, member.member)" />
-          </td>
-        </tr>
+            </td>
+            <td v-else class="minor hide-smartphone">
+              /
+            </td>
+            <td class="hide-smartphone member-description">
+              <p v-text="getMemberDescription(member.member)" />
+            </td>
+            <td>
+              <button
+                v-if="
+                  !member.member.details || member.member.details.isPlaceholder
+                "
+                v-tooltip="
+                  'De sleutel om de gegevens van dit lid te bekijken ontbreekt'
+                "
+                class="button icon gray key-lost"
+              />
+              <button
+                class="button icon gray more"
+                @click.stop="showMemberContextMenu($event, member.member)"
+              />
+            </td>
+          </tr>
         </tbody>
       </table>
 
@@ -151,8 +230,6 @@
           Er zijn nog geen leden ingeschreven in deze inschrijvingsperiode.
         </p>
       </template>
-
-
 
       <div v-if="canGoBack || canGoNext" class="history-navigation-bar">
         <button v-if="canGoBack" class="button text gray" @click="goBack">
@@ -169,32 +246,55 @@
 
     <STToolbar>
       <template #left>
-        {{ selectionCount ? selectionCount : "Geen" }} {{ selectionCount == 1 ? "lid" : "leden" }} geselecteerd
+        {{ selectionCount ? selectionCount : "Geen" }}
+        {{ selectionCount == 1 ? "lid" : "leden" }} geselecteerd
         <template v-if="selectionCountHidden">
           (waarvan {{ selectionCountHidden }} verborgen)
         </template>
       </template>
       <template #right>
-        <button v-if="waitingList" class="button secundary" :disabled="selectionCount == 0" @click="openMail()">
+        <button
+          v-if="waitingList"
+          class="button secundary"
+          :disabled="selectionCount == 0"
+          @click="openMail()"
+        >
           E-mailen
         </button>
-        <button v-if="waitingList" class="button secundary" :disabled="selectionCount == 0" @click="allowMembers(false)">
+        <button
+          v-if="waitingList"
+          class="button secundary"
+          :disabled="selectionCount == 0"
+          @click="allowMembers(false)"
+        >
           Toelating intrekken
         </button>
         <LoadingButton v-if="waitingList" :loading="actionLoading">
-          <button class="button primary" :disabled="selectionCount == 0" @click="allowMembers(true)">
-                        <span class="dropdown-text">
-                            Toelaten
-                        </span>
+          <button
+            class="button primary"
+            :disabled="selectionCount == 0"
+            @click="allowMembers(true)"
+          >
+            <span class="dropdown-text">
+              Toelaten
+            </span>
             <div class="dropdown" @click.stop="openMailDropdown" />
           </button>
         </LoadingButton>
         <template v-else>
-          <button class="button secundary hide-smartphone" :disabled="selectionCount == 0" @click="openSamenvatting">
+          <button
+            class="button secundary hide-smartphone"
+            :disabled="selectionCount == 0"
+            @click="openSamenvatting"
+          >
             Samenvatting
           </button>
           <LoadingButton :loading="actionLoading">
-            <button class="button primary" :disabled="selectionCount == 0" @click="openMail()">
+            <button
+              class="button primary"
+              :disabled="selectionCount == 0"
+              @click="openMail()"
+            >
               <span class="dropdown-text">E-mailen</span>
               <div class="dropdown" @click.stop="openMailDropdown" />
             </button>
@@ -207,37 +307,59 @@
 
 <script lang="ts">
 import { AutoEncoderPatchType } from "@simonbackx/simple-encoding";
-import { ComponentWithProperties, HistoryManager } from "@simonbackx/vue-app-navigation";
+import {
+  ComponentWithProperties,
+  HistoryManager
+} from "@simonbackx/vue-app-navigation";
 import { NavigationMixin } from "@simonbackx/vue-app-navigation";
 import { NavigationController } from "@simonbackx/vue-app-navigation";
-import { SegmentedControl,Toast,TooltipDirective as Tooltip } from "@stamhoofd/components";
+import {
+  SegmentedControl,
+  Toast,
+  TooltipDirective as Tooltip
+} from "@stamhoofd/components";
 import { STNavigationBar } from "@stamhoofd/components";
-import { BackButton, LoadingButton,Spinner, STNavigationTitle } from "@stamhoofd/components";
-import { Checkbox } from "@stamhoofd/components"
+import {
+  BackButton,
+  LoadingButton,
+  Spinner,
+  STNavigationTitle
+} from "@stamhoofd/components";
+import { Checkbox } from "@stamhoofd/components";
 import { STToolbar } from "@stamhoofd/components";
 import {
   EncryptedMemberWithRegistrationsPatch,
   getPermissionLevelNumber,
   Group,
   GroupCategory,
-  GroupCategoryTree, GroupPrivateSettings,
+  GroupCategoryTree,
+  GroupPrivateSettings,
   GroupSettings,
   Member,
   MemberWithRegistrations,
-  Organization, OrganizationMetaData,
+  Organization,
+  OrganizationMetaData,
   PermissionLevel,
-  Registration,
-} from '@stamhoofd/structures';
-import { Formatter } from '@stamhoofd/utility';
-import { Component, Mixins,Prop } from "vue-property-decorator";
+  Registration
+} from "@stamhoofd/structures";
+import { Formatter } from "@stamhoofd/utility";
+import { Component, Mixins, Prop } from "vue-property-decorator";
 
-import { CanNotSwimFilter, NoFilter, NotPaidFilter, RecordTypeFilter } from "../../../classes/member-filters";
-import { MemberChangeEvent,MemberManager } from '../../../classes/MemberManager';
+import {
+  CanNotSwimFilter,
+  NoFilter,
+  NotPaidFilter,
+  RecordTypeFilter
+} from "../../../classes/member-filters";
+import {
+  MemberChangeEvent,
+  MemberManager
+} from "../../../classes/MemberManager";
 import { OrganizationManager } from "../../../classes/OrganizationManager";
 import MailView from "../mail/MailView.vue";
-import EditMemberView from '../member/edit/EditMemberView.vue';
+import EditMemberView from "../member/edit/EditMemberView.vue";
 import MemberContextMenu from "../member/MemberContextMenu.vue";
-import MemberSummaryView from '../member/MemberSummaryView.vue';
+import MemberSummaryView from "../member/MemberSummaryView.vue";
 import MemberView from "../member/MemberView.vue";
 import BillingWarningBox from "../settings/packages/BillingWarningBox.vue";
 import EditGroupView from "./EditGroupView.vue";
@@ -249,7 +371,7 @@ class SelectableMember {
 
   constructor(member: MemberWithRegistrations, selected = true) {
     this.member = member;
-    this.selected = selected
+    this.selected = selected;
   }
 }
 
@@ -265,12 +387,12 @@ class SelectableMember {
     SegmentedControl,
     BillingWarningBox
   },
-  directives: { Tooltip },
+  directives: { Tooltip }
 })
 export default class GroupMembersView extends Mixins(NavigationMixin) {
-  tabLabels = ["Ingeschreven", "Wachtlijst"]
-  tabs = ["all", "waitingList"]
-  tab = this.tabs[0]
+  tabLabels = ["Ingeschreven", "Wachtlijst"];
+  tabs = ["all", "waitingList"];
+  tab = this.tabs[0];
 
   @Prop({ default: null })
   group!: Group | null;
@@ -283,209 +405,263 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
 
   members: SelectableMember[] = [];
   searchQuery = "";
-  filters = [new NoFilter(), new NotPaidFilter(), new CanNotSwimFilter(), ...RecordTypeFilter.generateAll()];
+  filters = [
+    new NoFilter(),
+    new NotPaidFilter(),
+    new CanNotSwimFilter(),
+    ...RecordTypeFilter.generateAll()
+  ];
   selectedFilter = 0;
   selectionCountHidden = 0;
   sortBy = "info";
   sortDirection = "ASC";
-  cycleOffset = 0
+  cycleOffset = 0;
 
   loading = false;
 
-  actionLoading = false
-  cachedWaitingList: boolean | null = null
+  actionLoading = false;
+  cachedWaitingList: boolean | null = null;
 
-  checkingInaccurate = false
+  checkingInaccurate = false;
 
   mounted() {
     //this.reload();
 
     // Set url
     if (this.group) {
-      HistoryManager.setUrl("/groups/"+Formatter.slug(this.group.settings.name))
-      document.title = "Stamhoofd - "+this.group.settings.name
+      HistoryManager.setUrl(
+        "/groups/" + Formatter.slug(this.group.settings.name)
+      );
+      document.title = "Stamhoofd - " + this.group.settings.name;
     } else {
       if (this.category) {
-        HistoryManager.setUrl("/category/"+Formatter.slug(this.category.settings.name)+"/all")
-        document.title = "Stamhoofd - "+ this.category.settings.name +" - Alle leden"
+        HistoryManager.setUrl(
+          "/category/" + Formatter.slug(this.category.settings.name) + "/all"
+        );
+        document.title =
+          "Stamhoofd - " + this.category.settings.name + " - Alle leden";
       } else {
-        HistoryManager.setUrl("/groups/all")
-        document.title = "Stamhoofd - Alle leden"
+        HistoryManager.setUrl("/groups/all");
+        document.title = "Stamhoofd - Alle leden";
       }
-
     }
   }
 
   async checkInaccurateMetaData() {
     if (this.checkingInaccurate) {
-      return
+      return;
     }
-    this.checkingInaccurate = true
-    let toast: Toast | null = null
+    this.checkingInaccurate = true;
+    let toast: Toast | null = null;
     try {
-      const inaccurate: MemberWithRegistrations[] = []
+      const inaccurate: MemberWithRegistrations[] = [];
       for (const m of this.members) {
-        const member = m.member
-        const meta = member.getDetailsMeta()
+        const member = m.member;
+        const meta = member.getDetailsMeta();
 
         // Check if meta is wrong
-        if (!member.details.isRecovered && (!meta || !meta.isAccurateFor(member.details))) {
-          console.warn("Found inaccurate meta data!")
-          inaccurate.push(member)
+        if (
+          !member.details.isRecovered &&
+          (!meta || !meta.isAccurateFor(member.details))
+        ) {
+          console.warn("Found inaccurate meta data!");
+          inaccurate.push(member);
         }
       }
       if (inaccurate.length > 0) {
-        toast = new Toast("Gegevens van leden updaten naar laatste versie...", "spinner").setHide(null).show()
+        toast = new Toast(
+          "Gegevens van leden updaten naar laatste versie...",
+          "spinner"
+        )
+          .setHide(null)
+          .show();
 
         // Patch member with new details
-        await MemberManager.patchMembersDetails(inaccurate)
+        await MemberManager.patchMembersDetails(inaccurate);
       }
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-    toast?.hide()
-    this.checkingInaccurate = false
+    toast?.hide();
+    this.checkingInaccurate = false;
   }
 
   get canGoBack() {
     if (!this.group) {
-      return false
+      return false;
     }
-    return this.group.cycle >= this.cycleOffset // always allow to go to -1
+    return this.group.cycle >= this.cycleOffset; // always allow to go to -1
   }
 
   get canGoNext() {
-    return this.cycleOffset > 0
+    return this.cycleOffset > 0;
   }
 
   get hasFull(): boolean {
     if (!this.group) {
-      return false
+      return false;
     }
 
     if (!this.group.privateSettings || !OrganizationManager.user.permissions) {
-      return false
+      return false;
     }
 
-    if(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions) !== PermissionLevel.Full) {
-      return false
+    if (
+      this.group.privateSettings.permissions.getPermissionLevel(
+        OrganizationManager.user.permissions
+      ) !== PermissionLevel.Full
+    ) {
+      return false;
     }
-    return true
+    return true;
   }
 
   get canCreate(): boolean {
     if (!OrganizationManager.user.permissions) {
-      return false
+      return false;
     }
 
     if (!this.group) {
       if (this.category) {
         for (const group of this.category.groups) {
           if (!group.privateSettings) {
-            continue
+            continue;
           }
 
-          if(getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
-            return true
+          if (
+            getPermissionLevelNumber(
+              group.privateSettings.permissions.getPermissionLevel(
+                OrganizationManager.user.permissions
+              )
+            ) >= getPermissionLevelNumber(PermissionLevel.Write)
+          ) {
+            return true;
           }
         }
       }
-      return false
+      return false;
     }
 
     if (!this.group.privateSettings) {
-      return false
+      return false;
     }
 
-    if(getPermissionLevelNumber(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Write)) {
-      return false
+    if (
+      getPermissionLevelNumber(
+        this.group.privateSettings.permissions.getPermissionLevel(
+          OrganizationManager.user.permissions
+        )
+      ) < getPermissionLevelNumber(PermissionLevel.Write)
+    ) {
+      return false;
     }
-    return true
+    return true;
   }
 
   goNext() {
-    this.cycleOffset--
-    this.reload()
+    this.cycleOffset--;
+    this.reload();
   }
 
   goBack() {
-    this.cycleOffset++
-    this.reload()
+    this.cycleOffset++;
+    this.reload();
   }
 
-  onUpdateMember(type: MemberChangeEvent, member: MemberWithRegistrations | null) {
-    if (type == "changedGroup" || type == "deleted" || type == "created" || type == "payment" || type == "encryption") {
-      this.reload()
+  onUpdateMember(
+    type: MemberChangeEvent,
+    member: MemberWithRegistrations | null
+  ) {
+    if (
+      type == "changedGroup" ||
+      type == "deleted" ||
+      type == "created" ||
+      type == "payment" ||
+      type == "encryption"
+    ) {
+      this.reload();
     }
   }
 
   activated() {
     this.reload();
-    MemberManager.addListener(this, this.onUpdateMember)
+    MemberManager.addListener(this, this.onUpdateMember);
   }
 
   deactivated() {
-    MemberManager.removeListener(this)
+    MemberManager.removeListener(this);
   }
 
   get isFull() {
     if (!this.group || this.group.settings.maxMembers === null) {
       return false;
     }
-    return this.members.length >= this.group.settings.maxMembers
+    return this.members.length >= this.group.settings.maxMembers;
   }
 
   get maxMembers() {
     if (!this.group || this.group.settings.maxMembers === null) {
       return 0;
     }
-    return this.group.settings.maxMembers
+    return this.group.settings.maxMembers;
   }
 
   get groupIds() {
     if (this.group) {
-      return [this.group.id]
+      return [this.group.id];
     }
     if (this.category) {
-      return this.category.groups.map(g => g.id) // needed because of permission check + existing check!
+      return this.category.groups.map(g => g.id); // needed because of permission check + existing check!
     }
-    return []
+    return [];
   }
 
   checkWaitingList() {
-    MemberManager.loadMembers(this.groupIds, true).then((members) => {
-      this.cachedWaitingList = members.length > 0
-    }).catch((e) => {
-      console.error(e)
-    })
+    MemberManager.loadMembers(this.groupIds, true)
+      .then(members => {
+        this.cachedWaitingList = members.length > 0;
+      })
+      .catch(e => {
+        console.error(e);
+      });
   }
 
   reload() {
     this.loading = true;
-    MemberManager.loadMembers(this.groupIds, this.waitingList, this.cycleOffset).then((members) => {
-      this.members = members.map((member) => {
-        const selected = this.members.find(m => m.member.id === member.id)?.selected
-        return new SelectableMember(member, selected !== undefined ?  selected : !this.waitingList);
-      }) ?? [];
-      this.checkInaccurateMetaData().catch(e => {
-        console.error(e)
+    MemberManager.loadMembers(this.groupIds, this.waitingList, this.cycleOffset)
+      .then(members => {
+        this.members =
+          members.map(member => {
+            const selected = this.members.find(m => m.member.id === member.id)
+              ?.selected;
+            return new SelectableMember(
+              member,
+              selected !== undefined ? selected : !this.waitingList
+            );
+          }) ?? [];
+        this.checkInaccurateMetaData().catch(e => {
+          console.error(e);
+        });
       })
-    }).catch((e) => {
-      console.error(e)
-    }).finally(() => {
-      this.loading = false
+      .catch(e => {
+        console.error(e);
+      })
+      .finally(() => {
+        this.loading = false;
 
-      if (!this.waitingList && this.group && !this.group.hasWaitingList()) {
-        this.checkWaitingList()
-      }
-    })
+        if (!this.waitingList && this.group && !this.group.hasWaitingList()) {
+          this.checkWaitingList();
+        }
+      });
   }
 
   openWaitingList() {
-    this.show(new ComponentWithProperties(GroupMembersView, {
-      group: this.group,
-      waitingList: true
-    }))
+    this.show(
+      new ComponentWithProperties(GroupMembersView, {
+        group: this.group,
+        waitingList: true
+      })
+    );
   }
 
   get hasWaitingList() {
@@ -493,52 +669,62 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
       return false;
     }
     if (this.cachedWaitingList !== null) {
-      return this.cachedWaitingList
+      return this.cachedWaitingList;
     }
     if (!this.group) {
       return false;
     }
-    return this.group.hasWaitingList()
+    return this.group.hasWaitingList();
   }
 
   get title() {
-    return this.waitingList ? "Wachtlijst" : (this.group ? this.group.settings.name : (this.category ? this.category.settings.name : "Alle leden"))
+    return this.waitingList
+      ? "Wachtlijst"
+      : this.group
+      ? this.group.settings.name
+      : this.category
+      ? this.category.settings.name
+      : "Alle leden";
   }
 
   get titleDescription() {
     if (this.cycleOffset === 1) {
-      return "Dit is de vorige inschrijvingsperiode"
+      return "Dit is de vorige inschrijvingsperiode";
     }
     if (this.cycleOffset > 1) {
-      return "Dit is "+this.cycleOffset+" inschrijvingsperiodes geleden"
+      return "Dit is " + this.cycleOffset + " inschrijvingsperiodes geleden";
     }
-    return ""
+    return "";
   }
 
   formatDate(date: Date) {
-    return Formatter.dateTime(date)
+    return Formatter.dateTime(date);
   }
 
   registrationDate(member: MemberWithRegistrations) {
     if (member.registrations.length == 0) {
-      return new Date()
+      return new Date();
     }
-    const reg = !this.group ? member.registrations[0] : member.registrations.find(r => r.groupId === this.group!.id)
+    const reg = !this.group
+      ? member.registrations[0]
+      : member.registrations.find(r => r.groupId === this.group!.id);
     if (!reg) {
-      return new Date()
+      return new Date();
     }
 
     if (!reg.registeredAt || this.waitingList) {
-      return reg.createdAt
+      return reg.createdAt;
     }
 
-    return reg.registeredAt
+    return reg.registeredAt;
   }
 
   addMember() {
-    this.present(new ComponentWithProperties(NavigationController, {
-      root: new ComponentWithProperties(EditMemberView, {})
-    }).setDisplayStyle("popup"))
+    this.present(
+      new ComponentWithProperties(NavigationController, {
+        root: new ComponentWithProperties(EditMemberView, {})
+      }).setDisplayStyle("popup")
+    );
   }
 
   duplicateGroup() {
@@ -549,83 +735,94 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
     const newGroup = Group.create({
       settings: GroupSettings.create(this.group?.settings),
       privateSettings: GroupPrivateSettings.create({})
-    })
-    newGroup.settings.name = newGroup.settings.name + " Kopie"
-    const meta = OrganizationMetaData.patch({})
+    });
+    newGroup.settings.name = newGroup.settings.name + " Kopie";
+    const meta = OrganizationMetaData.patch({});
 
     console.log(this.category);
 
-    const me = GroupCategory.patch({id: this.category?.id})
-    me.groupIds.addPut(newGroup.id)
-    meta.categories.addPatch(me)
+    const me = GroupCategory.patch({ id: this.category?.id });
+    me.groupIds.addPut(newGroup.id);
+    meta.categories.addPatch(me);
 
     const p = Organization.patch({
       id: OrganizationManager.organization.id,
       meta
-    })
+    });
 
-    p.groups.addPut(newGroup)
+    p.groups.addPut(newGroup);
 
-    this.present(new ComponentWithProperties(EditGroupView, {
-      group: newGroup,
-      organization: OrganizationManager.organization.patch(p),
-      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
-        await OrganizationManager.patch(p.patch(patch))
-        console.log("saved")
-        this.show(new ComponentWithProperties(GroupMembersView, {
-          group: newGroup
-        }))
-      }
-    }).setDisplayStyle("popup"))
+    this.present(
+      new ComponentWithProperties(EditGroupView, {
+        group: newGroup,
+        organization: OrganizationManager.organization.patch(p),
+        saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+          await OrganizationManager.patch(p.patch(patch));
+          console.log("saved");
+          this.show(
+            new ComponentWithProperties(GroupMembersView, {
+              group: newGroup
+            })
+          );
+        }
+      }).setDisplayStyle("popup")
+    );
   }
 
   modifyGroup() {
     if (!this.group) {
       return;
     }
-    this.present(new ComponentWithProperties(EditGroupView, {
-      group: this.group,
-      organization: OrganizationManager.organization,
-      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
-        patch.id = OrganizationManager.organization.id
-        await OrganizationManager.patch(patch)
-        const g = OrganizationManager.organization.groups.find(g => g.id === this.group!.id)
-        if (!g) {
-          this.pop({ force: true })
-        } else {
-          this.group!.set(g)
+    this.present(
+      new ComponentWithProperties(EditGroupView, {
+        group: this.group,
+        organization: OrganizationManager.organization,
+        saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+          patch.id = OrganizationManager.organization.id;
+          await OrganizationManager.patch(patch);
+          const g = OrganizationManager.organization.groups.find(
+            g => g.id === this.group!.id
+          );
+          if (!g) {
+            this.pop({ force: true });
+          } else {
+            this.group!.set(g);
+          }
         }
-      }
-    }).setDisplayStyle("popup"))
+      }).setDisplayStyle("popup")
+    );
   }
 
   isNew(member: MemberWithRegistrations) {
     if (!this.group) {
-      return false
+      return false;
     }
-    const reg = member.registrations.find(r => r.groupId === this.group!.id)
+    const reg = member.registrations.find(r => r.groupId === this.group!.id);
     if (!reg) {
-      return false
+      return false;
     }
 
     if (!reg.registeredAt) {
-      return true
+      return true;
     }
 
-    return reg.registeredAt > new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 14)
+    return (
+      reg.registeredAt >
+      new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 14)
+    );
   }
 
   get sortedMembers(): SelectableMember[] {
     if (this.sortBy == "info") {
       return this.filteredMembers.sort((a, b) => {
         if (!a.member.details && !b.member.details) {
-          return 0
+          return 0;
         }
         if (!a.member.details) {
-          return 1
+          return 1;
         }
         if (!b.member.details) {
-          return -1
+          return -1;
         }
         if (this.sortDirection == "ASC") {
           return (a.member.details.age ?? 99) - (b.member.details.age ?? 99);
@@ -635,7 +832,7 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
     }
 
     if (this.sortBy == "name") {
-      const s = Member.sorterByName(this.sortDirection)
+      const s = Member.sorterByName(this.sortDirection);
       return this.filteredMembers.sort((a, b) => s(a.member, b.member));
     }
 
@@ -643,26 +840,34 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
       if (this.waitingList) {
         return this.filteredMembers.sort((a, b) => {
           if (this.sortDirection == "ASC") {
-            if (this.registrationDate(a.member) > this.registrationDate(b.member)) {
+            if (
+              this.registrationDate(a.member) > this.registrationDate(b.member)
+            ) {
               return 1;
             }
-            if (this.registrationDate(a.member) < this.registrationDate(b.member)) {
+            if (
+              this.registrationDate(a.member) < this.registrationDate(b.member)
+            ) {
               return -1;
             }
             return 0;
           }
-          if (this.registrationDate(a.member) > this.registrationDate(b.member)) {
+          if (
+            this.registrationDate(a.member) > this.registrationDate(b.member)
+          ) {
             return -1;
           }
-          if (this.registrationDate(a.member) < this.registrationDate(b.member)) {
+          if (
+            this.registrationDate(a.member) < this.registrationDate(b.member)
+          ) {
             return 1;
           }
           return 0;
         });
       }
       return this.filteredMembers.sort((a, b) => {
-        const aa = this.getMemberDescription(a.member).toLowerCase()
-        const bb = this.getMemberDescription(b.member).toLowerCase()
+        const aa = this.getMemberDescription(a.member).toLowerCase();
+        const bb = this.getMemberDescription(b.member).toLowerCase();
         if (this.sortDirection == "ASC") {
           if (aa > bb) {
             return 1;
@@ -685,25 +890,33 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
   }
 
   isDescriptiveFilter() {
-    return !!((this.filters[this.selectedFilter] as any).getDescription)
+    return !!(this.filters[this.selectedFilter] as any).getDescription;
   }
 
   getMemberDescription(member: MemberWithRegistrations) {
     if (this.waitingList) {
-      return this.formatDate(this.registrationDate(member))
+      return this.formatDate(this.registrationDate(member));
     }
 
     if (this.isDescriptiveFilter()) {
-      return (this.filters[this.selectedFilter] as any).getDescription(member, OrganizationManager.organization)
+      return (this.filters[this.selectedFilter] as any).getDescription(
+        member,
+        OrganizationManager.organization
+      );
     }
 
-    return member.info
+    return member.info;
   }
 
   get filteredMembers(): SelectableMember[] {
     this.selectionCountHidden = 0;
     const filtered = this.members.filter((member: SelectableMember) => {
-      if (this.filters[this.selectedFilter].doesMatch(member.member, OrganizationManager.organization)) {
+      if (
+        this.filters[this.selectedFilter].doesMatch(
+          member.member,
+          OrganizationManager.organization
+        )
+      ) {
         return true;
       }
       this.selectionCountHidden += member.selected ? 1 : 0;
@@ -714,7 +927,10 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
       return filtered;
     }
     return filtered.filter((member: SelectableMember) => {
-      if (member.member.details && member.member.details.matchQuery(this.searchQuery)) {
+      if (
+        member.member.details &&
+        member.member.details.matchQuery(this.searchQuery)
+      ) {
         return true;
       }
       this.selectionCountHidden += member.selected ? 1 : 0;
@@ -724,7 +940,7 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
 
   get selectionCount(): number {
     let val = 0;
-    this.members.forEach((member) => {
+    this.members.forEach(member => {
       if (member.selected) {
         val++;
       }
@@ -752,7 +968,9 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
     // do nothing for now
   }
 
-  getPreviousMember(member: MemberWithRegistrations): MemberWithRegistrations | null {
+  getPreviousMember(
+    member: MemberWithRegistrations
+  ): MemberWithRegistrations | null {
     for (let index = 0; index < this.sortedMembers.length; index++) {
       const _member = this.sortedMembers[index];
       if (_member.member.id == member.id) {
@@ -765,7 +983,9 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
     return null;
   }
 
-  getNextMember(member: MemberWithRegistrations): MemberWithRegistrations | null {
+  getNextMember(
+    member: MemberWithRegistrations
+  ): MemberWithRegistrations | null {
     for (let index = 0; index < this.sortedMembers.length; index++) {
       const _member = this.sortedMembers[index];
       if (_member.member.id == member.id) {
@@ -790,18 +1010,21 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
         group: this.group,
         cycleOffset: this.cycleOffset,
         waitingList: this.waitingList
-      }),
+      })
     });
     component.modalDisplayStyle = "popup";
     this.present(component);
   }
 
   get selectAll() {
-    return this.selectionCount - this.selectionCountHidden >= this.filteredMembers.length && this.filteredMembers.length > 0
+    return (
+      this.selectionCount - this.selectionCountHidden >=
+        this.filteredMembers.length && this.filteredMembers.length > 0
+    );
   }
 
   set selectAll(selected: boolean) {
-    this.filteredMembers.forEach((member) => {
+    this.filteredMembers.forEach(member => {
       member.selected = selected;
     });
   }
@@ -820,19 +1043,25 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
 
   getSelectedMembers(): MemberWithRegistrations[] {
     return this.members
-        .filter((member: SelectableMember) => {
-          return member.selected;
-        })
-        .map((member: SelectableMember) => {
-          return member.member;
-        });
+      .filter((member: SelectableMember) => {
+        return member.selected;
+      })
+      .map((member: SelectableMember) => {
+        return member.member;
+      });
   }
 
   canRegister(member: MemberWithRegistrations) {
     if (!this.group) {
-      return false
+      return false;
     }
-    return member.registrations.find(r => r.groupId == this.group!.id && r.waitingList && r.canRegister && r.cycle == this.group!.cycle)
+    return member.registrations.find(
+      r =>
+        r.groupId == this.group!.id &&
+        r.waitingList &&
+        r.canRegister &&
+        r.cycle == this.group!.cycle
+    );
   }
 
   async allowMembers(allow = true) {
@@ -840,52 +1069,69 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
       return;
     }
 
-    const members = this.getSelectedMembers().filter(m => !this.group || (allow && m.waitingGroups.find(r => r.id === this.group!.id)) || (!allow && m.acceptedWaitingGroups.find(r => r.id === this.group!.id)))
+    const members = this.getSelectedMembers().filter(
+      m =>
+        !this.group ||
+        (allow && m.waitingGroups.find(r => r.id === this.group!.id)) ||
+        (!allow && m.acceptedWaitingGroups.find(r => r.id === this.group!.id))
+    );
     if (members.length == 0) {
       return;
     }
 
     this.actionLoading = true;
     try {
-      const patches = MemberManager.getPatchArray()
+      const patches = MemberManager.getPatchArray();
       for (const member of members) {
-        const registrationsPatch = MemberManager.getRegistrationsPatchArray()
+        const registrationsPatch = MemberManager.getRegistrationsPatchArray();
 
-        const registration = member.registrations.find(r => r.groupId == this.group!.id && r.waitingList == true && r.cycle == this.group!.cycle)
+        const registration = member.registrations.find(
+          r =>
+            r.groupId == this.group!.id &&
+            r.waitingList == true &&
+            r.cycle == this.group!.cycle
+        );
         if (!registration) {
-          throw new Error("Not found")
+          throw new Error("Not found");
         }
-        registrationsPatch.addPatch(Registration.patchType().create({
-          id: registration.id,
-          canRegister: allow
-        }))
+        registrationsPatch.addPatch(
+          Registration.patchType().create({
+            id: registration.id,
+            canRegister: allow
+          })
+        );
 
-        patches.addPatch(EncryptedMemberWithRegistrationsPatch.create({
-          id: member.id,
-          registrations: registrationsPatch
-        }))
+        patches.addPatch(
+          EncryptedMemberWithRegistrationsPatch.create({
+            id: member.id,
+            registrations: registrationsPatch
+          })
+        );
       }
-      await MemberManager.patchMembers(patches)
+      await MemberManager.patchMembers(patches);
     } catch (e) {
-      console.error(e)
+      console.error(e);
       // todo
     }
-    this.actionLoading = false
-    this.reload()
+    this.actionLoading = false;
+    this.reload();
 
     if (allow) {
-      this.openMail("Je kan nu inschrijven!")
+      this.openMail("Je kan nu inschrijven!");
     }
   }
 
   openMail(subject = "") {
-    const displayedComponent = new ComponentWithProperties(NavigationController, {
-      root: new ComponentWithProperties(MailView, {
-        members: this.getSelectedMembers(),
-        group: this.group,
-        defaultSubject: subject
-      })
-    });
+    const displayedComponent = new ComponentWithProperties(
+      NavigationController,
+      {
+        root: new ComponentWithProperties(MailView, {
+          members: this.getSelectedMembers(),
+          group: this.group,
+          defaultSubject: subject
+        })
+      }
+    );
     this.present(displayedComponent.setDisplayStyle("popup"));
   }
 
@@ -893,24 +1139,30 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
     if (this.selectionCount == 0) {
       return;
     }
-    const displayedComponent = new ComponentWithProperties(GroupListSelectionContextMenu, {
-      x: event.clientX,
-      y: event.clientY + 10,
-      members: this.getSelectedMembers(),
-      group: this.group,
-      cycleOffset: this.cycleOffset,
-      waitingList: this.waitingList
-    });
+    const displayedComponent = new ComponentWithProperties(
+      GroupListSelectionContextMenu,
+      {
+        x: event.clientX,
+        y: event.clientY + 10,
+        members: this.getSelectedMembers(),
+        group: this.group,
+        cycleOffset: this.cycleOffset,
+        waitingList: this.waitingList
+      }
+    );
     this.present(displayedComponent.setDisplayStyle("overlay"));
   }
 
   openSamenvatting() {
-    const displayedComponent = new ComponentWithProperties(NavigationController, {
-      root: new ComponentWithProperties(MemberSummaryView, {
-        members: this.getSelectedMembers(),
-        group: this.group
-      })
-    });
+    const displayedComponent = new ComponentWithProperties(
+      NavigationController,
+      {
+        root: new ComponentWithProperties(MemberSummaryView, {
+          members: this.getSelectedMembers(),
+          group: this.group
+        })
+      }
+    );
     this.present(displayedComponent.setDisplayStyle("popup"));
   }
 }

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
@@ -1,200 +1,208 @@
 <template>
-    <div class="st-view group-members-view background">
-        <STNavigationBar :sticky="false">
-            <template #left>
-                <BackButton v-if="canPop" slot="left" @click="pop" />
-                <STNavigationTitle v-else>
-                    <span class="icon-spacer">{{ title }}</span>
-                    <span v-if="!loading && maxMembers" class="style-tag" :class="{ error: isFull}">{{ members.length }} / {{ maxMembers }}</span>
+  <div class="st-view group-members-view background">
+    <STNavigationBar :sticky="false">
+      <template #left>
+        <BackButton v-if="canPop" slot="left" @click="pop" />
+        <STNavigationTitle v-else>
+          <span class="icon-spacer">{{ title }}</span>
+          <span v-if="!loading && maxMembers" class="style-tag" :class="{ error: isFull}">{{ members.length }} / {{ maxMembers }}</span>
 
-                    <button v-if="hasWaitingList" class="button text" @click="openWaitingList">
-                        <span class="icon clock-small" />
-                        <span>Wachtlijst</span>
-                    </button>
+          <button v-if="hasWaitingList" class="button text" @click="openWaitingList">
+            <span class="icon clock-small" />
+            <span>Wachtlijst</span>
+          </button>
 
-                    <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
-                    
-                    <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
-                        <span class="icon add" />
-                        <span>Nieuw</span>
-                    </button>
-                </STNavigationTitle>
-            </template>
-            <template #middle>
-                <div />
-            </template>
-            <template #right>
-                <select v-if="!waitingList" v-model="selectedFilter" class="input hide-small">
-                    <option v-for="(filter, index) in filters" :key="index" :value="index">
-                        {{ filter.getName() }}
-                    </option>
-                </select>
-                <input v-model="searchQuery" class="input search" placeholder="Zoeken" @input="searchQuery = $event.target.value">
-            </template>
-        </STNavigationBar>
-    
-        <main>
-            <h1 v-if="canPop">
-                <span class="icon-spacer">{{ title }}</span>
+          <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
 
-                <button v-if="hasWaitingList" class="button text" @click="openWaitingList">
-                    <span class="icon clock-small" />
-                    <span>Wachtlijst</span>
-                </button>
+          <button class="button text" @click="duplicateGroup">
+            <span class="icon copy" />
+          </button>
 
-                <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
+          <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
+            <span class="icon add" />
+            <span>Nieuw</span>
+          </button>
+        </STNavigationTitle>
+      </template>
+      <template #middle>
+        <div />
+      </template>
+      <template #right>
+        <select v-if="!waitingList" v-model="selectedFilter" class="input hide-small">
+          <option v-for="(filter, index) in filters" :key="index" :value="index">
+            {{ filter.getName() }}
+          </option>
+        </select>
+        <input v-model="searchQuery" class="input search" placeholder="Zoeken" @input="searchQuery = $event.target.value">
+      </template>
+    </STNavigationBar>
 
-                <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
-                    <span class="icon add" />
-                    <span>Nieuw</span>
-                </button>
-            </h1>
-            <span v-if="titleDescription" class="style-description title-description">{{ titleDescription }}</span>
+    <main>
+      <h1 v-if="canPop">
+        <span class="icon-spacer">{{ title }}</span>
 
-            <BillingWarningBox filter-types="members" />
+        <button v-if="hasWaitingList" class="button text" @click="openWaitingList">
+          <span class="icon clock-small" />
+          <span>Wachtlijst</span>
+        </button>
 
-            <Spinner v-if="loading && sortedMembers.length == 0" class="center" />
-            <table v-else class="data-table">
-                <thead>
-                    <tr>
-                        <th class="prefix">
-                            <Checkbox
-                                v-model="selectAll"
-                            />
-                        </th>
-                        <th @click="toggleSort('name')">
-                            Naam
-                            <span
-                                class="sort-arrow"
-                                :class="{
+        <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
+
+        <button class="button text" @click="duplicateGroup">
+          <span class="icon copy" />
+        </button>
+
+        <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
+          <span class="icon add" />
+          <span>Nieuw</span>
+        </button>
+      </h1>
+      <span v-if="titleDescription" class="style-description title-description">{{ titleDescription }}</span>
+
+      <BillingWarningBox filter-types="members" />
+
+      <Spinner v-if="loading && sortedMembers.length == 0" class="center" />
+      <table v-else class="data-table">
+        <thead>
+        <tr>
+          <th class="prefix">
+            <Checkbox
+                v-model="selectAll"
+            />
+          </th>
+          <th @click="toggleSort('name')">
+            Naam
+            <span
+                class="sort-arrow"
+                :class="{
                                     up: sortBy == 'name' && sortDirection == 'ASC',
                                     down: sortBy == 'name' && sortDirection == 'DESC',
                                 }"
-                            />
-                        </th>
-                        <th class="hide-smartphone" @click="toggleSort('info')">
-                            Leeftijd
-                            <span
-                                class="sort-arrow"
-                                :class="{
+            />
+          </th>
+          <th class="hide-smartphone" @click="toggleSort('info')">
+            Leeftijd
+            <span
+                class="sort-arrow"
+                :class="{
                                     up: sortBy == 'info' && sortDirection == 'ASC',
                                     down: sortBy == 'info' && sortDirection == 'DESC',
                                 }"
-                            />
-                        </th>
-                        <th class="hide-smartphone" @click="toggleSort('status')">
-                            {{ waitingList ? "Op wachtlijst sinds" : "Status" }}
-                            <span
-                                class="sort-arrow"
-                                :class="{
+            />
+          </th>
+          <th class="hide-smartphone" @click="toggleSort('status')">
+            {{ waitingList ? "Op wachtlijst sinds" : "Status" }}
+            <span
+                class="sort-arrow"
+                :class="{
                                     up: sortBy == 'status' && sortDirection == 'ASC',
                                     down: sortBy == 'status' && sortDirection == 'DESC',
                                 }"
-                            />
-                        </th>
-                        <th>Acties</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr v-for="member in sortedMembers" :key="member.id" class="selectable" @click="showMember(member)" @contextmenu.prevent="showMemberContextMenu($event, member.member)">
-                        <td class="prefix" @click.stop="">
-                            <Checkbox v-model="member.selected" @change="onChanged(member)" />
-                        </td>
-                        <td>
-                            <h2 class="style-title-list">
-                                <div
-                                    v-if="!waitingList && isNew(member.member)"
-                                    v-tooltip="'Ingeschreven op ' + formatDate(registrationDate(member.member))"
-                                    class="new-member-bubble"
-                                />
-                                {{ member.member.name }}
-                                <span v-if="waitingList && canRegister(member.member)" v-tooltip="'Dit lid kan zich inschrijven via de uitnodiging'" class="style-tag warn">Toegelaten</span>
-                            </h2>
-                            <p v-if="!group" class="style-description-small">
-                                {{ member.member.groups.map(g => g.settings.name ).join(", ") }}
-                            </p>
-                            <p v-if="member.member.details && !member.member.details.isPlaceholder" class="style-description-small only-smartphone">
-                                {{ member.member.details.age }} jaar
-                            </p>
-                        </td>
-                        <td v-if="member.member.details && !member.member.details.isPlaceholder" class="minor hide-smartphone">
-                            {{ member.member.details.age }} jaar
-                        </td>
-                        <td v-else class="minor hide-smartphone">
-                            /
-                        </td>
-                        <td class="hide-smartphone member-description">
-                            <p v-text="getMemberDescription(member.member)" />
-                        </td>
-                        <td>
-                            <button v-if="!member.member.details || member.member.details.isPlaceholder" v-tooltip="'De sleutel om de gegevens van dit lid te bekijken ontbreekt'" class="button icon gray key-lost" />
-                            <button class="button icon gray more" @click.stop="showMemberContextMenu($event, member.member)" />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            />
+          </th>
+          <th>Acties</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr v-for="member in sortedMembers" :key="member.id" class="selectable" @click="showMember(member)" @contextmenu.prevent="showMemberContextMenu($event, member.member)">
+          <td class="prefix" @click.stop="">
+            <Checkbox v-model="member.selected" @change="onChanged(member)" />
+          </td>
+          <td>
+            <h2 class="style-title-list">
+              <div
+                  v-if="!waitingList && isNew(member.member)"
+                  v-tooltip="'Ingeschreven op ' + formatDate(registrationDate(member.member))"
+                  class="new-member-bubble"
+              />
+              {{ member.member.name }}
+              <span v-if="waitingList && canRegister(member.member)" v-tooltip="'Dit lid kan zich inschrijven via de uitnodiging'" class="style-tag warn">Toegelaten</span>
+            </h2>
+            <p v-if="!group" class="style-description-small">
+              {{ member.member.groups.map(g => g.settings.name ).join(", ") }}
+            </p>
+            <p v-if="member.member.details && !member.member.details.isPlaceholder" class="style-description-small only-smartphone">
+              {{ member.member.details.age }} jaar
+            </p>
+          </td>
+          <td v-if="member.member.details && !member.member.details.isPlaceholder" class="minor hide-smartphone">
+            {{ member.member.details.age }} jaar
+          </td>
+          <td v-else class="minor hide-smartphone">
+            /
+          </td>
+          <td class="hide-smartphone member-description">
+            <p v-text="getMemberDescription(member.member)" />
+          </td>
+          <td>
+            <button v-if="!member.member.details || member.member.details.isPlaceholder" v-tooltip="'De sleutel om de gegevens van dit lid te bekijken ontbreekt'" class="button icon gray key-lost" />
+            <button class="button icon gray more" @click.stop="showMemberContextMenu($event, member.member)" />
+          </td>
+        </tr>
+        </tbody>
+      </table>
 
-            <template v-if="!loading && members.length == 0">
-                <p v-if="cycleOffset === 0" class="info-box">
-                    Er zijn nog geen leden ingeschreven in deze leeftijdsgroep.
-                </p>
+      <template v-if="!loading && members.length == 0">
+        <p v-if="cycleOffset === 0" class="info-box">
+          Er zijn nog geen leden ingeschreven in deze leeftijdsgroep.
+        </p>
 
-                <p v-else class="info-box">
-                    Er zijn nog geen leden ingeschreven in deze inschrijvingsperiode.
-                </p>
-            </template>
+        <p v-else class="info-box">
+          Er zijn nog geen leden ingeschreven in deze inschrijvingsperiode.
+        </p>
+      </template>
 
-            
 
-            <div v-if="canGoBack || canGoNext" class="history-navigation-bar">
-                <button v-if="canGoBack" class="button text gray" @click="goBack">
-                    <span class="icon arrow-left" />
-                    <span>Vorige inschrijvingsperiode</span>
-                </button>
 
-                <button v-if="canGoNext" class="button text gray" @click="goNext">
-                    <span>Volgende inschrijvingsperiode</span>
-                    <span class="icon arrow-right" />
-                </button>
-            </div>
-        </main>
+      <div v-if="canGoBack || canGoNext" class="history-navigation-bar">
+        <button v-if="canGoBack" class="button text gray" @click="goBack">
+          <span class="icon arrow-left" />
+          <span>Vorige inschrijvingsperiode</span>
+        </button>
 
-        <STToolbar>
-            <template #left>
-                {{ selectionCount ? selectionCount : "Geen" }} {{ selectionCount == 1 ? "lid" : "leden" }} geselecteerd
-                <template v-if="selectionCountHidden">
-                    (waarvan {{ selectionCountHidden }} verborgen)
-                </template>
-            </template>
-            <template #right>
-                <button v-if="waitingList" class="button secundary" :disabled="selectionCount == 0" @click="openMail()">
-                    E-mailen
-                </button>
-                <button v-if="waitingList" class="button secundary" :disabled="selectionCount == 0" @click="allowMembers(false)">
-                    Toelating intrekken
-                </button>
-                <LoadingButton v-if="waitingList" :loading="actionLoading">
-                    <button class="button primary" :disabled="selectionCount == 0" @click="allowMembers(true)">
+        <button v-if="canGoNext" class="button text gray" @click="goNext">
+          <span>Volgende inschrijvingsperiode</span>
+          <span class="icon arrow-right" />
+        </button>
+      </div>
+    </main>
+
+    <STToolbar>
+      <template #left>
+        {{ selectionCount ? selectionCount : "Geen" }} {{ selectionCount == 1 ? "lid" : "leden" }} geselecteerd
+        <template v-if="selectionCountHidden">
+          (waarvan {{ selectionCountHidden }} verborgen)
+        </template>
+      </template>
+      <template #right>
+        <button v-if="waitingList" class="button secundary" :disabled="selectionCount == 0" @click="openMail()">
+          E-mailen
+        </button>
+        <button v-if="waitingList" class="button secundary" :disabled="selectionCount == 0" @click="allowMembers(false)">
+          Toelating intrekken
+        </button>
+        <LoadingButton v-if="waitingList" :loading="actionLoading">
+          <button class="button primary" :disabled="selectionCount == 0" @click="allowMembers(true)">
                         <span class="dropdown-text">
                             Toelaten
                         </span>
-                        <div class="dropdown" @click.stop="openMailDropdown" />
-                    </button>
-                </LoadingButton>
-                <template v-else>
-                    <button class="button secundary hide-smartphone" :disabled="selectionCount == 0" @click="openSamenvatting">
-                        Samenvatting
-                    </button>
-                    <LoadingButton :loading="actionLoading">
-                        <button class="button primary" :disabled="selectionCount == 0" @click="openMail()">
-                            <span class="dropdown-text">E-mailen</span>
-                            <div class="dropdown" @click.stop="openMailDropdown" />
-                        </button>
-                    </LoadingButton>
-                </template>
-            </template>
-        </STToolbar>
-    </div>
+            <div class="dropdown" @click.stop="openMailDropdown" />
+          </button>
+        </LoadingButton>
+        <template v-else>
+          <button class="button secundary hide-smartphone" :disabled="selectionCount == 0" @click="openSamenvatting">
+            Samenvatting
+          </button>
+          <LoadingButton :loading="actionLoading">
+            <button class="button primary" :disabled="selectionCount == 0" @click="openMail()">
+              <span class="dropdown-text">E-mailen</span>
+              <div class="dropdown" @click.stop="openMailDropdown" />
+            </button>
+          </LoadingButton>
+        </template>
+      </template>
+    </STToolbar>
+  </div>
 </template>
 
 <script lang="ts">
@@ -207,7 +215,19 @@ import { STNavigationBar } from "@stamhoofd/components";
 import { BackButton, LoadingButton,Spinner, STNavigationTitle } from "@stamhoofd/components";
 import { Checkbox } from "@stamhoofd/components"
 import { STToolbar } from "@stamhoofd/components";
-import { EncryptedMemberWithRegistrationsPatch, getPermissionLevelNumber, Group, GroupCategory, GroupCategoryTree, Member,MemberWithRegistrations, Organization, PermissionLevel, Registration, WaitingListType } from '@stamhoofd/structures';
+import {
+  EncryptedMemberWithRegistrationsPatch,
+  getPermissionLevelNumber,
+  Group,
+  GroupCategory,
+  GroupCategoryTree, GroupPrivateSettings,
+  GroupSettings,
+  Member,
+  MemberWithRegistrations,
+  Organization, OrganizationMetaData,
+  PermissionLevel,
+  Registration,
+} from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { Component, Mixins,Prop } from "vue-property-decorator";
 
@@ -224,639 +244,675 @@ import EditGroupView from "./EditGroupView.vue";
 import GroupListSelectionContextMenu from "./GroupListSelectionContextMenu.vue";
 
 class SelectableMember {
-    member: MemberWithRegistrations;
-    selected = true;
+  member: MemberWithRegistrations;
+  selected = true;
 
-    constructor(member: MemberWithRegistrations, selected = true) {
-        this.member = member;
-        this.selected = selected
-    }
+  constructor(member: MemberWithRegistrations, selected = true) {
+    this.member = member;
+    this.selected = selected
+  }
 }
 
 @Component({
-    components: {
-        Checkbox,
-        STNavigationBar,
-        STNavigationTitle,
-        STToolbar,
-        BackButton,
-        Spinner,
-        LoadingButton,
-        SegmentedControl,
-        BillingWarningBox
-    },
-    directives: { Tooltip },
+  components: {
+    Checkbox,
+    STNavigationBar,
+    STNavigationTitle,
+    STToolbar,
+    BackButton,
+    Spinner,
+    LoadingButton,
+    SegmentedControl,
+    BillingWarningBox
+  },
+  directives: { Tooltip },
 })
 export default class GroupMembersView extends Mixins(NavigationMixin) {
-    tabLabels = ["Ingeschreven", "Wachtlijst"]
-    tabs = ["all", "waitingList"]
-    tab = this.tabs[0]
+  tabLabels = ["Ingeschreven", "Wachtlijst"]
+  tabs = ["all", "waitingList"]
+  tab = this.tabs[0]
 
-    @Prop({ default: null })
-    group!: Group | null;
+  @Prop({ default: null })
+  group!: Group | null;
 
-    @Prop({ default: null })
-    category!: GroupCategoryTree | null;
+  @Prop({ default: null })
+  category!: GroupCategoryTree | null;
 
-    @Prop({ default: false })
-    waitingList!: boolean;
+  @Prop({ default: false })
+  waitingList!: boolean;
 
-    members: SelectableMember[] = [];
-    searchQuery = "";
-    filters = [new NoFilter(), new NotPaidFilter(), new CanNotSwimFilter(), ...RecordTypeFilter.generateAll()];
-    selectedFilter = 0;
-    selectionCountHidden = 0;
-    sortBy = "info";
-    sortDirection = "ASC";
-    cycleOffset = 0
+  members: SelectableMember[] = [];
+  searchQuery = "";
+  filters = [new NoFilter(), new NotPaidFilter(), new CanNotSwimFilter(), ...RecordTypeFilter.generateAll()];
+  selectedFilter = 0;
+  selectionCountHidden = 0;
+  sortBy = "info";
+  sortDirection = "ASC";
+  cycleOffset = 0
 
-    loading = false;
+  loading = false;
 
-    actionLoading = false
-    cachedWaitingList: boolean | null = null
+  actionLoading = false
+  cachedWaitingList: boolean | null = null
 
-    checkingInaccurate = false
+  checkingInaccurate = false
 
-    mounted() {
-        //this.reload();
+  mounted() {
+    //this.reload();
 
-        // Set url
-        if (this.group) {
-            HistoryManager.setUrl("/groups/"+Formatter.slug(this.group.settings.name))
-            document.title = "Stamhoofd - "+this.group.settings.name
-        } else {
-            if (this.category) {
-                HistoryManager.setUrl("/category/"+Formatter.slug(this.category.settings.name)+"/all")    
-                document.title = "Stamhoofd - "+ this.category.settings.name +" - Alle leden"
-            } else {
-                HistoryManager.setUrl("/groups/all")    
-                document.title = "Stamhoofd - Alle leden"
-            }
-            
+    // Set url
+    if (this.group) {
+      HistoryManager.setUrl("/groups/"+Formatter.slug(this.group.settings.name))
+      document.title = "Stamhoofd - "+this.group.settings.name
+    } else {
+      if (this.category) {
+        HistoryManager.setUrl("/category/"+Formatter.slug(this.category.settings.name)+"/all")
+        document.title = "Stamhoofd - "+ this.category.settings.name +" - Alle leden"
+      } else {
+        HistoryManager.setUrl("/groups/all")
+        document.title = "Stamhoofd - Alle leden"
+      }
+
+    }
+  }
+
+  async checkInaccurateMetaData() {
+    if (this.checkingInaccurate) {
+      return
+    }
+    this.checkingInaccurate = true
+    let toast: Toast | null = null
+    try {
+      const inaccurate: MemberWithRegistrations[] = []
+      for (const m of this.members) {
+        const member = m.member
+        const meta = member.getDetailsMeta()
+
+        // Check if meta is wrong
+        if (!member.details.isRecovered && (!meta || !meta.isAccurateFor(member.details))) {
+          console.warn("Found inaccurate meta data!")
+          inaccurate.push(member)
         }
+      }
+      if (inaccurate.length > 0) {
+        toast = new Toast("Gegevens van leden updaten naar laatste versie...", "spinner").setHide(null).show()
+
+        // Patch member with new details
+        await MemberManager.patchMembersDetails(inaccurate)
+      }
+    } catch (e) {
+      console.error(e)
+    }
+    toast?.hide()
+    this.checkingInaccurate = false
+  }
+
+  get canGoBack() {
+    if (!this.group) {
+      return false
+    }
+    return this.group.cycle >= this.cycleOffset // always allow to go to -1
+  }
+
+  get canGoNext() {
+    return this.cycleOffset > 0
+  }
+
+  get hasFull(): boolean {
+    if (!this.group) {
+      return false
     }
 
-    async checkInaccurateMetaData() {
-        if (this.checkingInaccurate) {
-            return
-        }
-        this.checkingInaccurate = true
-        let toast: Toast | null = null
-        try {
-            const inaccurate: MemberWithRegistrations[] = []
-            for (const m of this.members) {
-                const member = m.member
-                const meta = member.getDetailsMeta()
-
-                // Check if meta is wrong
-                if (!member.details.isRecovered && (!meta || !meta.isAccurateFor(member.details))) {
-                    console.warn("Found inaccurate meta data!")
-                    inaccurate.push(member)
-                }
-            }
-            if (inaccurate.length > 0) {
-                toast = new Toast("Gegevens van leden updaten naar laatste versie...", "spinner").setHide(null).show()
-
-                // Patch member with new details
-                await MemberManager.patchMembersDetails(inaccurate)
-            }
-        } catch (e) {
-            console.error(e)
-        }
-        toast?.hide()
-        this.checkingInaccurate = false
+    if (!this.group.privateSettings || !OrganizationManager.user.permissions) {
+      return false
     }
 
-    get canGoBack() {
-        if (!this.group) {
-            return false
-        }
-        return this.group.cycle >= this.cycleOffset // always allow to go to -1
+    if(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions) !== PermissionLevel.Full) {
+      return false
+    }
+    return true
+  }
+
+  get canCreate(): boolean {
+    if (!OrganizationManager.user.permissions) {
+      return false
     }
 
-    get canGoNext() {
-        return this.cycleOffset > 0
-    }
+    if (!this.group) {
+      if (this.category) {
+        for (const group of this.category.groups) {
+          if (!group.privateSettings) {
+            continue
+          }
 
-    get hasFull(): boolean {
-        if (!this.group) {
-            return false
-        }
-
-        if (!this.group.privateSettings || !OrganizationManager.user.permissions) {
-            return false
-        }
-
-        if(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions) !== PermissionLevel.Full) {
-            return false
-        }
-        return true
-    }
-
-    get canCreate(): boolean {
-        if (!OrganizationManager.user.permissions) {
-            return false
-        }
-
-        if (!this.group) {
-            if (this.category) {
-                for (const group of this.category.groups) {
-                    if (!group.privateSettings) {
-                        continue
-                    }
-
-                    if(getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
-                        return true
-                    }
-                }
-            }
-            return false
-        }
-
-        if (!this.group.privateSettings) {
-            return false
-        }
-
-        if(getPermissionLevelNumber(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Write)) {
-            return false
-        }
-        return true
-    }
-
-    goNext() {
-        this.cycleOffset--
-        this.reload()
-    }
-
-    goBack() {
-        this.cycleOffset++
-        this.reload()
-    }
-
-    onUpdateMember(type: MemberChangeEvent, member: MemberWithRegistrations | null) {
-        if (type == "changedGroup" || type == "deleted" || type == "created" || type == "payment" || type == "encryption") {
-            this.reload()
-        }
-    }
-
-    activated() {
-        this.reload();
-        MemberManager.addListener(this, this.onUpdateMember)
-    }
-
-    deactivated() {
-        MemberManager.removeListener(this)
-    }
-
-    get isFull() {
-        if (!this.group || this.group.settings.maxMembers === null) {
-            return false;
-        }
-        return this.members.length >= this.group.settings.maxMembers
-    }
-
-    get maxMembers() {
-         if (!this.group || this.group.settings.maxMembers === null) {
-            return 0;
-        }
-        return this.group.settings.maxMembers
-    }
-
-    get groupIds() {
-        if (this.group) {
-            return [this.group.id]
-        }
-        if (this.category) {
-            return this.category.groups.map(g => g.id) // needed because of permission check + existing check!
-        }
-        return []
-    }
-
-    checkWaitingList() {
-        MemberManager.loadMembers(this.groupIds, true).then((members) => {
-            this.cachedWaitingList = members.length > 0
-        }).catch((e) => {
-            console.error(e)
-        })
-    }
-
-    reload() {
-        this.loading = true;
-        MemberManager.loadMembers(this.groupIds, this.waitingList, this.cycleOffset).then((members) => {
-            this.members = members.map((member) => {
-                const selected = this.members.find(m => m.member.id === member.id)?.selected
-                return new SelectableMember(member, selected !== undefined ?  selected : !this.waitingList);
-            }) ?? [];
-            this.checkInaccurateMetaData().catch(e => {
-                console.error(e)
-            })
-        }).catch((e) => {
-            console.error(e)
-        }).finally(() => {
-            this.loading = false
-
-            if (!this.waitingList && this.group && !this.group.hasWaitingList()) {
-                this.checkWaitingList()
-            }
-        })
-    }
-
-    openWaitingList() {
-        this.show(new ComponentWithProperties(GroupMembersView, {
-            group: this.group,
-            waitingList: true
-        }))
-    }
-
-    get hasWaitingList() {
-        if (this.waitingList) {
-            return false;
-        }
-        if (this.cachedWaitingList !== null) {
-            return this.cachedWaitingList
-        }
-        if (!this.group) {
-            return false;
-        }
-        return this.group.hasWaitingList()
-    }
-
-    get title() {
-        return this.waitingList ? "Wachtlijst" : (this.group ? this.group.settings.name : (this.category ? this.category.settings.name : "Alle leden"))
-    }
-
-    get titleDescription() {
-        if (this.cycleOffset === 1) {
-            return "Dit is de vorige inschrijvingsperiode"
-        }
-        if (this.cycleOffset > 1) {
-            return "Dit is "+this.cycleOffset+" inschrijvingsperiodes geleden"
-        }
-        return ""
-    }
-
-    formatDate(date: Date) {
-        return Formatter.dateTime(date)
-    }
-
-    registrationDate(member: MemberWithRegistrations) {
-        if (member.registrations.length == 0) {
-            return new Date()
-        }
-        const reg = !this.group ? member.registrations[0] : member.registrations.find(r => r.groupId === this.group!.id)
-        if (!reg) {
-            return new Date()
-        }
-
-        if (!reg.registeredAt || this.waitingList) {
-            return reg.createdAt
-        }
-        
-        return reg.registeredAt
-    }
-
-    addMember() {
-        this.present(new ComponentWithProperties(NavigationController, {
-            root: new ComponentWithProperties(EditMemberView, {
-
-            })
-        }).setDisplayStyle("popup"))
-    }
-
-    modifyGroup() {
-        if (!this.group) {
-            return;
-        }
-        this.present(new ComponentWithProperties(EditGroupView, { 
-            group: this.group, 
-            organization: OrganizationManager.organization, 
-            saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
-                patch.id = OrganizationManager.organization.id
-                await OrganizationManager.patch(patch)
-                const g = OrganizationManager.organization.groups.find(g => g.id === this.group!.id)
-                if (!g) {
-                    this.pop({ force: true })
-                } else {
-                    this.group!.set(g)
-                }
-            }
-        }).setDisplayStyle("popup"))
-    }
-
-    isNew(member: MemberWithRegistrations) {
-        if (!this.group) {
-            return false
-        }
-        const reg = member.registrations.find(r => r.groupId === this.group!.id)
-        if (!reg) {
-            return false
-        }
-
-        if (!reg.registeredAt) {
+          if(getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
             return true
+          }
         }
-        
-        return reg.registeredAt > new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 14)
+      }
+      return false
     }
 
-    get sortedMembers(): SelectableMember[] {
-        if (this.sortBy == "info") {
-            return this.filteredMembers.sort((a, b) => {
-                if (!a.member.details && !b.member.details) {
-                    return 0
-                }
-                if (!a.member.details) {
-                    return 1
-                }
-                if (!b.member.details) {
-                    return -1
-                }
-                if (this.sortDirection == "ASC") {
-                    return (a.member.details.age ?? 99) - (b.member.details.age ?? 99);
-                }
-                return (b.member.details.age ?? 99) - (a.member.details.age ?? 99);
-            });
-        }
+    if (!this.group.privateSettings) {
+      return false
+    }
 
-        if (this.sortBy == "name") {
-            const s = Member.sorterByName(this.sortDirection)
-            return this.filteredMembers.sort((a, b) => s(a.member, b.member));
-        }
+    if(getPermissionLevelNumber(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Write)) {
+      return false
+    }
+    return true
+  }
 
-        if (this.sortBy == "status") {
-            if (this.waitingList) {
-                return this.filteredMembers.sort((a, b) => {
-                    if (this.sortDirection == "ASC") {
-                        if (this.registrationDate(a.member) > this.registrationDate(b.member)) {
-                            return 1;
-                        }
-                        if (this.registrationDate(a.member) < this.registrationDate(b.member)) {
-                            return -1;
-                        }
-                        return 0;
-                    }
-                    if (this.registrationDate(a.member) > this.registrationDate(b.member)) {
-                        return -1;
-                    }
-                    if (this.registrationDate(a.member) < this.registrationDate(b.member)) {
-                        return 1;
-                    }
-                    return 0;
-                });
+  goNext() {
+    this.cycleOffset--
+    this.reload()
+  }
+
+  goBack() {
+    this.cycleOffset++
+    this.reload()
+  }
+
+  onUpdateMember(type: MemberChangeEvent, member: MemberWithRegistrations | null) {
+    if (type == "changedGroup" || type == "deleted" || type == "created" || type == "payment" || type == "encryption") {
+      this.reload()
+    }
+  }
+
+  activated() {
+    this.reload();
+    MemberManager.addListener(this, this.onUpdateMember)
+  }
+
+  deactivated() {
+    MemberManager.removeListener(this)
+  }
+
+  get isFull() {
+    if (!this.group || this.group.settings.maxMembers === null) {
+      return false;
+    }
+    return this.members.length >= this.group.settings.maxMembers
+  }
+
+  get maxMembers() {
+    if (!this.group || this.group.settings.maxMembers === null) {
+      return 0;
+    }
+    return this.group.settings.maxMembers
+  }
+
+  get groupIds() {
+    if (this.group) {
+      return [this.group.id]
+    }
+    if (this.category) {
+      return this.category.groups.map(g => g.id) // needed because of permission check + existing check!
+    }
+    return []
+  }
+
+  checkWaitingList() {
+    MemberManager.loadMembers(this.groupIds, true).then((members) => {
+      this.cachedWaitingList = members.length > 0
+    }).catch((e) => {
+      console.error(e)
+    })
+  }
+
+  reload() {
+    this.loading = true;
+    MemberManager.loadMembers(this.groupIds, this.waitingList, this.cycleOffset).then((members) => {
+      this.members = members.map((member) => {
+        const selected = this.members.find(m => m.member.id === member.id)?.selected
+        return new SelectableMember(member, selected !== undefined ?  selected : !this.waitingList);
+      }) ?? [];
+      this.checkInaccurateMetaData().catch(e => {
+        console.error(e)
+      })
+    }).catch((e) => {
+      console.error(e)
+    }).finally(() => {
+      this.loading = false
+
+      if (!this.waitingList && this.group && !this.group.hasWaitingList()) {
+        this.checkWaitingList()
+      }
+    })
+  }
+
+  openWaitingList() {
+    this.show(new ComponentWithProperties(GroupMembersView, {
+      group: this.group,
+      waitingList: true
+    }))
+  }
+
+  get hasWaitingList() {
+    if (this.waitingList) {
+      return false;
+    }
+    if (this.cachedWaitingList !== null) {
+      return this.cachedWaitingList
+    }
+    if (!this.group) {
+      return false;
+    }
+    return this.group.hasWaitingList()
+  }
+
+  get title() {
+    return this.waitingList ? "Wachtlijst" : (this.group ? this.group.settings.name : (this.category ? this.category.settings.name : "Alle leden"))
+  }
+
+  get titleDescription() {
+    if (this.cycleOffset === 1) {
+      return "Dit is de vorige inschrijvingsperiode"
+    }
+    if (this.cycleOffset > 1) {
+      return "Dit is "+this.cycleOffset+" inschrijvingsperiodes geleden"
+    }
+    return ""
+  }
+
+  formatDate(date: Date) {
+    return Formatter.dateTime(date)
+  }
+
+  registrationDate(member: MemberWithRegistrations) {
+    if (member.registrations.length == 0) {
+      return new Date()
+    }
+    const reg = !this.group ? member.registrations[0] : member.registrations.find(r => r.groupId === this.group!.id)
+    if (!reg) {
+      return new Date()
+    }
+
+    if (!reg.registeredAt || this.waitingList) {
+      return reg.createdAt
+    }
+
+    return reg.registeredAt
+  }
+
+  addMember() {
+    this.present(new ComponentWithProperties(NavigationController, {
+      root: new ComponentWithProperties(EditMemberView, {})
+    }).setDisplayStyle("popup"))
+  }
+
+  duplicateGroup() {
+    if (!this.group && !this.category) {
+      return;
+    }
+
+    const newGroup = Group.create({
+      settings: GroupSettings.create(this.group?.settings),
+      privateSettings: GroupPrivateSettings.create({})
+    })
+    newGroup.settings.name = newGroup.settings.name + " Kopie"
+    const meta = OrganizationMetaData.patch({})
+
+    console.log(this.category);
+
+    const me = GroupCategory.patch({id: this.category?.id})
+    me.groupIds.addPut(newGroup.id)
+    meta.categories.addPatch(me)
+
+    const p = Organization.patch({
+      id: OrganizationManager.organization.id,
+      meta
+    })
+
+    p.groups.addPut(newGroup)
+
+    this.present(new ComponentWithProperties(EditGroupView, {
+      group: newGroup,
+      organization: OrganizationManager.organization.patch(p),
+      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+        await OrganizationManager.patch(p.patch(patch))
+        console.log("saved")
+        this.show(new ComponentWithProperties(GroupMembersView, {
+          group: newGroup
+        }))
+      }
+    }).setDisplayStyle("popup"))
+  }
+
+  modifyGroup() {
+    if (!this.group) {
+      return;
+    }
+    this.present(new ComponentWithProperties(EditGroupView, {
+      group: this.group,
+      organization: OrganizationManager.organization,
+      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+        patch.id = OrganizationManager.organization.id
+        await OrganizationManager.patch(patch)
+        const g = OrganizationManager.organization.groups.find(g => g.id === this.group!.id)
+        if (!g) {
+          this.pop({ force: true })
+        } else {
+          this.group!.set(g)
+        }
+      }
+    }).setDisplayStyle("popup"))
+  }
+
+  isNew(member: MemberWithRegistrations) {
+    if (!this.group) {
+      return false
+    }
+    const reg = member.registrations.find(r => r.groupId === this.group!.id)
+    if (!reg) {
+      return false
+    }
+
+    if (!reg.registeredAt) {
+      return true
+    }
+
+    return reg.registeredAt > new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 14)
+  }
+
+  get sortedMembers(): SelectableMember[] {
+    if (this.sortBy == "info") {
+      return this.filteredMembers.sort((a, b) => {
+        if (!a.member.details && !b.member.details) {
+          return 0
+        }
+        if (!a.member.details) {
+          return 1
+        }
+        if (!b.member.details) {
+          return -1
+        }
+        if (this.sortDirection == "ASC") {
+          return (a.member.details.age ?? 99) - (b.member.details.age ?? 99);
+        }
+        return (b.member.details.age ?? 99) - (a.member.details.age ?? 99);
+      });
+    }
+
+    if (this.sortBy == "name") {
+      const s = Member.sorterByName(this.sortDirection)
+      return this.filteredMembers.sort((a, b) => s(a.member, b.member));
+    }
+
+    if (this.sortBy == "status") {
+      if (this.waitingList) {
+        return this.filteredMembers.sort((a, b) => {
+          if (this.sortDirection == "ASC") {
+            if (this.registrationDate(a.member) > this.registrationDate(b.member)) {
+              return 1;
             }
-            return this.filteredMembers.sort((a, b) => {
-                const aa = this.getMemberDescription(a.member).toLowerCase()
-                const bb = this.getMemberDescription(b.member).toLowerCase()
-                if (this.sortDirection == "ASC") {
-                    if (aa > bb) {
-                        return 1;
-                    }
-                    if (aa < bb) {
-                        return -1;
-                    }
-                    return 0;
-                }
-                if (aa > bb) {
-                    return -1;
-                }
-                if (aa < bb) {
-                    return 1;
-                }
-                return 0;
-            });
-        }
-        return this.filteredMembers;
-    }
-
-    isDescriptiveFilter() {
-        return !!((this.filters[this.selectedFilter] as any).getDescription)
-    }
-
-    getMemberDescription(member: MemberWithRegistrations) {
-        if (this.waitingList) {
-            return this.formatDate(this.registrationDate(member))
-        }
-
-        if (this.isDescriptiveFilter()) {
-            return (this.filters[this.selectedFilter] as any).getDescription(member, OrganizationManager.organization)
-        }
-
-        return member.info
-    }
-
-    get filteredMembers(): SelectableMember[] {
-        this.selectionCountHidden = 0;
-        const filtered = this.members.filter((member: SelectableMember) => {
-            if (this.filters[this.selectedFilter].doesMatch(member.member, OrganizationManager.organization)) {
-                return true;
+            if (this.registrationDate(a.member) < this.registrationDate(b.member)) {
+              return -1;
             }
-            this.selectionCountHidden += member.selected ? 1 : 0;
-            return false;
+            return 0;
+          }
+          if (this.registrationDate(a.member) > this.registrationDate(b.member)) {
+            return -1;
+          }
+          if (this.registrationDate(a.member) < this.registrationDate(b.member)) {
+            return 1;
+          }
+          return 0;
         });
-
-        if (this.searchQuery == "") {
-            return filtered;
+      }
+      return this.filteredMembers.sort((a, b) => {
+        const aa = this.getMemberDescription(a.member).toLowerCase()
+        const bb = this.getMemberDescription(b.member).toLowerCase()
+        if (this.sortDirection == "ASC") {
+          if (aa > bb) {
+            return 1;
+          }
+          if (aa < bb) {
+            return -1;
+          }
+          return 0;
         }
-        return filtered.filter((member: SelectableMember) => {
-            if (member.member.details && member.member.details.matchQuery(this.searchQuery)) {
-                return true;
-            }
-            this.selectionCountHidden += member.selected ? 1 : 0;
-            return false;
+        if (aa > bb) {
+          return -1;
+        }
+        if (aa < bb) {
+          return 1;
+        }
+        return 0;
+      });
+    }
+    return this.filteredMembers;
+  }
+
+  isDescriptiveFilter() {
+    return !!((this.filters[this.selectedFilter] as any).getDescription)
+  }
+
+  getMemberDescription(member: MemberWithRegistrations) {
+    if (this.waitingList) {
+      return this.formatDate(this.registrationDate(member))
+    }
+
+    if (this.isDescriptiveFilter()) {
+      return (this.filters[this.selectedFilter] as any).getDescription(member, OrganizationManager.organization)
+    }
+
+    return member.info
+  }
+
+  get filteredMembers(): SelectableMember[] {
+    this.selectionCountHidden = 0;
+    const filtered = this.members.filter((member: SelectableMember) => {
+      if (this.filters[this.selectedFilter].doesMatch(member.member, OrganizationManager.organization)) {
+        return true;
+      }
+      this.selectionCountHidden += member.selected ? 1 : 0;
+      return false;
+    });
+
+    if (this.searchQuery == "") {
+      return filtered;
+    }
+    return filtered.filter((member: SelectableMember) => {
+      if (member.member.details && member.member.details.matchQuery(this.searchQuery)) {
+        return true;
+      }
+      this.selectionCountHidden += member.selected ? 1 : 0;
+      return false;
+    });
+  }
+
+  get selectionCount(): number {
+    let val = 0;
+    this.members.forEach((member) => {
+      if (member.selected) {
+        val++;
+      }
+    });
+    return val;
+  }
+
+  toggleSort(field: string) {
+    if (this.sortBy == field) {
+      if (this.sortDirection == "ASC") {
+        this.sortDirection = "DESC";
+      } else {
+        this.sortDirection = "ASC";
+      }
+      return;
+    }
+    this.sortBy = field;
+  }
+
+  next() {
+    this.show(new ComponentWithProperties(GroupMembersView, {}));
+  }
+
+  onChanged(_selectableMember: SelectableMember) {
+    // do nothing for now
+  }
+
+  getPreviousMember(member: MemberWithRegistrations): MemberWithRegistrations | null {
+    for (let index = 0; index < this.sortedMembers.length; index++) {
+      const _member = this.sortedMembers[index];
+      if (_member.member.id == member.id) {
+        if (index == 0) {
+          return null;
+        }
+        return this.sortedMembers[index - 1].member;
+      }
+    }
+    return null;
+  }
+
+  getNextMember(member: MemberWithRegistrations): MemberWithRegistrations | null {
+    for (let index = 0; index < this.sortedMembers.length; index++) {
+      const _member = this.sortedMembers[index];
+      if (_member.member.id == member.id) {
+        if (index == this.sortedMembers.length - 1) {
+          return null;
+        }
+        return this.sortedMembers[index + 1].member;
+      }
+    }
+    return null;
+  }
+
+  showMember(selectableMember: SelectableMember) {
+    const component = new ComponentWithProperties(NavigationController, {
+      root: new ComponentWithProperties(MemberView, {
+        member: selectableMember.member,
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        getNextMember: this.getNextMember,
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        getPreviousMember: this.getPreviousMember,
+
+        group: this.group,
+        cycleOffset: this.cycleOffset,
+        waitingList: this.waitingList
+      }),
+    });
+    component.modalDisplayStyle = "popup";
+    this.present(component);
+  }
+
+  get selectAll() {
+    return this.selectionCount - this.selectionCountHidden >= this.filteredMembers.length && this.filteredMembers.length > 0
+  }
+
+  set selectAll(selected: boolean) {
+    this.filteredMembers.forEach((member) => {
+      member.selected = selected;
+    });
+  }
+
+  showMemberContextMenu(event, member: MemberWithRegistrations) {
+    const displayedComponent = new ComponentWithProperties(MemberContextMenu, {
+      x: event.clientX,
+      y: event.clientY + 10,
+      member: member,
+      group: this.group,
+      cycleOffset: this.cycleOffset,
+      waitingList: this.waitingList
+    });
+    this.present(displayedComponent.setDisplayStyle("overlay"));
+  }
+
+  getSelectedMembers(): MemberWithRegistrations[] {
+    return this.members
+        .filter((member: SelectableMember) => {
+          return member.selected;
+        })
+        .map((member: SelectableMember) => {
+          return member.member;
         });
+  }
+
+  canRegister(member: MemberWithRegistrations) {
+    if (!this.group) {
+      return false
+    }
+    return member.registrations.find(r => r.groupId == this.group!.id && r.waitingList && r.canRegister && r.cycle == this.group!.cycle)
+  }
+
+  async allowMembers(allow = true) {
+    if (this.actionLoading) {
+      return;
     }
 
-    get selectionCount(): number {
-        let val = 0;
-        this.members.forEach((member) => {
-            if (member.selected) {
-                val++;
-            }
-        });
-        return val;
+    const members = this.getSelectedMembers().filter(m => !this.group || (allow && m.waitingGroups.find(r => r.id === this.group!.id)) || (!allow && m.acceptedWaitingGroups.find(r => r.id === this.group!.id)))
+    if (members.length == 0) {
+      return;
     }
 
-    toggleSort(field: string) {
-        if (this.sortBy == field) {
-            if (this.sortDirection == "ASC") {
-                this.sortDirection = "DESC";
-            } else {
-                this.sortDirection = "ASC";
-            }
-            return;
+    this.actionLoading = true;
+    try {
+      const patches = MemberManager.getPatchArray()
+      for (const member of members) {
+        const registrationsPatch = MemberManager.getRegistrationsPatchArray()
+
+        const registration = member.registrations.find(r => r.groupId == this.group!.id && r.waitingList == true && r.cycle == this.group!.cycle)
+        if (!registration) {
+          throw new Error("Not found")
         }
-        this.sortBy = field;
+        registrationsPatch.addPatch(Registration.patchType().create({
+          id: registration.id,
+          canRegister: allow
+        }))
+
+        patches.addPatch(EncryptedMemberWithRegistrationsPatch.create({
+          id: member.id,
+          registrations: registrationsPatch
+        }))
+      }
+      await MemberManager.patchMembers(patches)
+    } catch (e) {
+      console.error(e)
+      // todo
     }
+    this.actionLoading = false
+    this.reload()
 
-    next() {
-        this.show(new ComponentWithProperties(GroupMembersView, {}));
+    if (allow) {
+      this.openMail("Je kan nu inschrijven!")
     }
+  }
 
-    onChanged(_selectableMember: SelectableMember) {
-        // do nothing for now
+  openMail(subject = "") {
+    const displayedComponent = new ComponentWithProperties(NavigationController, {
+      root: new ComponentWithProperties(MailView, {
+        members: this.getSelectedMembers(),
+        group: this.group,
+        defaultSubject: subject
+      })
+    });
+    this.present(displayedComponent.setDisplayStyle("popup"));
+  }
+
+  openMailDropdown(event) {
+    if (this.selectionCount == 0) {
+      return;
     }
+    const displayedComponent = new ComponentWithProperties(GroupListSelectionContextMenu, {
+      x: event.clientX,
+      y: event.clientY + 10,
+      members: this.getSelectedMembers(),
+      group: this.group,
+      cycleOffset: this.cycleOffset,
+      waitingList: this.waitingList
+    });
+    this.present(displayedComponent.setDisplayStyle("overlay"));
+  }
 
-    getPreviousMember(member: MemberWithRegistrations): MemberWithRegistrations | null {
-        for (let index = 0; index < this.sortedMembers.length; index++) {
-            const _member = this.sortedMembers[index];
-            if (_member.member.id == member.id) {
-                if (index == 0) {
-                    return null;
-                }
-                return this.sortedMembers[index - 1].member;
-            }
-        }
-        return null;
-    }
-
-    getNextMember(member: MemberWithRegistrations): MemberWithRegistrations | null {
-        for (let index = 0; index < this.sortedMembers.length; index++) {
-            const _member = this.sortedMembers[index];
-            if (_member.member.id == member.id) {
-                if (index == this.sortedMembers.length - 1) {
-                    return null;
-                }
-                return this.sortedMembers[index + 1].member;
-            }
-        }
-        return null;
-    }
-
-    showMember(selectableMember: SelectableMember) {
-        const component = new ComponentWithProperties(NavigationController, {
-            root: new ComponentWithProperties(MemberView, {
-                member: selectableMember.member,
-                // eslint-disable-next-line @typescript-eslint/unbound-method
-                getNextMember: this.getNextMember,
-                // eslint-disable-next-line @typescript-eslint/unbound-method
-                getPreviousMember: this.getPreviousMember,
-
-                group: this.group,
-                cycleOffset: this.cycleOffset,
-                waitingList: this.waitingList
-            }),
-        });
-        component.modalDisplayStyle = "popup";
-        this.present(component);
-    }
-
-    get selectAll() {
-        return this.selectionCount - this.selectionCountHidden >= this.filteredMembers.length && this.filteredMembers.length > 0
-    }
-
-    set selectAll(selected: boolean) {
-        this.filteredMembers.forEach((member) => {
-            member.selected = selected;
-        });
-    }
-
-    showMemberContextMenu(event, member: MemberWithRegistrations) {
-        const displayedComponent = new ComponentWithProperties(MemberContextMenu, {
-            x: event.clientX,
-            y: event.clientY + 10,
-            member: member,
-            group: this.group,
-            cycleOffset: this.cycleOffset,
-            waitingList: this.waitingList
-        });
-        this.present(displayedComponent.setDisplayStyle("overlay"));
-    }
-
-    getSelectedMembers(): MemberWithRegistrations[] {
-        return this.members
-            .filter((member: SelectableMember) => {
-                return member.selected;
-            })
-            .map((member: SelectableMember) => {
-                return member.member;
-            });
-    }
-
-    canRegister(member: MemberWithRegistrations) {
-        if (!this.group) {
-            return false
-        }
-        return member.registrations.find(r => r.groupId == this.group!.id && r.waitingList && r.canRegister && r.cycle == this.group!.cycle)
-    }
-
-    async allowMembers(allow = true) {
-        if (this.actionLoading) {
-            return;
-        }
-
-        const members = this.getSelectedMembers().filter(m => !this.group || (allow && m.waitingGroups.find(r => r.id === this.group!.id)) || (!allow && m.acceptedWaitingGroups.find(r => r.id === this.group!.id)))
-        if (members.length == 0) {
-            return;
-        }
-
-        this.actionLoading = true;
-        try {
-            const patches = MemberManager.getPatchArray()
-            for (const member of members) {
-                const registrationsPatch = MemberManager.getRegistrationsPatchArray()
-
-                const registration = member.registrations.find(r => r.groupId == this.group!.id && r.waitingList == true && r.cycle == this.group!.cycle)
-                if (!registration) {
-                    throw new Error("Not found")
-                }
-                registrationsPatch.addPatch(Registration.patchType().create({
-                    id: registration.id,
-                    canRegister: allow
-                }))
-
-                patches.addPatch(EncryptedMemberWithRegistrationsPatch.create({
-                    id: member.id,
-                    registrations: registrationsPatch
-                }))
-            }
-            await MemberManager.patchMembers(patches)
-        } catch (e) {
-            console.error(e)
-            // todo
-        }
-        this.actionLoading = false
-        this.reload()
-
-        if (allow) {
-            this.openMail("Je kan nu inschrijven!")
-        }
-    }
-
-    openMail(subject = "") {
-        const displayedComponent = new ComponentWithProperties(NavigationController, {
-            root: new ComponentWithProperties(MailView, {
-                members: this.getSelectedMembers(),
-                group: this.group,
-                defaultSubject: subject
-            })
-        });
-        this.present(displayedComponent.setDisplayStyle("popup"));
-    }
-
-    openMailDropdown(event) {
-        if (this.selectionCount == 0) {
-            return;
-        }
-        const displayedComponent = new ComponentWithProperties(GroupListSelectionContextMenu, {
-            x: event.clientX,
-            y: event.clientY + 10,
-            members: this.getSelectedMembers(),
-            group: this.group,
-            cycleOffset: this.cycleOffset,
-            waitingList: this.waitingList
-        });
-        this.present(displayedComponent.setDisplayStyle("overlay"));
-    }
-
-    openSamenvatting() {
-        const displayedComponent = new ComponentWithProperties(NavigationController, {
-            root: new ComponentWithProperties(MemberSummaryView, {
-                members: this.getSelectedMembers(),
-                group: this.group
-            })
-        });
-        this.present(displayedComponent.setDisplayStyle("popup"));
-    }
+  openSamenvatting() {
+    const displayedComponent = new ComponentWithProperties(NavigationController, {
+      root: new ComponentWithProperties(MemberSummaryView, {
+        members: this.getSelectedMembers(),
+        group: this.group
+      })
+    });
+    this.present(displayedComponent.setDisplayStyle("popup"));
+  }
 }
 </script>
 
@@ -865,36 +921,36 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
 @use '@stamhoofd/scss/base/text-styles.scss';
 
 .group-members-view {
-    .new-member-bubble {
-        display: inline-block;
-        vertical-align: middle;
-        width: 5px;
-        height: 5px;
-        border-radius: 2.5px;
-        background: $color-primary;
-        margin-left: -10px;
-        margin-right: 5px;
-    }
+  .new-member-bubble {
+    display: inline-block;
+    vertical-align: middle;
+    width: 5px;
+    height: 5px;
+    border-radius: 2.5px;
+    background: $color-primary;
+    margin-left: -10px;
+    margin-right: 5px;
+  }
 
-    .member-description > p {
-        white-space: pre-wrap;
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 3;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
+  .member-description > p {
+    white-space: pre-wrap;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
-    .history-navigation-bar {
-        display: flex;
-        padding-top: 20px;
-        justify-content: space-between;
-        align-items: center;
-        flex-direction: row;
-    }
+  .history-navigation-bar {
+    display: flex;
+    padding-top: 20px;
+    justify-content: space-between;
+    align-items: center;
+    flex-direction: row;
+  }
 
-    .title-description {
-        margin-bottom: 20px;
-    }
+  .title-description {
+    margin-bottom: 20px;
+  }
 }
 </style>


### PR DESCRIPTION
When setting up a new category (a weekend or camp). Most of the settings are the same for all groups. But you have to manually create all of these groups which wastes time and increases mistakes. 

So I had to idea to add a duplicate button on GroupMembersView. It automatically creates a new group with all of the same settings.