### PR TITLE
[Improvement] Added extra permission type Manage

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionContextMenu.vue
@@ -6,7 +6,7 @@
         <ContextMenuItem @click="setPermission('write')">
             Bekijken en bewerken
         </ContextMenuItem>
-        <ContextMenuItem @click="setPermission('Manage')">
+        <ContextMenuItem @click="setPermission('manage')">
             Beheren
         </ContextMenuItem>
         <ContextMenuItem @click="setPermission('full')">
@@ -36,7 +36,7 @@ export default class GroupPermissionContextMenu extends Mixins(NavigationMixin) 
     y!: number;
 
     @Prop()
-    callback!: (status: "read" | "write" | "Manage" | "full") => void;
+    callback!: (status: "read" | "write" | "manage" | "full") => void;
 
     setPermission(status) {
         this.callback(status)

--- a/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionContextMenu.vue
@@ -6,6 +6,9 @@
         <ContextMenuItem @click="setPermission('write')">
             Bekijken en bewerken
         </ContextMenuItem>
+        <ContextMenuItem @click="setPermission('Manage')">
+            Beheren
+        </ContextMenuItem>
         <ContextMenuItem @click="setPermission('full')">
             Volledige toegang
         </ContextMenuItem>
@@ -33,7 +36,7 @@ export default class GroupPermissionContextMenu extends Mixins(NavigationMixin) 
     y!: number;
 
     @Prop()
-    callback!: (status: "read" | "write" | "full") => void;
+    callback!: (status: "read" | "write" | "Manage" | "full") => void;
 
     setPermission(status) {
         this.callback(status)

--- a/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionRow.vue
+++ b/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionRow.vue
@@ -77,7 +77,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         }
     }
 
-    getGroupPermission(group: Group): "none" | "write" | "read" | "manage" | "full" {
+    getGroupPermission(group: Group): "none" | "read" | "write" | "manage" | "full" {
         for (const role of group.privateSettings!.permissions.full) {
             if (role.id === this.role.id) {
                 return "full"
@@ -105,7 +105,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         return "none"
     }
 
-    setGroupPermission(group: Group, level: "none" | "write" | "read" | "manage" | "full") {
+    setGroupPermission(group: Group, level: "none" | "read" | "write" | "manage" | "full") {
         if (this.getGroupPermission(group) === level) {
             return
         }
@@ -198,11 +198,11 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         }
     }
 
-    getLevelText(level: "none" | "write" | "read" | "manage" | "full"): string {
+    getLevelText(level: "none" | "read" | "write" | "manage" | "full"): string {
         switch(level) {
             case "none": return "Geen toegang";
-            case "write": return "Bekijken en bewerken";
             case "read": return "Bekijken";
+            case "write": return "Bekijken en bewerken";
             case "manage": return "Beheren";
             case "full": return "Volledige toegang";
         }
@@ -212,7 +212,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         const displayedComponent = new ComponentWithProperties(GroupPermissionContextMenu, {
             x: event.clientX,
             y: event.clientY,
-            callback: (level: "none" | "write" | "read" | "manage" | "full") => {
+            callback: (level: "none" | "read" | "write" | "manage" | "full") => {
                 this.setGroupPermission(group, level)
             }
         });

--- a/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionRow.vue
+++ b/frontend/app/dashboard/src/views/dashboard/admins/GroupPermissionRow.vue
@@ -77,10 +77,16 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         }
     }
 
-    getGroupPermission(group: Group): "none" | "write" | "read" | "full" {
+    getGroupPermission(group: Group): "none" | "write" | "read" | "manage" | "full" {
         for (const role of group.privateSettings!.permissions.full) {
             if (role.id === this.role.id) {
                 return "full"
+            }
+        }
+        
+        for (const role of group.privateSettings!.permissions.manage) {
+            if (role.id === this.role.id) {
+                return "manage"
             }
         }
 
@@ -99,7 +105,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         return "none"
     }
 
-    setGroupPermission(group: Group, level: "none" | "write" | "read" | "full") {
+    setGroupPermission(group: Group, level: "none" | "write" | "read" | "manage" | "full") {
         if (this.getGroupPermission(group) === level) {
             return
         }
@@ -118,6 +124,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
                     permissions: PermissionsByRole.patch({
                         read: del,
                         write: del,
+                        manage: del,
                         full: del
                     })
                 })
@@ -133,6 +140,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
                     permissions: PermissionsByRole.patch({
                         read: add,
                         write: del,
+                        manage: del,
                         full: del
                     })
                 })
@@ -148,6 +156,23 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
                     permissions: PermissionsByRole.patch({
                         read: del,
                         write: add,
+                        manage: del,
+                        full: del
+                    })
+                })
+            }))
+            this.addPatch(p)
+            return
+        }
+        
+        if (level === "manage") {
+            p.groups.addPatch(Group.patch({
+                id: group.id,
+                privateSettings: GroupPrivateSettings.patch({
+                    permissions: PermissionsByRole.patch({
+                        read: del,
+                        write: del,
+                        manage: add,
                         full: del
                     })
                 })
@@ -163,6 +188,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
                     permissions: PermissionsByRole.patch({
                         read: del,
                         write: del,
+                        manage: del,
                         full: add
                     })
                 })
@@ -172,11 +198,12 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         }
     }
 
-    getLevelText(level: "none" | "write" | "read" | "full"): string {
+    getLevelText(level: "none" | "write" | "read" | "manage" | "full"): string {
         switch(level) {
             case "none": return "Geen toegang";
             case "write": return "Bekijken en bewerken";
             case "read": return "Bekijken";
+            case "manage": return "Beheren";
             case "full": return "Volledige toegang";
         }
     }
@@ -185,7 +212,7 @@ export default class GroupPermissionRow extends Mixins(NavigationMixin) {
         const displayedComponent = new ComponentWithProperties(GroupPermissionContextMenu, {
             x: event.clientX,
             y: event.clientY,
-            callback: (level: "none" | "write" | "read" | "full") => {
+            callback: (level: "none" | "write" | "read" | "manage" | "full") => {
                 this.setGroupPermission(group, level)
             }
         });

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupListSelectionContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupListSelectionContextMenu.vue
@@ -22,28 +22,30 @@
             Mailen
         </ContextMenuItem>
 
-        <ContextMenuLine />
+        <template v-if="hasManage">
+            <ContextMenuLine />
 
-        <ContextMenuItem v-if="waitingList" @click="acceptWaitingList">
-            Schrijf in
-        </ContextMenuItem>
-        <ContextMenuItem v-else-if="hasWaitingList" @click="moveToWaitingList">
-            Verplaatst naar wachtlijst
-            <span slot="right" class="icon clock-small" />
-        </ContextMenuItem>
+            <ContextMenuItem v-if="waitingList" @click="acceptWaitingList">
+                Schrijf in
+            </ContextMenuItem>
+            <ContextMenuItem v-else-if="hasWaitingList" @click="moveToWaitingList">
+                Verplaatst naar wachtlijst
+                <span slot="right" class="icon clock-small" />
+            </ContextMenuItem>
 
-        <ContextMenuItem @click="deleteRegistration">
-            Uitschrijven
-            <span slot="right" class="icon unregister" />
-        </ContextMenuItem>
-        <ContextMenuItem @click="deleteRecords">
-            <span slot="right" class="icon trash" />
-            Gegevens gedeeltelijk wissen
-        </ContextMenuItem>
-        <ContextMenuItem @click="deleteData">
-            <span slot="right" class="icon trash" />
-            Verwijderen
-        </ContextMenuItem>
+            <ContextMenuItem @click="deleteRegistration">
+                Uitschrijven
+                <span slot="right" class="icon unregister" />
+            </ContextMenuItem>
+            <ContextMenuItem @click="deleteRecords">
+                <span slot="right" class="icon trash" />
+                Gegevens gedeeltelijk wissen
+            </ContextMenuItem>
+            <ContextMenuItem @click="deleteData">
+                <span slot="right" class="icon trash" />
+                Verwijderen
+            </ContextMenuItem>
+        </template>
     </ContextMenu>
 </template>
 
@@ -57,6 +59,7 @@ import { AppManager } from "@stamhoofd/networking";
 import { Group, MemberWithRegistrations } from '@stamhoofd/structures';
 import { Component, Mixins,Prop } from "vue-property-decorator";
 
+import { OrganizationManager } from "../../../classes/OrganizationManager";
 import { MemberManager } from "../../../classes/MemberManager";
 import MailView from "../mail/MailView.vue";
 import MemberSummaryView from "../member/MemberSummaryView.vue";
@@ -117,6 +120,19 @@ export default class GroupListSelectionContextMenu extends Mixins(NavigationMixi
 
     get hasWaitingList() {
         return this.group?.hasWaitingList() ?? false
+    }
+    
+    get hasManage(): boolean {
+        if (!OrganizationManager.user.permissions) {
+            return false
+        }
+        for (const group of this.member.groups) {
+            if(group.privateSettings && getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Manage)) {
+                return true
+            }
+        }
+        
+        return false
     }
 
     async excel() {

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupMembersView.vue
@@ -407,7 +407,7 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
                         continue
                     }
 
-                    if(getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
+                    if(getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Manage)) {
                         return true
                     }
                 }
@@ -419,7 +419,7 @@ export default class GroupMembersView extends Mixins(NavigationMixin) {
             return false
         }
 
-        if(getPermissionLevelNumber(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Write)) {
+        if(getPermissionLevelNumber(this.group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Manage)) {
             return false
         }
         return true

--- a/frontend/app/dashboard/src/views/dashboard/member/MemberContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/MemberContextMenu.vue
@@ -10,7 +10,8 @@
                 Gegevens wijzigen
                 <span slot="right" class="icon edit" />
             </ContextMenuItem>
-
+        </template>
+        <template v-if="hasManage">
             <ContextMenuItem @click="changeGroup">
                 Inschrijvingen wijzigen
                 <span slot="right" class="icon sync" />
@@ -46,9 +47,9 @@
             </ContextMenuItem>
         </template>
 
-        <ContextMenuLine v-if="hasWrite || canDelete" />
+        <ContextMenuLine v-if="hasManage || canDelete" />
 
-        <ContextMenuItem v-if="hasWrite" @click="deleteRegistration">
+        <ContextMenuItem v-if="hasManage" @click="deleteRegistration">
             Uitschrijven
             <span slot="right" class="icon unregister" />
         </ContextMenuItem>
@@ -117,7 +118,7 @@ export default class MemberContextMenu extends Mixins(NavigationMixin) {
         }
 
         for (const group of this.member.groups) {
-            if(!group.privateSettings || getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Write)) {
+            if(!group.privateSettings || getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) < getPermissionLevelNumber(PermissionLevel.Manage)) {
                 return false
             }
         }
@@ -132,6 +133,20 @@ export default class MemberContextMenu extends Mixins(NavigationMixin) {
 
         for (const group of this.member.groups) {
             if(group.privateSettings && getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    get hasManage(): boolean {
+        if (!OrganizationManager.user.permissions) {
+            return false
+        }
+
+        for (const group of this.member.groups) {
+            if(group.privateSettings && getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Manage)) {
                 return true
             }
         }

--- a/frontend/app/dashboard/src/views/dashboard/member/MemberViewDetails.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/MemberViewDetails.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="member-view-details">
         <div>
-            <p v-if="hasWrite && member.activeRegistrations.length == 0" class="info-box with-button selectable" @click="editGroup()">
+            <p v-if="hasManage && member.activeRegistrations.length == 0" class="info-box with-button selectable" @click="editGroup()">
                 {{ member.firstName }} is niet ingeschreven
                 <span class="button icon edit" />
             </p>
@@ -371,6 +371,25 @@ export default class MemberViewDetails extends Mixins(NavigationMixin) {
 
         for (const group of this.member.groups) {
             if(group.privateSettings && getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+        get hasManage(): boolean {
+        if (!OrganizationManager.user.permissions) {
+            return false
+        }
+
+        if (OrganizationManager.user.permissions.hasFullAccess()) {
+            // Can edit members without groups
+            return true
+        }
+
+        for (const group of this.member.groups) {
+            if(group.privateSettings && getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Manage)) {
                 return true
             }
         }

--- a/frontend/app/dashboard/src/views/dashboard/member/MemberViewPayments.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/MemberViewPayments.vue
@@ -8,7 +8,7 @@
                     <h2 class="style-with-button">
                         <div>Afrekening</div>
                         <div class="hover-show">
-                            <button v-if="hasWrite" class="button icon gray edit" @click="editPayment(payment)" />
+                            <button v-if="hasManage" class="button icon gray edit" @click="editPayment(payment)" />
                         </div>
                     </h2>
 
@@ -137,7 +137,7 @@ export default class MemberViewPayments extends Mixins(NavigationMixin) {
         })
     }
 
-    get hasWrite(): boolean {
+    get hasManage(): boolean {
         if (!OrganizationManager.user.permissions) {
             return false
         }

--- a/frontend/app/dashboard/src/views/dashboard/member/MemberViewPayments.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/MemberViewPayments.vue
@@ -153,7 +153,7 @@ export default class MemberViewPayments extends Mixins(NavigationMixin) {
         }
 
         for (const group of this.member.groups) {
-            if(group.privateSettings && getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Write)) {
+            if(group.privateSettings && getPermissionLevelNumber(group.privateSettings.permissions.getPermissionLevel(OrganizationManager.user.permissions)) >= getPermissionLevelNumber(PermissionLevel.Manage)) {
                 return true
             }
         }

--- a/frontend/app/dashboard/src/views/dashboard/member/MemberViewPayments.vue
+++ b/frontend/app/dashboard/src/views/dashboard/member/MemberViewPayments.vue
@@ -69,23 +69,26 @@
                     <p v-if="payment.status == 'Succeeded' && payment.paidAt" class="success-box">
                         Betaald op {{ payment.paidAt | date }}
                     </p>
-
-                    <LoadingButton :loading="loading">
-                        <button v-if="payment.status == 'Succeeded' && payment.paidAt" class="button secundary" @click="markNotPaid(payment)">
-                            Toch niet betaald
-                        </button>
-                        <button v-else class="button primary" @click="markPaid(payment)">
-                            Markeer als betaald
-                        </button>
-                    </LoadingButton>
+                    <template v-if="hasManage">
+                        <LoadingButton :loading="loading">
+                            <button v-if="payment.status == 'Succeeded' && payment.paidAt" class="button secundary" @click="markNotPaid(payment)">
+                                Toch niet betaald
+                            </button>
+                            <button v-else class="button primary" @click="markPaid(payment)">
+                                Markeer als betaald
+                            </button>
+                        </LoadingButton>
+                    </template>
                 </div>
                 <p v-if="payments.length == 0" class="info-box">
                     Er zijn nog geen betalingen aangemaakt voor dit lid. Hiermee kan je bijhouden dat er nog een bepaald bedrag verschuldigd is voor een inschrijving.
                 </p>
-                <button v-if="hasRegistrationsWithoutPayments" class="button text" @click="addPayment">
-                    <span class="icon add" />
-                    <span>Afrekening aanmaken</span>
-                </button>
+                <template v-if="hasManage">
+                    <button v-if="hasRegistrationsWithoutPayments" class="button text" @click="addPayment">
+                        <span class="icon add" />
+                        <span>Afrekening aanmaken</span>
+                    </button>
+                </template>
             </template>
         </main>
     </div>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/OrderView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/OrderView.vue
@@ -253,7 +253,8 @@ export default class OrderView extends Mixins(NavigationMixin){
         if (p.canManagePayments(OrganizationManager.organization.privateMeta?.roles ?? []) || p.hasFullAccess()) {
             return true
         }
-        return getPermissionLevelNumber(this.webshop.privateMeta.permissions.getPermissionLevel(p)) >= getPermissionLevelNumber(PermissionLevel.Write)
+        return this.preview.privateMeta.permissions.getPermissionLevel(OrganizationManager.user.permissions) >= PermissionLevel.Write
+        
     }
 
 

--- a/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
@@ -27,7 +27,7 @@
             <h1 v-if="canPop" class="data-table-prefix">
                 <span class="icon-spacer">{{ title }}</span>
 
-                <button v-tooltip="'Instellingen'" class="button gray icon settings" @click="editSettings" />
+                <button v-if="hasFullPermissions" v-tooltip="'Instellingen'" class="button gray icon settings" @click="editSettings" />
                 <a v-tooltip="'Webshop openen'" class="button gray icon external" :href="'https://'+webshopUrl" target="_blank" />
             </h1>
 
@@ -134,7 +134,7 @@
                 </template>
             </template>
             <template #right>
-                <button class="button secundary" :disabled="selectionCount == 0 || isLoadingOrders" @click="markAs">
+                <button v-if="hasWrite" class="button secundary" :disabled="selectionCount == 0 || isLoadingOrders" @click="markAs">
                     <span class="dropdown-text">Markeren als...</span>
                 </button>
                 <LoadingButton :loading="actionLoading">
@@ -260,6 +260,13 @@ export default class WebshopView extends Mixins(NavigationMixin) {
             return false
         }
         return this.preview.privateMeta.permissions.getPermissionLevel(OrganizationManager.user.permissions) === PermissionLevel.Full
+    }
+    
+    get hasWrite() {
+        if (!OrganizationManager.user.permissions) {
+            return false
+        }
+        return this.preview.privateMeta.permissions.getPermissionLevel(OrganizationManager.user.permissions) >= PermissionLevel.Write
     }
 
     toggleSort(field: string) {
@@ -506,6 +513,9 @@ export default class WebshopView extends Mixins(NavigationMixin) {
     }
 
     showOrderContextMenu(event, order: Order) {
+        if (!hasWrite) {
+            return;
+        }
         const displayedComponent = new ComponentWithProperties(OrderContextMenu, {
             x: event.clientX,
             y: event.clientY,
@@ -514,7 +524,7 @@ export default class WebshopView extends Mixins(NavigationMixin) {
         });
         this.present(displayedComponent.setDisplayStyle("overlay"));
     }
-
+    
 }
 </script>
 


### PR DESCRIPTION
Suggestion to add a 4th permission type for backend users.

- read -> can no longer delete, move, unsubscribe, play with payments...
- write -> can only edit member information (no delete, move, unsubscribe, edit payments ...)
- **manage** -> can edit members and also delete, move, unsubscribe, accept and change payments... (same rights as old write access level)
- full -> unchanged

This is an improvement - I feel - because in a big youth movement I want my youth leaders to be involved in maintaining the member information, but not give them the right to delete, unsubscribe, move, play with payments... These radical actions involve further followup in other parts of the administration, so should be kept a little more secure. I believe at least a few (big) youth movements will have a _secretariaat_ that manages members and should be the sole users with the rights to do so.

In the old (=current) setup a user with only 'read' access is allowed to e.g. delete a user. This update should block that possibility.
