### PR TITLE
Prevent current group

### DIFF
--- a/frontend/app/registration/src/views/groups/GroupView.vue
+++ b/frontend/app/registration/src/views/groups/GroupView.vue
@@ -324,6 +324,15 @@ export default class GroupView extends Mixins(NavigationMixin){
                 who = prefix + "\n" + who
             }
         }
+        
+        if (this.group.settings.preventGroupIds.length > 0) {
+            const prefix = "Iedereen die niet ingeschreven is bij "+Formatter.joinLast(this.group.settings.preventGroupIds.map(id => OrganizationManager.organization.groups.find(g => g.id == id)?.settings.name ?? "Onbekend"), ", ", " of ")
+            if (!who) {
+                who += prefix
+            } else {
+                who = prefix + "\n" + who
+            }
+        }
 
         if (this.group.settings.preventPreviousGroupIds.length > 0) {
             const prefix = "Iedereen die de vorige keer niet ingeschreven was bij "+Formatter.joinLast(this.group.settings.preventPreviousGroupIds.map(id => OrganizationManager.organization.groups.find(g => g.id == id)?.settings.name ?? "Onbekend"), ", ", " of ")

--- a/shared/structures/src/GroupSettings.ts
+++ b/shared/structures/src/GroupSettings.ts
@@ -182,6 +182,9 @@ export class GroupSettings extends AutoEncoder {
      */
     @field({ decoder: new ArrayDecoder(StringDecoder), version: 100 })
     requirePreviousGroupIds: string[] = []
+    
+    @field({ decoder: new ArrayDecoder(StringDecoder), version: 102 })  //geen idee wat dat versienummer doet
+    preventGroupIds: string[] = []
 
     @field({ decoder: new ArrayDecoder(StringDecoder), version: 102 })
     preventPreviousGroupIds: string[] = []

--- a/shared/structures/src/members/MemberWithRegistrations.ts
+++ b/shared/structures/src/members/MemberWithRegistrations.ts
@@ -191,6 +191,19 @@ export class MemberWithRegistrations extends Member {
                 return "Niet toegelaten"
             }
         }
+        
+        // Check if registrations are limited
+        if (group.settings.preventGroupIds.length > 0) {
+            if (this.registrations.find(r => {
+                const registrationGroup = groups.find(g => g.id === r.groupId)
+                if (!registrationGroup) {
+                    return false
+                }
+                return group.settings.preventGroupIds.includes(r.groupId) && r.registeredAt !== null && r.deactivatedAt === null && !r.waitingList && r.cycle === registrationGroup.cycle - 1
+            })) {
+                return "Niet toegelaten"
+            }
+        }
 
         // Check if registrations are limited
         if (group.settings.preventPreviousGroupIds.length > 0) {

--- a/shared/structures/src/members/checkout/RegisterCartValidator.ts
+++ b/shared/structures/src/members/checkout/RegisterCartValidator.ts
@@ -55,6 +55,22 @@ export class RegisterCartValidator {
         }
 
         // Check if registrations are limited
+        if (group.settings.preventGroupIds.length > 0) {
+            if (member.registrations.find(r => {
+                const registrationGroup = groups.find(g => g.id === r.groupId)
+                if (!registrationGroup) {
+                    return false
+                }
+                return group.settings.preventGroupIds.includes(r.groupId) && r.registeredAt !== null && r.deactivatedAt === null && !r.waitingList && r.cycle === registrationGroup.cycle - 1
+            })) {
+                return {
+                    closed: true,
+                    waitingList: false,
+                    message: "Niet toegelaten",
+                    description: "Inschrijven voor "+group.settings.name+" kan enkel als je niet al bent ingeschreven voor "+Formatter.joinLast(group.settings.preventGroupIds.map(id => groups.find(g => g.id === id)?.settings.name ?? "Onbekend"), ", ", " of ")
+                }
+            }
+        }
         if (group.settings.preventPreviousGroupIds.length > 0) {
             if (member.registrations.find(r => {
                 const registrationGroup = groups.find(g => g.id === r.groupId)


### PR DESCRIPTION
This addition will allow administrators to set up extra rules for dubscribing.
Similarly to 'prevent previous groups', there now also is a 'prevent groups' for current subscriptions to groups.

This could partly be achieved by selecting 'een lid kan maar voor één groep inschrijven', but that option was limited to groups within the same category. This addition allows to go past this limitation.

Quite probably there also need to be some additions in the database? I don't really know how that is all managed.
Please check the code for correctness and omissions; I'm not a real programmer...