### PR TITLE
🐛️ Avoid overloading server during export (STA-1051)

### DIFF
--- a/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
@@ -89,7 +89,7 @@ export class ExportToExcelEndpoint extends Endpoint<Params, Query, Body, Respons
         await Platform.getSharedStruct();
 
         const result = await Promise.race([
-            this.job(loader, request.body, request.params.type).then(async (url: string) => {
+            this.job(loader, request.body, request.params.type, user.id).then(async (url: string) => {
                 if (sendEmail) {
                     await sendEmailTemplate(null, {
                         template: {
@@ -138,10 +138,10 @@ export class ExportToExcelEndpoint extends Endpoint<Params, Query, Body, Respons
         }));
     }
 
-    async job(loader: ExcelExporter<unknown>, request: ExcelExportRequest, type: string): Promise<string> {
+    async job(loader: ExcelExporter<unknown>, request: ExcelExportRequest, type: string, userId: string): Promise<string> {
         // Only run 1 export per user at the same time
-        return await QueueHandler.schedule('user-export-to-excel-' + Context.user!.id, async () => {
-            // Allow maximum 2 running Excel jobs at the same time for all users
+        return await QueueHandler.schedule('user-export-to-excel-' + userId, async () => {
+            // Allow maximum 5 running Excel jobs at the same time for all users; queue the rest.
             return await QueueHandler.schedule('export-to-excel', async () => {
                 // Estimate how long it will take.
                 // If too long, we'll schedule it and write it to Digitalocean Spaces
@@ -165,7 +165,7 @@ export class ExportToExcelEndpoint extends Endpoint<Params, Query, Body, Respons
 
                 const url = 'https://' + STAMHOOFD.domains.api + '/v' + Version + '/file-cache?file=' + encodeURIComponent(file) + '&name=' + encodeURIComponent(request.title ?? type);
                 return url;
-            }, 2);
+            }, 5);
         });
     }
 }

--- a/shared/excel-writer/src/exportToExcel.ts
+++ b/shared/excel-writer/src/exportToExcel.ts
@@ -1,6 +1,7 @@
 import type { XlsxTransformerSheet, XlsxWorkbookFilter, XlsxWriterAdapter } from './interfaces.js';
 import { XlsxColumnFilterer } from './XlsxColumnFilterer.js';
 import { XlsxTransformer } from './XlsxTransformer.js';
+import { sleep } from '@stamhoofd/utility';
 
 export async function exportToExcel<T>({ definitions, writer, dataGenerator, filter }: {
     filter: XlsxWorkbookFilter;
@@ -19,6 +20,9 @@ export async function exportToExcel<T>({ definitions, writer, dataGenerator, fil
         // Start looping over the data
         for await (const data of dataGenerator) {
             await transformer.process(data);
+            // Sleep for a short duration to reduce load on the server.
+            // There's no rush to do things quickly for an export.
+            await sleep(100);
         }
 
         await writer.close();


### PR DESCRIPTION
Fixes STA-1051 by adding a simple sleep during the export. Any proper implementation would require some infra changes and this should be good enough for now. Also increases concurrency to 5 from 2, as talked about. I'm passing the user id as well to make it clear it's a requirement instead of using `!`.