### PR TITLE
UiTPAS endpoint

### DIFF
--- a/backend/app/api/src/endpoints/organization/webshops/retrieveUitpasSocialTariffPrice.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/retrieveUitpasSocialTariffPrice.ts
@@ -39,7 +39,7 @@ export class retrieveUitpasSocialTariffPrice extends Endpoint<Params, Query, Bod
             throw new SimpleError({
                 code: 'not_implemented',
                 message: 'Official flow not yet implemented',
-                human: $t(`De officiële flow voor het valideren van een UiTPAS-nummer wordt nog niet ondersteund.`),
+                human: 'De officiële flow voor het valideren van een UiTPAS-nummer wordt nog niet ondersteund.',
             });
         }
         else {

--- a/backend/app/api/src/endpoints/organization/webshops/retrieveUitpasSocialTariffPrice.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/retrieveUitpasSocialTariffPrice.ts
@@ -44,12 +44,19 @@ export class retrieveUitpasSocialTariffPrice extends Endpoint<Params, Query, Bod
         }
         else {
             // NON-OFFICIAL FLOW
-            // request should include reduced price AND base price
+            // request should include UiTPAS-number, reduced price AND base price
             if (!request.body.reducedPrice) {
                 throw new SimpleError({
                     code: 'missing_reduced_price',
                     message: 'Reduced price must be provided for non-official flow.',
                     human: $t('Je moet een verlaagd tarief opgeven voor de UiTPAS.'),
+                });
+            }
+            if (!request.body.uitpasNumber) {
+                throw new SimpleError({
+                    code: 'missing_uitpas_number',
+                    message: 'Uitpas number must be provided for non-official flow.',
+                    human: $t('Je moet een UiTPAS-nummer opgeven.'),
                 });
             }
             await UitpasNumberValidator.checkUitpasNumber(request.body.uitpasNumber);

--- a/backend/app/api/src/endpoints/organization/webshops/retrieveUitpasSocialTariffPrice.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/retrieveUitpasSocialTariffPrice.ts
@@ -1,0 +1,63 @@
+import { DecodedRequest, Endpoint, Request, Response } from '@simonbackx/simple-endpoints';
+import { SimpleError } from '@simonbackx/simple-errors';
+import { UitpasPriceCheckRequest, UitpasPriceCheckResponse } from '@stamhoofd/structures';
+
+import { UitpasNumberValidator } from '../../../helpers/UitpasNumberValidator';
+import { Decoder } from '@simonbackx/simple-encoding';
+type Params = Record<string, never>;
+type Query = undefined;
+type Body = UitpasPriceCheckRequest;
+type ResponseBody = UitpasPriceCheckResponse;
+
+export class retrieveUitpasSocialTariffPrice extends Endpoint<Params, Query, Body, ResponseBody> {
+    bodyDecoder = UitpasPriceCheckRequest as Decoder<UitpasPriceCheckRequest>;
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'POST') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/uitpas', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        // uitpasEventID and uitpasNumber cannot be null at the same time
+        if (!request.body.uitpasEventId && !request.body.uitpasNumber) {
+            throw new SimpleError({
+                code: 'missing_uitpas_event_id_or_number',
+                message: 'Either uitpasEventId or uitpasNumber must be provided, or both.',
+                human: $t('Je moet minstens een UiTPAS evenement ID of een UiTPAS nummer opgeven.'),
+            });
+        }
+
+        if (request.body.uitpasEventId) {
+            // OFFICIAL FLOW -> price is the base price
+            // const basePrice = request.body.price;
+
+            if (request.body.uitpasNumber) {
+                // both uitpasEventId and uitpasNumber are provided -> validate specific uitpas number
+            }
+            else {
+                // only uitpasEventId is provided -> do a static check up (independent of uitpas number)
+            }
+
+            throw new SimpleError({
+                code: 'not_implemented',
+                message: 'Official flow not yet implemented',
+                human: $t(`De officiële flow voor het valideren van een UiTPAS-nummer wordt nog niet ondersteund.`),
+            });
+        }
+        // NON-OFFICIAL FLOW -> price is the reduced price
+        const reducedPrice = request.body.price;
+        await UitpasNumberValidator.checkUitpasNumber(request.body.uitpasNumber as string);
+        const uitpasPriceCheckResponse = UitpasPriceCheckResponse.create({
+            price: reducedPrice,
+        });
+        return new Response(uitpasPriceCheckResponse);
+    }
+}

--- a/shared/build-development-env/src/presets/internal.ts
+++ b/shared/build-development-env/src/presets/internal.ts
@@ -39,7 +39,7 @@ export async function build(service: Service) {
         // Add UiTPAS credentials
         Object.assign(config, {
             UITPAS_API_CLIENT_ID: await read1PasswordCli('op://Localhost/hjnat3l3mj2rojlyiwluqzurci/client ID', { optional: true }),
-            UITPAS_API_SECRET: await read1PasswordCli('op://Localhost/hjnat3l3mj2rojlyiwluqzurci/client secret', { optional: true }),
+            UITPAS_API_CLIENT_SECRET: await read1PasswordCli('op://Localhost/hjnat3l3mj2rojlyiwluqzurci/client secret', { optional: true }),
         });
     }
 

--- a/shared/structures/index.ts
+++ b/shared/structures/index.ts
@@ -126,6 +126,7 @@ export * from './src/endpoints/tokens/RefreshTokenGrantStruct.js';
 export * from './src/endpoints/tokens/RequestChallengeGrantStruct.js';
 export * from './src/endpoints/VerifyEmailRequest.js';
 export * from './src/endpoints/WebshopUriAvailabilityResponse.js';
+export * from './src/endpoints/UitpasPriceCheckRequest.js';
 
 // email
 export * from './src/email/EditorSmartButton.js';

--- a/shared/structures/src/endpoints/UitpasPriceCheckRequest.ts
+++ b/shared/structures/src/endpoints/UitpasPriceCheckRequest.ts
@@ -2,7 +2,14 @@ import { AutoEncoder, StringDecoder, field, IntegerDecoder } from '@simonbackx/s
 
 export class UitpasPriceCheckRequest extends AutoEncoder {
     @field({ decoder: IntegerDecoder })
-    price: number;
+    basePrice: number;
+
+    /**
+     * The reduced price in the non-official flow is an estimate, the response will have the effective price for this UiTPAS number
+     * The reduced price can thus only be null when doing a static check (using uitpasEventId and without UiTPAS number) (e.g. when configuring the webshop)
+     */
+    @field({ decoder: IntegerDecoder, nullable: true })
+    reducedPrice: number;
 
     @field({ decoder: StringDecoder, nullable: true })
     uitpasEventId: string;

--- a/shared/structures/src/endpoints/UitpasPriceCheckRequest.ts
+++ b/shared/structures/src/endpoints/UitpasPriceCheckRequest.ts
@@ -9,13 +9,13 @@ export class UitpasPriceCheckRequest extends AutoEncoder {
      * The reduced price can thus only be null when doing a static check (using uitpasEventId and without UiTPAS number) (e.g. when configuring the webshop)
      */
     @field({ decoder: IntegerDecoder, nullable: true })
-    reducedPrice: number;
+    reducedPrice: number | null;
 
     @field({ decoder: StringDecoder, nullable: true })
-    uitpasEventId: string;
+    uitpasEventId: string | null;
 
     @field({ decoder: StringDecoder, nullable: true })
-    uitpasNumber: string;
+    uitpasNumber: string | null;
 }
 
 export class UitpasPriceCheckResponse extends AutoEncoder {

--- a/shared/structures/src/endpoints/UitpasPriceCheckRequest.ts
+++ b/shared/structures/src/endpoints/UitpasPriceCheckRequest.ts
@@ -1,0 +1,17 @@
+import { AutoEncoder, StringDecoder, field, IntegerDecoder } from '@simonbackx/simple-encoding';
+
+export class UitpasPriceCheckRequest extends AutoEncoder {
+    @field({ decoder: IntegerDecoder })
+    price: number;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    uitpasEventId: string;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    uitpasNumber: string;
+}
+
+export class UitpasPriceCheckResponse extends AutoEncoder {
+    @field({ decoder: IntegerDecoder })
+    price: number;
+}


### PR DESCRIPTION
1 endpoint om 3 scenario's te ondersteunen
* input = **UiTPAS-nummer** & **prijs**: dit is de niet-officiële flow en de endpoint controleert het UiTPAS-nummer op geldigheid voor het kansentarief. De prijs is de gereduceerde prijs.
* input = **event_id** & **prijs**: dit is de statische officiële flow en de endpoint zoekt de kansentarief prijs onafhankelijk van een UiTPAS-nummer, maar specifiek voor dit UiTPAS-evenement. De prijs is de basis prijs. (_nog niet geïmplementeerd)_
* input = **UiTPAS-nummer**, **event_id** & **prijs**: dit is de officiële flow, de endpoint zoekt het kansentarief voor dit event én voor dit UiTPAS-nummer. De prijs is de basis prijs. (_nog niet geïmplementeerd)_