### PR TITLE
Add exception for email domain mailo.com on email domain typo validation

### DIFF
--- a/shared/utility/src/DataValidator.ts
+++ b/shared/utility/src/DataValidator.ts
@@ -43,6 +43,11 @@ export class DataValidator {
             return true;
         }
 
+        if (domain === 'mailo.com') {
+            // Exception for typo on gmail.com
+            return true;
+        }
+
         if (foundInvalid) {
             return false;
         }


### PR DESCRIPTION
mailo.com is identified as a typo for gmail.com. As this is a valid mail domain, an exception needs to be added.