### PR TITLE
Excel export file names (STA-1069)

### DIFF
--- a/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
@@ -163,7 +163,7 @@ export class ExportToExcelEndpoint extends Endpoint<Params, Query, Body, Respons
 
                 console.log('Done writing excel file');
 
-                const url = 'https://' + STAMHOOFD.domains.api + '/v' + Version + '/file-cache?file=' + encodeURIComponent(file) + '&name=' + encodeURIComponent(type);
+                const url = 'https://' + STAMHOOFD.domains.api + '/v' + Version + '/file-cache?file=' + encodeURIComponent(file) + '&name=' + encodeURIComponent(request.title ?? type);
                 return url;
             }, 2);
         });

--- a/frontend/app/admin/src/views/event-notifications/EventNotificationsTableView.vue
+++ b/frontend/app/admin/src/views/event-notifications/EventNotificationsTableView.vue
@@ -224,6 +224,7 @@ async function exportToExcel(selection: TableActionSelection<ObjectType>) {
                     filter: selection.filter,
                     workbook: getSelectableWorkbook(platform.value),
                     configurationId: configurationId.value,
+                    title: $t('Kampmeldingen'),
                 }),
             }),
         ],

--- a/frontend/app/admin/src/views/organizations/OrganizationsTableView.vue
+++ b/frontend/app/admin/src/views/organizations/OrganizationsTableView.vue
@@ -277,12 +277,25 @@ async function exportToExcel(selection: TableActionSelection<ObjectType>) {
                     filter: selection.filter,
                     workbook: getSelectableWorkbook(platform.value),
                     configurationId: configurationId.value,
+                    title: getExcelTitle(selection),
                 }),
             }),
         ],
         modalDisplayStyle: 'popup',
     });
 }
+
+function getExcelTitle(selection: TableActionSelection<ObjectType>) {
+        if (selection.markedRows && selection.markedRowsAreSelected && selection.markedRows.size === 1) {
+            return [...selection.markedRows.values()][0].name;
+        }
+        const parts = [
+            props.tag?.id ? props.tag.name : null,
+            $t('#Groepen'),
+        ];
+
+        return parts.filter(Boolean).join(' - ');
+    }
 
 if (auth.hasPlatformFullAccess()) {
     actions.push(

--- a/frontend/app/dashboard/src/classes/OrdersExcelExport.ts
+++ b/frontend/app/dashboard/src/classes/OrdersExcelExport.ts
@@ -839,15 +839,16 @@ export class OrdersExcelExport {
             XLSX.utils.book_append_sheet(wb, this.createSettlements(webshop, orders), $t(`%xS`));
         }
 
+        const fileName = Formatter.fileSlug(webshop.meta.name) + '.xlsx';
         if (AppManager.shared.downloadFile) {
             const data: ArrayBuffer = XLSX.write(wb, { type: 'array' });
             const blob = new Blob([data], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-            AppManager.shared.downloadFile(blob, $t(`%xT`)).catch((e) => {
+            AppManager.shared.downloadFile(blob, fileName).catch((e) => {
                 Toast.fromError(e).show();
             });
         }
         else {
-            XLSX.writeFile(wb, $t(`%xT`));
+            XLSX.writeFile(wb, fileName);
         }
     }
 }

--- a/frontend/app/dashboard/src/views/dashboard/balance-items/BalanceItemsTableView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/balance-items/BalanceItemsTableView.vue
@@ -280,6 +280,7 @@ const actions = [
                             filter: selection.filter,
                             workbook: getSelectableWorkbook(),
                             configurationId: configurationId.value,
+                            title: [organization.value?.name, $t('Aanrekeningen')].filter(Boolean).join(' - '),
                         }),
                     }),
                 ],

--- a/frontend/app/dashboard/src/views/dashboard/invoices/InvoicesTableView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/invoices/InvoicesTableView.vue
@@ -216,6 +216,7 @@ const actions: TableAction<ObjectType>[] = [
                             filter: selection.filter,
                             workbook: getSelectableWorkbook(),
                             configurationId: configurationId.value,
+                            title: [organization.value?.name, $t('Facturen')].filter(Boolean).join(' - '),
                         }),
                     }),
                 ],

--- a/frontend/app/dashboard/src/views/dashboard/payments/PaymentActionBuilder.ts
+++ b/frontend/app/dashboard/src/views/dashboard/payments/PaymentActionBuilder.ts
@@ -15,7 +15,7 @@ import { usePlatform } from '@stamhoofd/components/hooks/usePlatform.ts';
 import { ExcelExportView } from '@stamhoofd/frontend-excel-export';
 import type { SessionContext } from '@stamhoofd/networking/SessionContext';
 import type { Organization, Platform } from '@stamhoofd/structures';
-import { EmailRecipientFilterType, EmailRecipientSubfilter, ExcelExportType, mergeFilters, Payment, PaymentGeneral, PaymentMethod, PaymentStatus } from '@stamhoofd/structures';
+import { EmailRecipientFilterType, EmailRecipientSubfilter, ExcelExportType, mergeFilters, Payment, PaymentGeneral, PaymentMethod, PaymentMethodHelper, PaymentStatus } from '@stamhoofd/structures';
 import type { ComputedRef, Ref } from 'vue';
 import { useSelectableWorkbook } from './getSelectableWorkbook';
 import { useMarkPaymentsPaid } from './hooks/useMarkPaymentsPaid';
@@ -121,6 +121,7 @@ export class PaymentActionBuilder {
                                     filter: selection.filter,
                                     workbook: this.selectableWorkbook.getSelectableWorkbook(),
                                     configurationId: this.configurationId.value,
+                                    title: this.getExcelTitle(),
                                 }),
                             }),
                         ],
@@ -136,6 +137,15 @@ export class PaymentActionBuilder {
         }
 
         return actions.filter(action => action !== null);
+    }
+
+     private getExcelTitle() {
+        const parts = [
+            this.organization && this.context.value.auth.hasSomePlatformAccess() ? this.organization.name : null,
+            this.methods?.length === 1 ? PaymentMethodHelper.getPluralNameCapitalized(this.methods[0]) : $t('Betalingen'),
+        ];
+
+        return parts.filter(Boolean).join(' - ');
     }
 
     private getEmailAction() {

--- a/frontend/app/dashboard/src/views/dashboard/receivable-balances/ReceivableBalancesTableView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/receivable-balances/ReceivableBalancesTableView.vue
@@ -174,6 +174,7 @@ const actions: TableAction<ObjectType>[] = [
                             filter: selection.filter,
                             workbook: getSelectableWorkbook(),
                             configurationId: configurationId.value,
+                            title: [organization.value?.name, $t('Openstaande bedragen')].filter(Boolean).join(' - '),
                         }),
                     }),
                 ],

--- a/frontend/app/dashboard/src/views/dashboard/settings/administration/ConfigurePaymentExportView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/administration/ConfigurePaymentExportView.vue
@@ -396,6 +396,11 @@ export default class ConfigurePaymentExportView extends Mixins(NavigationMixin) 
                         }),
                         workbook: getSelectableWorkbook(),
                         configurationId: 'configure-payment-export',
+                        title: [
+                            this.organization && this.$context.auth.hasSomePlatformAccess() ? this.organization.name : null,
+                            this.methods.length === 1 ? PaymentMethodHelper.getPluralNameCapitalized(this.methods[0]) : $t('Betalingen'),
+                            Formatter.dateRange(this.startDate, this.endDate, ' tem ', false)
+                        ].filter(Boolean).join(' - '),
                     }),
                 ],
             });
@@ -405,6 +410,8 @@ export default class ConfigurePaymentExportView extends Mixins(NavigationMixin) 
         }
         this.saving = false;
     }
+
+    
 
     buildFilter(): StamhoofdFilter {
         return {

--- a/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
+++ b/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
@@ -930,11 +930,27 @@ export class MemberActionBuilder {
                         filter: selection.filter,
                         workbook: getSelectableWorkbook(this.platform, this.organizations.length === 1 ? this.organizations[0] : null, this.groups, this.context.auth),
                         configurationId: 'members',
+                        title: this.getExcelTitle(selection),
                     }),
                 }),
             ],
             modalDisplayStyle: 'popup',
         });
+    }
+
+    private getExcelTitle(selection: TableActionSelection<PlatformMember>) {
+        if (selection.markedRows && selection.markedRowsAreSelected && selection.markedRows.size === 1) {
+            return [...selection.markedRows.values()][0].member.name;
+        }
+        const parts = [
+            this.organizations.length === 1 && this.context.auth.hasSomePlatformAccess() ? this.organizations[0].name : null,
+            this.organizations.length === 1 && this.organizations[0].period.period.id !== this.platform.period.id ? this.organizations[0].period.period.name : null,
+            this.categories.length === 1 ? this.categories[0].settings.name :
+                (this.groups.length === 1 ? this.groups[0].settings.name : null),
+            $t('Leden'),
+        ];
+
+        return parts.filter(Boolean).join(' - ');
     }
 
     private getExportToPdfAction() {

--- a/frontend/shared/components/src/platform-memberships/classes/PlatformMembershipActionBuilder.ts
+++ b/frontend/shared/components/src/platform-memberships/classes/PlatformMembershipActionBuilder.ts
@@ -78,10 +78,22 @@ export class PlatformMembershipActionBuilder {
                         filter: selection.filter,
                         workbook: getSelectableWorkbook(),
                         configurationId: 'platform-memberships',
+                        title: this.getExcelTitle(selection),
                     }),
                 }),
             ],
             modalDisplayStyle: 'popup',
         });
+    }
+
+    private getExcelTitle(selection: TableActionSelection<PlatformMembership>) {
+        if (selection.markedRows && selection.markedRowsAreSelected  && selection.markedRows.size === 1) {
+            return [...selection.markedRows.values()][0].member.name;
+        }
+        const parts = [
+            $t('Aansluitingen'),
+        ];
+
+        return parts.filter(Boolean).join(' - ');
     }
 }

--- a/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
+++ b/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
@@ -778,11 +778,27 @@ export class RegistrationActionBuilder {
                         filter: selection.filter,
                         workbook: getSelectableWorkbook(this.platform, this.organizations.length === 1 ? this.organizations[0] : null, this.groups, this.context.auth),
                         configurationId: 'registrations',
+                        title: this.getExcelTitle(selection),
                     }),
                 }),
             ],
             modalDisplayStyle: 'popup',
         });
+    }
+
+    private getExcelTitle(selection: TableActionSelection<PlatformRegistration>) {
+        if (selection.markedRows && selection.markedRowsAreSelected && selection.markedRows.size === 1) {
+            return [...selection.markedRows.values()][0].member.member.name;
+        }
+        const parts = [
+            this.organizations.length === 1 && this.context.auth.hasSomePlatformAccess() ? this.organizations[0].name : null,
+            this.organizations.length === 1 && this.organizations[0].period.period.id !== this.platform.period.id ? this.organizations[0].period.period.name : null,
+            this.categories.length === 1 ? this.categories[0].settings.name :
+                (this.groups.length === 1 ? this.groups[0].settings.name : null),
+            $t('Inschrijvingen'),
+        ];
+
+        return parts.filter(Boolean).join(' - ');
     }
 
     private async exportToPdf(members: PlatformMember[]) {

--- a/frontend/shared/excel-export/src/ExcelExportView.vue
+++ b/frontend/shared/excel-export/src/ExcelExportView.vue
@@ -60,12 +60,18 @@ import { Formatter } from '@stamhoofd/utility';
 import { onMounted, ref } from 'vue';
 import type { SelectableWorkbook } from './SelectableWorkbook';
 
-const props = defineProps<{
-    type: ExcelExportType;
-    filter: LimitedFilteredRequest;
-    workbook: SelectableWorkbook;
-    configurationId: string; // How to store the filters for easy reuse
-}>();
+const props = withDefaults(
+    defineProps<{
+        type: ExcelExportType;
+        title?: string | null; // file name to use for the excel file, without extension
+        filter: LimitedFilteredRequest;
+        workbook: SelectableWorkbook;
+        configurationId: string; // How to store the filters for easy reuse
+    }>(),
+    {
+        title: null,
+    },
+);
 
 const visibleSheet = ref(props.workbook.sheets[0]);
 const exporting = ref(false);
@@ -126,12 +132,14 @@ async function startExport() {
 
 async function doExport() {
     try {
+        let title = Formatter.fileSlug(props.title ?? props.type);
         const response = await context.value.authenticatedServer.request({
             method: 'POST',
             path: `/export/excel/${props.type}`,
             body: ExcelExportRequest.create({
                 filter: props.filter,
                 workbookFilter: props.workbook.getFilter(),
+                title: title,
             }),
             decoder: ExcelExportResponse as Decoder<ExcelExportResponse>,
             shouldRetry: false,
@@ -139,11 +147,13 @@ async function doExport() {
 
         if (response.data.url) {
             const url = new URL(response.data.url);
-            const filename = Formatter.fileSlug(props.type) + '.xlsx';
+            if (url.searchParams.has('name')) {
+                title = Formatter.fileSlug(url.searchParams.get('name')!)
+            }
             new Toast($t('%1B6'), 'download')
                 .setButton(
                     new ToastButton($t('%1B7'), () => {
-                        AppManager.shared.downloadFile(url, filename).catch((e) => {
+                        AppManager.shared.downloadFile(url, title + '.xlsx').catch((e) => {
                             Toast.fromError(e).setHide(15_000).show();
                         });
                     }),

--- a/shared/structures/src/filters/ExcelExportRequest.ts
+++ b/shared/structures/src/filters/ExcelExportRequest.ts
@@ -49,6 +49,12 @@ export class ExcelExportRequest extends AutoEncoder {
 
     @field({ decoder: ExcelWorkbookFilter })
     workbookFilter: ExcelWorkbookFilter;
+
+    /**
+     * File name to use for the excel file, without extension.
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    title: string | null = null;
 }
 
 export class ExcelExportResponse extends AutoEncoder {


### PR DESCRIPTION
# STA-1069

| Export | File name parts (joined with `-` , ends with `.xlsx`) |
| --- | --- |
| Event notifications | • `Kampmeldingen` |
| Organizations | • `Tag` *(if tag)*<br>• `#Groepen`<br>If only 1 organization: `Org name` |
| Balance items | • `Org name` if 1 org ~~& user *hasSomePlatformAccess*~~<br>• `Aanrekeningen` |
| Receivable balances | • `Org name` if 1 org ~~& user *hasSomePlatformAccess*~~<br>• `Openstaande bedragen` |
| Invoices (action is commented out) | • `Org name` if 1 org ~~& user *hasSomePlatformAccess*~~<br>• `Facturen` |
| Payments (via *ConfigurePaymentExportView*) | • `Org name` if 1 org & user *hasSomePlatformAccess*<br>• `Method name` if one method, else `Betalingen`<br>• `{fromDate}` tem `{toDate}` |
| Payments (via *PaymentActionBuilder*) | • `Org name` if 1 org & user *hasSomePlatformAccess*<br>• `Method name` if one method, else `Betalingen` |
| Members | • `Org name` if 1 org & user *hasSomePlatformAccess*<br>• `Period name` if org period ≠ platform period<br>• `Category name` if 1 category, `[Group name]` if 1 group<br>• `Leden`<br>If only 1 member: `Member name` |
| Registrations | • `Org name` if 1 org & user *hasSomePlatformAccess*<br>• `Period name` if org period ≠ platform period<br>• `Category name` if 1 category, `[Group name]` if 1 group<br>• `Inschrijvingen`<br>If only 1 registration: `Member name` |
| Platform memberships | • `Aansluitingen`<br>If only 1 platform membership: `Member name` |
| Webshops | • `Webshop name` |

Bij Balance items, Receivable balances en Invoices is er te weinig context om _hasSomePlatformAccess_ te weten. Is dit een probleem?
Bij webshops idem & daar is ook de organisatie naam niet bereikbaar.