### PR TITLE
Do not show financial support when price is zero

### DIFF
--- a/frontend/app/registration/src/views/checkout/CartView.vue
+++ b/frontend/app/registration/src/views/checkout/CartView.vue
@@ -117,7 +117,7 @@ export default class CartView extends Mixins(NavigationMixin){
 
         try {
             // todo: go to checkout ;)
-            if (OrganizationManager.organization.meta.recordsConfiguration.financialSupport) {
+            if (OrganizationManager.organization.meta.recordsConfiguration.financialSupport && cart.price > 0) {
                 // Go to financial view
                 const component = (await import(/* webpackChunkName: "FinancialSupportView" */ './FinancialSupportView.vue')).default;
                 this.present(


### PR DESCRIPTION
Suggestion to not show the fianncial support screen when the cart price is zero.
We have quite a few groups that are free; it's a bit strange that users are able to select financial support when they don't have to pay anyway.