### PR TITLE
🎨 remove feature flag registration-invites (STA-1127)

### DIFF
--- a/frontend/app/admin/src/views/settings/LabsView.vue
+++ b/frontend/app/admin/src/views/settings/LabsView.vue
@@ -46,10 +46,6 @@
             <Checkbox :model-value="getFeatureFlag('uitpas')" @update:model-value="setFeatureFlag('uitpas', !!$event)">
                 UiTPAS-kansentarief op webshops (onvolledig)
             </Checkbox>
-
-            <Checkbox :model-value="getFeatureFlag('registration-invites')" @update:model-value="setFeatureFlag('registration-invites', !!$event)">
-                {{ $t('%1R9') }}
-            </Checkbox>
         </template>
 
         <hr><h2>{{ $t('%HJ') }}</h2>

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupOverview.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupOverview.vue
@@ -773,11 +773,6 @@ const invitationsFetcher = useRegistrationInvitationsObjectFetcher({
 });
 
 async function fetchInvitationCount() {
-    if (!featureFlag('registration-invites')) {
-        invitationsCount.value = 0;
-        return;
-    }
-
     try {
         invitationsCount.value = await countAll(invitationsFetcher);
     } catch (e) {

--- a/frontend/shared/components/src/events/EventOverview.vue
+++ b/frontend/shared/components/src/events/EventOverview.vue
@@ -946,11 +946,6 @@ const invitationsFetcher = useRegistrationInvitationsObjectFetcher(props.event.g
     : {});
 
 async function fetchInvitationCount() {
-    if (!featureFlag('registration-invites')) {
-        invitationsCount.value = 0;
-        return;
-    }
-
     if (!props.event.group) {
         invitationsCount.value = 0;
         return;

--- a/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
+++ b/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
@@ -597,10 +597,6 @@ export class MemberActionBuilder {
             return [];
         }
 
-        if (!manualFeatureFlag('registration-invites', this.context)) {
-            return [];
-        }
-
         let categoryTree: null | GroupCategoryTree = null;
 
         if (this.isWaitingList) {

--- a/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
+++ b/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
@@ -849,10 +849,6 @@ export class RegistrationActionBuilder {
             return [];
         }
 
-        if (!manualFeatureFlag('registration-invites', this.context)) {
-            return [];
-        }
-
         let categoryTree: null | GroupCategoryTree = null;
 
         if (this.isWaitingList) {


### PR DESCRIPTION
Kleine vraag: de %1R9 vertaling is ongebruikt nog. Kan dat automatisch verwijderd worden ipv manueel?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783762329&installation_id=138085646&pr_number=432&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F432&signature=ca5079e2a16b993a55e92fa60331dafec33a66f585cff63b06945775358b2953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->