### PR TITLE
Let api-users also use GET endpoint /organization/admins

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/users/GetOrganizationAdminsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/users/GetOrganizationAdminsEndpoint.ts
@@ -27,7 +27,7 @@ export class GetOrganizationAdminsEndpoint extends Endpoint<Params, Query, Body,
         await Context.authenticate();
 
         // Fast throw first (more in depth checking for patches later)
-        if (!await Context.auth.canManageAdmins(organization.id)) {
+        if (!await Context.auth.hasFullAccess(organization.id)) {
             throw Context.auth.error();
         }
 


### PR DESCRIPTION
`canManageAccess` vraagt én full access én dat het géén api user is.

```typescript
async canManageAdmins(organizationId: string) {
    return !this.user.isApiUser && (await this.hasFullAccess(organizationId));
}
```

Voor het lezen van de admins, lijkt mij enkel full access voldoende

