### PR TITLE
[Feature] extra order status -> collect

### DIFF
--- a/frontend/app/dashboard/src/classes/order-filters/StatusFilter.ts
+++ b/frontend/app/dashboard/src/classes/order-filters/StatusFilter.ts
@@ -15,6 +15,7 @@ export class StatusFilter implements Filter {
         switch (this.status) {
             case OrderStatus.Created: return this.invert ? "Niet nieuw" : "Nieuw";
             case OrderStatus.Prepared: return this.invert ? "Niet verwerkt" :"Verwerkt";
+            case OrderStatus.Pickup: return this.invert ? "Niet ophalen" :"Ophalen";
             case OrderStatus.Completed: return this.invert ? "Niet voltooid" :"Voltooid";
             case OrderStatus.Canceled: return this.invert ? "Niet geannuleerd" : "Geannuleerd";
         }
@@ -30,6 +31,7 @@ export class StatusFilter implements Filter {
 
         base.push(new StatusFilter(OrderStatus.Created, true))
         base.push(new StatusFilter(OrderStatus.Prepared, true))
+        base.push(new StatusFilter(OrderStatus.Pickup, true))
         base.push(new StatusFilter(OrderStatus.Completed, true))
         base.push(new StatusFilter(OrderStatus.Canceled, true))
 

--- a/frontend/app/dashboard/src/classes/order-filters/StatusFilter.ts
+++ b/frontend/app/dashboard/src/classes/order-filters/StatusFilter.ts
@@ -15,7 +15,7 @@ export class StatusFilter implements Filter {
         switch (this.status) {
             case OrderStatus.Created: return this.invert ? "Niet nieuw" : "Nieuw";
             case OrderStatus.Prepared: return this.invert ? "Niet verwerkt" :"Verwerkt";
-            case OrderStatus.Pickup: return this.invert ? "Niet ophalen" :"Ophalen";
+            case OrderStatus.Collect: return this.invert ? "Ligt niet klaar" :"Ligt klaar";
             case OrderStatus.Completed: return this.invert ? "Niet voltooid" :"Voltooid";
             case OrderStatus.Canceled: return this.invert ? "Niet geannuleerd" : "Geannuleerd";
         }
@@ -31,7 +31,7 @@ export class StatusFilter implements Filter {
 
         base.push(new StatusFilter(OrderStatus.Created, true))
         base.push(new StatusFilter(OrderStatus.Prepared, true))
-        base.push(new StatusFilter(OrderStatus.Pickup, true))
+        base.push(new StatusFilter(OrderStatus.Collect, true))
         base.push(new StatusFilter(OrderStatus.Completed, true))
         base.push(new StatusFilter(OrderStatus.Canceled, true))
 

--- a/frontend/app/dashboard/src/views/dashboard/member/MemberViewDetails.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/MemberViewDetails.vue
@@ -276,7 +276,7 @@
                 <h2>
                     <span class="icon-spacer">Kunnen registereren</span><span
                         v-tooltip="
-                            'Nieuwe accounts met één van deze e-mailadressen krijgen automatisch toegang tot dit lid (registreren kan op inschrijvingspagina). Deze worden automatisch bepaald aan de hand van de gegevens van het lid.'
+                            'Nieuwe accounts met één van deze e-mailadressen krijgen automatisch toegang tot dit lid (registreren kan op de inschrijvingspagina). Deze worden automatisch bepaald aan de hand van de gegevens van het lid.'
                         "
                         class="icon gray help"
                     />

--- a/frontend/app/dashboard/src/views/dashboard/webshop/OrderStatusContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/OrderStatusContextMenu.vue
@@ -6,6 +6,9 @@
         <ContextMenuItem @click="markAs(OrderStatus.Prepared)">
             Verwerkt
         </ContextMenuItem>
+        <ContextMenuItem @click="markAs(OrderStatus.Pickup)">
+            Ophalen
+        </ContextMenuItem>
         <ContextMenuItem @click="markAs(OrderStatus.Completed)">
             Voltooid
         </ContextMenuItem>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/OrderStatusContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/OrderStatusContextMenu.vue
@@ -6,8 +6,8 @@
         <ContextMenuItem @click="markAs(OrderStatus.Prepared)">
             Verwerkt
         </ContextMenuItem>
-        <ContextMenuItem @click="markAs(OrderStatus.Pickup)">
-            Ophalen
+        <ContextMenuItem @click="markAs(OrderStatus.Collect)">
+            Ligt klaar
         </ContextMenuItem>
         <ContextMenuItem @click="markAs(OrderStatus.Completed)">
             Voltooid

--- a/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
@@ -115,6 +115,7 @@
                         <td>
                             <span v-if="order.order.payment && order.order.payment.status !== 'Succeeded'" class="style-tag warn">Niet betaald</span>
                             <span v-if="order.order.status == 'Prepared'" class="style-tag">Verwerkt</span>
+                            <span v-if="order.order.status == 'Pickup'" v-tooltip="'Ophalen'" class="success icon green" />
                             <span v-if="order.order.status == 'Completed'" v-tooltip="'Voltooid'" class="success icon green" />
                             <span v-if="order.order.status == 'Canceled'" v-tooltip="'Geannuleerd'" class="error icon canceled" />
                         </td>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
@@ -115,7 +115,7 @@
                         <td>
                             <span v-if="order.order.payment && order.order.payment.status !== 'Succeeded'" class="style-tag warn">Niet betaald</span>
                             <span v-if="order.order.status == 'Prepared'" class="style-tag">Verwerkt</span>
-                            <span v-if="order.order.status == 'Pickup'" v-tooltip="'Ophalen'" class="success icon green" />
+                            <span v-if="order.order.status == 'Collect'" class="style-tag">Ligt klaar</span>
                             <span v-if="order.order.status == 'Completed'" v-tooltip="'Voltooid'" class="success icon green" />
                             <span v-if="order.order.status == 'Canceled'" v-tooltip="'Geannuleerd'" class="error icon canceled" />
                         </td>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/locations/EditTimeSlotView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/locations/EditTimeSlotView.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="st-view product-price-edit-view">
-        <STNavigationBar :title="isNew ? 'Tijdsvak toevoegen' : 'Tijdsvak bewerken'">
+        <STNavigationBar :title="isNew ? 'Tijdvak toevoegen' : 'Tijdvak bewerken'">
             <template slot="right">
                 <button class="button text" v-if="!isNew" @click="deleteMe">
                     <span class="icon trash"/>
@@ -12,10 +12,10 @@
 
         <main>
             <h1 v-if="isNew">
-                Tijdsvak toevoegen
+                Tijdvak toevoegen
             </h1>
             <h1 v-else>
-                Tijdsvak bewerken
+                Tijdvak bewerken
             </h1>
           
             <STErrorsDefault :error-box="errorBox" />
@@ -122,7 +122,7 @@ export default class EditTimeSlotView extends Mixins(NavigationMixin) {
     }
 
     async deleteMe() {
-        if (!await CenteredMessage.confirm("Ben je zeker dat je dit tijdsvak wilt verwijderen?", "Verwijderen")) {
+        if (!await CenteredMessage.confirm("Ben je zeker dat je dit tijdvak wilt verwijderen?", "Verwijderen")) {
             return
         }
        const p = WebshopTimeSlots.patch({})

--- a/frontend/app/webshop/src/views/orders/OrderView.vue
+++ b/frontend/app/webshop/src/views/orders/OrderView.vue
@@ -69,7 +69,7 @@
 
                         <template slot="right">
                             <span v-if="order.status == 'Prepared'" class="style-tag">Verwerkt</span>
-                            <span v-else-if="order.status == 'Pickup'" class="style-tag success">Ophalen</span>
+                            <span v-else-if="order.status == 'Collect'" class="style-tag">Ligt klaar</span>
                             <span v-else-if="order.status == 'Completed'" class="style-tag success">Voltooid</span>
                             <span v-else-if="order.status == 'Canceled'" class="style-tag error">Geannuleerd</span>
                             <span v-else>Geplaatst</span>

--- a/frontend/app/webshop/src/views/orders/OrderView.vue
+++ b/frontend/app/webshop/src/views/orders/OrderView.vue
@@ -69,6 +69,7 @@
 
                         <template slot="right">
                             <span v-if="order.status == 'Prepared'" class="style-tag">Verwerkt</span>
+                            <span v-else-if="order.status == 'Pickup'" class="style-tag success">Ophalen</span>
                             <span v-else-if="order.status == 'Completed'" class="style-tag success">Voltooid</span>
                             <span v-else-if="order.status == 'Canceled'" class="style-tag error">Geannuleerd</span>
                             <span v-else>Geplaatst</span>

--- a/shared/structures/src/webshops/Order.ts
+++ b/shared/structures/src/webshops/Order.ts
@@ -7,7 +7,7 @@ import { Checkout } from './Checkout';
 export enum OrderStatus {
     Created = "Created",
     Prepared = "Prepared",
-    Pickup = "Pickup",
+    Collect = "Collect",
     Completed = "Completed",
     Canceled = "Canceled",
 }
@@ -17,7 +17,7 @@ export class OrderStatusHelper {
         switch (status) {
             case OrderStatus.Created: return "Nieuw"
             case OrderStatus.Prepared: return "Verwerkt"
-            case OrderStatus.Pickup: return "Ophalen"
+            case OrderStatus.Collect: return "Ligt klaar"
             case OrderStatus.Completed: return "Voltooid"
             case OrderStatus.Canceled: return "Geannuleerd"
         }

--- a/shared/structures/src/webshops/Order.ts
+++ b/shared/structures/src/webshops/Order.ts
@@ -7,6 +7,7 @@ import { Checkout } from './Checkout';
 export enum OrderStatus {
     Created = "Created",
     Prepared = "Prepared",
+    Pickup = "Pickup",
     Completed = "Completed",
     Canceled = "Canceled",
 }
@@ -16,6 +17,7 @@ export class OrderStatusHelper {
         switch (status) {
             case OrderStatus.Created: return "Nieuw"
             case OrderStatus.Prepared: return "Verwerkt"
+            case OrderStatus.Pickup: return "Ophalen"
             case OrderStatus.Completed: return "Voltooid"
             case OrderStatus.Canceled: return "Geannuleerd"
         }


### PR DESCRIPTION
Feature proposal: "Ophalen" as extra status for orders. 
This extra status option is needed/useful for webshops that do not keep stock. 'Prepared'(=verwerkt) as a status would then mean it is passed on to the supplier. Ophalen means it is ready for the buyer to collect. Buyers that check their order (via email link) will see the status as 'ophalen' and thus know they can come to collect.