### PR TITLE
UiTPAS order UI

### DIFF
--- a/frontend/shared/components/src/views/CartItemRow.vue
+++ b/frontend/shared/components/src/views/CartItemRow.vue
@@ -22,7 +22,7 @@
             </p>
             <div @click.stop>
                 <span v-if="cartItem.formattedAmount" class="amount">{{ cartItem.formattedAmount }}</span>
-                <StepperInput v-if="editable && !cartItem.cartError && cartItem.seats.length === 0 && (maximumRemaining === null || maximumRemaining > 1)" v-model="amount" :min="1" :max="maximumRemaining" @click.native.stop />
+                <StepperInput v-if="editable && !cartItem.cartError && cartItem.seats.length === 0 && (maximumRemaining === null || maximumRemaining > 1) && cartItem.productPrice.uitpasBaseProductPriceId === null" v-model="amount" :min="1" :max="maximumRemaining" @click.native.stop />
                 <button v-if="editable" class="button icon trash" type="button" @click="deleteItem()" />
             </div>
         </footer>

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -193,6 +193,7 @@ const canDismiss = useCanDismiss();
 const pricedItem = ref(props.cartItem) as Ref<CartItem>;
 const pricedCheckout = ref(props.checkout) as Ref<Checkout>;
 const errors = useErrors();
+const owner = useRequestOwner();
 
 const willNeedSeats = computed(() => withSeats.value);
 const cart = computed(() => props.checkout.cart);
@@ -321,7 +322,7 @@ async function validateUitpasNumbers() {
         const response = await context.value.optionalAuthenticatedServer.request({
             method: 'POST',
             path: '/uitpas',
-            owner: useRequestOwner(),
+            owner: owner,
             shouldRetry: false,
             body: UitpasPriceCheckRequest.create({
                 basePrice: baseProductPrice.price,

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -111,12 +111,12 @@
             <template v-if="canOrder && props.cartItem.productPrice.uitpasBaseProductPriceId !== null">
                 <hr><h2>{{ cartItem.amount < 2 ? $t('UiTPAS-nummer') : $t('UiTPAS-nummers') }}</h2>
 
-                <STInputBox v-for="(value, index) in uitpasNumbers" :key="index" :error-fields="'uitpasNumbers.' + index" :error-box="errors.errorBox" class="uitpas-number-input" :title="'UiTPAS-nummer' + (cartItem.amount < 2 ? '' : ` ${index + 1}`)">
+                <STInputBox v-for="(value, index) in uitpasNumbers" :key="index" :error-fields="'uitpasNumbers.' + index" :error-box="errors.errorBox" class="uitpas-number-input">
                     <input
                         v-model="uitpasNumbers[index]"
                         class="input"
                         type="text"
-                        placeholder="Het nummer op de achterkant van je UiTPAS-kaart, onder de barcode."
+                        :placeholder="index === 0 ? 'Geef jouw UiTPAS-nummer in' : 'UiTPAS-nummer ' + (index + 1)"
                     >
                 </STInputBox>
 

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -111,7 +111,7 @@
             <template v-if="canOrder && props.cartItem.productPrice.uitpasBaseProductPriceId !== null">
                 <hr><h2>{{ cartItem.amount < 2 ? $t('UiTPAS-nummer') : $t('UiTPAS-nummers') }}</h2>
 
-                <STInputBox v-for="(value, index) in uitpasNumbers" :key="index" :error-fields="'uitpasNumbers.' + index" :error-box="errors.errorBox" class="uitpas-number-input">
+                <STInputBox v-for="(value, index) in uitpasNumbers" :key="index" :error-fields="'uitpasNumbers.' + index" :error-box="errors.errorBox" class="max uitpas-number-input">
                     <input
                         v-model="uitpasNumbers[index]"
                         class="input"
@@ -119,8 +119,6 @@
                         :placeholder="index === 0 ? 'Geef jouw UiTPAS-nummer in' : 'UiTPAS-nummer ' + (index + 1)"
                     >
                 </STInputBox>
-
-                <p v-if="stockText" class="style-description-smal" v-text="stockText" />
             </template>
 
             <div v-if="!cartEnabled && (pricedCheckout.priceBreakown.length > 1 || pricedCheckout.totalPrice > 0)" class="pricing-box max">
@@ -280,7 +278,7 @@ async function validateUitpasNumbers() {
         throw new SimpleError({
             code: 'uitpas_numbers_does_not_match_amount',
             message: 'UiTPAS numbers does not match ordered amount',
-            human: $t('Geef evenveel UiTPAS nummers in als het aantal dat je bestelt. besteld = ' + props.cartItem.amount + ', ingegeven = ' + props.cartItem.uitpasNumbers.length),
+            human: $t('Geef evenveel UiTPAS nummers in als het aantal dat je bestelt.'),
         });
     }
 

--- a/shared/structures/src/webshops/Cart.ts
+++ b/shared/structures/src/webshops/Cart.ts
@@ -22,6 +22,7 @@ export class Cart extends AutoEncoder {
             if (i.code === c && allowMerge) {
                 i.amount += item.amount;
                 i.seats.push(...item.seats);
+                i.uitpasNumbers.push(...item.uitpasNumbers);
                 return;
             }
         }
@@ -47,6 +48,7 @@ export class Cart extends AutoEncoder {
             if (i.code === c && i.code !== oldCode) {
                 i.amount += item.amount;
                 i.seats.push(...item.seats);
+                i.uitpasNumbers.push(...item.uitpasNumbers);
                 this.removeItem(old);
                 return;
             }

--- a/shared/structures/src/webshops/CartItem.ts
+++ b/shared/structures/src/webshops/CartItem.ts
@@ -508,10 +508,7 @@ export class CartItem extends AutoEncoder {
                 descriptions.push($t('UiTPAS-nummer') + ': ' + this.uitpasNumbers[0]);
             }
             else {
-                descriptions.push($t('UiTPAS-nummers') + ':');
-                for (const uitpasNumber of this.uitpasNumbers) {
-                    descriptions.push(' ' + uitpasNumber);
-                }
+                descriptions.push($t('UiTPAS-nummers') + ': ' + this.uitpasNumbers.join(', '));
             }
         }
         return descriptions.filter(d => !!d).join('\n');

--- a/shared/structures/src/webshops/CartItem.ts
+++ b/shared/structures/src/webshops/CartItem.ts
@@ -502,6 +502,18 @@ export class CartItem extends AutoEncoder {
                 + this.seats.slice().sort(ReservedSeat.sort).map(s => s.getShortName(this.product)).join(', '),
             );
         }
+
+        if (this.uitpasNumbers.length) {
+            if (this.uitpasNumbers.length === 1) {
+                descriptions.push($t('UiTPAS-nummer') + ': ' + this.uitpasNumbers[0]);
+            }
+            else {
+                descriptions.push($t('UiTPAS-nummers') + ':');
+                for (const uitpasNumber of this.uitpasNumbers) {
+                    descriptions.push(' ' + uitpasNumber);
+                }
+            }
+        }
         return descriptions.filter(d => !!d).join('\n');
     }
 


### PR DESCRIPTION
When ordering a product with a UiTPAS social tariff:

- as much input boxes as the ordered amount will pop-up
- decreasing the amount will remove empty boxes
- the numbers are statically (frontend side) checked and if all succeed by a backend call. All numbers in one go.
- If you order the same item twice, the cart will 'merge' them and the UiTPAS numbers will merge too
- UiTPAS numbers are displayed in the overview of an order

:x: problem still to be fixed, bad UI:
<img width="378" height="329" alt="Screenshot 2025-07-10 at 16 04 07" src="https://github.com/user-attachments/assets/565e329f-26a8-450d-b6c3-c51bb1f949a7" />

