### PR TITLE
Revert "Fixed SQL Age filter"

### DIFF
--- a/backend/shared/sql/src/SQLExpressions.ts
+++ b/backend/shared/sql/src/SQLExpressions.ts
@@ -242,9 +242,9 @@ export class SQLAge implements SQLExpression {
 
     getSQL(options?: SQLExpressionOptions): SQLQuery {
         return joinSQLQuery([
-            '(TIMESTAMPDIFF(YEAR, ',
+            'TIMESTAMPDIFF(YEAR, ',
             this.expression.getSQL(options),
-            ', CURDATE()) + 1)',
+            ', CURDATE())',
         ]);
     }
 }


### PR DESCRIPTION
This reverts commit d99794ccad960ad071026778e009910400502de5.

Volgens mij is dit niet correct? zie voorbeeld: https://www.w3resource.com/mysql/date-and-time-functions/mysql-timestampdiff-function.php

Zie Slack bericht van Carola: https://stamhoofd.slack.com/archives/C080NT0ENNR/p1744191162209549