### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/stamhoofd/stamhoofd/security/code-scanning/40](https://github.com/stamhoofd/stamhoofd/security/code-scanning/40)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are recommended:
- `contents: read` for accessing repository contents.
- Additional permissions (e.g., `issues: write`, `pull-requests: write`) should be added only if required by specific jobs.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within individual jobs to tailor permissions for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
