### PR TITLE
[Improvement] Hide emergency contacts from EditMemberContactsView when setting NotAsked

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/member/edit/EditMemberContactsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/edit/EditMemberContactsView.vue
@@ -41,7 +41,7 @@
                 Er zijn geen ouders ingesteld bij dit lid
             </p>
 
-            <div v-if="isNotAsked">
+            <template v-if="isNotAsked">
                 <hr>
                 <h2 :class="{ 'style-with-button': emergencyContacts.length == 0}">
                     <span>Noodcontact</span>
@@ -72,7 +72,7 @@
                 <p v-else class="info-box">
                     Er is geen noodcontact ingesteld bij dit lid
                 </p>
-            </div> 
+            </template> 
             
         </main>
     </div>

--- a/frontend/app/dashboard/src/views/dashboard/member/edit/EditMemberContactsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/edit/EditMemberContactsView.vue
@@ -86,6 +86,7 @@ import { EmergencyContact, MemberWithRegistrations, Parent,Version } from "@stam
 import { MemberDetails } from '@stamhoofd/structures';
 import { Component, Mixins, Prop } from "vue-property-decorator";
 
+import { OrganizationManager } from '../../classes/OrganizationManager';
 import { FamilyManager } from '../../../../classes/FamilyManager';
 import EditMemberEmergencyContactView from './EditMemberEmergencyContactView.vue';
 import EditMemberParentView from './EditMemberParentView.vue';

--- a/frontend/app/dashboard/src/views/dashboard/member/edit/EditMemberContactsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/edit/EditMemberContactsView.vue
@@ -41,37 +41,39 @@
                 Er zijn geen ouders ingesteld bij dit lid
             </p>
 
-            <hr>
+            <div v-if="isNotAsked">
+                <hr>
+                <h2 :class="{ 'style-with-button': emergencyContacts.length == 0}">
+                    <span>Noodcontact</span>
+                    <div v-if="emergencyContacts.length == 0">
+                        <button type="button" class="button text" @click="addEmergencyContact">
+                            <span class="icon add" />
+                            <span>Toevoegen</span>
+                        </button>
+                    </div>
+                </h2>
 
-            <h2 :class="{ 'style-with-button': emergencyContacts.length == 0}">
-                <span>Noodcontact</span>
-                <div v-if="emergencyContacts.length == 0">
-                    <button type="button" class="button text" @click="addEmergencyContact">
-                        <span class="icon add" />
-                        <span>Toevoegen</span>
-                    </button>
-                </div>
-            </h2>
+                <STList v-if="emergencyContacts.length > 0">
+                    <STListItem v-for="contact in emergencyContacts" :key="contact.id" :selectable="true" element-name="label" class="right-stack">
+                        <h2 class="style-title-list">
+                            {{ contact.name }} ({{ contact.title }})
+                        </h2>
+                        <p v-if="contact.phone" class="style-description-small">
+                            {{ contact.phone }}
+                        </p>
 
-            <STList v-if="emergencyContacts.length > 0">
-                <STListItem v-for="contact in emergencyContacts" :key="contact.id" :selectable="true" element-name="label" class="right-stack">
-                    <h2 class="style-title-list">
-                        {{ contact.name }} ({{ contact.title }})
-                    </h2>
-                    <p v-if="contact.phone" class="style-description-small">
-                        {{ contact.phone }}
-                    </p>
+                        <button slot="right" class="button text limit-space" @click.stop="editEmergencyContact()">
+                            <span class="icon edit" />
+                            <span>Bewerken</span>
+                        </button>
+                    </STListItem>
+                </STList>
 
-                    <button slot="right" class="button text limit-space" @click.stop="editEmergencyContact()">
-                        <span class="icon edit" />
-                        <span>Bewerken</span>
-                    </button>
-                </STListItem>
-            </STList>
-
-            <p v-else class="info-box">
-                Er is geen noodcontact ingesteld bij dit lid
-            </p>
+                <p v-else class="info-box">
+                    Er is geen noodcontact ingesteld bij dit lid
+                </p>
+            </div> 
+            
         </main>
     </div>
 </template>
@@ -191,6 +193,10 @@ export default class EditMemberContactsView extends Mixins(NavigationMixin) {
 
     get emergencyContacts(): EmergencyContact[]  {
         return this.memberDetails?.emergencyContacts ?? []
+    }
+    
+    get isNotAsked() {
+        return OrganizationManager.organization.meta.recordsConfiguration.emergencyContact === AskRequirement.NotAsked
     }
 
     get parents(): SelectableParent[]  {


### PR DESCRIPTION
Do not show emergency contact in editmembercontactview when it is set to 'not asked' by admin.
This tweak is supposed to hide the emergency contacts section from the below screen.
![image](https://user-images.githubusercontent.com/87519741/129300854-7ba75efb-6277-4105-a6a1-4c2ee34b3203.png)

Please triple check what I'm proposing in the code, because I'm by no means a pro in coding. :)
