### PR TITLE
Fixed Yarn 1.x stripping -- separator before lerna in lint command

### DIFF
--- a/shared/cli/src/runtime/monorepo-runner.ts
+++ b/shared/cli/src/runtime/monorepo-runner.ts
@@ -55,11 +55,11 @@ export async function buildAll(context: CliContext): Promise<void> {
 }
 
 export async function lint(context: CliContext): Promise<void> {
-    await run('yarn', ['-s', 'lerna', 'run', 'lint', '--', '--quiet'], { cwd: context.rootDir, env: { NX_DAEMON: 'false' }, verbose: context.verbose });
+    await run('yarn', ['-s', 'lerna', 'run', 'lint', '--', '--', '--quiet'], { cwd: context.rootDir, env: { NX_DAEMON: 'false' }, verbose: context.verbose });
 }
 
 export async function typecheck(context: CliContext): Promise<void> {
-    await run('yarn', ['-s', 'lerna', 'run', 'typecheck', '--'], { cwd: context.rootDir, env: { NX_DAEMON: 'false' }, verbose: context.verbose });
+    await run('yarn', ['-s', 'lerna', 'run', 'typecheck'], { cwd: context.rootDir, env: { NX_DAEMON: 'false' }, verbose: context.verbose });
 }
 
 export async function migrate(context: CliContext): Promise<void> {


### PR DESCRIPTION
The command `yarn stam check lint` gave an error with me. Claude suggested a fix (that worked for me). My yarn version is 1.22.19.

```bash
benjamin@Mac temp % git clone git@github.com:stamhoofd/stamhoofd.git
benjamin@Mac temp % cd stamhoofd
benjamin@Mac stamhoofd % nvm install
benjamin@Mac stamhoofd % yarn install
benjamin@Mac stamhoofd % yarn build:shared
benjamin@Mac stamhoofd % yarn stam check lint
yarn run v1.22.22
$ exec node shared/cli/bin/stam.js check lint
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
ERR! lerna Unknown argument: quiet
Error: yarn -s lerna run lint -- --quiet exited with status 1
    at ChildProcess.<anonymous> (file:///Users/benjamin/Development/temp/stamhoofd/shared/cli/dist/runtime/command-runner.js:51:20)
    at ChildProcess.emit (node:events:519:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```


Fixed by doubling the -- in the CLI runner so after Yarn removes one, lerna still receives -- --quiet to correctly forward flags to lint scripts. 
Also removed the trailing -- from the typecheck command which was a no-op.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783322687&installation_id=138085646&pr_number=417&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F417&signature=89e24cac372bd8be34f4eb77b00a86d9c9ef193a514d202ea4e41811a09c3840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->