### PR TITLE
[Feature] Quickly duplicate groups

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
@@ -125,16 +125,7 @@ import { NavigationController } from "@simonbackx/vue-app-navigation";
 import { CenteredMessage, Logo, Toast, ToastButton, TooltipDirective } from '@stamhoofd/components';
 import { Sodium } from "@stamhoofd/crypto";
 import { Keychain, LoginHelper,SessionManager } from '@stamhoofd/networking';
-import {
-  Category,
-  Group,
-  GroupCategory,
-  GroupCategoryTree,
-  OrganizationType,
-  Permissions,
-  UmbrellaOrganization,
-  WebshopPreview
-} from '@stamhoofd/structures';
+import { Group, GroupCategory, GroupCategoryTree, OrganizationType, Permissions, UmbrellaOrganization, WebshopPreview } from '@stamhoofd/structures';
 import { Formatter } from "@stamhoofd/utility";
 import { Component, Mixins } from "vue-property-decorator";
 

--- a/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
@@ -31,6 +31,8 @@
             <span class="bubble">{{ organization.privateMeta.requestKeysCount }}</span>
         </button>
 
+        <hr v-if="whatsNewBadge || enableMemberModule || (fullAccess && organization.privateMeta.requestKeysCount > 0)">
+
         <template v-if="enableMemberModule">
             <div v-for="category in tree.categories">
                 <div>
@@ -63,7 +65,7 @@
                 <hr>
             </div>
         </template>
-
+    
 
         <div v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
             <button class="menu-button heading">
@@ -87,7 +89,7 @@
         </div>
         <hr v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
 
-        <button v-if="canManagePayments" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-payments'}" @click="managePayments(true)">
+        <button v-if="canManagePayments" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-payments'}" @click="managePayments(true)"> 
             <span class="icon card" />
             <span>Overschrijvingen</span>
         </button>
@@ -145,309 +147,309 @@ import EditWebshopView from './webshop/EditWebshopView.vue';
 import WebshopView from './webshop/WebshopView.vue';
 
 @Component({
-  components: {
-    Logo
-  },
-  directives: {
-    tooltip: TooltipDirective
-  }
+    components: {
+        Logo
+    },
+    directives: {
+        tooltip: TooltipDirective
+    }
 })
 export default class Menu extends Mixins(NavigationMixin) {
-  SessionManager = SessionManager // needed to make session reactive
-  currentlySelected: string | null = null
-  whatsNewBadge = ""
+    SessionManager = SessionManager // needed to make session reactive
+    currentlySelected: string | null = null
+    whatsNewBadge = ""
 
-  get organization() {
-    return OrganizationManager.organization
-  }
+    get organization() {
+        return OrganizationManager.organization
+    }
+    
+    get registerUrl() {
+        if (this.organization.registerDomain) {
+            return "https://"+this.organization.registerDomain
+        } 
 
-  get registerUrl() {
-    if (this.organization.registerDomain) {
-      return "https://"+this.organization.registerDomain
+        return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
     }
 
-    return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
-  }
-
-  get isSGV() {
-    return this.organization.meta.type == OrganizationType.Youth && this.organization.meta.umbrellaOrganization == UmbrellaOrganization.ScoutsEnGidsenVlaanderen
-  }
-
-  get tree() {
-    return this.organization.categoryTreeForPermissions(OrganizationManager.user.permissions ?? Permissions.create({}))
-  }
-
-  mounted() {
-    const path = window.location.pathname;
-    const parts = path.substring(1).split("/");
-    let didSet = false
-
-    if ((parts.length >= 1 && parts[0] == 'settings') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'mollie')) {
-      if (this.fullAccess) {
-        this.manageSettings(false)
-        didSet = true
-      }
+    get isSGV() {
+        return this.organization.meta.type == OrganizationType.Youth && this.organization.meta.umbrellaOrganization == UmbrellaOrganization.ScoutsEnGidsenVlaanderen
     }
 
-    if (parts.length >= 1 && parts[0] == 'transfers') {
-      if (this.canManagePayments) {
-        this.managePayments(false)
-        didSet = true
-      }
+    get tree() {
+        return this.organization.categoryTreeForPermissions(OrganizationManager.user.permissions ?? Permissions.create({}))
     }
 
-    if (parts.length >= 1 && parts[0] == 'account') {
-      this.manageAccount(false)
-      didSet = true
-    }
+    mounted() {
+        const path = window.location.pathname;
+        const parts = path.substring(1).split("/");
+        let didSet = false
 
-    if ((parts.length >= 1 && parts[0] == 'scouts-en-gidsen-vlaanderen') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'sgv')) {
-      if (this.fullAccess) {
-        this.openSyncScoutsEnGidsen(false)
-        didSet = true
-      }
-    }
-
-    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "category") {
-      for (const category of this.organization.meta.categories) {
-        if (parts[1] == Formatter.slug(category.settings.name)) {
-          if (parts[2] && parts[2] == "all") {
-            this.openCategoryMembers(category, false)
-          } else {
-            this.openCategory(category, false)
-          }
-          didSet = true
-          break;
-        }
-      }
-    }
-
-    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
-      for (const group of this.organization.groups) {
-        if (parts[1] == Formatter.slug(group.settings.name)) {
-          this.openGroup(group, false)
-          didSet = true
-          break;
-        }
-      }
-    }
-
-    if (!didSet && this.enableWebshopModule && parts.length >= 2 && parts[0] == "webshops") {
-      for (const webshop of this.organization.webshops) {
-        if (parts[1] == Formatter.slug(webshop.meta.name)) {
-          this.openWebshop(webshop, false)
-          didSet = true
-          break;
-        }
-      }
-    }
-
-    if (!didSet) {
-      HistoryManager.setUrl("/")
-    }
-
-    if (!didSet && !this.splitViewController?.shouldCollapse()) {
-      //if (this.groups.length > 0) {
-      //this.openGroup(this.groups[0], false)
-      //} else {
-      if (this.fullAccess) {
-        this.manageSettings(false)
-      } else {
-        this.manageAccount(false)
-      }
-      //}
-    }
-
-    document.title = "Stamhoofd - "+OrganizationManager.organization.name
-
-    this.checkKey().catch(e => {
-      console.error(e)
-    })
-
-    const currentCount = localStorage.getItem("what-is-new")
-    if (currentCount) {
-      const c = parseInt(currentCount)
-      if (!isNaN(c) && WhatsNewCount - c > 0) {
-        this.whatsNewBadge = (WhatsNewCount - c).toString()
-      }
-    } else {
-      localStorage.setItem("what-is-new", (WhatsNewCount as any).toString());
-    }
-
-    if (!didSet) {
-      if (!this.organization.meta.modules.useMembers && !this.organization.meta.modules.useWebshops) {
-        this.present(new ComponentWithProperties(SignupModulesView, { }).setDisplayStyle("popup").setAnimated(false))
-      }
-    }
-  }
-
-  async checkKey() {
-    // Check if public and private key matches
-    const user = SessionManager.currentSession!.user!
-    const privateKey = SessionManager.currentSession!.getUserPrivateKey()!
-    const publicKey = user.publicKey
-
-    if (!await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey)) {
-
-      // Gather all keychain items, and check which ones are still valid
-      // Oops! Error with public private key
-      await LoginHelper.fixPublicKey(SessionManager.currentSession!)
-      new Toast("We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.", "success green").setHide(15*1000).show()
-      MemberManager.callListeners("encryption", null)
-    }
-
-
-    if (SessionManager.currentSession!.user!.incomingInvites.length > 0) {
-      for (const invite of user.incomingInvites) {
-        try {
-          const decryptedKeychainItems = await Sodium.unsealMessage(invite.keychainItems!, publicKey, privateKey)
-          await LoginHelper.addToKeychain(SessionManager.currentSession!, decryptedKeychainItems)
-          new Toast(invite.sender.firstName+" heeft een encryptiesleutel met jou gedeeld", "key green").setHide(15*1000).show()
-        } catch (e) {
-          console.error(e)
-          new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
+        if ((parts.length >= 1 && parts[0] == 'settings') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'mollie')) {
+            if (this.fullAccess) {
+                this.manageSettings(false)
+                didSet = true
+            }
         }
 
-        // Remove invite if succeeded
-        await SessionManager.currentSession!.authenticatedServer.request({
-          method: "POST",
-          path: "/invite/"+encodeURIComponent(invite.key)+"/trade"
+        if (parts.length >= 1 && parts[0] == 'transfers') {
+            if (this.canManagePayments) {
+                this.managePayments(false)
+                didSet = true
+            }
+        }
+
+        if (parts.length >= 1 && parts[0] == 'account') {
+            this.manageAccount(false)
+            didSet = true
+        }
+
+        if ((parts.length >= 1 && parts[0] == 'scouts-en-gidsen-vlaanderen') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'sgv')) {
+            if (this.fullAccess) {
+                this.openSyncScoutsEnGidsen(false)
+                didSet = true
+            }
+        }
+
+        if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "category") {
+            for (const category of this.organization.meta.categories) {
+                if (parts[1] == Formatter.slug(category.settings.name)) {
+                    if (parts[2] && parts[2] == "all") {
+                        this.openCategoryMembers(category, false)
+                    } else {
+                        this.openCategory(category, false)
+                    }
+                    didSet = true
+                    break;
+                }
+            }
+        }
+
+        if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
+            for (const group of this.organization.groups) {
+                if (parts[1] == Formatter.slug(group.settings.name)) {
+                    this.openGroup(group, false)
+                    didSet = true
+                    break;
+                }
+            }
+        }
+
+        if (!didSet && this.enableWebshopModule && parts.length >= 2 && parts[0] == "webshops") {
+            for (const webshop of this.organization.webshops) {
+                if (parts[1] == Formatter.slug(webshop.meta.name)) {
+                    this.openWebshop(webshop, false)
+                    didSet = true
+                    break;
+                }
+            }
+        }
+
+        if (!didSet) {
+            HistoryManager.setUrl("/")
+        }
+        
+        if (!didSet && !this.splitViewController?.shouldCollapse()) {
+            //if (this.groups.length > 0) {
+                //this.openGroup(this.groups[0], false)
+            //} else {
+                if (this.fullAccess) {
+                    this.manageSettings(false)
+                } else {
+                    this.manageAccount(false)
+                }
+            //}
+        }
+
+        document.title = "Stamhoofd - "+OrganizationManager.organization.name
+
+        this.checkKey().catch(e => {
+            console.error(e)
         })
-      }
 
-      // Reload all views
-      MemberManager.callListeners("encryption", null)
+        const currentCount = localStorage.getItem("what-is-new")
+        if (currentCount) {
+            const c = parseInt(currentCount)
+            if (!isNaN(c) && WhatsNewCount - c > 0) {
+                this.whatsNewBadge = (WhatsNewCount - c).toString()
+            }
+        } else {
+            localStorage.setItem("what-is-new", (WhatsNewCount as any).toString());
+        }
+
+        if (!didSet) {
+            if (!this.organization.meta.modules.useMembers && !this.organization.meta.modules.useWebshops) {
+                this.present(new ComponentWithProperties(SignupModulesView, { }).setDisplayStyle("popup").setAnimated(false))
+            }
+        }
     }
 
-    try {
-      const keychainItem = Keychain.getItem(OrganizationManager.organization.publicKey)
-      if (!keychainItem) {
-        throw new Error("Missing organization keychain")
-      }
+    async checkKey() {
+        // Check if public and private key matches
+        const user = SessionManager.currentSession!.user!
+        const privateKey = SessionManager.currentSession!.getUserPrivateKey()!
+        const publicKey = user.publicKey
 
-      const session = SessionManager.currentSession!
-      await session.decryptKeychainItem(keychainItem)
+        if (!await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey)) {
 
-    } catch (e) {
-      console.error(e)
+            // Gather all keychain items, and check which ones are still valid
+            // Oops! Error with public private key
+            await LoginHelper.fixPublicKey(SessionManager.currentSession!)
+            new Toast("We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.", "success green").setHide(15*1000).show()
+            MemberManager.callListeners("encryption", null)
+        }
 
-      // Show warnign instead
-      new Toast("Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.", "key-lost yellow").setHide(15*1000).setButton(new ToastButton("Meer info", () => {
-        this.present(new ComponentWithProperties(NoKeyView, {}).setDisplayStyle("popup"))
-      })).show()
+
+        if (SessionManager.currentSession!.user!.incomingInvites.length > 0) {
+            for (const invite of user.incomingInvites) {
+                try {
+                    const decryptedKeychainItems = await Sodium.unsealMessage(invite.keychainItems!, publicKey, privateKey)
+                    await LoginHelper.addToKeychain(SessionManager.currentSession!, decryptedKeychainItems)
+                    new Toast(invite.sender.firstName+" heeft een encryptiesleutel met jou gedeeld", "key green").setHide(15*1000).show()
+                } catch (e) {
+                    console.error(e)
+                    new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
+                }
+                
+                // Remove invite if succeeded
+                await SessionManager.currentSession!.authenticatedServer.request({
+                    method: "POST",
+                    path: "/invite/"+encodeURIComponent(invite.key)+"/trade"
+                })
+            }
+
+            // Reload all views
+            MemberManager.callListeners("encryption", null)
+        }
+
+        try {
+            const keychainItem = Keychain.getItem(OrganizationManager.organization.publicKey)
+            if (!keychainItem) {
+                throw new Error("Missing organization keychain")
+            }
+
+            const session = SessionManager.currentSession!
+            await session.decryptKeychainItem(keychainItem)
+
+        } catch (e) {
+            console.error(e)
+
+            // Show warnign instead
+            new Toast("Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.", "key-lost yellow").setHide(15*1000).setButton(new ToastButton("Meer info", () => {
+                this.present(new ComponentWithProperties(NoKeyView, {}).setDisplayStyle("popup"))
+            })).show()
+        }
     }
-  }
 
-  get webshops() {
-    return this.organization.webshops
-  }
-
-  switchOrganization() {
-    SessionManager.deactivateSession()
-  }
-
-  openAll(animated = true) {
-    this.currentlySelected = "group-all"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
-  }
-
-  openGroup(group: Group, animated = true) {
-    this.currentlySelected = "group-"+group.id
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group }) }).setAnimated(animated));
-  }
-
-  manageKeys(animated = true) {
-    this.currentlySelected = "keys"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(KeysView) }).setAnimated(animated));
-  }
-
-  openCategory(category: GroupCategory, animated = true) {
-    this.currentlySelected = "category-"+category.id
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(CategoryView, { category }) }).setAnimated(animated));
-  }
-
-  openCategoryMembers(category: GroupCategory, animated = true) {
-    this.currentlySelected = "category-"+category.id
-
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
-        category: GroupCategoryTree.build(category, this.organization.meta.categories, this.organization.groups)
-      }) }).setAnimated(animated));
-  }
-
-  openWebshop(webshop: WebshopPreview, animated = true) {
-    this.currentlySelected = "webshop-"+webshop.id
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(WebshopView, { preview: webshop }) }).setAnimated(animated));
-  }
-
-  managePayments(animated = true) {
-    this.currentlySelected = "manage-payments"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(PaymentsView, {}) }).setAnimated(animated));
-  }
-
-  manageSettings(animated = true) {
-    this.currentlySelected = "manage-settings"
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SettingsView, {}) }).setAnimated(animated));
-  }
-
-  manageAccount(animated = true) {
-    this.currentlySelected = "manage-account"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(AccountSettingsView, {}) }).setAnimated(animated));
-  }
-
-  manageWhatsNew() {
-    this.whatsNewBadge = ""
-
-    window.open('https://www.stamhoofd.be/release-notes', '_blank');
-    localStorage.setItem("what-is-new", WhatsNewCount.toString());
-  }
-
-  async logout() {
-    if (!await CenteredMessage.confirm("Ben je zeker dat je wilt uitloggen?", "Uitloggen")) {
-      return;
+    get webshops() {
+        return this.organization.webshops
     }
-    SessionManager.logout()
-  }
 
-  openSyncScoutsEnGidsen(animated = true) {
-    this.currentlySelected = "manage-sgv-groepsadministratie"
-    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SGVGroepsadministratieView, {}) }).setAnimated(animated));
-  }
+    switchOrganization() {
+        SessionManager.deactivateSession()
+    }
 
-  importMembers() {
-    new CenteredMessage("Binnenkort beschikbaar!", "Binnenkort kan je leden importeren via Excel of manueel.", "sync").addCloseButton().show()
-  }
+    openAll(animated = true) {
+        this.currentlySelected = "group-all"
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
+    }
 
-  addWebshop() {
-    this.present(new ComponentWithProperties(EditWebshopView, { }).setDisplayStyle("popup"))
-  }
+    openGroup(group: Group, animated = true) {
+        this.currentlySelected = "group-"+group.id
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group }) }).setAnimated(animated));
+    }
 
-  get canCreateWebshops() {
-    return OrganizationManager.user.permissions?.canCreateWebshops(OrganizationManager.organization.privateMeta?.roles ?? [])
-  }
+    manageKeys(animated = true) {
+        this.currentlySelected = "keys"
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(KeysView) }).setAnimated(animated));
+    }
 
-  get canManagePayments() {
-    return OrganizationManager.user.permissions?.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? [])
-  }
+    openCategory(category: GroupCategory, animated = true) {
+        this.currentlySelected = "category-"+category.id
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(CategoryView, { category }) }).setAnimated(animated));
+    }
 
-  get fullAccess() {
-    return SessionManager.currentSession!.user!.permissions!.hasFullAccess()
-  }
+    openCategoryMembers(category: GroupCategory, animated = true) {
+        this.currentlySelected = "category-"+category.id
 
-  get fullReadAccess() {
-    return SessionManager.currentSession!.user!.permissions!.hasReadAccess()
-  }
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
+            category: GroupCategoryTree.build(category, this.organization.meta.categories, this.organization.groups)
+        }) }).setAnimated(animated));
+    }
 
-  get enableMemberModule() {
-    return this.organization.meta.modules.useMembers
-  }
+    openWebshop(webshop: WebshopPreview, animated = true) {
+        this.currentlySelected = "webshop-"+webshop.id
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(WebshopView, { preview: webshop }) }).setAnimated(animated));
+    }
 
-  get enableWebshopModule() {
-    return this.organization.meta.modules.useWebshops
-  }
+    managePayments(animated = true) {
+        this.currentlySelected = "manage-payments"
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(PaymentsView, {}) }).setAnimated(animated));
+    }
 
-  isCategoryDeactivated(category: GroupCategoryTree) {
-    return this.organization.isCategoryDeactivated(category)
-  }
+    manageSettings(animated = true) {
+        this.currentlySelected = "manage-settings"
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SettingsView, {}) }).setAnimated(animated));
+    }
+
+    manageAccount(animated = true) {
+        this.currentlySelected = "manage-account"
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(AccountSettingsView, {}) }).setAnimated(animated));
+    }
+
+    manageWhatsNew() {
+        this.whatsNewBadge = ""
+
+        window.open('https://www.stamhoofd.be/release-notes', '_blank');
+        localStorage.setItem("what-is-new", WhatsNewCount.toString());
+    }
+
+    async logout() {
+        if (!await CenteredMessage.confirm("Ben je zeker dat je wilt uitloggen?", "Uitloggen")) {
+            return;
+        }
+        SessionManager.logout()
+    }
+
+    openSyncScoutsEnGidsen(animated = true) {
+        this.currentlySelected = "manage-sgv-groepsadministratie"
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SGVGroepsadministratieView, {}) }).setAnimated(animated));
+    }
+
+    importMembers() {
+        new CenteredMessage("Binnenkort beschikbaar!", "Binnenkort kan je leden importeren via Excel of manueel.", "sync").addCloseButton().show()
+    }
+
+    addWebshop() {
+        this.present(new ComponentWithProperties(EditWebshopView, { }).setDisplayStyle("popup"))
+    }
+
+    get canCreateWebshops() {
+        return OrganizationManager.user.permissions?.canCreateWebshops(OrganizationManager.organization.privateMeta?.roles ?? [])
+    }
+
+    get canManagePayments() {
+        return OrganizationManager.user.permissions?.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? [])
+    }
+
+    get fullAccess() {
+        return SessionManager.currentSession!.user!.permissions!.hasFullAccess()
+    }
+
+    get fullReadAccess() {
+        return SessionManager.currentSession!.user!.permissions!.hasReadAccess()
+    }
+
+    get enableMemberModule() {
+        return this.organization.meta.modules.useMembers
+    }
+
+    get enableWebshopModule() {
+        return this.organization.meta.modules.useWebshops
+    }
+
+    isCategoryDeactivated(category: GroupCategoryTree) {
+        return this.organization.isCategoryDeactivated(category)
+    }
 }
 </script>

--- a/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
@@ -145,309 +145,309 @@ import EditWebshopView from './webshop/EditWebshopView.vue';
 import WebshopView from './webshop/WebshopView.vue';
 
 @Component({
-    components: {
-        Logo
-    },
-    directives: {
-        tooltip: TooltipDirective
-    }
+  components: {
+    Logo
+  },
+  directives: {
+    tooltip: TooltipDirective
+  }
 })
 export default class Menu extends Mixins(NavigationMixin) {
-    SessionManager = SessionManager // needed to make session reactive
-    currentlySelected: string | null = null
-    whatsNewBadge = ""
+  SessionManager = SessionManager // needed to make session reactive
+  currentlySelected: string | null = null
+  whatsNewBadge = ""
 
-    get organization() {
-        return OrganizationManager.organization
+  get organization() {
+    return OrganizationManager.organization
+  }
+
+  get registerUrl() {
+    if (this.organization.registerDomain) {
+      return "https://"+this.organization.registerDomain
     }
 
-    get registerUrl() {
-        if (this.organization.registerDomain) {
-            return "https://"+this.organization.registerDomain
-        }
+    return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
+  }
 
-        return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
+  get isSGV() {
+    return this.organization.meta.type == OrganizationType.Youth && this.organization.meta.umbrellaOrganization == UmbrellaOrganization.ScoutsEnGidsenVlaanderen
+  }
+
+  get tree() {
+    return this.organization.categoryTreeForPermissions(OrganizationManager.user.permissions ?? Permissions.create({}))
+  }
+
+  mounted() {
+    const path = window.location.pathname;
+    const parts = path.substring(1).split("/");
+    let didSet = false
+
+    if ((parts.length >= 1 && parts[0] == 'settings') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'mollie')) {
+      if (this.fullAccess) {
+        this.manageSettings(false)
+        didSet = true
+      }
     }
 
-    get isSGV() {
-        return this.organization.meta.type == OrganizationType.Youth && this.organization.meta.umbrellaOrganization == UmbrellaOrganization.ScoutsEnGidsenVlaanderen
+    if (parts.length >= 1 && parts[0] == 'transfers') {
+      if (this.canManagePayments) {
+        this.managePayments(false)
+        didSet = true
+      }
     }
 
-    get tree() {
-        return this.organization.categoryTreeForPermissions(OrganizationManager.user.permissions ?? Permissions.create({}))
+    if (parts.length >= 1 && parts[0] == 'account') {
+      this.manageAccount(false)
+      didSet = true
     }
 
-    mounted() {
-        const path = window.location.pathname;
-        const parts = path.substring(1).split("/");
-        let didSet = false
-
-        if ((parts.length >= 1 && parts[0] == 'settings') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'mollie')) {
-            if (this.fullAccess) {
-                this.manageSettings(false)
-                didSet = true
-            }
-        }
-
-        if (parts.length >= 1 && parts[0] == 'transfers') {
-            if (this.canManagePayments) {
-                this.managePayments(false)
-                didSet = true
-            }
-        }
-
-        if (parts.length >= 1 && parts[0] == 'account') {
-            this.manageAccount(false)
-            didSet = true
-        }
-
-        if ((parts.length >= 1 && parts[0] == 'scouts-en-gidsen-vlaanderen') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'sgv')) {
-            if (this.fullAccess) {
-                this.openSyncScoutsEnGidsen(false)
-                didSet = true
-            }
-        }
-
-        if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "category") {
-            for (const category of this.organization.meta.categories) {
-                if (parts[1] == Formatter.slug(category.settings.name)) {
-                    if (parts[2] && parts[2] == "all") {
-                        this.openCategoryMembers(category, false)
-                    } else {
-                        this.openCategory(category, false)
-                    }
-                    didSet = true
-                    break;
-                }
-            }
-        }
-
-        if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
-            for (const group of this.organization.groups) {
-                if (parts[1] == Formatter.slug(group.settings.name)) {
-                    this.openGroup(group, false)
-                    didSet = true
-                    break;
-                }
-            }
-        }
-
-        if (!didSet && this.enableWebshopModule && parts.length >= 2 && parts[0] == "webshops") {
-            for (const webshop of this.organization.webshops) {
-                if (parts[1] == Formatter.slug(webshop.meta.name)) {
-                    this.openWebshop(webshop, false)
-                    didSet = true
-                    break;
-                }
-            }
-        }
-
-        if (!didSet) {
-            HistoryManager.setUrl("/")
-        }
-
-        if (!didSet && !this.splitViewController?.shouldCollapse()) {
-            //if (this.groups.length > 0) {
-                //this.openGroup(this.groups[0], false)
-            //} else {
-                if (this.fullAccess) {
-                    this.manageSettings(false)
-                } else {
-                    this.manageAccount(false)
-                }
-            //}
-        }
-
-        document.title = "Stamhoofd - "+OrganizationManager.organization.name
-
-        this.checkKey().catch(e => {
-            console.error(e)
-        })
-
-        const currentCount = localStorage.getItem("what-is-new")
-        if (currentCount) {
-            const c = parseInt(currentCount)
-            if (!isNaN(c) && WhatsNewCount - c > 0) {
-                this.whatsNewBadge = (WhatsNewCount - c).toString()
-            }
-        } else {
-            localStorage.setItem("what-is-new", (WhatsNewCount as any).toString());
-        }
-
-        if (!didSet) {
-            if (!this.organization.meta.modules.useMembers && !this.organization.meta.modules.useWebshops) {
-                this.present(new ComponentWithProperties(SignupModulesView, { }).setDisplayStyle("popup").setAnimated(false))
-            }
-        }
+    if ((parts.length >= 1 && parts[0] == 'scouts-en-gidsen-vlaanderen') || (parts.length == 2 && parts[0] == 'oauth' && parts[1] == 'sgv')) {
+      if (this.fullAccess) {
+        this.openSyncScoutsEnGidsen(false)
+        didSet = true
+      }
     }
 
-    async checkKey() {
-        // Check if public and private key matches
-        const user = SessionManager.currentSession!.user!
-        const privateKey = SessionManager.currentSession!.getUserPrivateKey()!
-        const publicKey = user.publicKey
-
-        if (!await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey)) {
-
-            // Gather all keychain items, and check which ones are still valid
-            // Oops! Error with public private key
-            await LoginHelper.fixPublicKey(SessionManager.currentSession!)
-            new Toast("We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.", "success green").setHide(15*1000).show()
-            MemberManager.callListeners("encryption", null)
+    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "category") {
+      for (const category of this.organization.meta.categories) {
+        if (parts[1] == Formatter.slug(category.settings.name)) {
+          if (parts[2] && parts[2] == "all") {
+            this.openCategoryMembers(category, false)
+          } else {
+            this.openCategory(category, false)
+          }
+          didSet = true
+          break;
         }
+      }
+    }
 
-
-        if (SessionManager.currentSession!.user!.incomingInvites.length > 0) {
-            for (const invite of user.incomingInvites) {
-                try {
-                    const decryptedKeychainItems = await Sodium.unsealMessage(invite.keychainItems!, publicKey, privateKey)
-                    await LoginHelper.addToKeychain(SessionManager.currentSession!, decryptedKeychainItems)
-                    new Toast(invite.sender.firstName+" heeft een encryptiesleutel met jou gedeeld", "key green").setHide(15*1000).show()
-                } catch (e) {
-                    console.error(e)
-                    new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
-                }
-
-                // Remove invite if succeeded
-                await SessionManager.currentSession!.authenticatedServer.request({
-                    method: "POST",
-                    path: "/invite/"+encodeURIComponent(invite.key)+"/trade"
-                })
-            }
-
-            // Reload all views
-            MemberManager.callListeners("encryption", null)
+    if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
+      for (const group of this.organization.groups) {
+        if (parts[1] == Formatter.slug(group.settings.name)) {
+          this.openGroup(group, false)
+          didSet = true
+          break;
         }
+      }
+    }
 
+    if (!didSet && this.enableWebshopModule && parts.length >= 2 && parts[0] == "webshops") {
+      for (const webshop of this.organization.webshops) {
+        if (parts[1] == Formatter.slug(webshop.meta.name)) {
+          this.openWebshop(webshop, false)
+          didSet = true
+          break;
+        }
+      }
+    }
+
+    if (!didSet) {
+      HistoryManager.setUrl("/")
+    }
+
+    if (!didSet && !this.splitViewController?.shouldCollapse()) {
+      //if (this.groups.length > 0) {
+      //this.openGroup(this.groups[0], false)
+      //} else {
+      if (this.fullAccess) {
+        this.manageSettings(false)
+      } else {
+        this.manageAccount(false)
+      }
+      //}
+    }
+
+    document.title = "Stamhoofd - "+OrganizationManager.organization.name
+
+    this.checkKey().catch(e => {
+      console.error(e)
+    })
+
+    const currentCount = localStorage.getItem("what-is-new")
+    if (currentCount) {
+      const c = parseInt(currentCount)
+      if (!isNaN(c) && WhatsNewCount - c > 0) {
+        this.whatsNewBadge = (WhatsNewCount - c).toString()
+      }
+    } else {
+      localStorage.setItem("what-is-new", (WhatsNewCount as any).toString());
+    }
+
+    if (!didSet) {
+      if (!this.organization.meta.modules.useMembers && !this.organization.meta.modules.useWebshops) {
+        this.present(new ComponentWithProperties(SignupModulesView, { }).setDisplayStyle("popup").setAnimated(false))
+      }
+    }
+  }
+
+  async checkKey() {
+    // Check if public and private key matches
+    const user = SessionManager.currentSession!.user!
+    const privateKey = SessionManager.currentSession!.getUserPrivateKey()!
+    const publicKey = user.publicKey
+
+    if (!await Sodium.isMatchingEncryptionPublicPrivate(publicKey, privateKey)) {
+
+      // Gather all keychain items, and check which ones are still valid
+      // Oops! Error with public private key
+      await LoginHelper.fixPublicKey(SessionManager.currentSession!)
+      new Toast("We hebben jouw persoonlijke encryptiesleutel gecorrigeerd. Er was iets fout gegaan toen je je wachtwoord had gewijzigd.", "success green").setHide(15*1000).show()
+      MemberManager.callListeners("encryption", null)
+    }
+
+
+    if (SessionManager.currentSession!.user!.incomingInvites.length > 0) {
+      for (const invite of user.incomingInvites) {
         try {
-            const keychainItem = Keychain.getItem(OrganizationManager.organization.publicKey)
-            if (!keychainItem) {
-                throw new Error("Missing organization keychain")
-            }
-
-            const session = SessionManager.currentSession!
-            await session.decryptKeychainItem(keychainItem)
-
+          const decryptedKeychainItems = await Sodium.unsealMessage(invite.keychainItems!, publicKey, privateKey)
+          await LoginHelper.addToKeychain(SessionManager.currentSession!, decryptedKeychainItems)
+          new Toast(invite.sender.firstName+" heeft een encryptiesleutel met jou gedeeld", "key green").setHide(15*1000).show()
         } catch (e) {
-            console.error(e)
-
-            // Show warnign instead
-            new Toast("Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.", "key-lost yellow").setHide(15*1000).setButton(new ToastButton("Meer info", () => {
-                this.present(new ComponentWithProperties(NoKeyView, {}).setDisplayStyle("popup"))
-            })).show()
+          console.error(e)
+          new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
         }
+
+        // Remove invite if succeeded
+        await SessionManager.currentSession!.authenticatedServer.request({
+          method: "POST",
+          path: "/invite/"+encodeURIComponent(invite.key)+"/trade"
+        })
+      }
+
+      // Reload all views
+      MemberManager.callListeners("encryption", null)
     }
 
-    get webshops() {
-        return this.organization.webshops
+    try {
+      const keychainItem = Keychain.getItem(OrganizationManager.organization.publicKey)
+      if (!keychainItem) {
+        throw new Error("Missing organization keychain")
+      }
+
+      const session = SessionManager.currentSession!
+      await session.decryptKeychainItem(keychainItem)
+
+    } catch (e) {
+      console.error(e)
+
+      // Show warnign instead
+      new Toast("Je hebt geen toegang tot de huidige encryptiesleutel van deze vereniging. Vraag een hoofdbeheerder om jou terug toegang te geven.", "key-lost yellow").setHide(15*1000).setButton(new ToastButton("Meer info", () => {
+        this.present(new ComponentWithProperties(NoKeyView, {}).setDisplayStyle("popup"))
+      })).show()
     }
+  }
 
-    switchOrganization() {
-        SessionManager.deactivateSession()
+  get webshops() {
+    return this.organization.webshops
+  }
+
+  switchOrganization() {
+    SessionManager.deactivateSession()
+  }
+
+  openAll(animated = true) {
+    this.currentlySelected = "group-all"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
+  }
+
+  openGroup(group: Group, animated = true) {
+    this.currentlySelected = "group-"+group.id
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group }) }).setAnimated(animated));
+  }
+
+  manageKeys(animated = true) {
+    this.currentlySelected = "keys"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(KeysView) }).setAnimated(animated));
+  }
+
+  openCategory(category: GroupCategory, animated = true) {
+    this.currentlySelected = "category-"+category.id
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(CategoryView, { category }) }).setAnimated(animated));
+  }
+
+  openCategoryMembers(category: GroupCategory, animated = true) {
+    this.currentlySelected = "category-"+category.id
+
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
+        category: GroupCategoryTree.build(category, this.organization.meta.categories, this.organization.groups)
+      }) }).setAnimated(animated));
+  }
+
+  openWebshop(webshop: WebshopPreview, animated = true) {
+    this.currentlySelected = "webshop-"+webshop.id
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(WebshopView, { preview: webshop }) }).setAnimated(animated));
+  }
+
+  managePayments(animated = true) {
+    this.currentlySelected = "manage-payments"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(PaymentsView, {}) }).setAnimated(animated));
+  }
+
+  manageSettings(animated = true) {
+    this.currentlySelected = "manage-settings"
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SettingsView, {}) }).setAnimated(animated));
+  }
+
+  manageAccount(animated = true) {
+    this.currentlySelected = "manage-account"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(AccountSettingsView, {}) }).setAnimated(animated));
+  }
+
+  manageWhatsNew() {
+    this.whatsNewBadge = ""
+
+    window.open('https://www.stamhoofd.be/release-notes', '_blank');
+    localStorage.setItem("what-is-new", WhatsNewCount.toString());
+  }
+
+  async logout() {
+    if (!await CenteredMessage.confirm("Ben je zeker dat je wilt uitloggen?", "Uitloggen")) {
+      return;
     }
+    SessionManager.logout()
+  }
 
-    openAll(animated = true) {
-        this.currentlySelected = "group-all"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
-    }
+  openSyncScoutsEnGidsen(animated = true) {
+    this.currentlySelected = "manage-sgv-groepsadministratie"
+    this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SGVGroepsadministratieView, {}) }).setAnimated(animated));
+  }
 
-    openGroup(group: Group, animated = true) {
-        this.currentlySelected = "group-"+group.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group }) }).setAnimated(animated));
-    }
+  importMembers() {
+    new CenteredMessage("Binnenkort beschikbaar!", "Binnenkort kan je leden importeren via Excel of manueel.", "sync").addCloseButton().show()
+  }
 
-    manageKeys(animated = true) {
-        this.currentlySelected = "keys"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(KeysView) }).setAnimated(animated));
-    }
+  addWebshop() {
+    this.present(new ComponentWithProperties(EditWebshopView, { }).setDisplayStyle("popup"))
+  }
 
-    openCategory(category: GroupCategory, animated = true) {
-        this.currentlySelected = "category-"+category.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(CategoryView, { category }) }).setAnimated(animated));
-    }
+  get canCreateWebshops() {
+    return OrganizationManager.user.permissions?.canCreateWebshops(OrganizationManager.organization.privateMeta?.roles ?? [])
+  }
 
-    openCategoryMembers(category: GroupCategory, animated = true) {
-        this.currentlySelected = "category-"+category.id
+  get canManagePayments() {
+    return OrganizationManager.user.permissions?.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? [])
+  }
 
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {
-            category: GroupCategoryTree.build(category, this.organization.meta.categories, this.organization.groups)
-        }) }).setAnimated(animated));
-    }
+  get fullAccess() {
+    return SessionManager.currentSession!.user!.permissions!.hasFullAccess()
+  }
 
-    openWebshop(webshop: WebshopPreview, animated = true) {
-        this.currentlySelected = "webshop-"+webshop.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(WebshopView, { preview: webshop }) }).setAnimated(animated));
-    }
+  get fullReadAccess() {
+    return SessionManager.currentSession!.user!.permissions!.hasReadAccess()
+  }
 
-    managePayments(animated = true) {
-        this.currentlySelected = "manage-payments"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(PaymentsView, {}) }).setAnimated(animated));
-    }
+  get enableMemberModule() {
+    return this.organization.meta.modules.useMembers
+  }
 
-    manageSettings(animated = true) {
-        this.currentlySelected = "manage-settings"
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SettingsView, {}) }).setAnimated(animated));
-    }
+  get enableWebshopModule() {
+    return this.organization.meta.modules.useWebshops
+  }
 
-    manageAccount(animated = true) {
-        this.currentlySelected = "manage-account"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(AccountSettingsView, {}) }).setAnimated(animated));
-    }
-
-    manageWhatsNew() {
-        this.whatsNewBadge = ""
-
-        window.open('https://www.stamhoofd.be/release-notes', '_blank');
-        localStorage.setItem("what-is-new", WhatsNewCount.toString());
-    }
-
-    async logout() {
-        if (!await CenteredMessage.confirm("Ben je zeker dat je wilt uitloggen?", "Uitloggen")) {
-            return;
-        }
-        SessionManager.logout()
-    }
-
-    openSyncScoutsEnGidsen(animated = true) {
-        this.currentlySelected = "manage-sgv-groepsadministratie"
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(SGVGroepsadministratieView, {}) }).setAnimated(animated));
-    }
-
-    importMembers() {
-        new CenteredMessage("Binnenkort beschikbaar!", "Binnenkort kan je leden importeren via Excel of manueel.", "sync").addCloseButton().show()
-    }
-
-    addWebshop() {
-        this.present(new ComponentWithProperties(EditWebshopView, { }).setDisplayStyle("popup"))
-    }
-
-    get canCreateWebshops() {
-        return OrganizationManager.user.permissions?.canCreateWebshops(OrganizationManager.organization.privateMeta?.roles ?? [])
-    }
-
-    get canManagePayments() {
-        return OrganizationManager.user.permissions?.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? [])
-    }
-
-    get fullAccess() {
-        return SessionManager.currentSession!.user!.permissions!.hasFullAccess()
-    }
-
-    get fullReadAccess() {
-        return SessionManager.currentSession!.user!.permissions!.hasReadAccess()
-    }
-
-    get enableMemberModule() {
-        return this.organization.meta.modules.useMembers
-    }
-
-    get enableWebshopModule() {
-        return this.organization.meta.modules.useWebshops
-    }
-
-    isCategoryDeactivated(category: GroupCategoryTree) {
-        return this.organization.isCategoryDeactivated(category)
-    }
+  isCategoryDeactivated(category: GroupCategoryTree) {
+    return this.organization.isCategoryDeactivated(category)
+  }
 }
 </script>

--- a/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
@@ -45,7 +45,7 @@
                         :key="group.id"
                         class="menu-button button"
                         :class="{ selected: currentlySelected == 'group-'+group.id }"
-                        @click="openGroup(group)"
+                        @click="openGroup(category,group)"
                     >
                         <span>{{ group.settings.name }}</span>
                     </button>
@@ -125,7 +125,16 @@ import { NavigationController } from "@simonbackx/vue-app-navigation";
 import { CenteredMessage, Logo, Toast, ToastButton, TooltipDirective } from '@stamhoofd/components';
 import { Sodium } from "@stamhoofd/crypto";
 import { Keychain, LoginHelper,SessionManager } from '@stamhoofd/networking';
-import { Group, GroupCategory, GroupCategoryTree, OrganizationType, Permissions, UmbrellaOrganization, WebshopPreview } from '@stamhoofd/structures';
+import {
+  Category,
+  Group,
+  GroupCategory,
+  GroupCategoryTree,
+  OrganizationType,
+  Permissions,
+  UmbrellaOrganization,
+  WebshopPreview
+} from '@stamhoofd/structures';
 import { Formatter } from "@stamhoofd/utility";
 import { Component, Mixins } from "vue-property-decorator";
 
@@ -225,7 +234,7 @@ export default class Menu extends Mixins(NavigationMixin) {
         if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
             for (const group of this.organization.groups) {
                 if (parts[1] == Formatter.slug(group.settings.name)) {
-                    this.openGroup(group, false)
+                    this.openGroup(this.organization.categoryTree,group, false)
                     didSet = true
                     break;
                 }
@@ -351,9 +360,9 @@ export default class Menu extends Mixins(NavigationMixin) {
         this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
     }
 
-    openGroup(group: Group, animated = true) {
+    openGroup(category: GroupCategoryTree, group: Group, animated = true) {
         this.currentlySelected = "group-"+group.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group }) }).setAnimated(animated));
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group, category }) }).setAnimated(animated));
     }
 
     manageKeys(animated = true) {

--- a/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/DashboardMenu.vue
@@ -45,7 +45,7 @@
                         :key="group.id"
                         class="menu-button button"
                         :class="{ selected: currentlySelected == 'group-'+group.id }"
-                        @click="openGroup(category,group)"
+                        @click="openGroup(group)"
                     >
                         <span>{{ group.settings.name }}</span>
                     </button>
@@ -63,7 +63,7 @@
                 <hr>
             </div>
         </template>
-    
+
 
         <div v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
             <button class="menu-button heading">
@@ -87,7 +87,7 @@
         </div>
         <hr v-if="enableWebshopModule && (canCreateWebshops || webshops.length > 0)">
 
-        <button v-if="canManagePayments" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-payments'}" @click="managePayments(true)"> 
+        <button v-if="canManagePayments" class="menu-button button heading" :class="{ selected: currentlySelected == 'manage-payments'}" @click="managePayments(true)">
             <span class="icon card" />
             <span>Overschrijvingen</span>
         </button>
@@ -160,11 +160,11 @@ export default class Menu extends Mixins(NavigationMixin) {
     get organization() {
         return OrganizationManager.organization
     }
-    
+
     get registerUrl() {
         if (this.organization.registerDomain) {
             return "https://"+this.organization.registerDomain
-        } 
+        }
 
         return "https://"+this.organization.uri+'.'+process.env.HOSTNAME_REGISTRATION
     }
@@ -225,7 +225,7 @@ export default class Menu extends Mixins(NavigationMixin) {
         if (!didSet && this.enableMemberModule && parts.length >= 2 && parts[0] == "groups") {
             for (const group of this.organization.groups) {
                 if (parts[1] == Formatter.slug(group.settings.name)) {
-                    this.openGroup(this.organization.categoryTree,group, false)
+                    this.openGroup(group, false)
                     didSet = true
                     break;
                 }
@@ -245,7 +245,7 @@ export default class Menu extends Mixins(NavigationMixin) {
         if (!didSet) {
             HistoryManager.setUrl("/")
         }
-        
+
         if (!didSet && !this.splitViewController?.shouldCollapse()) {
             //if (this.groups.length > 0) {
                 //this.openGroup(this.groups[0], false)
@@ -307,7 +307,7 @@ export default class Menu extends Mixins(NavigationMixin) {
                     console.error(e)
                     new Toast(invite.sender.firstName+" wou een encryptiesleutel met jou delen, maar deze uitnodiging is ongeldig geworden. Vraag om de uitnodiging opnieuw te versturen.", "error red").setHide(15*1000).show()
                 }
-                
+
                 // Remove invite if succeeded
                 await SessionManager.currentSession!.authenticatedServer.request({
                     method: "POST",
@@ -351,9 +351,9 @@ export default class Menu extends Mixins(NavigationMixin) {
         this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, {}) }).setAnimated(animated));
     }
 
-    openGroup(category: GroupCategoryTree, group: Group, animated = true) {
+    openGroup(group: Group, animated = true) {
         this.currentlySelected = "group-"+group.id
-        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group, category }) }).setAnimated(animated));
+        this.showDetail(new ComponentWithProperties(NavigationController, { root: new ComponentWithProperties(GroupMembersView, { group }) }).setAnimated(animated));
     }
 
     manageKeys(animated = true) {

--- a/frontend/app/dashboard/src/views/dashboard/groups/CategoryView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/CategoryView.vue
@@ -160,7 +160,8 @@ export default class CategoryView extends Mixins(NavigationMixin) {
 
     openGroup(group: Group) {
         this.show(new ComponentWithProperties(GroupMembersView, {
-            group
+            group,
+            category: this.category
         }))
     }
 

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupContextMenu.vue
@@ -1,0 +1,162 @@
+<template>
+    <ContextMenu v-bind="{ x, y }">
+
+        <ContextMenuItem v-if="hasWrite" @click="editGroup">
+            Gegevens wijzigen
+            <span slot="right" class="icon edit" />
+        </ContextMenuItem>
+      
+        <ContextMenuItem v-if="hasWrite" @click="duplicateGroup">
+            Dupliceren
+            <span slot="right" class="icon copy" />
+        </ContextMenuItem>
+
+        <ContextMenuLine v-if="canDelete" />
+      
+        <ContextMenuItem v-if="canDelete" @click="deleteGroup">
+            <span slot="right" class="icon trash" />
+            Verwijderen
+        </ContextMenuItem>
+
+    </ContextMenu>
+</template>
+
+<script lang="ts">
+import {AutoEncoderPatchType} from "@simonbackx/simple-encoding";
+import {ComponentWithProperties, NavigationMixin} from "@simonbackx/vue-app-navigation";
+import {ContextMenu, ContextMenuItem, ContextMenuLine, Toast} from "@stamhoofd/components";
+import {Logger} from "@stamhoofd/logger";
+import {
+  getPermissionLevelNumber,
+  Group,
+  GroupCategory,
+  GroupPrivateSettings,
+  Organization,
+  OrganizationMetaData,
+  ParentTypeHelper,
+  PermissionLevel
+} from '@stamhoofd/structures';
+import {Component, Mixins, Prop} from "vue-property-decorator";
+
+import {OrganizationManager} from "../../../classes/OrganizationManager";
+import EditGroupView from "./EditGroupView.vue";
+
+@Component({
+  components: {
+    ContextMenu,
+    ContextMenuItem,
+    ContextMenuLine,
+  },
+})
+export default class GroupContextMenu extends Mixins(NavigationMixin) {
+  @Prop({default: 0})
+  x!: number;
+
+  @Prop({default: 0})
+  y!: number;
+
+  @Prop({default: null})
+  group: Group | null;
+
+  created() {
+    (this as any).ParentTypeHelper = ParentTypeHelper;
+  }
+
+  get canDelete(): boolean {
+    if (!OrganizationManager.user.permissions) {
+      return false
+    }
+
+    if (!this.group?.privateSettings || getPermissionLevelNumber(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Write)) {
+      return false
+    }
+
+    return true
+  }
+
+  get hasWrite(): boolean {
+    if (!OrganizationManager.user.permissions) {
+      return false
+    }
+
+    if (this.group?.privateSettings && getPermissionLevelNumber(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
+      return true
+    }
+
+    return false
+  }
+
+  deleteGroup() {
+    if (confirm("Ben je zeker dat je deze groep wilt verwijderen? All leden worden automatisch ook uitgeschreven. Je kan dit niet ongedaan maken!")) {
+      if (confirm("Heel zeker?")) {
+        const patch = OrganizationManager.getPatch()
+        patch.groups.addDelete(this.group.id)
+        OrganizationManager.patch(patch)
+            .then(() => {
+              new Toast("De groep is verwijderd", "green success").show()
+            })
+            .catch(e => {
+              Logger.error(e)
+              new Toast("Er ging iets mis: " + (e.human ?? e.message), "error").show()
+            })
+      }
+    }
+  }
+
+  editGroup() {
+    this.present(new ComponentWithProperties(EditGroupView, {
+      group: this.group,
+      organization: OrganizationManager.organization,
+      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+        patch.id = OrganizationManager.organization.id
+        await OrganizationManager.patch(patch)
+        const g = OrganizationManager.organization.groups.find(g => g.id === this.group!.id)
+        if (!g) {
+          this.pop({force: true})
+        } else {
+          this.group!.set(g)
+        }
+      }
+    }).setDisplayStyle("popup"))
+  }
+
+  duplicateGroup() {
+    const newGroup = Group.create({
+      settings: this.group?.settings,
+      privateSettings: GroupPrivateSettings.create({})
+    })
+    const meta = OrganizationMetaData.patch({})
+
+    const me = GroupCategory.patch({id: this.groupCategory.id})
+    me.groupIds.addPut(newGroup.id)
+    meta.categories.addPatch(me)
+
+    const p = Organization.patch({
+      id: this.organization.id,
+      meta
+    })
+
+    p.groups.addPut(newGroup)
+
+    this.present(new ComponentWithProperties(EditGroupView, {
+      group: newGroup,
+      organization: this.organization.patch(p),
+      saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
+        await OrganizationManager.patch(p.patch(patch))
+      }
+    }).setDisplayStyle("popup"))
+  }
+
+  get groupCategory() {
+    return OrganizationManager.organization.categoryTree.categories
+        .find(category => category.groups
+            .find(group => group.id === group.id))
+  }
+
+  get organization() {
+    return OrganizationManager.organization
+  }
+
+
+}
+</script>

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
@@ -215,20 +215,7 @@ import { STNavigationBar } from "@stamhoofd/components";
 import { BackButton, LoadingButton,Spinner, STNavigationTitle } from "@stamhoofd/components";
 import { Checkbox } from "@stamhoofd/components"
 import { STToolbar } from "@stamhoofd/components";
-import {
-  EncryptedMemberWithRegistrationsPatch,
-  getPermissionLevelNumber,
-  Group,
-  GroupCategory,
-  GroupCategoryTree, GroupPrivateSettings,
-  GroupSettings,
-  Member,
-  MemberWithRegistrations,
-  Organization, OrganizationMetaData,
-  PermissionLevel,
-  Registration,
-  WaitingListType
-} from '@stamhoofd/structures';
+import { EncryptedMemberWithRegistrationsPatch, getPermissionLevelNumber, Group, GroupCategory, GroupCategoryTree, GroupPrivateSettings, GroupSettings, Member, MemberWithRegistrations, Organization, OrganizationMetaData, PermissionLevel, Registration } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { Component, Mixins,Prop } from "vue-property-decorator";
 
@@ -555,8 +542,6 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
       })
       newGroup.settings.name = newGroup.settings.name + " Kopie"
       const meta = OrganizationMetaData.patch({})
-
-      console.log(this.category);
 
       const me = GroupCategory.patch({id: this.category?.id})
       me.groupIds.addPut(newGroup.id)

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
@@ -13,10 +13,6 @@
                     </button>
 
                     <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
-
-                    <button class="button text" @click="duplicateGroup">
-                        <span class="icon copy" />
-                    </button>
                     
                     <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
                         <span class="icon add" />
@@ -47,10 +43,6 @@
                 </button>
 
                 <button v-if="group && hasFull" class="button icon settings gray" @click="modifyGroup" />
-
-                <button class="button text" @click="duplicateGroup">
-                    <span class="icon copy" />
-                </button>
 
                 <button v-if="cycleOffset === 0 && !waitingList && canCreate" class="button text" @click="addMember">
                     <span class="icon add" />
@@ -529,42 +521,6 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
 
             })
         }).setDisplayStyle("popup"))
-    }
-
-    duplicateGroup() {
-      if (!this.group && !this.category && this.group) {
-        return;
-      }
-
-      const newGroup = Group.create({
-        settings: GroupSettings.create({...this.group?.settings}),
-        privateSettings: GroupPrivateSettings.create({})
-      })
-      newGroup.settings.name = newGroup.settings.name + " Kopie"
-      const meta = OrganizationMetaData.patch({})
-
-      const me = GroupCategory.patch({id: this.category?.id})
-      me.groupIds.addPut(newGroup.id)
-      meta.categories.addPatch(me)
-
-      const p = Organization.patch({
-        id: OrganizationManager.organization.id,
-        meta
-      })
-
-      p.groups.addPut(newGroup)
-
-      this.present(new ComponentWithProperties(EditGroupView, {
-        group: newGroup,
-        organization: OrganizationManager.organization.patch(p),
-        saveHandler: async (patch: AutoEncoderPatchType<Organization>) => {
-          await OrganizationManager.patch(p.patch(patch))
-          console.log("saved")
-          this.show(new ComponentWithProperties(GroupMembersView, {
-            group: newGroup
-          }))
-        }
-      }).setDisplayStyle("popup"))
     }
 
     modifyGroup() {


### PR DESCRIPTION
When setting up a new category (a weekend or camp). Most of the settings are the same for all groups. But you have to manually create all of these groups which wastes time and increases mistakes.

So I had the idea to add a duplicate button on GroupMembersView. It automatically creates a new group with all of the same settings.