### PR TITLE
Finetuning: max persons for event when there is only one timeslot

### DIFF
--- a/shared/structures/src/webshops/Checkout.ts
+++ b/shared/structures/src/webshops/Checkout.ts
@@ -250,18 +250,19 @@ export class Checkout extends AutoEncoder {
         // Check maximum
         if (timeSlot.remainingPersons !== null && this.cart.persons - this.reservedPersons > timeSlot.remainingPersons) {
             const remaingPersons = timeSlot.remainingPersons
+            const availableTimeslots = this.checkoutMethod.timeSlots.timeSlots.length
             if (remaingPersons === 0) {
                 throw new SimpleError({
                     code: "timeslot_full",
                     message: "Timeslot has reached maximum orders",
-                    human: "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk.",
+                    human: (availableTimeslots !=1 ? "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk." : "Het evenement is helaas volzet. We aanvaarden geen verdere bestellingen."),
                     field: "timeSlot"
                 })
             }
             throw new SimpleError({
                 code: "timeslot_full",
                 message: "Timeslot has reached maximum persons",
-                human: "Er "+(remaingPersons != 1 ? "zijn" : "is")+" nog maar "+remaingPersons+" "+(remaingPersons != 1 ? "plaatsen" : "plaats")+" vrij op het gekozen tijdstip. Jouw mandje is voor " + this.cart.persons + " "+(this.cart.persons != 1 ? "personen" : "persoon")+". Kies een ander tijdstip indien mogelijk.",
+                human: "Er "+(remaingPersons != 1 ? "zijn" : "is")+" nog maar "+remaingPersons+" "+(remaingPersons != 1 ? "plaatsen" : "plaats")+" vrij "+(availableTimeslots !=1 ? "op het gekozen tijdstip" : "voor dit evenement")+". Jouw mandje is voor " + this.cart.persons + " "+(this.cart.persons != 1 ? "personen" : "persoon")+(availableTimeslots !=1 ? ". Kies een ander tijdstip indien mogelijk." : ""),
                 field: "timeSlot"
             })
         }

--- a/shared/structures/src/webshops/Checkout.ts
+++ b/shared/structures/src/webshops/Checkout.ts
@@ -275,7 +275,7 @@ export class Checkout extends AutoEncoder {
             throw new SimpleError({
                 code: "invalid_first_name",
                 message: "Invalid first name",
-                human: "Het voornaam dat je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
+                human: "De voornaam die je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
                 field: "customer.firstName"
             })
         }
@@ -284,7 +284,7 @@ export class Checkout extends AutoEncoder {
             throw new SimpleError({
                 code: "invalid_last_name",
                 message: "Invalid last name",
-                human: "Het achternaam dat je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
+                human: "De achternaam die je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
                 field: "customer.lastName"
             })
         }

--- a/shared/structures/src/webshops/Checkout.ts
+++ b/shared/structures/src/webshops/Checkout.ts
@@ -227,6 +227,7 @@ export class Checkout extends AutoEncoder {
         
         const current = this.timeSlot
         const timeSlot = this.checkoutMethod.timeSlots.timeSlots.find(s => s.id == current.id)
+        const availableTimeslots = this.checkoutMethod.timeSlots.timeSlots.length
         
         if (!timeSlot) {
             throw new SimpleError({
@@ -242,7 +243,7 @@ export class Checkout extends AutoEncoder {
             throw new SimpleError({
                 code: "timeslot_full",
                 message: "Timeslot has reached maximum orders",
-                human: "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk.",
+                human: (availableTimeslots !=1 ? "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk." : "Het evenement is helaas volzet. We aanvaarden geen verdere bestellingen."),
                 field: "timeSlot"
             })
         }
@@ -250,7 +251,6 @@ export class Checkout extends AutoEncoder {
         // Check maximum
         if (timeSlot.remainingPersons !== null && this.cart.persons - this.reservedPersons > timeSlot.remainingPersons) {
             const remaingPersons = timeSlot.remainingPersons
-            const availableTimeslots = this.checkoutMethod.timeSlots.timeSlots.length
             if (remaingPersons === 0) {
                 throw new SimpleError({
                     code: "timeslot_full",


### PR DESCRIPTION
This is a suggestion to finetune the handling of full timeslots.

In case there is only one timeslot, this is not shown to the user during the ordering process. If this single timeslot has a capacitiy cap set up (max persons) and this number is reached, the user will be shown a warning that they have to select a different timeslot if possible. Confusing for the user, because there was no mention of timeslots for the event ever before.

This edit aims to not show the suggestion to pick another (not existing) timeslot when there is only one timeslot available. The event is just full, plain and simple. 

This is also nice for the administrator to know: in this way, a hard cap for the amount of visitors to an event can easily be set. Just set up a single timeslot with a max persons cap.

Also: 2 spelling edits in this pull request int he same file