### PR TITLE
[Fix] Webshop custom dns settings

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/settings/PersonalizeSettingsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/PersonalizeSettingsView.vue
@@ -45,7 +45,7 @@
             <hr>
             <h2>Domeinnaam</h2>
 
-            <p>Alle informatie over domeinnaamen vind je op <a class="inline-link" href="https://stamhoofd.be/docs/domeinnaam-koppelen" target="_blank">deze pagina</a>.</p>
+            <p>Alle informatie over domeinnamen vind je op <a class="inline-link" href="https://stamhoofd.be/docs/domeinnaam-koppelen" target="_blank">deze pagina</a>.</p>
 
 
             <template v-if="organization.privateMeta && organization.privateMeta.pendingMailDomain">

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
@@ -280,7 +280,7 @@ export default class EditWebshopPageView extends Mixins(NavigationMixin) {
         return DNSRecord.create({
             type: DNSRecordType.CNAME,
             name: this.webshop.domain,
-            value: "domains.stamhoofd.be."
+            value: "domains.stamhoofd.shop."
         })
     }
 

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
@@ -279,7 +279,7 @@ export default class EditWebshopPageView extends Mixins(NavigationMixin) {
         }
         return DNSRecord.create({
             type: DNSRecordType.CNAME,
-            name: this.webshop.domain+".",
+            name: this.webshop.domain,
             value: "domains.stamhoofd.be."
         })
     }

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
@@ -280,7 +280,7 @@ export default class EditWebshopPageView extends Mixins(NavigationMixin) {
         return DNSRecord.create({
             type: DNSRecordType.CNAME,
             name: this.webshop.domain+".",
-            value: "domains.stamhoofd.shop"
+            value: "domains.stamhoofd.be."
         })
     }
 

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
@@ -279,7 +279,7 @@ export default class EditWebshopPageView extends Mixins(NavigationMixin) {
         }
         return DNSRecord.create({
             type: DNSRecordType.CNAME,
-            name: this.webshop.domain,
+            name: this.webshop.domain+".",
             value: "domains.stamhoofd.shop."
         })
     }


### PR DESCRIPTION
By using Stamhoofd myself, I discovered that the custom DNS settings for the webshops didn't work. When I tried using the regular domain (domains.stamhoofd.be.), the custom URLs worked as expected.