### PR TITLE
✨️ Add justfile with Linux local development support

### DIFF
--- a/.development/just/common.sh
+++ b/.development/just/common.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERATED_DIR="$ROOT_DIR/.development/just/generated"
+CERT_DIR="$GENERATED_DIR/certs"
+DEV_CA_CRT="$CERT_DIR/stamhoofd-dev-ca.crt"
+DEV_CA_KEY="$CERT_DIR/stamhoofd-dev-ca.key"
+DEV_CERT_CRT="$CERT_DIR/stamhoofd-dev.crt"
+DEV_CERT_KEY="$CERT_DIR/stamhoofd-dev.key"
+DEV_CERT_CSR="$CERT_DIR/stamhoofd-dev.csr"
+DEV_CERT_EXT="$CERT_DIR/stamhoofd-dev.ext"
+TRUSTED_DEV_CA_CRT="/usr/local/share/ca-certificates/stamhoofd-dev-ca.crt"
+RESOLVED_RUNTIME_CONFIG="/run/systemd/resolved.conf.d/stamhoofd.conf"
+KEYCLOAK_IMPORT_DIR="$GENERATED_DIR/keycloak"
+KEYCLOAK_REALM_CONFIG="$KEYCLOAK_IMPORT_DIR/stamhoofd-realm.json"
+
+STAMHOOFD_DEV_NAME="${STAMHOOFD_DEV_NAME:-stamhoofd}"
+STAMHOOFD_DOMAIN="${STAMHOOFD_DOMAIN:-stamhoofd}"
+
+MYSQL_CONTAINER="${STAMHOOFD_DEV_NAME}-mysql"
+MAILDEV_CONTAINER="${STAMHOOFD_DEV_NAME}-maildev"
+CADDY_CONTAINER="${STAMHOOFD_DEV_NAME}-caddy"
+COREDNS_CONTAINER="${STAMHOOFD_DEV_NAME}-coredns"
+KEYCLOAK_CONTAINER="${STAMHOOFD_DEV_NAME}-keycloak"
+TEST_MYSQL_CONTAINER="${STAMHOOFD_TEST_MYSQL_CONTAINER:-${STAMHOOFD_DEV_NAME}-test-mysql-$$}"
+
+MYSQL_VOLUME="${STAMHOOFD_DEV_NAME}-mysql-data"
+CADDY_DATA_VOLUME="${STAMHOOFD_DEV_NAME}-caddy-data"
+CADDY_CONFIG_VOLUME="${STAMHOOFD_DEV_NAME}-caddy-config"
+KEYCLOAK_IMAGE="${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.0.7}"
+KEYCLOAK_REALM="${KEYCLOAK_REALM:-stamhoofd}"
+KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-stamhoofd-local}"
+KEYCLOAK_CLIENT_SECRET="${KEYCLOAK_CLIENT_SECRET:-stamhoofd-local-secret}"
+KEYCLOAK_ADMIN_USER="${KEYCLOAK_ADMIN_USER:-admin}"
+KEYCLOAK_ADMIN_PASSWORD="${KEYCLOAK_ADMIN_PASSWORD:-admin}"
+KEYCLOAK_USER_EMAIL="${KEYCLOAK_USER_EMAIL:-sso@example.com}"
+KEYCLOAK_USER_PASSWORD="${KEYCLOAK_USER_PASSWORD:-password}"
+KEYCLOAK_USER_NAME="${KEYCLOAK_USER_NAME:-Local SSO User}"
+KEYCLOAK_USER_ID="${KEYCLOAK_USER_ID:-local-sso-user}"
+
+common_confirm() {
+    local prompt="$1"
+    local answer
+    read -r -p "$prompt [y/N] " answer
+    case "$answer" in
+        y|Y|yes|YES) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+common_require_command() {
+    local command_name="$1"
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        echo "Missing required command: $command_name" >&2
+        return 1
+    fi
+}
+
+common_container_is_running() {
+    local container_name="$1"
+    [ "$(docker inspect -f '{{.State.Running}}' "$container_name" 2>/dev/null || true)" = "true" ]
+}
+
+common_prepare_dev_dirs() {
+    mkdir -p "$GENERATED_DIR"
+}
+
+common_json_string() {
+    node -e 'process.stdout.write(JSON.stringify(process.argv[1] ?? ""))' "$1"
+}
+
+common_wait_for_mysql_container() {
+    local container_name="$1"
+    echo "Waiting for MySQL to accept connections..."
+    for _ in {1..60}; do
+        if docker exec "$container_name" mysql -h127.0.0.1 -uroot -proot -e 'SELECT 1' >/dev/null 2>&1; then
+            echo "MySQL is ready."
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "MySQL did not become ready in time." >&2
+    docker logs "$container_name" >&2 || true
+    return 1
+}

--- a/.development/just/common.sh
+++ b/.development/just/common.sh
@@ -5,17 +5,43 @@ GENERATED_DIR="$ROOT_DIR/.development/just/generated"
 CERT_DIR="$GENERATED_DIR/certs"
 DEV_CA_CRT="$CERT_DIR/stamhoofd-dev-ca.crt"
 DEV_CA_KEY="$CERT_DIR/stamhoofd-dev-ca.key"
+DEV_CA_SERIAL="$CERT_DIR/stamhoofd-dev-ca.srl"
 DEV_CERT_CRT="$CERT_DIR/stamhoofd-dev.crt"
 DEV_CERT_KEY="$CERT_DIR/stamhoofd-dev.key"
 DEV_CERT_CSR="$CERT_DIR/stamhoofd-dev.csr"
 DEV_CERT_EXT="$CERT_DIR/stamhoofd-dev.ext"
 TRUSTED_DEV_CA_CRT="/usr/local/share/ca-certificates/stamhoofd-dev-ca.crt"
+TRUSTED_DEV_CA_PEM="/etc/ssl/certs/stamhoofd-dev-ca.pem"
+RESOLVED_RUNTIME_CONFIG_DIR="/run/systemd/resolved.conf.d"
 RESOLVED_RUNTIME_CONFIG="/run/systemd/resolved.conf.d/stamhoofd.conf"
 KEYCLOAK_IMPORT_DIR="$GENERATED_DIR/keycloak"
 KEYCLOAK_REALM_CONFIG="$KEYCLOAK_IMPORT_DIR/stamhoofd-realm.json"
+MYSQL_IMAGE="${MYSQL_IMAGE:-mysql:8.4}"
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-root}"
+MAILDEV_IMAGE="${MAILDEV_IMAGE:-maildev/maildev:2.2.1}"
+COREDNS_IMAGE="${COREDNS_IMAGE:-coredns/coredns:1.11.3}"
+CADDY_IMAGE="${CADDY_IMAGE:-caddy:2.8}"
 
 STAMHOOFD_DEV_NAME="${STAMHOOFD_DEV_NAME:-stamhoofd}"
 STAMHOOFD_DOMAIN="${STAMHOOFD_DOMAIN:-stamhoofd}"
+LOCAL_HOST="${LOCAL_HOST:-127.0.0.1}"
+LOCAL_IPV6_HOST="${LOCAL_IPV6_HOST:-::1}"
+
+DASHBOARD_PORT="${DASHBOARD_PORT:-8080}"
+REGISTRATION_PORT="${REGISTRATION_PORT:-8081}"
+SHOP_PORT="${SHOP_PORT:-8082}"
+API_PORT="${API_PORT:-9091}"
+RENDERER_PORT="${RENDERER_PORT:-9093}"
+MYSQL_PORT="${MYSQL_PORT:-3306}"
+MYSQL_CONTAINER_PORT="${MYSQL_CONTAINER_PORT:-3306}"
+MYSQL_CLIENT_HOST="${MYSQL_CLIENT_HOST:-127.0.0.1}"
+DNS_PORT="${DNS_PORT:-53}"
+MAILDEV_SMTP_PORT="${MAILDEV_SMTP_PORT:-1025}"
+MAILDEV_HTTP_PORT="${MAILDEV_HTTP_PORT:-1080}"
+MAILDEV_CONTAINER_SMTP_PORT="${MAILDEV_CONTAINER_SMTP_PORT:-1025}"
+MAILDEV_CONTAINER_HTTP_PORT="${MAILDEV_CONTAINER_HTTP_PORT:-1080}"
+SSO_PORT="${SSO_PORT:-5556}"
+KEYCLOAK_CONTAINER_PORT="${KEYCLOAK_CONTAINER_PORT:-8080}"
 
 MYSQL_CONTAINER="${STAMHOOFD_DEV_NAME}-mysql"
 MAILDEV_CONTAINER="${STAMHOOFD_DEV_NAME}-maildev"
@@ -38,6 +64,17 @@ KEYCLOAK_USER_PASSWORD="${KEYCLOAK_USER_PASSWORD:-password}"
 KEYCLOAK_USER_NAME="${KEYCLOAK_USER_NAME:-Local SSO User}"
 KEYCLOAK_USER_ID="${KEYCLOAK_USER_ID:-local-sso-user}"
 
+DASHBOARD_URL="https://dashboard.${STAMHOOFD_DOMAIN}"
+API_URL="https://api.${STAMHOOFD_DOMAIN}"
+RENDERER_URL="https://renderer.${STAMHOOFD_DOMAIN}"
+MAILDEV_URL="http://${LOCAL_HOST}:${MAILDEV_HTTP_PORT}"
+SSO_BASE_URL="https://sso.${STAMHOOFD_DOMAIN}/dex"
+SSO_ADMIN_URL="${SSO_BASE_URL}/admin"
+SSO_EXAMPLE_REDIRECT_URI="https://<organization-id>.api.${STAMHOOFD_DOMAIN}/openid/callback"
+CADDY_CERT_DIR="/etc/caddy/certs"
+CADDY_DEV_CERT_CRT="$CADDY_CERT_DIR/$(basename "$DEV_CERT_CRT")"
+CADDY_DEV_CERT_KEY="$CADDY_CERT_DIR/$(basename "$DEV_CERT_KEY")"
+
 common_confirm() {
     local prompt="$1"
     local answer
@@ -54,6 +91,73 @@ common_require_command() {
         echo "Missing required command: $command_name" >&2
         return 1
     fi
+}
+
+common_print_command() {
+    local separator='  '
+    local argument
+    for argument in "$@"; do
+        printf '%s%q' "$separator" "$argument"
+        separator=' '
+    done
+    printf '\n'
+}
+
+common_print_run_command() {
+    if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+        printf '\033[2m'
+        common_print_command "$@"
+        printf '\033[0m'
+    else
+        common_print_command "$@"
+    fi
+}
+
+common_command() {
+    local mode="$1"
+    shift
+
+    case "$mode" in
+        print)
+            common_print_command "$@"
+            ;;
+        run)
+            common_print_run_command "$@"
+            "$@"
+            ;;
+        *)
+            echo "Unknown command mode: $mode" >&2
+            return 1
+            ;;
+    esac
+}
+
+common_command_quiet() {
+    local mode="$1"
+    shift
+
+    case "$mode" in
+        print)
+            common_print_command "$@"
+            ;;
+        run)
+            common_print_run_command "$@"
+            "$@" >/dev/null
+            ;;
+        *)
+            echo "Unknown command mode: $mode" >&2
+            return 1
+            ;;
+    esac
+}
+
+common_docker_rm() {
+    common_print_run_command docker rm -f "$@"
+    docker rm -f "$@" >/dev/null 2>&1 || true
+}
+
+common_docker_volume_create() {
+    common_command_quiet run docker volume create "$1"
 }
 
 common_container_is_running() {
@@ -73,7 +177,7 @@ common_wait_for_mysql_container() {
     local container_name="$1"
     echo "Waiting for MySQL to accept connections..."
     for _ in {1..60}; do
-        if docker exec "$container_name" mysql -h127.0.0.1 -uroot -proot -e 'SELECT 1' >/dev/null 2>&1; then
+        if docker exec "$container_name" mysql -h"$MYSQL_CLIENT_HOST" -uroot -p"$MYSQL_ROOT_PASSWORD" -e 'SELECT 1' >/dev/null 2>&1; then
             echo "MySQL is ready."
             return 0
         fi
@@ -83,4 +187,31 @@ common_wait_for_mysql_container() {
     echo "MySQL did not become ready in time." >&2
     docker logs "$container_name" >&2 || true
     return 1
+}
+
+common_start_mysql_container() {
+    local container_name="$1"
+    local port_mapping="$2"
+    local volume_mount="${3:-}"
+
+    local docker_args=(
+        run -d
+        --name "$container_name"
+        -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD"
+        -p "$port_mapping"
+    )
+
+    if [ -n "$volume_mount" ]; then
+        docker_args+=(
+            -v "$volume_mount"
+        )
+    fi
+
+    docker_args+=(
+        "$MYSQL_IMAGE"
+        --mysql-native-password=ON
+        --sort-buffer-size=2M
+    )
+
+    common_command_quiet run docker "${docker_args[@]}"
 }

--- a/.development/just/db.sh
+++ b/.development/just/db.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+db_shell() {
+    exec docker exec -it "$MYSQL_CONTAINER" mysql -uroot -proot
+}
+
+db_clean() {
+    echo "This will remove the local MySQL Docker volume: $MYSQL_VOLUME"
+    if ! common_confirm "Continue?"; then
+        echo "Database reset skipped."
+        return 0
+    fi
+    docker rm -f "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    docker volume rm "$MYSQL_VOLUME"
+    echo "Database volume removed. Run: just dev backend --env stamhoofd"
+}

--- a/.development/just/db.sh
+++ b/.development/just/db.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 db_shell() {
-    exec docker exec -it "$MYSQL_CONTAINER" mysql -uroot -proot
+    exec docker exec -it "$MYSQL_CONTAINER" mysql -uroot -p"$MYSQL_ROOT_PASSWORD"
 }
 
 db_clean() {
@@ -10,7 +10,7 @@ db_clean() {
         echo "Database reset skipped."
         return 0
     fi
-    docker rm -f "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
-    docker volume rm "$MYSQL_VOLUME"
+    common_docker_rm "$MYSQL_CONTAINER"
+    common_command run docker volume rm "$MYSQL_VOLUME"
     echo "Database volume removed. Run: just dev backend --env stamhoofd"
 }

--- a/.development/just/dev.sh
+++ b/.development/just/dev.sh
@@ -4,71 +4,71 @@ dev_write_caddyfile() {
     common_prepare_dev_dirs
     cat > "$GENERATED_DIR/Caddyfile" <<EOF
 (dev_tls) {
-    tls /etc/caddy/certs/stamhoofd-dev.crt /etc/caddy/certs/stamhoofd-dev.key
+    tls ${CADDY_DEV_CERT_CRT} ${CADDY_DEV_CERT_KEY}
 }
 
 dashboard.${STAMHOOFD_DOMAIN}, *.dashboard.${STAMHOOFD_DOMAIN} {
     import dev_tls
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:8080
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${DASHBOARD_PORT}
 }
 
 api.${STAMHOOFD_DOMAIN}, *.api.${STAMHOOFD_DOMAIN} {
     import dev_tls
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:9091
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${API_PORT}
     header Cache-Control no-store
 }
 
 renderer.${STAMHOOFD_DOMAIN}, *.renderer.${STAMHOOFD_DOMAIN} {
     import dev_tls
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:9093
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${RENDERER_PORT}
 }
 
 *.registration.${STAMHOOFD_DOMAIN} {
     import dev_tls
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:8081
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${REGISTRATION_PORT}
 }
 
 shop.${STAMHOOFD_DOMAIN}, *.shop.${STAMHOOFD_DOMAIN} {
     import dev_tls
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:8082
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${SHOP_PORT}
 }
 
 sso.${STAMHOOFD_DOMAIN} {
     import dev_tls
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:5556
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${SSO_PORT}
 }
 
 :80 {
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:8082
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${SHOP_PORT}
 }
 
 :443 {
     import dev_tls
-    bind 127.0.0.1
-    reverse_proxy 127.0.0.1:8082
+    bind ${LOCAL_HOST}
+    reverse_proxy ${LOCAL_HOST}:${SHOP_PORT}
 }
 EOF
 }
 
 dev_write_corefile() {
     common_prepare_dev_dirs
-    cat > "$GENERATED_DIR/Corefile" <<'EOF'
-stamhoofd {
+    cat > "$GENERATED_DIR/Corefile" <<EOF
+${STAMHOOFD_DOMAIN} {
     log
 
     template IN A {
-        answer "{{ .Name }} 300 IN A 127.0.0.1"
+        answer "{{ .Name }} 300 IN A ${LOCAL_HOST}"
     }
 
     template IN AAAA {
-        answer "{{ .Name }} 300 IN AAAA ::1"
+        answer "{{ .Name }} 300 IN AAAA ${LOCAL_IPV6_HOST}"
     }
 }
 
@@ -83,17 +83,10 @@ EOF
 }
 
 dev_start_mysql() {
-    echo "Starting MySQL on 127.0.0.1:3306..."
-    docker rm -f "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
-    docker volume create "$MYSQL_VOLUME" >/dev/null
-    docker run -d \
-        --name "$MYSQL_CONTAINER" \
-        -e MYSQL_ROOT_PASSWORD=root \
-        -p 127.0.0.1:3306:3306 \
-        -v "$MYSQL_VOLUME:/var/lib/mysql" \
-        mysql:8.4 \
-        --mysql-native-password=ON \
-        --sort-buffer-size=2M >/dev/null
+    echo "Starting MySQL on ${LOCAL_HOST}:${MYSQL_PORT}..."
+    common_docker_rm "$MYSQL_CONTAINER"
+    common_docker_volume_create "$MYSQL_VOLUME"
+    common_start_mysql_container "$MYSQL_CONTAINER" "${LOCAL_HOST}:${MYSQL_PORT}:${MYSQL_CONTAINER_PORT}" "$MYSQL_VOLUME:/var/lib/mysql"
     dev_wait_for_mysql
 }
 
@@ -102,51 +95,51 @@ dev_wait_for_mysql() {
 }
 
 dev_start_maildev() {
-    echo "Starting MailDev on 127.0.0.1:1080..."
-    docker rm -f "$MAILDEV_CONTAINER" >/dev/null 2>&1 || true
-    docker run -d \
+    echo "Starting MailDev on ${MAILDEV_URL}..."
+    common_docker_rm "$MAILDEV_CONTAINER"
+    common_command_quiet run docker run -d \
         --name "$MAILDEV_CONTAINER" \
-        -p 127.0.0.1:1025:1025 \
-        -p 127.0.0.1:1080:1080 \
-        maildev/maildev:2.2.1 \
-        maildev --ip 0.0.0.0 --incoming-user username --incoming-pass password >/dev/null
+        -p "${LOCAL_HOST}:${MAILDEV_SMTP_PORT}:${MAILDEV_CONTAINER_SMTP_PORT}" \
+        -p "${LOCAL_HOST}:${MAILDEV_HTTP_PORT}:${MAILDEV_CONTAINER_HTTP_PORT}" \
+        "$MAILDEV_IMAGE" \
+        maildev --ip 0.0.0.0 --incoming-user username --incoming-pass password
 }
 
 dev_start_coredns() {
-    echo "Starting CoreDNS on 127.0.0.1:53..."
+    echo "Starting CoreDNS on ${LOCAL_HOST}:${DNS_PORT}..."
     dev_write_corefile
-    docker rm -f "$COREDNS_CONTAINER" >/dev/null 2>&1 || true
-    docker run -d \
+    common_docker_rm "$COREDNS_CONTAINER"
+    common_command_quiet run docker run -d \
         --name "$COREDNS_CONTAINER" \
-        -p 127.0.0.1:53:53/udp \
-        -p 127.0.0.1:53:53/tcp \
+        -p "${LOCAL_HOST}:${DNS_PORT}:53/udp" \
+        -p "${LOCAL_HOST}:${DNS_PORT}:53/tcp" \
         -v "$GENERATED_DIR/Corefile:/Corefile:ro" \
-        coredns/coredns:1.11.3 \
-        -conf /Corefile >/dev/null
+        "$COREDNS_IMAGE" \
+        -conf /Corefile
 }
 
 dev_start_caddy() {
-    echo "Starting Caddy on 127.0.0.1:80 and 127.0.0.1:443..."
+    echo "Starting Caddy on ${LOCAL_HOST}:80 and ${LOCAL_HOST}:443..."
     setup_require_dev_certificates
     dev_write_caddyfile
-    docker rm -f "$CADDY_CONTAINER" >/dev/null 2>&1 || true
-    docker volume create "$CADDY_DATA_VOLUME" >/dev/null
-    docker volume create "$CADDY_CONFIG_VOLUME" >/dev/null
-    docker run -d \
+    common_docker_rm "$CADDY_CONTAINER"
+    common_docker_volume_create "$CADDY_DATA_VOLUME"
+    common_docker_volume_create "$CADDY_CONFIG_VOLUME"
+    common_command_quiet run docker run -d \
         --name "$CADDY_CONTAINER" \
         --network host \
         -v "$GENERATED_DIR/Caddyfile:/etc/caddy/Caddyfile:ro" \
-        -v "$CERT_DIR:/etc/caddy/certs:ro" \
+        -v "$CERT_DIR:$CADDY_CERT_DIR:ro" \
         -v "$CADDY_DATA_VOLUME:/data" \
         -v "$CADDY_CONFIG_VOLUME:/config" \
-        caddy:2.8 >/dev/null
+        "$CADDY_IMAGE"
 }
 
 dev_reload_caddy() {
     echo "Reloading Caddy configuration..."
     setup_require_dev_certificates
     dev_write_caddyfile
-    docker exec "$CADDY_CONTAINER" caddy reload --config /etc/caddy/Caddyfile >/dev/null
+    common_command_quiet run docker exec "$CADDY_CONTAINER" caddy reload --config /etc/caddy/Caddyfile
 }
 
 dev_start_network_services() {
@@ -172,7 +165,7 @@ dev_ensure_network_services() {
 }
 
 dev_stop_network_services() {
-    docker rm -f "$CADDY_CONTAINER" "$COREDNS_CONTAINER" >/dev/null 2>&1 || true
+    common_docker_rm "$CADDY_CONTAINER" "$COREDNS_CONTAINER"
     echo "Network services stopped."
 }
 
@@ -184,7 +177,7 @@ dev_start_backend_services() {
 }
 
 dev_stop_backend_services() {
-    docker rm -f "$MAILDEV_CONTAINER" "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    common_docker_rm "$MAILDEV_CONTAINER" "$MYSQL_CONTAINER"
     echo "Backend services stopped."
 }
 
@@ -210,27 +203,31 @@ dev_tail_network_logs() {
     wait "$coredns_logs_pid" "$caddy_logs_pid"
 }
 
+dev_run_concurrently() {
+    local lerna_command="$1"
+
+    common_command run npx --no-install concurrently -r \
+        'yarn -s dev:init' \
+        'yarn -s build:shared:watch' \
+        "wait-on shared/locales/dist/index.d.ts && $lerna_command"
+}
+
 dev_run() {
     local target="$1"
     local env_name="$2"
     export STAMHOOFD_ENV="$env_name"
     export STAMHOOFD_SKIP_DEV_SERVICES=1
+    export npm_config_script_shell="${npm_config_script_shell:-/bin/bash}"
     cd "$ROOT_DIR"
     case "$target" in
         all)
-            yarn -s dev
+            dev_run_concurrently 'lerna run dev --ignore @stamhoofd/calculator --stream --parallel'
             ;;
         backend)
-            npx concurrently -r \
-                'yarn -s dev:init' \
-                'yarn -s build:shared:watch' \
-                'wait-on shared/locales/dist/index.d.ts && lerna run dev --scope @stamhoofd/backend --scope @stamhoofd/backend-renderer --stream --parallel'
+            dev_run_concurrently 'lerna run dev --scope @stamhoofd/backend --scope @stamhoofd/backend-renderer --stream --parallel'
             ;;
         frontend)
-            npx concurrently -r \
-                'yarn -s dev:init' \
-                'yarn -s build:shared:watch' \
-                'wait-on shared/locales/dist/index.d.ts && lerna run dev --scope @stamhoofd/dashboard --scope @stamhoofd/registration --scope @stamhoofd/webshop --stream --parallel'
+            dev_run_concurrently 'lerna run dev --scope @stamhoofd/dashboard --scope @stamhoofd/registration --scope @stamhoofd/webshop --stream --parallel'
             ;;
         *)
             echo "Unknown dev target: $target" >&2

--- a/.development/just/dev.sh
+++ b/.development/just/dev.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+dev_write_caddyfile() {
+    common_prepare_dev_dirs
+    cat > "$GENERATED_DIR/Caddyfile" <<EOF
+(dev_tls) {
+    tls /etc/caddy/certs/stamhoofd-dev.crt /etc/caddy/certs/stamhoofd-dev.key
+}
+
+dashboard.${STAMHOOFD_DOMAIN}, *.dashboard.${STAMHOOFD_DOMAIN} {
+    import dev_tls
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:8080
+}
+
+api.${STAMHOOFD_DOMAIN}, *.api.${STAMHOOFD_DOMAIN} {
+    import dev_tls
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:9091
+    header Cache-Control no-store
+}
+
+renderer.${STAMHOOFD_DOMAIN}, *.renderer.${STAMHOOFD_DOMAIN} {
+    import dev_tls
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:9093
+}
+
+*.registration.${STAMHOOFD_DOMAIN} {
+    import dev_tls
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:8081
+}
+
+shop.${STAMHOOFD_DOMAIN}, *.shop.${STAMHOOFD_DOMAIN} {
+    import dev_tls
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:8082
+}
+
+sso.${STAMHOOFD_DOMAIN} {
+    import dev_tls
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:5556
+}
+
+:80 {
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:8082
+}
+
+:443 {
+    import dev_tls
+    bind 127.0.0.1
+    reverse_proxy 127.0.0.1:8082
+}
+EOF
+}
+
+dev_write_corefile() {
+    common_prepare_dev_dirs
+    cat > "$GENERATED_DIR/Corefile" <<'EOF'
+stamhoofd {
+    log
+
+    template IN A {
+        answer "{{ .Name }} 300 IN A 127.0.0.1"
+    }
+
+    template IN AAAA {
+        answer "{{ .Name }} 300 IN AAAA ::1"
+    }
+}
+
+use-application-dns.net {
+    log
+}
+
+. {
+    forward . 8.8.8.8 9.9.9.9
+}
+EOF
+}
+
+dev_start_mysql() {
+    echo "Starting MySQL on 127.0.0.1:3306..."
+    docker rm -f "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    docker volume create "$MYSQL_VOLUME" >/dev/null
+    docker run -d \
+        --name "$MYSQL_CONTAINER" \
+        -e MYSQL_ROOT_PASSWORD=root \
+        -p 127.0.0.1:3306:3306 \
+        -v "$MYSQL_VOLUME:/var/lib/mysql" \
+        mysql:8.4 \
+        --mysql-native-password=ON \
+        --sort-buffer-size=2M >/dev/null
+    dev_wait_for_mysql
+}
+
+dev_wait_for_mysql() {
+    common_wait_for_mysql_container "$MYSQL_CONTAINER"
+}
+
+dev_start_maildev() {
+    echo "Starting MailDev on 127.0.0.1:1080..."
+    docker rm -f "$MAILDEV_CONTAINER" >/dev/null 2>&1 || true
+    docker run -d \
+        --name "$MAILDEV_CONTAINER" \
+        -p 127.0.0.1:1025:1025 \
+        -p 127.0.0.1:1080:1080 \
+        maildev/maildev:2.2.1 \
+        maildev --ip 0.0.0.0 --incoming-user username --incoming-pass password >/dev/null
+}
+
+dev_start_coredns() {
+    echo "Starting CoreDNS on 127.0.0.1:53..."
+    dev_write_corefile
+    docker rm -f "$COREDNS_CONTAINER" >/dev/null 2>&1 || true
+    docker run -d \
+        --name "$COREDNS_CONTAINER" \
+        -p 127.0.0.1:53:53/udp \
+        -p 127.0.0.1:53:53/tcp \
+        -v "$GENERATED_DIR/Corefile:/Corefile:ro" \
+        coredns/coredns:1.11.3 \
+        -conf /Corefile >/dev/null
+}
+
+dev_start_caddy() {
+    echo "Starting Caddy on 127.0.0.1:80 and 127.0.0.1:443..."
+    setup_require_dev_certificates
+    dev_write_caddyfile
+    docker rm -f "$CADDY_CONTAINER" >/dev/null 2>&1 || true
+    docker volume create "$CADDY_DATA_VOLUME" >/dev/null
+    docker volume create "$CADDY_CONFIG_VOLUME" >/dev/null
+    docker run -d \
+        --name "$CADDY_CONTAINER" \
+        --network host \
+        -v "$GENERATED_DIR/Caddyfile:/etc/caddy/Caddyfile:ro" \
+        -v "$CERT_DIR:/etc/caddy/certs:ro" \
+        -v "$CADDY_DATA_VOLUME:/data" \
+        -v "$CADDY_CONFIG_VOLUME:/config" \
+        caddy:2.8 >/dev/null
+}
+
+dev_reload_caddy() {
+    echo "Reloading Caddy configuration..."
+    setup_require_dev_certificates
+    dev_write_caddyfile
+    docker exec "$CADDY_CONTAINER" caddy reload --config /etc/caddy/Caddyfile >/dev/null
+}
+
+dev_start_network_services() {
+    common_require_command docker
+    dev_ensure_network_services
+    echo "Network services started."
+}
+
+dev_ensure_network_services() {
+    common_require_command docker
+
+    if common_container_is_running "$COREDNS_CONTAINER"; then
+        echo "CoreDNS is already running."
+    else
+        dev_start_coredns
+    fi
+
+    if common_container_is_running "$CADDY_CONTAINER"; then
+        dev_reload_caddy
+    else
+        dev_start_caddy
+    fi
+}
+
+dev_stop_network_services() {
+    docker rm -f "$CADDY_CONTAINER" "$COREDNS_CONTAINER" >/dev/null 2>&1 || true
+    echo "Network services stopped."
+}
+
+dev_start_backend_services() {
+    common_require_command docker
+    dev_start_mysql
+    dev_start_maildev
+    echo "Backend services started."
+}
+
+dev_stop_backend_services() {
+    docker rm -f "$MAILDEV_CONTAINER" "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    echo "Backend services stopped."
+}
+
+dev_tail_logs() {
+    docker logs -f "$MYSQL_CONTAINER" &
+    local mysql_logs_pid=$!
+    docker logs -f "$MAILDEV_CONTAINER" &
+    local maildev_logs_pid=$!
+    docker logs -f "$COREDNS_CONTAINER" &
+    local coredns_logs_pid=$!
+    docker logs -f "$CADDY_CONTAINER" &
+    local caddy_logs_pid=$!
+    trap 'kill "$mysql_logs_pid" "$maildev_logs_pid" "$coredns_logs_pid" "$caddy_logs_pid" 2>/dev/null || true' RETURN
+    wait "$mysql_logs_pid" "$maildev_logs_pid" "$coredns_logs_pid" "$caddy_logs_pid"
+}
+
+dev_tail_network_logs() {
+    docker logs -f "$COREDNS_CONTAINER" &
+    local coredns_logs_pid=$!
+    docker logs -f "$CADDY_CONTAINER" &
+    local caddy_logs_pid=$!
+    trap 'kill "$coredns_logs_pid" "$caddy_logs_pid" 2>/dev/null || true' RETURN
+    wait "$coredns_logs_pid" "$caddy_logs_pid"
+}
+
+dev_run() {
+    local target="$1"
+    local env_name="$2"
+    export STAMHOOFD_ENV="$env_name"
+    export STAMHOOFD_SKIP_DEV_SERVICES=1
+    cd "$ROOT_DIR"
+    case "$target" in
+        all)
+            yarn -s dev
+            ;;
+        backend)
+            npx concurrently -r \
+                'yarn -s dev:init' \
+                'yarn -s build:shared:watch' \
+                'wait-on shared/locales/dist/index.d.ts && lerna run dev --scope @stamhoofd/backend --scope @stamhoofd/backend-renderer --stream --parallel'
+            ;;
+        frontend)
+            npx concurrently -r \
+                'yarn -s dev:init' \
+                'yarn -s build:shared:watch' \
+                'wait-on shared/locales/dist/index.d.ts && lerna run dev --scope @stamhoofd/dashboard --scope @stamhoofd/registration --scope @stamhoofd/webshop --stream --parallel'
+            ;;
+        *)
+            echo "Unknown dev target: $target" >&2
+            return 1
+            ;;
+    esac
+}

--- a/.development/just/dns.sh
+++ b/.development/just/dns.sh
@@ -13,7 +13,7 @@ dns_check() {
         return 1
     fi
 
-    resolvectl query "dashboard.${STAMHOOFD_DOMAIN}" 2>/dev/null | grep -q '127\.0\.0\.1'
+    resolvectl query "dashboard.${STAMHOOFD_DOMAIN}" 2>/dev/null | grep -Fq "$LOCAL_HOST"
 }
 
 dns_check_config() {
@@ -22,12 +22,29 @@ dns_check_config() {
     fi
 
     [ -f "$RESOLVED_RUNTIME_CONFIG" ] || return 1
-    grep -Fxq 'DNS=127.0.0.1' "$RESOLVED_RUNTIME_CONFIG" || return 1
+    grep -Fxq "DNS=${LOCAL_HOST}" "$RESOLVED_RUNTIME_CONFIG" || return 1
     grep -Fxq "Domains=~${STAMHOOFD_DOMAIN}" "$RESOLVED_RUNTIME_CONFIG" || return 1
 }
 
 dns_active_interface() {
     ip route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit }}'
+}
+
+dns_active_connection() {
+    command -v nmcli >/dev/null 2>&1 || return 1
+
+    local interface connection
+    interface="${STAMHOOFD_DNS_INTERFACE:-$(dns_active_interface)}"
+    if [ -z "$interface" ]; then
+        return 1
+    fi
+
+    connection="$(nmcli -t -f GENERAL.CONNECTION device show "$interface" 2>/dev/null | cut -d: -f2-)"
+    if [ -z "$connection" ] || [ "$connection" = "--" ]; then
+        return 1
+    fi
+
+    printf '%s' "$connection"
 }
 
 dns_require_linux_resolved() {
@@ -42,27 +59,38 @@ dns_require_linux_resolved() {
     fi
 }
 
+dns_networkmanager_cleanup() {
+    local mode="$1"
+    local connection="$2"
+
+    common_command "$mode" sudo nmcli connection modify "$connection" -ipv4.dns "$LOCAL_HOST" -ipv4.dns-search "~${STAMHOOFD_DOMAIN}"
+    common_command "$mode" sudo nmcli connection up "$connection"
+}
+
 dns_remove_networkmanager_entries() {
-    command -v nmcli >/dev/null 2>&1 || return 0
+    local mode="${1:-run}"
+    local connection
+    connection="$(dns_active_connection)" || return 0
 
-    local interface connection
-    interface="${STAMHOOFD_DNS_INTERFACE:-$(dns_active_interface)}"
-    if [ -z "$interface" ]; then
-        return 0
-    fi
-
-    connection="$(nmcli -t -f GENERAL.CONNECTION device show "$interface" 2>/dev/null | cut -d: -f2-)"
-    if [ -z "$connection" ] || [ "$connection" = "--" ]; then
+    if [ "$mode" = "print" ]; then
+        echo "  # May also run when NetworkManager has stale DNS entries:"
+        dns_networkmanager_cleanup print "$connection"
         return 0
     fi
 
     echo "Removing stale NetworkManager DNS entries from '$connection' if present..."
     if sudo -n true >/dev/null 2>&1; then
-        sudo nmcli connection modify "$connection" -ipv4.dns 127.0.0.1 -ipv4.dns-search "~${STAMHOOFD_DOMAIN}" >/dev/null 2>&1 || true
-        sudo nmcli connection up "$connection" >/dev/null 2>&1 || true
+        dns_networkmanager_cleanup run "$connection" >/dev/null 2>&1 || true
     else
         echo "Skipping stale NetworkManager cleanup until sudo credentials are available."
     fi
+}
+
+dns_remove_resolved_config() {
+    local mode="$1"
+
+    common_command "$mode" sudo rm -f "$RESOLVED_RUNTIME_CONFIG"
+    common_command "$mode" sudo systemctl restart systemd-resolved
 }
 
 dns_status() {
@@ -73,19 +101,18 @@ dns_status() {
 dns_clean() {
     dns_require_linux_resolved
     echo "This will remove the temporary Stamhoofd systemd-resolved DNS config."
-    echo "It will also remove stale NetworkManager entries for 127.0.0.1 and ~${STAMHOOFD_DOMAIN}."
+    echo "It will also remove stale NetworkManager entries for ${LOCAL_HOST} and ~${STAMHOOFD_DOMAIN}."
     echo
     echo "Commands to run:"
-    echo "  sudo rm -f ${RESOLVED_RUNTIME_CONFIG}"
-    echo "  sudo systemctl restart systemd-resolved"
+    dns_remove_networkmanager_entries print
+    dns_remove_resolved_config print
     echo
     if ! common_confirm "Remove this DNS configuration?"; then
         echo "DNS reset skipped."
         return 0
     fi
 
-    dns_remove_networkmanager_entries
-    sudo rm -f "$RESOLVED_RUNTIME_CONFIG"
-    sudo systemctl restart systemd-resolved
+    dns_remove_networkmanager_entries run
+    dns_remove_resolved_config run
     echo "Temporary Stamhoofd DNS config removed."
 }

--- a/.development/just/dns.sh
+++ b/.development/just/dns.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+dns_check() {
+    if [ "$(uname -s)" != "Linux" ]; then
+        return 1
+    fi
+
+    if ! command -v resolvectl >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if ! systemctl is-active --quiet systemd-resolved; then
+        return 1
+    fi
+
+    resolvectl query "dashboard.${STAMHOOFD_DOMAIN}" 2>/dev/null | grep -q '127\.0\.0\.1'
+}
+
+dns_check_config() {
+    if [ "$(uname -s)" != "Linux" ]; then
+        return 1
+    fi
+
+    [ -f "$RESOLVED_RUNTIME_CONFIG" ] || return 1
+    grep -Fxq 'DNS=127.0.0.1' "$RESOLVED_RUNTIME_CONFIG" || return 1
+    grep -Fxq "Domains=~${STAMHOOFD_DOMAIN}" "$RESOLVED_RUNTIME_CONFIG" || return 1
+}
+
+dns_active_interface() {
+    ip route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit }}'
+}
+
+dns_require_linux_resolved() {
+    if [ "$(uname -s)" != "Linux" ]; then
+        echo "This DNS helper currently supports Linux only." >&2
+        return 1
+    fi
+    common_require_command resolvectl
+    if ! systemctl is-active --quiet systemd-resolved; then
+        echo "systemd-resolved is not active. Split DNS setup was not changed." >&2
+        return 1
+    fi
+}
+
+dns_remove_networkmanager_entries() {
+    command -v nmcli >/dev/null 2>&1 || return 0
+
+    local interface connection
+    interface="${STAMHOOFD_DNS_INTERFACE:-$(dns_active_interface)}"
+    if [ -z "$interface" ]; then
+        return 0
+    fi
+
+    connection="$(nmcli -t -f GENERAL.CONNECTION device show "$interface" 2>/dev/null | cut -d: -f2-)"
+    if [ -z "$connection" ] || [ "$connection" = "--" ]; then
+        return 0
+    fi
+
+    echo "Removing stale NetworkManager DNS entries from '$connection' if present..."
+    if sudo -n true >/dev/null 2>&1; then
+        sudo nmcli connection modify "$connection" -ipv4.dns 127.0.0.1 -ipv4.dns-search "~${STAMHOOFD_DOMAIN}" >/dev/null 2>&1 || true
+        sudo nmcli connection up "$connection" >/dev/null 2>&1 || true
+    else
+        echo "Skipping stale NetworkManager cleanup until sudo credentials are available."
+    fi
+}
+
+dns_status() {
+    common_require_command resolvectl
+    resolvectl status | sed -n "/DNS Servers\|DNS Domain\|~${STAMHOOFD_DOMAIN}/p"
+}
+
+dns_clean() {
+    dns_require_linux_resolved
+    echo "This will remove the temporary Stamhoofd systemd-resolved DNS config."
+    echo "It will also remove stale NetworkManager entries for 127.0.0.1 and ~${STAMHOOFD_DOMAIN}."
+    echo
+    echo "Commands to run:"
+    echo "  sudo rm -f ${RESOLVED_RUNTIME_CONFIG}"
+    echo "  sudo systemctl restart systemd-resolved"
+    echo
+    if ! common_confirm "Remove this DNS configuration?"; then
+        echo "DNS reset skipped."
+        return 0
+    fi
+
+    dns_remove_networkmanager_entries
+    sudo rm -f "$RESOLVED_RUNTIME_CONFIG"
+    sudo systemctl restart systemd-resolved
+    echo "Temporary Stamhoofd DNS config removed."
+}

--- a/.development/just/load.sh
+++ b/.development/just/load.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+JUST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$JUST_DIR/common.sh"
+source "$JUST_DIR/dns.sh"
+source "$JUST_DIR/setup.sh"
+source "$JUST_DIR/dev.sh"
+source "$JUST_DIR/sso.sh"
+source "$JUST_DIR/status.sh"
+source "$JUST_DIR/db.sh"
+source "$JUST_DIR/test.sh"

--- a/.development/just/setup.sh
+++ b/.development/just/setup.sh
@@ -20,6 +20,13 @@ setup_check() {
         fi
     fi
 
+    if [ -d "$ROOT_DIR/node_modules" ]; then
+        echo "Node dependencies: installed."
+    else
+        echo "Node dependencies: missing. Run: just install"
+        missing=1
+    fi
+
     if ! docker info >/dev/null 2>&1; then
         echo "Docker is not available or the daemon is not reachable."
         missing=1
@@ -70,8 +77,8 @@ setup_check_cert() {
         cmp -s "$DEV_CA_CRT" "$TRUSTED_DEV_CA_CRT" && return 0
     fi
 
-    if [ -f /etc/ssl/certs/stamhoofd-dev-ca.pem ]; then
-        cmp -s "$DEV_CA_CRT" /etc/ssl/certs/stamhoofd-dev-ca.pem && return 0
+    if [ -f "$TRUSTED_DEV_CA_PEM" ]; then
+        cmp -s "$DEV_CA_CRT" "$TRUSTED_DEV_CA_PEM" && return 0
     fi
 
     if command -v trust >/dev/null 2>&1; then
@@ -99,55 +106,86 @@ setup_generate_dev_certificates() {
     common_require_command openssl
     setup_prepare_cert_dir
 
+    if setup_have_dev_certificates; then
+        echo "Stamhoofd development certificates already exist in $CERT_DIR."
+        if ! common_confirm "Generate new development certificates?"; then
+            echo "Keeping existing development certificates."
+            return 0
+        fi
+
+        common_command run rm -f "$DEV_CA_CRT" "$DEV_CA_KEY" "$DEV_CERT_CRT" "$DEV_CERT_KEY" "$DEV_CERT_CSR" "$DEV_CERT_EXT" "$DEV_CA_SERIAL"
+    fi
+
     if [ ! -f "$DEV_CA_CRT" ] || [ ! -f "$DEV_CA_KEY" ]; then
         echo "Generating Stamhoofd development CA..."
-        openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+        common_command_quiet run openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
             -keyout "$DEV_CA_KEY" \
             -out "$DEV_CA_CRT" \
             -subj "/CN=Stamhoofd Development CA" \
             -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
-            -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1
-        chmod 600 "$DEV_CA_KEY"
+            -addext "keyUsage=critical,keyCertSign,cRLSign"
+        common_command run chmod 600 "$DEV_CA_KEY"
     fi
 
     if [ ! -f "$DEV_CERT_CRT" ] || [ ! -f "$DEV_CERT_KEY" ]; then
         echo "Generating Stamhoofd development TLS certificate..."
-        cat > "$DEV_CERT_EXT" <<'EOF'
+        cat > "$DEV_CERT_EXT" <<EOF
 basicConstraints=CA:FALSE
 keyUsage=digitalSignature,keyEncipherment
 extendedKeyUsage=serverAuth
 subjectAltName=@alt_names
 
 [alt_names]
-DNS.1=stamhoofd
-DNS.2=*.stamhoofd
-DNS.3=dashboard.stamhoofd
-DNS.4=*.dashboard.stamhoofd
-DNS.5=api.stamhoofd
-DNS.6=*.api.stamhoofd
-DNS.7=renderer.stamhoofd
-DNS.8=*.renderer.stamhoofd
-DNS.9=registration.stamhoofd
-DNS.10=*.registration.stamhoofd
-DNS.11=shop.stamhoofd
-DNS.12=*.shop.stamhoofd
-DNS.13=sso.stamhoofd
+DNS.1=${STAMHOOFD_DOMAIN}
+DNS.2=*.${STAMHOOFD_DOMAIN}
+DNS.3=dashboard.${STAMHOOFD_DOMAIN}
+DNS.4=*.dashboard.${STAMHOOFD_DOMAIN}
+DNS.5=api.${STAMHOOFD_DOMAIN}
+DNS.6=*.api.${STAMHOOFD_DOMAIN}
+DNS.7=renderer.${STAMHOOFD_DOMAIN}
+DNS.8=*.renderer.${STAMHOOFD_DOMAIN}
+DNS.9=registration.${STAMHOOFD_DOMAIN}
+DNS.10=*.registration.${STAMHOOFD_DOMAIN}
+DNS.11=shop.${STAMHOOFD_DOMAIN}
+DNS.12=*.shop.${STAMHOOFD_DOMAIN}
+DNS.13=sso.${STAMHOOFD_DOMAIN}
 EOF
 
-        openssl req -new -newkey rsa:2048 -nodes \
+        common_command_quiet run openssl req -new -newkey rsa:2048 -nodes \
             -keyout "$DEV_CERT_KEY" \
             -out "$DEV_CERT_CSR" \
-            -subj "/CN=*.stamhoofd" >/dev/null 2>&1
-        openssl x509 -req -sha256 -days 825 \
+            -subj "/CN=*.${STAMHOOFD_DOMAIN}"
+        common_command_quiet run openssl x509 -req -sha256 -days 825 \
             -in "$DEV_CERT_CSR" \
             -CA "$DEV_CA_CRT" \
             -CAkey "$DEV_CA_KEY" \
             -CAcreateserial \
             -out "$DEV_CERT_CRT" \
-            -extfile "$DEV_CERT_EXT" >/dev/null 2>&1
-        chmod 600 "$DEV_CERT_KEY"
-        rm -f "$DEV_CERT_CSR"
+            -extfile "$DEV_CERT_EXT"
+        common_command run chmod 600 "$DEV_CERT_KEY"
+        common_command run rm -f "$DEV_CERT_CSR"
     fi
+}
+
+setup_resolved_config_content() {
+    printf '[Resolve]\nDNS=%s\nDomains=~%s\n' "$LOCAL_HOST" "$STAMHOOFD_DOMAIN"
+}
+
+setup_write_resolved_config() {
+    local mode="$1"
+    local content
+    content="$(setup_resolved_config_content)"
+
+    common_command "$mode" sudo mkdir -p "$RESOLVED_RUNTIME_CONFIG_DIR"
+
+    if [ "$mode" = "print" ]; then
+        printf '  printf %%s %q | sudo tee %q >/dev/null\n' "$content" "$RESOLVED_RUNTIME_CONFIG"
+    else
+        printf '  printf %%s %q | sudo tee %q >/dev/null\n' "$content" "$RESOLVED_RUNTIME_CONFIG"
+        printf '%s' "$content" | sudo tee "$RESOLVED_RUNTIME_CONFIG" >/dev/null
+    fi
+
+    common_command "$mode" sudo systemctl restart systemd-resolved
 }
 
 setup_dns() {
@@ -159,26 +197,23 @@ setup_dns() {
     echo
     echo "Runtime config to write to ${RESOLVED_RUNTIME_CONFIG}:"
     echo "  [Resolve]"
-    echo "  DNS=127.0.0.1"
+    echo "  DNS=${LOCAL_HOST}"
     echo "  Domains=~${STAMHOOFD_DOMAIN}"
     echo
     echo "Commands to run:"
-    echo "  sudo mkdir -p /run/systemd/resolved.conf.d"
-    echo "  sudo tee ${RESOLVED_RUNTIME_CONFIG}"
-    echo "  sudo systemctl restart systemd-resolved"
+    dns_remove_networkmanager_entries print
+    setup_write_resolved_config print
     echo
     if ! common_confirm "Apply this DNS configuration?"; then
         echo "DNS setup skipped."
         return 0
     fi
 
-    dns_remove_networkmanager_entries
-    sudo mkdir -p /run/systemd/resolved.conf.d
-    printf '[Resolve]\nDNS=127.0.0.1\nDomains=~%s\n' "$STAMHOOFD_DOMAIN" | sudo tee "$RESOLVED_RUNTIME_CONFIG" >/dev/null
-    sudo systemctl restart systemd-resolved
+    dns_remove_networkmanager_entries run
+    setup_write_resolved_config run
 
     if ! dns_check; then
-        echo "DNS setup was written, but dashboard.${STAMHOOFD_DOMAIN} did not resolve to 127.0.0.1." >&2
+        echo "DNS setup was written, but dashboard.${STAMHOOFD_DOMAIN} did not resolve to ${LOCAL_HOST}." >&2
         echo "Make sure 'just dev network' is running, then retry 'just setup dns'." >&2
         return 1
     fi
@@ -194,20 +229,58 @@ Manual Stamhoofd development certificate setup:
 
 This generates local certificate files in:
 
-  .development/just/generated/certs/
+  ${CERT_DIR}
 
-Manual trust commands on Linux:
+Manual trust commands on Linux for this machine:
 
-  sudo cp .development/just/generated/certs/stamhoofd-dev-ca.crt ${TRUSTED_DEV_CA_CRT}
-  sudo update-ca-certificates
-
-Afterwards, restart your browser.
+EOF
+    setup_install_cert print
+    echo
+    cat <<EOF
+Afterwards, test whether the certificate is trusted. Restarting your browser might not be necessary, but try it if it does not work.
 
 Firefox may need one extra step:
   - Set security.enterprise_roots.enabled=true in about:config, or
-  - Import .development/just/generated/certs/stamhoofd-dev-ca.crt manually in Firefox certificate settings.
+  - Import ${DEV_CA_CRT} manually in Firefox certificate settings.
+
+Firefox on Fedora should not need a restart.
 
 EOF
+}
+
+setup_install_cert_with_update_ca_certificates() {
+    local mode="$1"
+
+    common_command "$mode" sudo cp "$DEV_CA_CRT" "$TRUSTED_DEV_CA_CRT"
+    common_command "$mode" sudo update-ca-certificates
+}
+
+setup_install_cert_with_trust() {
+    local mode="$1"
+
+    common_command "$mode" sudo trust anchor "$DEV_CA_CRT"
+}
+
+setup_install_cert() {
+    local mode="$1"
+
+    if [ "$(uname -s)" != "Linux" ]; then
+        echo "  # Automatic certificate setup currently supports Linux only."
+        [ "$mode" = "print" ] && return 0
+        return 1
+    fi
+
+    if command -v update-ca-certificates >/dev/null 2>&1; then
+        setup_install_cert_with_update_ca_certificates "$mode"
+    elif command -v trust >/dev/null 2>&1; then
+        setup_install_cert_with_trust "$mode"
+    else
+        echo "  # Could not find update-ca-certificates or trust. Depending on your distribution, run one of:"
+        setup_install_cert_with_update_ca_certificates print
+        setup_install_cert_with_trust print
+        [ "$mode" = "print" ] && return 0
+        return 1
+    fi
 }
 
 setup_cert() {
@@ -217,19 +290,10 @@ setup_cert() {
         echo "Automatic certificate setup skipped."
         return 0
     fi
-    if [ "$(uname -s)" != "Linux" ]; then
-        echo "Automatic certificate setup currently supports Linux only." >&2
+    echo "Executing trust commands:"
+    if ! setup_install_cert run; then
+        echo "Automatic certificate setup failed. Use the manual instructions above." >&2
         return 1
     fi
-    if command -v update-ca-certificates >/dev/null 2>&1; then
-        sudo cp "$DEV_CA_CRT" "$TRUSTED_DEV_CA_CRT"
-        sudo update-ca-certificates
-    elif command -v trust >/dev/null 2>&1; then
-        sudo trust anchor "$DEV_CA_CRT"
-    else
-        echo "Could not find update-ca-certificates or trust. Use the manual instructions above." >&2
-        return 1
-    fi
-    echo "Stamhoofd development CA installed. Restart your browser."
-    echo "Firefox may still require security.enterprise_roots.enabled=true or manual import."
+    echo "The trust commands above were executed successfully."
 }

--- a/.development/just/setup.sh
+++ b/.development/just/setup.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+setup_check() {
+    local missing=0
+    for command_name in docker node yarn just; do
+        if ! command -v "$command_name" >/dev/null 2>&1; then
+            echo "Missing: $command_name"
+            missing=1
+        else
+            echo "Found: $command_name ($(command -v "$command_name"))"
+        fi
+    done
+
+    if [ -f "$ROOT_DIR/.nvmrc" ]; then
+        local expected_node current_node
+        expected_node="$(tr -d '[:space:]' < "$ROOT_DIR/.nvmrc")"
+        current_node="$(node --version 2>/dev/null | sed 's/^v//' | cut -d. -f1 || true)"
+        if [ -n "$current_node" ] && [ "$current_node" != "$expected_node" ]; then
+            echo "Node major version is $current_node, expected $expected_node from .nvmrc"
+        fi
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        echo "Docker is not available or the daemon is not reachable."
+        missing=1
+    fi
+
+    if dns_check; then
+        echo "DNS: split DNS for .${STAMHOOFD_DOMAIN} is configured."
+    elif dns_check_config; then
+        echo "DNS: split DNS for .${STAMHOOFD_DOMAIN} seems to be configured, but the DNS server is not running so it cannot be fully checked."
+        echo "DNS: start it with 'just dev network' or 'just dev all'."
+    else
+        echo "DNS: split DNS for .${STAMHOOFD_DOMAIN} is not configured. Run: just setup dns"
+        missing=1
+    fi
+
+    if setup_check_cert; then
+        echo "Certificate: Stamhoofd development CA exists and appears to be trusted."
+    else
+        echo "Certificate: Stamhoofd development CA is missing or not trusted. Run: just setup cert"
+        missing=1
+    fi
+
+    if [ "$missing" = "0" ]; then
+        echo
+        echo "Next steps:"
+        echo "  just dev all"
+        echo "  just"
+    fi
+    return "$missing"
+}
+
+setup_prepare_cert_dir() {
+    mkdir -p "$CERT_DIR"
+    chmod 700 "$CERT_DIR"
+}
+
+setup_check_cert() {
+    if [ "$(uname -s)" != "Linux" ]; then
+        return 1
+    fi
+
+    [ -f "$DEV_CA_CRT" ] || return 1
+    [ -f "$DEV_CA_KEY" ] || return 1
+    [ -f "$DEV_CERT_CRT" ] || return 1
+    [ -f "$DEV_CERT_KEY" ] || return 1
+
+    if [ -f "$TRUSTED_DEV_CA_CRT" ]; then
+        cmp -s "$DEV_CA_CRT" "$TRUSTED_DEV_CA_CRT" && return 0
+    fi
+
+    if [ -f /etc/ssl/certs/stamhoofd-dev-ca.pem ]; then
+        cmp -s "$DEV_CA_CRT" /etc/ssl/certs/stamhoofd-dev-ca.pem && return 0
+    fi
+
+    if command -v trust >/dev/null 2>&1; then
+        trust list 2>/dev/null | grep -A4 -F 'label: Stamhoofd Development CA' | grep -q 'trust: anchor' && return 0
+    fi
+
+    return 1
+}
+
+setup_have_dev_certificates() {
+    [ -f "$DEV_CA_CRT" ] \
+        && [ -f "$DEV_CA_KEY" ] \
+        && [ -f "$DEV_CERT_CRT" ] \
+        && [ -f "$DEV_CERT_KEY" ]
+}
+
+setup_require_dev_certificates() {
+    if ! setup_have_dev_certificates; then
+        echo "Missing Stamhoofd development certificates. Run: just setup cert" >&2
+        return 1
+    fi
+}
+
+setup_generate_dev_certificates() {
+    common_require_command openssl
+    setup_prepare_cert_dir
+
+    if [ ! -f "$DEV_CA_CRT" ] || [ ! -f "$DEV_CA_KEY" ]; then
+        echo "Generating Stamhoofd development CA..."
+        openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+            -keyout "$DEV_CA_KEY" \
+            -out "$DEV_CA_CRT" \
+            -subj "/CN=Stamhoofd Development CA" \
+            -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" >/dev/null 2>&1
+        chmod 600 "$DEV_CA_KEY"
+    fi
+
+    if [ ! -f "$DEV_CERT_CRT" ] || [ ! -f "$DEV_CERT_KEY" ]; then
+        echo "Generating Stamhoofd development TLS certificate..."
+        cat > "$DEV_CERT_EXT" <<'EOF'
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=@alt_names
+
+[alt_names]
+DNS.1=stamhoofd
+DNS.2=*.stamhoofd
+DNS.3=dashboard.stamhoofd
+DNS.4=*.dashboard.stamhoofd
+DNS.5=api.stamhoofd
+DNS.6=*.api.stamhoofd
+DNS.7=renderer.stamhoofd
+DNS.8=*.renderer.stamhoofd
+DNS.9=registration.stamhoofd
+DNS.10=*.registration.stamhoofd
+DNS.11=shop.stamhoofd
+DNS.12=*.shop.stamhoofd
+DNS.13=sso.stamhoofd
+EOF
+
+        openssl req -new -newkey rsa:2048 -nodes \
+            -keyout "$DEV_CERT_KEY" \
+            -out "$DEV_CERT_CSR" \
+            -subj "/CN=*.stamhoofd" >/dev/null 2>&1
+        openssl x509 -req -sha256 -days 825 \
+            -in "$DEV_CERT_CSR" \
+            -CA "$DEV_CA_CRT" \
+            -CAkey "$DEV_CA_KEY" \
+            -CAcreateserial \
+            -out "$DEV_CERT_CRT" \
+            -extfile "$DEV_CERT_EXT" >/dev/null 2>&1
+        chmod 600 "$DEV_CERT_KEY"
+        rm -f "$DEV_CERT_CSR"
+    fi
+}
+
+setup_dns() {
+    dns_require_linux_resolved
+    echo "This will configure temporary split DNS for .${STAMHOOFD_DOMAIN} only."
+    echo "Existing DNS servers remain responsible for all other domains."
+    echo "The config is written to /run and disappears on reboot."
+    echo "systemd-resolved will be restarted."
+    echo
+    echo "Runtime config to write to ${RESOLVED_RUNTIME_CONFIG}:"
+    echo "  [Resolve]"
+    echo "  DNS=127.0.0.1"
+    echo "  Domains=~${STAMHOOFD_DOMAIN}"
+    echo
+    echo "Commands to run:"
+    echo "  sudo mkdir -p /run/systemd/resolved.conf.d"
+    echo "  sudo tee ${RESOLVED_RUNTIME_CONFIG}"
+    echo "  sudo systemctl restart systemd-resolved"
+    echo
+    if ! common_confirm "Apply this DNS configuration?"; then
+        echo "DNS setup skipped."
+        return 0
+    fi
+
+    dns_remove_networkmanager_entries
+    sudo mkdir -p /run/systemd/resolved.conf.d
+    printf '[Resolve]\nDNS=127.0.0.1\nDomains=~%s\n' "$STAMHOOFD_DOMAIN" | sudo tee "$RESOLVED_RUNTIME_CONFIG" >/dev/null
+    sudo systemctl restart systemd-resolved
+
+    if ! dns_check; then
+        echo "DNS setup was written, but dashboard.${STAMHOOFD_DOMAIN} did not resolve to 127.0.0.1." >&2
+        echo "Make sure 'just dev network' is running, then retry 'just setup dns'." >&2
+        return 1
+    fi
+
+    echo "Temporary split DNS configured for .${STAMHOOFD_DOMAIN}."
+}
+
+setup_print_cert_instructions() {
+    cat <<EOF
+Manual Stamhoofd development certificate setup:
+
+  just setup cert
+
+This generates local certificate files in:
+
+  .development/just/generated/certs/
+
+Manual trust commands on Linux:
+
+  sudo cp .development/just/generated/certs/stamhoofd-dev-ca.crt ${TRUSTED_DEV_CA_CRT}
+  sudo update-ca-certificates
+
+Afterwards, restart your browser.
+
+Firefox may need one extra step:
+  - Set security.enterprise_roots.enabled=true in about:config, or
+  - Import .development/just/generated/certs/stamhoofd-dev-ca.crt manually in Firefox certificate settings.
+
+EOF
+}
+
+setup_cert() {
+    setup_generate_dev_certificates
+    setup_print_cert_instructions
+    if ! common_confirm "Trust the Stamhoofd development CA automatically?"; then
+        echo "Automatic certificate setup skipped."
+        return 0
+    fi
+    if [ "$(uname -s)" != "Linux" ]; then
+        echo "Automatic certificate setup currently supports Linux only." >&2
+        return 1
+    fi
+    if command -v update-ca-certificates >/dev/null 2>&1; then
+        sudo cp "$DEV_CA_CRT" "$TRUSTED_DEV_CA_CRT"
+        sudo update-ca-certificates
+    elif command -v trust >/dev/null 2>&1; then
+        sudo trust anchor "$DEV_CA_CRT"
+    else
+        echo "Could not find update-ca-certificates or trust. Use the manual instructions above." >&2
+        return 1
+    fi
+    echo "Stamhoofd development CA installed. Restart your browser."
+    echo "Firefox may still require security.enterprise_roots.enabled=true or manual import."
+}

--- a/.development/just/sso.sh
+++ b/.development/just/sso.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+
+sso_issuer() {
+    printf 'https://sso.%s/dex/realms/%s' "$STAMHOOFD_DOMAIN" "$KEYCLOAK_REALM"
+}
+
+sso_validate_redirect_uri() {
+    local redirect_uri="$1"
+    if [ -z "$redirect_uri" ]; then
+        echo "Missing redirect URI. Copy it from the SSO settings view and run:" >&2
+        echo "  just sso start https://<organization-id>.api.${STAMHOOFD_DOMAIN}/openid/callback" >&2
+        return 1
+    fi
+
+    case "$redirect_uri" in
+        https://*/openid/callback) ;;
+        *)
+            echo "Invalid redirect URI: $redirect_uri" >&2
+            echo "Expected an HTTPS /openid/callback URL copied from the SSO settings view." >&2
+            return 1
+            ;;
+    esac
+}
+
+sso_keycloak_split_name() {
+    local full_name="$1"
+    local first_name last_name
+    first_name="${full_name%% *}"
+    if [ "$first_name" = "$full_name" ]; then
+        last_name="User"
+    else
+        last_name="${full_name#* }"
+    fi
+    printf '%s\n%s\n' "$first_name" "$last_name"
+}
+
+sso_write_keycloak_realm() {
+    local redirect_uri="$1"
+    local first_name last_name split_name
+    split_name="$(sso_keycloak_split_name "$KEYCLOAK_USER_NAME")"
+    first_name="$(printf '%s' "$split_name" | sed -n '1p')"
+    last_name="$(printf '%s' "$split_name" | sed -n '2p')"
+
+    local realm_json client_id_json client_secret_json redirect_uri_json user_id_json user_email_json username_json first_name_json last_name_json password_json
+    realm_json="$(common_json_string "$KEYCLOAK_REALM")"
+    client_id_json="$(common_json_string "$KEYCLOAK_CLIENT_ID")"
+    client_secret_json="$(common_json_string "$KEYCLOAK_CLIENT_SECRET")"
+    redirect_uri_json="$(common_json_string "$redirect_uri")"
+    user_id_json="$(common_json_string "$KEYCLOAK_USER_ID")"
+    user_email_json="$(common_json_string "$KEYCLOAK_USER_EMAIL")"
+    username_json="$(common_json_string "$KEYCLOAK_USER_EMAIL")"
+    first_name_json="$(common_json_string "$first_name")"
+    last_name_json="$(common_json_string "$last_name")"
+    password_json="$(common_json_string "$KEYCLOAK_USER_PASSWORD")"
+
+    common_prepare_dev_dirs
+    mkdir -p "$KEYCLOAK_IMPORT_DIR"
+    cat > "$KEYCLOAK_REALM_CONFIG" <<EOF
+{
+  "realm": ${realm_json},
+  "enabled": true,
+  "displayName": "Stamhoofd Local",
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "defaultSignatureAlgorithm": "RS256",
+  "clients": [
+    {
+      "clientId": ${client_id_json},
+      "name": "Stamhoofd Local",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "secret": ${client_secret_json},
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [${redirect_uri_json}],
+      "webOrigins": ["+"],
+      "defaultClientScopes": ["web-origins", "acr", "profile", "roles", "email"],
+      "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "+"
+      }
+    }
+  ],
+  "users": [
+    {
+      "id": ${user_id_json},
+      "username": ${username_json},
+      "email": ${user_email_json},
+      "firstName": ${first_name_json},
+      "lastName": ${last_name_json},
+      "enabled": true,
+      "emailVerified": true,
+      "realmRoles": ["offline_access"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": ${password_json},
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+
+sso_config() {
+    local redirect_uri="$1"
+    local issuer
+    issuer="$(sso_issuer)"
+
+    cat <<EOF
+Local SSO settings:
+
+  Issuer:        ${issuer}
+  Discovery:     ${issuer}/.well-known/openid-configuration
+  Client ID:     ${KEYCLOAK_CLIENT_ID}
+  Client secret: ${KEYCLOAK_CLIENT_SECRET}
+  Redirect URI:  ${redirect_uri:-copy this from the SSO settings view}
+
+Test user:
+
+  Email:         ${KEYCLOAK_USER_EMAIL}
+  Password:      ${KEYCLOAK_USER_PASSWORD}
+  Name:          ${KEYCLOAK_USER_NAME}
+
+Commands:
+
+  just sso start "${redirect_uri:-https://<organization-id>.api.${STAMHOOFD_DOMAIN}/openid/callback}"
+  just sso start --background "${redirect_uri:-https://<organization-id>.api.${STAMHOOFD_DOMAIN}/openid/callback}"
+  just sso logs
+  just sso stop
+
+Note: use the Issuer value in the app. The Keycloak admin console is available at https://sso.${STAMHOOFD_DOMAIN}/dex/admin with ${KEYCLOAK_ADMIN_USER}/${KEYCLOAK_ADMIN_PASSWORD}.
+EOF
+}
+
+sso_start() {
+    local redirect_uri="$1"
+    local background="${2:-false}"
+    sso_validate_redirect_uri "$redirect_uri"
+    common_require_command docker
+    sso_write_keycloak_realm "$redirect_uri"
+
+    dev_ensure_network_services
+
+    echo "Starting Keycloak on 127.0.0.1:5556..."
+    docker rm -f "$KEYCLOAK_CONTAINER" >/dev/null 2>&1 || true
+
+    if [ "$background" = "true" ]; then
+        docker run -d \
+            --name "$KEYCLOAK_CONTAINER" \
+            -p 127.0.0.1:5556:8080 \
+            -e KC_BOOTSTRAP_ADMIN_USERNAME="$KEYCLOAK_ADMIN_USER" \
+            -e KC_BOOTSTRAP_ADMIN_PASSWORD="$KEYCLOAK_ADMIN_PASSWORD" \
+            -e KC_HTTP_RELATIVE_PATH=/dex \
+            -v "$KEYCLOAK_IMPORT_DIR:/opt/keycloak/data/import:ro" \
+            "$KEYCLOAK_IMAGE" \
+            start-dev --import-realm --hostname="https://sso.${STAMHOOFD_DOMAIN}/dex" --proxy-headers=xforwarded >/dev/null
+
+        echo "Local SSO server started in the background."
+        echo
+        sso_config "$redirect_uri"
+        return 0
+    fi
+
+    sso_config "$redirect_uri"
+    echo
+    echo "Keycloak is running in the foreground. Press Ctrl+C to stop it."
+
+    cleanup_done=0
+    cleanup() {
+        if [ "$cleanup_done" = "1" ]; then
+            return
+        fi
+        cleanup_done=1
+        trap - EXIT INT TERM
+        docker rm -f "$KEYCLOAK_CONTAINER" >/dev/null 2>&1 || true
+        echo "Local SSO server stopped."
+    }
+    trap cleanup EXIT INT TERM
+
+    docker run --rm \
+        --name "$KEYCLOAK_CONTAINER" \
+        -p 127.0.0.1:5556:8080 \
+        -e KC_BOOTSTRAP_ADMIN_USERNAME="$KEYCLOAK_ADMIN_USER" \
+        -e KC_BOOTSTRAP_ADMIN_PASSWORD="$KEYCLOAK_ADMIN_PASSWORD" \
+        -e KC_HTTP_RELATIVE_PATH=/dex \
+        -v "$KEYCLOAK_IMPORT_DIR:/opt/keycloak/data/import:ro" \
+        "$KEYCLOAK_IMAGE" \
+        start-dev --import-realm --hostname="https://sso.${STAMHOOFD_DOMAIN}/dex" --proxy-headers=xforwarded
+}
+
+sso_stop() {
+    docker rm -f "$KEYCLOAK_CONTAINER" >/dev/null 2>&1 || true
+    echo "Local SSO server stopped."
+}
+
+sso_logs() {
+    exec docker logs -f "$KEYCLOAK_CONTAINER"
+}

--- a/.development/just/sso.sh
+++ b/.development/just/sso.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 sso_issuer() {
-    printf 'https://sso.%s/dex/realms/%s' "$STAMHOOFD_DOMAIN" "$KEYCLOAK_REALM"
+    printf '%s/realms/%s' "$SSO_BASE_URL" "$KEYCLOAK_REALM"
 }
 
 sso_validate_redirect_uri() {
     local redirect_uri="$1"
     if [ -z "$redirect_uri" ]; then
         echo "Missing redirect URI. Copy it from the SSO settings view and run:" >&2
-        echo "  just sso start https://<organization-id>.api.${STAMHOOFD_DOMAIN}/openid/callback" >&2
+        echo "  just sso start ${SSO_EXAMPLE_REDIRECT_URI}" >&2
         return 1
     fi
 
@@ -136,13 +136,43 @@ Test user:
 
 Commands:
 
-  just sso start "${redirect_uri:-https://<organization-id>.api.${STAMHOOFD_DOMAIN}/openid/callback}"
-  just sso start --background "${redirect_uri:-https://<organization-id>.api.${STAMHOOFD_DOMAIN}/openid/callback}"
+  just sso start "${redirect_uri:-${SSO_EXAMPLE_REDIRECT_URI}}"
+  just sso start --background "${redirect_uri:-${SSO_EXAMPLE_REDIRECT_URI}}"
   just sso logs
   just sso stop
 
-Note: use the Issuer value in the app. The Keycloak admin console is available at https://sso.${STAMHOOFD_DOMAIN}/dex/admin with ${KEYCLOAK_ADMIN_USER}/${KEYCLOAK_ADMIN_PASSWORD}.
+Note: use the Issuer value in the app. The Keycloak admin console is available at ${SSO_ADMIN_URL} with ${KEYCLOAK_ADMIN_USER}/${KEYCLOAK_ADMIN_PASSWORD}.
 EOF
+}
+
+sso_run_keycloak() {
+    local mode="$1"
+    local docker_args=(
+        --name "$KEYCLOAK_CONTAINER"
+        -p "${LOCAL_HOST}:${SSO_PORT}:${KEYCLOAK_CONTAINER_PORT}"
+        -e "KC_BOOTSTRAP_ADMIN_USERNAME=$KEYCLOAK_ADMIN_USER"
+        -e "KC_BOOTSTRAP_ADMIN_PASSWORD=$KEYCLOAK_ADMIN_PASSWORD"
+        -e KC_HTTP_RELATIVE_PATH=/dex
+        -v "$KEYCLOAK_IMPORT_DIR:/opt/keycloak/data/import:ro"
+        "$KEYCLOAK_IMAGE"
+        start-dev
+        --import-realm
+        --hostname="$SSO_BASE_URL"
+        --proxy-headers=xforwarded
+    )
+
+    case "$mode" in
+        background)
+            common_command_quiet run docker run -d "${docker_args[@]}"
+            ;;
+        foreground)
+            common_command run docker run --rm "${docker_args[@]}"
+            ;;
+        *)
+            echo "Unknown Keycloak mode: $mode" >&2
+            return 1
+            ;;
+    esac
 }
 
 sso_start() {
@@ -154,19 +184,11 @@ sso_start() {
 
     dev_ensure_network_services
 
-    echo "Starting Keycloak on 127.0.0.1:5556..."
-    docker rm -f "$KEYCLOAK_CONTAINER" >/dev/null 2>&1 || true
+    echo "Starting Keycloak on ${LOCAL_HOST}:${SSO_PORT}..."
+    common_docker_rm "$KEYCLOAK_CONTAINER"
 
     if [ "$background" = "true" ]; then
-        docker run -d \
-            --name "$KEYCLOAK_CONTAINER" \
-            -p 127.0.0.1:5556:8080 \
-            -e KC_BOOTSTRAP_ADMIN_USERNAME="$KEYCLOAK_ADMIN_USER" \
-            -e KC_BOOTSTRAP_ADMIN_PASSWORD="$KEYCLOAK_ADMIN_PASSWORD" \
-            -e KC_HTTP_RELATIVE_PATH=/dex \
-            -v "$KEYCLOAK_IMPORT_DIR:/opt/keycloak/data/import:ro" \
-            "$KEYCLOAK_IMAGE" \
-            start-dev --import-realm --hostname="https://sso.${STAMHOOFD_DOMAIN}/dex" --proxy-headers=xforwarded >/dev/null
+        sso_run_keycloak background
 
         echo "Local SSO server started in the background."
         echo
@@ -185,24 +207,16 @@ sso_start() {
         fi
         cleanup_done=1
         trap - EXIT INT TERM
-        docker rm -f "$KEYCLOAK_CONTAINER" >/dev/null 2>&1 || true
+        common_docker_rm "$KEYCLOAK_CONTAINER"
         echo "Local SSO server stopped."
     }
     trap cleanup EXIT INT TERM
 
-    docker run --rm \
-        --name "$KEYCLOAK_CONTAINER" \
-        -p 127.0.0.1:5556:8080 \
-        -e KC_BOOTSTRAP_ADMIN_USERNAME="$KEYCLOAK_ADMIN_USER" \
-        -e KC_BOOTSTRAP_ADMIN_PASSWORD="$KEYCLOAK_ADMIN_PASSWORD" \
-        -e KC_HTTP_RELATIVE_PATH=/dex \
-        -v "$KEYCLOAK_IMPORT_DIR:/opt/keycloak/data/import:ro" \
-        "$KEYCLOAK_IMAGE" \
-        start-dev --import-realm --hostname="https://sso.${STAMHOOFD_DOMAIN}/dex" --proxy-headers=xforwarded
+    sso_run_keycloak foreground
 }
 
 sso_stop() {
-    docker rm -f "$KEYCLOAK_CONTAINER" >/dev/null 2>&1 || true
+    common_docker_rm "$KEYCLOAK_CONTAINER"
     echo "Local SSO server stopped."
 }
 

--- a/.development/just/status.sh
+++ b/.development/just/status.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+status_show_dev_services() {
+    docker ps --filter "name=${STAMHOOFD_DEV_NAME}-" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+}
+
+status() {
+    echo "Dev name:    $STAMHOOFD_DEV_NAME"
+    echo "Domain:      .$STAMHOOFD_DOMAIN"
+    echo
+    echo "URLs:"
+    echo "  Dashboard: https://dashboard.${STAMHOOFD_DOMAIN}"
+    echo "  API:       https://api.${STAMHOOFD_DOMAIN}"
+    echo "  Renderer:  https://renderer.${STAMHOOFD_DOMAIN}"
+    echo "  SSO:       $(sso_issuer)"
+    echo "  MailDev:   http://127.0.0.1:1080"
+    echo
+    echo "Containers:"
+    status_show_dev_services || true
+    echo
+    echo "DNS:"
+    if command -v resolvectl >/dev/null 2>&1; then
+        dns_status || true
+    else
+        echo "  resolvectl not found"
+    fi
+}

--- a/.development/just/status.sh
+++ b/.development/just/status.sh
@@ -9,11 +9,11 @@ status() {
     echo "Domain:      .$STAMHOOFD_DOMAIN"
     echo
     echo "URLs:"
-    echo "  Dashboard: https://dashboard.${STAMHOOFD_DOMAIN}"
-    echo "  API:       https://api.${STAMHOOFD_DOMAIN}"
-    echo "  Renderer:  https://renderer.${STAMHOOFD_DOMAIN}"
+    echo "  Dashboard: ${DASHBOARD_URL}"
+    echo "  API:       ${API_URL}"
+    echo "  Renderer:  ${RENDERER_URL}"
     echo "  SSO:       $(sso_issuer)"
-    echo "  MailDev:   http://127.0.0.1:1080"
+    echo "  MailDev:   ${MAILDEV_URL}"
     echo
     echo "Containers:"
     status_show_dev_services || true

--- a/.development/just/test.sh
+++ b/.development/just/test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+test_prepare_database() {
+    local container_name="${1:-$MYSQL_CONTAINER}"
+    docker exec "$container_name" mysql -h127.0.0.1 -uroot -proot -e 'CREATE DATABASE IF NOT EXISTS `stamhoofd-tests` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;'
+}
+
+test_start_services() {
+    common_require_command docker
+    echo "Starting isolated test MySQL..."
+    docker rm -f "$TEST_MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    docker run -d \
+        --name "$TEST_MYSQL_CONTAINER" \
+        -e MYSQL_ROOT_PASSWORD=root \
+        -p 127.0.0.1::3306 \
+        mysql:8.4 \
+        --mysql-native-password=ON \
+        --sort-buffer-size=2M >/dev/null
+    export DB_PORT="$(docker port "$TEST_MYSQL_CONTAINER" 3306/tcp | sed 's/.*://')"
+    echo "Test MySQL is mapped to 127.0.0.1:${DB_PORT}."
+    common_wait_for_mysql_container "$TEST_MYSQL_CONTAINER"
+    test_prepare_database "$TEST_MYSQL_CONTAINER"
+}
+
+test_stop_services() {
+    docker rm -f "$TEST_MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    echo "Test infrastructure stopped."
+}
+
+test_unit() {
+    local ci="${1:-false}"
+    local status=0
+
+    test_start_services
+    cleanup_done=0
+    cleanup() {
+        if [ "$cleanup_done" = "1" ]; then
+            return
+        fi
+        cleanup_done=1
+        trap - EXIT INT TERM
+        test_stop_services
+    }
+    trap cleanup EXIT INT TERM
+
+    if [ "$ci" = "true" ]; then
+        CI=true NX_DAEMON=false yarn -s lerna run test --ignore @stamhoofd/playwright --ignore @stamhoofd/dashboard || status=$?
+    else
+        NX_DAEMON=false yarn -s lerna run test --ignore @stamhoofd/playwright --ignore @stamhoofd/dashboard || status=$?
+    fi
+
+    cleanup
+    return "$status"
+}
+
+test_e2e() {
+    local ci="${1:-false}"
+
+    if [ "$ci" = "true" ]; then
+        CI=true NX_DAEMON=false yarn -s test:playwright
+    else
+        NX_DAEMON=false yarn -s test:playwright
+    fi
+}

--- a/.development/just/test.sh
+++ b/.development/just/test.sh
@@ -2,28 +2,22 @@
 
 test_prepare_database() {
     local container_name="${1:-$MYSQL_CONTAINER}"
-    docker exec "$container_name" mysql -h127.0.0.1 -uroot -proot -e 'CREATE DATABASE IF NOT EXISTS `stamhoofd-tests` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;'
+    docker exec "$container_name" mysql -h"$MYSQL_CLIENT_HOST" -uroot -p"$MYSQL_ROOT_PASSWORD" -e 'CREATE DATABASE IF NOT EXISTS `stamhoofd-tests` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;'
 }
 
 test_start_services() {
     common_require_command docker
     echo "Starting isolated test MySQL..."
-    docker rm -f "$TEST_MYSQL_CONTAINER" >/dev/null 2>&1 || true
-    docker run -d \
-        --name "$TEST_MYSQL_CONTAINER" \
-        -e MYSQL_ROOT_PASSWORD=root \
-        -p 127.0.0.1::3306 \
-        mysql:8.4 \
-        --mysql-native-password=ON \
-        --sort-buffer-size=2M >/dev/null
+    common_docker_rm "$TEST_MYSQL_CONTAINER"
+    common_start_mysql_container "$TEST_MYSQL_CONTAINER" "${LOCAL_HOST}::${MYSQL_CONTAINER_PORT}"
     export DB_PORT="$(docker port "$TEST_MYSQL_CONTAINER" 3306/tcp | sed 's/.*://')"
-    echo "Test MySQL is mapped to 127.0.0.1:${DB_PORT}."
+    echo "Test MySQL is mapped to ${LOCAL_HOST}:${DB_PORT}."
     common_wait_for_mysql_container "$TEST_MYSQL_CONTAINER"
     test_prepare_database "$TEST_MYSQL_CONTAINER"
 }
 
 test_stop_services() {
-    docker rm -f "$TEST_MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    common_docker_rm "$TEST_MYSQL_CONTAINER"
     echo "Test infrastructure stopped."
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ web_modules/
 # dotenv environment variables file
 .env
 .env.test
+.development/just/generated/
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ You can read the documentation of the most important building blocks of Stamhoof
 - Afterwards install yarn 2: `npm install --global yarn` - this will globally install yarn. Every time node is updated you'll need to reinstall yarn (which isn't a huge issue as it will keep the installation directory clean).
 - Set the yarn version used to the one used by the project by running `yarn policies set-version 1.22.19`. We currently use version version 1.22.19 of yarn because of a bug in workspaces after that version (https://github.com/yarnpkg/yarn/issues/7807).
 - Run `yarn install`
+- Install [`just`](https://just.systems/man/en/packages.html) and run `just` in the project root for local development help and common commands.
 
 #### Dependencies
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,338 @@
+# Stamhoofd justfile - contributor-facing task runner
+# Install just: https://just.systems/man/en/packages.html
+# Usage: just <recipe>
+
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+export STAMHOOFD_DEV_NAME := env_var_or_default("STAMHOOFD_DEV_NAME", "stamhoofd")
+export STAMHOOFD_DOMAIN := env_var_or_default("STAMHOOFD_DOMAIN", "stamhoofd")
+dev_script := ".development/just/load.sh"
+
+# Show beginner help and list contributor-facing recipes
+default:
+    @printf '%s\n' 'Stamhoofd local development'
+    @printf '\n%s\n' 'First time setup:'
+    @printf '%s\n' '  just install            Install Node dependencies'
+    @printf '%s\n' '  just setup check        Check required tools and local configuration'
+    @printf '%s\n' '  just setup dns          Configure local .stamhoofd DNS'
+    @printf '%s\n' '  just setup cert         Generate and trust local HTTPS certificates'
+    @printf '\n%s\n' 'Start developing:'
+    @printf '%s\n' '  just dev all            Start the full local stack'
+    @printf '%s\n' '  just dev backend        Start backend services and backend apps'
+    @printf '%s\n' '  just dev frontend       Start frontend apps only'
+    @printf '%s\n' '  just status             Show local URLs, containers, and DNS status'
+    @printf '\n%s\n' 'Check your work:'
+    @printf '%s\n' '  just check all          Build, lint, typecheck, unit tests, and E2E tests'
+    @printf '%s\n' '  just validate           Alias for just check all'
+    @printf '\n%s\n' 'Cleanup:'
+    @printf '%s\n' '  just clean              Show cleanup commands'
+    @printf '%s\n' '  just clean build        Remove build artifacts'
+    @printf '%s\n' '  just clean all          Clean all local generated/development state'
+    @printf '\n%s\n' 'Tips:'
+    @printf '%s\n' '  Commands with subcommands show usage when run without a subcommand.'
+    @printf '%s\n' '  Use --env <name> with dev commands, e.g. just dev all --env keeo.'
+    @printf '%s\n' '  Run just --usage <command> for command arguments.'
+    @printf '%s\n' '  Run just --list to see every command.'
+    @printf '\n'
+    @just --list
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+
+[arg("target", help="check | dns | cert")]
+[doc("Install/check local development prerequisites.")]
+setup target="":
+    #!/usr/bin/env bash
+    if [ -z "{{ target }}" ]; then
+      just --usage setup
+      exit 0
+    fi
+    case "{{ target }}" in
+      check) just _setup-check ;;
+      dns) just _setup-dns ;;
+      cert) just _setup-cert ;;
+      *) echo "Unknown setup target: {{ target }}" >&2; exit 1 ;;
+    esac
+
+[arg("action", help="status | clean")]
+[doc("Inspect or clean local .stamhoofd DNS configuration.")]
+dns action="":
+    #!/usr/bin/env bash
+    if [ -z "{{ action }}" ]; then
+      just --usage dns
+      exit 0
+    fi
+    case "{{ action }}" in
+      status) just _dns-status ;;
+      clean) just _dns-clean ;;
+      *) echo "Unknown dns action: {{ action }}" >&2; exit 1 ;;
+    esac
+
+# ── Infrastructure ────────────────────────────────────────────────────────────
+
+# Show local development status
+status:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    status
+
+[arg("action", help="start | stop | logs | config | clean")]
+[arg("redirect_uri", help="Redirect URI copied from the SSO settings view")]
+[arg("background", long, value="true", help="Run the local SSO server in the background")]
+[doc("Manage a local OpenID Connect server for SSO testing.")]
+sso action="" redirect_uri="" background="false":
+    #!/usr/bin/env bash
+    if [ -z "{{ action }}" ]; then
+      just --usage sso
+      exit 0
+    fi
+    case "{{ action }}" in
+      start) just _sso-start "{{ redirect_uri }}" {{ background }} ;;
+      stop) just _sso-stop ;;
+      logs) just _sso-logs ;;
+      config) just _sso-config "{{ redirect_uri }}" ;;
+      clean) just _sso-clean ;;
+      *) echo "Unknown sso action: {{ action }}" >&2; exit 1 ;;
+    esac
+
+# ── Development ───────────────────────────────────────────────────────────────
+
+[arg("target", help="all | network | backend | frontend")]
+[arg("env", long, help="Development environment")]
+[doc("Run local development for the selected target.")]
+dev target="" env="stamhoofd":
+    #!/usr/bin/env bash
+    if [ -z "{{ target }}" ]; then
+      just --usage dev
+      exit 0
+    fi
+    case "{{ target }}" in
+      all|network|backend|frontend) just _dev {{ target }} {{ env }} ;;
+      *) echo "Unknown dev target: {{ target }}" >&2; exit 1 ;;
+    esac
+
+[arg("action", help="shell | migrate | clean")]
+[doc("Manage the local development database.")]
+db action="":
+    #!/usr/bin/env bash
+    if [ -z "{{ action }}" ]; then
+      just --usage db
+      exit 0
+    fi
+    case "{{ action }}" in
+      shell) just _db-shell ;;
+      migrate) just _db-migrate ;;
+      clean) just _db-clean ;;
+      *) echo "Unknown database action: {{ action }}" >&2; exit 1 ;;
+    esac
+
+# ── Build & Validation ────────────────────────────────────────────────────────
+
+[arg("target", help="all | lint | typecheck | build")]
+[doc("Run validation checks for the selected target.")]
+check target="":
+    #!/usr/bin/env bash
+    if [ -z "{{ target }}" ]; then
+      just --usage check
+      exit 0
+    fi
+    case "{{ target }}" in
+      all) just _check-all ;;
+      lint) just _check-lint ;;
+      typecheck) just _check-typecheck ;;
+      build) just _build ;;
+      *) echo "Unknown check target: {{ target }}" >&2; exit 1 ;;
+    esac
+
+[arg("target", help="all | unit | e2e")]
+[arg("ci", long, value="true", help="Use non-interactive CI-style test execution")]
+[doc("Run tests for the selected target.")]
+test target="" ci="false":
+    #!/usr/bin/env bash
+    if [ -z "{{ target }}" ]; then
+      just --usage test
+      exit 0
+    fi
+    case "{{ target }}" in
+      all) just _test-all {{ ci }} ;;
+      unit) just _test-unit {{ ci }} ;;
+      e2e) just _test-e2e {{ ci }} ;;
+      *) echo "Unknown test target: {{ target }}" >&2; exit 1 ;;
+    esac
+
+# Install Node dependencies
+install:
+    yarn install
+
+# Run the full local validation flow; alias for `just check all`
+[doc("Alias for `just check all`.")]
+validate: _check-all
+
+[arg("target", help="all | build | db | dns | sso")]
+[doc("Clean local generated state for the selected target.")]
+clean target="":
+    #!/usr/bin/env bash
+    if [ -z "{{ target }}" ]; then
+      just --usage clean
+      exit 0
+    fi
+    case "{{ target }}" in
+      all) just _clean-all ;;
+      build) just _clean-build ;;
+      db) just db clean ;;
+      dns) just dns clean ;;
+      sso) just sso clean ;;
+      *) echo "Unknown clean target: {{ target }}" >&2; exit 1 ;;
+    esac
+
+[private]
+_setup-check:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    setup_check
+
+[private]
+_setup-dns:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    setup_dns
+
+[private]
+_setup-cert:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    setup_cert
+
+[private]
+_dns-status:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    dns_status
+
+[private]
+_dns-clean:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    dns_clean
+
+[private]
+_sso-start redirect_uri background:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    sso_start "{{ redirect_uri }}" "{{ background }}"
+
+[private]
+_sso-stop:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    sso_stop
+
+[private]
+_sso-clean:
+    just _sso-stop
+
+[private]
+_sso-logs:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    sso_logs
+
+[private]
+_sso-config redirect_uri:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    sso_config "{{ redirect_uri }}"
+
+[private]
+_dev target env:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    case "{{ target }}" in
+      all)
+        dev_start_network_services
+        dev_start_backend_services
+        cleanup_done=0
+        cleanup() { if [ "$cleanup_done" = "1" ]; then return; fi; cleanup_done=1; trap - EXIT INT TERM; dev_stop_backend_services; dev_stop_network_services; }
+        trap cleanup EXIT INT TERM
+        dev_run all "{{ env }}"
+        ;;
+      network)
+        dev_start_network_services
+        cleanup_done=0
+        cleanup() { if [ "$cleanup_done" = "1" ]; then return; fi; cleanup_done=1; trap - EXIT INT TERM; dev_stop_network_services; }
+        trap cleanup EXIT INT TERM
+        dev_tail_network_logs
+        ;;
+      backend)
+        dev_start_backend_services
+        cleanup_done=0
+        cleanup() { if [ "$cleanup_done" = "1" ]; then return; fi; cleanup_done=1; trap - EXIT INT TERM; dev_stop_backend_services; }
+        trap cleanup EXIT INT TERM
+        dev_run backend "{{ env }}"
+        ;;
+      frontend)
+        dev_run frontend "{{ env }}"
+        ;;
+    esac
+
+[private]
+_db-shell:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    db_shell
+
+[private]
+_db-migrate:
+    yarn -s migrate
+
+[private]
+_db-clean:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    db_clean
+
+[private]
+_clean-build:
+    yarn clear
+
+[private]
+_clean-all:
+    just _clean-build
+    just db clean
+    just dns clean
+    just sso clean
+
+[private]
+_build:
+    NX_DAEMON=false yarn dev:build
+
+[private]
+_check-lint:
+    NX_DAEMON=false yarn lint
+
+[private]
+_check-typecheck:
+    NX_DAEMON=false yarn typecheck
+
+[private]
+_check-all:
+    just _build
+    just _check-lint
+    just _check-typecheck
+    just _test-all true
+
+[private]
+_test-unit ci:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    test_unit "{{ ci }}"
+
+[private]
+_test-e2e ci:
+    #!/usr/bin/env bash
+    source {{ dev_script }}
+    test_e2e "{{ ci }}"
+
+[private]
+_test-all ci:
+    just _test-unit {{ ci }}
+    just _test-e2e {{ ci }}

--- a/shared/build-development-env/src/init.ts
+++ b/shared/build-development-env/src/init.ts
@@ -5,6 +5,12 @@ import chalk from 'chalk';
 
 async function init() {
     console.log(chalk.magenta('[INIT]') + ' Initializing development environment...');
+
+    if (process.env.STAMHOOFD_SKIP_DEV_SERVICES === '1') {
+        console.log(chalk.magenta('[INIT]') + ' Skipping development services because STAMHOOFD_SKIP_DEV_SERVICES=1');
+        return;
+    }
+
     const services: ConcurrentlyCommandInput[] = [];
 
     // Loop all presets with a init method and call that method.

--- a/shared/build-development-env/src/presets/services/stripe.ts
+++ b/shared/build-development-env/src/presets/services/stripe.ts
@@ -6,6 +6,10 @@ import type { Service } from '../../Service.js';
 const execPromise = util.promisify(exec);
 
 export async function inject(config: BackendEnvironment, service: Service) {
+    if (process.env.STAMHOOFD_SKIP_DEV_SERVICES === '1') {
+        return {};
+    }
+
     if (!('backend' in service) || !service.backend) {
         return {};
     }


### PR DESCRIPTION
This adds a `justfile` and a few scripts to make it easy to setup the local developer environment on Linux. MacOS can be added as it is supported in the Node implementation, I don't have a Mac to test however. It spins up everything you need, and even supports running a local SSO server for testing. It kind of looks like this:

```
➜ just
Stamhoofd local development

First time setup:
  just install            Install Node dependencies
  just setup check        Check required tools and local configuration
  just setup dns          Configure local .stamhoofd DNS
  just setup cert         Generate and trust local HTTPS certificates

Start developing:
  just dev all            Start the full local stack
  just dev backend        Start backend services and backend apps
  just dev frontend       Start frontend apps only
  just status             Show local URLs, containers, and DNS status

Check your work:
  just check all          Build, lint, typecheck, unit tests, and E2E tests
  just validate           Alias for just check all

Cleanup:
  just clean              Show cleanup commands
  just clean build        Remove build artifacts
  just clean all          Clean all local generated/development state

Tips:
  Commands with subcommands show usage when run without a subcommand.
  Use --env <name> with dev commands, e.g. just dev all --env keeo.
  Run just --usage <command> for command arguments.
  Run just --list to see every command.

Available recipes:
    check target=""                                  # Run validation checks for the selected target.
    clean target=""                                  # Clean local generated state for the selected target.
    db action=""                                     # Manage the local development database.
    default                                          # Show beginner help and list contributor-facing recipes
    dev target="" env="stamhoofd"                    # Run local development for the selected target.
    dns action=""                                    # Inspect or clean local .stamhoofd DNS configuration.
    install                                          # Install Node dependencies
    setup target=""                                  # Install/check local development prerequisites.
    sso action="" redirect_uri="" background="false" # Manage a local OpenID Connect server for SSO testing.
    status                                           # Show local development status
    test target="" ci="false"                        # Run tests for the selected target.
    validate                                         # Alias for `just check all`.
```
```
➜ just dev all
Starting CoreDNS on 127.0.0.1:53...
  docker rm -f stamhoofd-coredns
  docker run -d --name stamhoofd-coredns -p 127.0.0.1:53:53/udp -p 127.0.0.1:53:53/tcp -v ~/dev/stamhoofd/main/.development/just/generated/Corefile:/Corefile:ro coredns/coredns:1.11.3 -conf /Corefile
Starting Caddy on 127.0.0.1:80 and 127.0.0.1:443...
  docker rm -f stamhoofd-caddy
  docker volume create stamhoofd-caddy-data
  docker volume create stamhoofd-caddy-config
  docker run -d --name stamhoofd-caddy --network host -v ~/dev/stamhoofd/main/.development/just/generated/Caddyfile:/etc/caddy/Caddyfile:ro -v ~/dev/stamhoofd/main/.development/just/generated/certs:/etc/caddy/certs:ro -v stamhoofd-caddy-data:/data -v stamhoofd-caddy-config:/config caddy:2.8
Network services started.
Starting MySQL on 127.0.0.1:3306...
  docker rm -f stamhoofd-mysql
  docker volume create stamhoofd-mysql-data
  docker run -d --name stamhoofd-mysql -e MYSQL_ROOT_PASSWORD=root -p 127.0.0.1:3306:3306 -v stamhoofd-mysql-data:/var/lib/mysql mysql:8.4 --mysql-native-password=ON --sort-buffer-size=2M
Waiting for MySQL to accept connections...
MySQL is ready.
Starting MailDev on http://127.0.0.1:1080...
  docker rm -f stamhoofd-maildev
  docker run -d --name stamhoofd-maildev -p 127.0.0.1:1025:1025 -p 127.0.0.1:1080:1080 maildev/maildev:2.2.1 maildev --ip 0.0.0.0 --incoming-user username --incoming-pass password
Backend services started.
  npx --no-install concurrently -r yarn\ -s\ dev:init yarn\ -s\ build:shared:watch wait-on\ shared/locales/dist/index.d.ts\ \&\&\ lerna\ run\ dev\ --ignore\ @stamhoofd/calculator\ --stream\ --parallel
\033[35m[BUILD]\033[0m Building globally shared dependencies...
[INIT] Initializing development environment...
[INIT] Skipping development services because STAMHOOFD_SKIP_DEV_SERVICES=1
lerna notice cli v9.0.4
lerna notice filter excluding "@stamhoofd/calculator"
lerna info filter [ '!@stamhoofd/calculator' ]

 Lerna (powered by Nx)   Running target dev for 5 projects:
# ...
 ```


```
➜ just setup dns
This will configure temporary split DNS for .stamhoofd only.
Existing DNS servers remain responsible for all other domains.
The config is written to /run and disappears on reboot.
systemd-resolved will be restarted.

Runtime config to write to /run/systemd/resolved.conf.d/stamhoofd.conf:
  [Resolve]
  DNS=127.0.0.1
  Domains=~stamhoofd

Commands to run:
  # May also run when NetworkManager has stale DNS entries:
  sudo nmcli connection modify Wired\ connection\ 1 -ipv4.dns 127.0.0.1 -ipv4.dns-search \~stamhoofd
  sudo nmcli connection up Wired\ connection\ 1
  sudo mkdir -p /run/systemd/resolved.conf.d
  printf %s $'[Resolve]\nDNS=127.0.0.1\nDomains=~stamhoofd' | sudo tee /run/systemd/resolved.conf.d/stamhoofd.conf >/dev/null
  sudo systemctl restart systemd-resolved

Apply this DNS configuration? [y/N] y
Removing stale NetworkManager DNS entries from 'Wired connection 1' if present...
  sudo mkdir -p /run/systemd/resolved.conf.d
  printf %s $'[Resolve]\nDNS=127.0.0.1\nDomains=~stamhoofd' | sudo tee /run/systemd/resolved.conf.d/stamhoofd.conf >/dev/null
  sudo systemctl restart systemd-resolved
Temporary split DNS configured for .stamhoofd.
```

```
➜ just setup check
Found: docker (/usr/bin/docker)
Found: node (/usr/bin/node)
Found: yarn (/usr/bin/yarn)
Found: just (/usr/bin/just)
Node dependencies: installed.
DNS: split DNS for .stamhoofd is configured.
Certificate: Stamhoofd development CA exists and appears to be trusted.

Next steps:
  just dev all
  just
```

```
➜ just status
Dev name:    stamhoofd
Domain:      .stamhoofd

URLs:
  Dashboard: https://dashboard.stamhoofd
  API:       https://api.stamhoofd
  Renderer:  https://renderer.stamhoofd
  SSO:       https://sso.stamhoofd/dex/realms/stamhoofd
  MailDev:   http://127.0.0.1:1080

Containers:
NAMES               STATUS                          PORTS
stamhoofd-maildev   Up About a minute (unhealthy)   127.0.0.1:1025->1025/tcp, 127.0.0.1:1080->1080/tcp
stamhoofd-mysql     Up About a minute               127.0.0.1:3306->3306/tcp, 33060/tcp
stamhoofd-caddy     Up About a minute
stamhoofd-coredns   Up About a minute               127.0.0.1:53->53/tcp, 127.0.0.1:53->53/udp

DNS:
       DNS Servers: 127.0.0.1
        DNS Domain: ~stamhoofd
```