### PR TITLE
Hide internal admins and functions when members are disabled in organization mode

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/admins/ApiUserView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/admins/ApiUserView.vue
@@ -10,8 +10,8 @@
         </STInputBox>
 
         <div class="container">
-            <hr><h2>{{ $t('%Jm') }}</h2>
-            <p>{{ $t('%Jn') }}</p>
+            <hr><h2>{{ adminRolesTitle }}</h2>
+            <p>{{ apiUserRolesDescription }}</p>
 
             <EditUserPermissionsBox :user="patched" @patch:user="addPatch($event)" />
         </div>
@@ -80,6 +80,7 @@ import { SimpleError, SimpleErrors } from '@simonbackx/simple-errors';
 import { ComponentWithProperties, usePop, useShow } from '@simonbackx/vue-app-navigation';
 import { CenteredMessage } from '@stamhoofd/components/overlays/CenteredMessage.ts';
 import EditUserPermissionsBox from '@stamhoofd/components/admins/components/EditUserPermissionsBox.vue';
+import { useAdminLabels } from '@stamhoofd/components/admins/hooks/useAdminLabels';
 import { ErrorBox } from '@stamhoofd/components/errors/ErrorBox.ts';
 import SaveView from '@stamhoofd/components/navigation/SaveView.vue';
 import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
@@ -106,6 +107,7 @@ const props = defineProps<{
     callback: () => void;
 }>();
 const { patch, patched, addPatch, hasChanges } = usePatch(props.user);
+const { adminRolesTitle, apiUserRolesDescription } = useAdminLabels();
 
 const title = computed(() => {
     if (props.isNew) {

--- a/frontend/shared/components/src/admins/AdminsView.vue
+++ b/frontend/shared/components/src/admins/AdminsView.vue
@@ -8,7 +8,7 @@
                 <p>{{ $t('%30') }}</p>
 
                 <STList class="illustration-list">
-                    <STListItem :selectable="true" class="left-center" @click="$navigate(Routes.Responsibilities)">
+                    <STListItem v-if="showInternalAdmins" :selectable="true" class="left-center" @click="$navigate(Routes.Responsibilities)">
                         <template #left>
                             <img src="@stamhoofd/assets/images/illustrations/admin-role.svg">
                         </template>
@@ -22,9 +22,23 @@
                             <span class="icon arrow-right-small gray" />
                         </template>
                     </STListItem>
+                    <STListItem v-else :selectable="true" class="left-center" @click="$navigate(Routes.Roles)">
+                        <template #left>
+                            <img src="@stamhoofd/assets/images/illustrations/admin-role.svg">
+                        </template>
+                        <h2 class="style-title-list">
+                            {{ $t('Beheerdersrollen beheren') }}
+                        </h2>
+                        <p class="style-description">
+                            {{ $t('Maak rollen aan en stel de toegangsrechten voor elke rol in.') }}
+                        </p>
+                        <template #right>
+                            <span class="icon arrow-right-small gray" />
+                        </template>
+                    </STListItem>
                 </STList>
 
-                <InternalAdminsBox />
+                <InternalAdminsBox v-if="showInternalAdmins" />
                 <ExternalAdminsBox />
             </main>
         </div>
@@ -37,10 +51,12 @@ import EditResponsibilitiesView from '#responsibilities/EditResponsibilitiesView
 import { defineRoutes, useNavigate } from '@simonbackx/vue-app-navigation';
 import ExternalAdminsBox from './ExternalAdminsBox.vue';
 import { useAdmins } from './hooks/useAdmins';
+import { useShowInternalAdmins } from './hooks/useShowInternalAdmins';
 import InternalAdminsBox from './InternalAdminsBox.vue';
 import RolesView from './RolesView.vue';
 
 const { loading } = useAdmins({forceLoadOnMount: true});
+const showInternalAdmins = useShowInternalAdmins();
 
 enum Routes {
     Roles = 'rollen',

--- a/frontend/shared/components/src/admins/EditAdminView.vue
+++ b/frontend/shared/components/src/admins/EditAdminView.vue
@@ -10,10 +10,10 @@
         </template>
         <template v-else>
             <h1 v-if="isNew">
-                {{ $t('%Yk') }}
+                {{ addAdminTitle }}
             </h1>
             <h1 v-else-if="!user.memberId">
-                {{ $t('%Yl') }}
+                {{ editAdminTitle }}
             </h1>
             <h1 v-else>
                 {{ $t('%Ym') }}
@@ -50,8 +50,8 @@
 
         <template v-if="getUnloadedPermissions(user)">
             <div v-if="!user.memberId || getUnloadedPermissions(user)" class="container">
-                <hr><h2>{{ $t('%Jm') }}</h2>
-                <p>{{ $t('%Yq') }}</p>
+                <hr><h2>{{ adminRolesTitle }}</h2>
+                <p>{{ adminRolesPersonDescription }}</p>
 
                 <EditUserPermissionsBox :user="patched" @patch:user="(event) => addPatch(event)" />
             </div>
@@ -104,6 +104,7 @@ import { User, UserWithMembers } from '@stamhoofd/structures';
 import { computed, ref } from 'vue';
 
 import ResourcePermissionRow from './components/ResourcePermissionRow.vue';
+import { useAdminLabels } from './hooks/useAdminLabels';
 import { useAdmins, usePermissionsCache } from './hooks/useAdmins';
 
 const $errors = useErrors();
@@ -122,6 +123,7 @@ const props = defineProps<{
 const { patch, patched, addPatch, hasChanges } = usePatch(props.user);
 const { pushInMemory, dropFromMemory, getPermissionsPatch } = useAdmins();
 const { clearPermissionCache, getPermissions, getUnloadedPermissions } = usePermissionsCache();
+const { addAdminTitle, editAdminTitle, adminRolesTitle, adminRolesPersonDescription } = useAdminLabels();
 
 const permissions = useUninheritedPermissions({ patchedUser: patched });
 const resources = computed(() => {

--- a/frontend/shared/components/src/admins/EditResourceRolesView.vue
+++ b/frontend/shared/components/src/admins/EditResourceRolesView.vue
@@ -15,8 +15,8 @@
             </STList>
         </div>
 
-        <hr><h2>{{ $t('%Jm') }}</h2>
-        <p>{{ $t('%Yw') }}</p>
+        <hr><h2>{{ adminRolesTitle }}</h2>
+        <p>{{ resourceAdminRolesDescription }}</p>
 
         <p v-if="roles.length === 0" class="info-box">
             {{ $t('%Yx') }}
@@ -37,6 +37,7 @@ import { computed } from 'vue';
 import { useOrganization } from '../hooks';
 import { Toast } from '../overlays/Toast';
 import ResourcePermissionRow from './components/ResourcePermissionRow.vue';
+import { useAdminLabels } from './hooks/useAdminLabels';
 import { usePatchRoles } from './hooks/useRoles';
 
 withDefaults(
@@ -54,6 +55,7 @@ withDefaults(
 const { errors, hasChanges, patchRoles, roles, inheritedResponsibilityRoles, inheritedResponsibilitiesWithGroup, applicableResponsibilities, responsibilities, patchResponsibilities, patchInheritedResponsibilityRoles, createRolePatchArray, createResponsibilityPatchArray, createInheritedResponsibilityRolePatchArray, saving, save: rawSave } = usePatchRoles();
 const pop = usePop();
 const organization = useOrganization();
+const { adminRolesTitle, resourceAdminRolesDescription } = useAdminLabels();
 
 const addPatch = (role: AutoEncoderPatchType<PermissionRoleDetailed>) => {
     const arr = createRolePatchArray();

--- a/frontend/shared/components/src/admins/ExternalAdminsBox.vue
+++ b/frontend/shared/components/src/admins/ExternalAdminsBox.vue
@@ -1,14 +1,14 @@
 <template>
     <hr>
     <h2 class="style-with-button">
-        <div>{{ $t('%Yf') }}</div>
+        <div>{{ adminsTitle }}</div>
         <div>
             <button type="button" class="button icon add" data-testid="add-admin-button" @click="createAdmin" />
         </div>
     </h2>
 
-    <p>{{ $t('%Yg') }}</p>
-    <p class="info-box">
+    <p>{{ adminsDescription }}</p>
+    <p v-if="showInternalAdmins" class="info-box">
         {{ $t('%Bx') }}
     </p>
 
@@ -21,7 +21,7 @@
     </div>
 
     <p v-if="sortedAdmins.length === 0" class="info-box">
-        {{ $t('%Yh') }}
+        {{ adminsEmptyDescription }}
     </p>
     <p v-if="filteredAdmins.length === 0 && sortedAdmins.length > 0" class="info-box">
         {{ $t('%1AX') }}
@@ -79,11 +79,15 @@ import type { User } from '@stamhoofd/structures';
 import { PermissionLevel, Permissions, UserPermissions, UserWithMembers } from '@stamhoofd/structures';
 import { computed, ref } from 'vue';
 import EditAdminView from './EditAdminView.vue';
+import { useAdminLabels } from './hooks/useAdminLabels';
 import { useAdmins } from './hooks/useAdmins';
+import { useShowInternalAdmins } from './hooks/useShowInternalAdmins';
 
 const me = useUser();
 const organization = useOrganization();
 const { sortedAdmins, sortedMembers, loadPromise, getPermissions, getUnloadedPermissions } = useAdmins();
+const { adminsTitle, adminsDescription, adminsEmptyDescription } = useAdminLabels();
+const showInternalAdmins = useShowInternalAdmins();
 const MAX_VISIBLE_DEFAULT = 5;
 const searchQuery = ref('');
 const showAll = ref(false);

--- a/frontend/shared/components/src/admins/ExternalAdminsBox.vue
+++ b/frontend/shared/components/src/admins/ExternalAdminsBox.vue
@@ -8,7 +8,7 @@
     </h2>
 
     <p>{{ adminsDescription }}</p>
-    <p v-if="showInternalAdmins" class="info-box">
+    <p v-if="showInternalAdmins && isPlatform" class="info-box">
         {{ $t('%Bx') }}
     </p>
 
@@ -88,6 +88,7 @@ const organization = useOrganization();
 const { sortedAdmins, sortedMembers, loadPromise, getPermissions, getUnloadedPermissions } = useAdmins();
 const { adminsTitle, adminsDescription, adminsEmptyDescription } = useAdminLabels();
 const showInternalAdmins = useShowInternalAdmins();
+const isPlatform = STAMHOOFD.userMode === 'platform';
 const MAX_VISIBLE_DEFAULT = 5;
 const searchQuery = ref('');
 const showAll = ref(false);

--- a/frontend/shared/components/src/admins/RolesView.vue
+++ b/frontend/shared/components/src/admins/RolesView.vue
@@ -4,8 +4,8 @@
             <button class="button icon add" aria-label="Nieuwe beheerder" type="button" @click="addRole" />
         </template>
 
-        <h1>{{ $t('%Jm') }}</h1>
-        <p>{{ $t('%3I') }}</p>
+        <h1>{{ adminRolesTitle }}</h1>
+        <p>{{ adminRolesDescription }}</p>
 
         <p class="info-box">
             {{ $t('%ZG') }}
@@ -78,6 +78,7 @@ import type { PermissionRoleForResponsibility } from '@stamhoofd/structures';
 import { PermissionRoleDetailed } from '@stamhoofd/structures';
 import STList from '../layout/STList.vue';
 import EditRoleView from './EditRoleView.vue';
+import { useAdminLabels } from './hooks/useAdminLabels';
 import { useAdmins } from './hooks/useAdmins';
 import { usePatchRoles } from './hooks/useRoles';
 
@@ -146,6 +147,7 @@ const $navigate = useNavigate();
 
 const { getPermissions, getUnloadedPermissions, loading, admins } = useAdmins();
 const { createRolePatchArray, errors, hasChanges, patchRoles, roles, saving, save: rawSave } = usePatchRoles();
+const { adminRolesTitle, adminRolesDescription } = useAdminLabels();
 
 const pop = usePop();
 

--- a/frontend/shared/components/src/admins/hooks/useAdminLabels.ts
+++ b/frontend/shared/components/src/admins/hooks/useAdminLabels.ts
@@ -1,0 +1,48 @@
+import { computed } from 'vue';
+import { useShowInternalAdmins } from './useShowInternalAdmins';
+
+/**
+ * Labels for administrators and admin roles.
+ *
+ * When internal administrators (members with functions) are enabled, external administrators are a separate concept,
+ * so we keep the 'externe beheerders(rollen)' naming. When internal administrators are disabled, there is only one kind
+ * of administrator, so we drop the 'externe' prefix and simply use 'beheerders(rollen)'.
+ */
+export function useAdminLabels() {
+    const showInternalAdmins = useShowInternalAdmins();
+
+    return {
+        // 'Externe beheerdersrollen' / 'Beheerdersrollen'
+        adminRolesTitle: computed(() => showInternalAdmins.value ? $t('Externe beheerdersrollen') : $t('Beheerdersrollen')),
+        // 'Externe beheerders' / 'Beheerders'
+        adminsTitle: computed(() => showInternalAdmins.value ? $t('Externe beheerders') : $t('Beheerders')),
+        // 'Externe beheerder toevoegen' / 'Beheerder toevoegen'
+        addAdminTitle: computed(() => showInternalAdmins.value ? $t('Externe beheerder toevoegen') : $t('Beheerder toevoegen')),
+        // 'Externe beheerder bewerken' / 'Beheerder bewerken'
+        editAdminTitle: computed(() => showInternalAdmins.value ? $t('Externe beheerder bewerken') : $t('Beheerder bewerken')),
+        // Description shown above the admins list (ExternalAdminsBox)
+        adminsDescription: computed(() => showInternalAdmins.value
+            ? $t('%Yg')
+            : $t('Beheerders hebben een account waarmee ze toegang krijgen tot Stamhoofd.')),
+        // Empty-state shown when there are no admins yet (ExternalAdminsBox)
+        adminsEmptyDescription: computed(() => showInternalAdmins.value
+            ? $t('%Yh')
+            : $t('Er zijn nog geen beheerders. Nodig iemand uit om beheerder te worden.')),
+        // Description shown above the roles list (RolesView)
+        adminRolesDescription: computed(() => showInternalAdmins.value
+            ? $t('%3I')
+            : $t('Maak beheerdersrollen aan en ken die vervolgens toe aan je beheerders om hun toegang te bepalen.')),
+        // Description shown above the roles of a single administrator (EditAdminView)
+        adminRolesPersonDescription: computed(() => showInternalAdmins.value
+            ? $t('%Yq')
+            : $t('Je kan een beheerder verschillende rollen toekennen. Een beheerder zonder rollen heeft geen enkele toegang.')),
+        // Description shown above the roles list of a resource, e.g. a webshop or group (EditResourceRolesView)
+        resourceAdminRolesDescription: computed(() => showInternalAdmins.value
+            ? $t('%Yw')
+            : $t('Je kan toegang geven aan beheerders via beheerdersrollen.')),
+        // Description shown above the roles of an API-key (ApiUserView)
+        apiUserRolesDescription: computed(() => showInternalAdmins.value
+            ? $t('%Jn')
+            : $t('Je kan een API-key verschillende rollen geven, net zoals een beheerder. Hiermee kan je jouw key beter beveiligen en enkel toegang geven waarvoor je het nodig hebt.')),
+    };
+}

--- a/frontend/shared/components/src/admins/hooks/useShowInternalAdmins.ts
+++ b/frontend/shared/components/src/admins/hooks/useShowInternalAdmins.ts
@@ -1,0 +1,17 @@
+import { useOrganization } from '#hooks/useOrganization.ts';
+import { computed } from 'vue';
+
+/**
+ * Whether internal administrators (members with responsibilities/functions) are relevant.
+ * When disabled, we hide the functions/internal admins UI and rename 'externe beheerdersrollen' to 'beheerdersrollen'.
+ *
+ * See Organization.showInternalAdmins for the underlying logic.
+ */
+export function useShowInternalAdmins() {
+    const organization = useOrganization();
+
+    return computed(() => {
+        // No organization means we're in a platform-wide context, where internal admins are always relevant.
+        return organization.value ? organization.value.showInternalAdmins : true;
+    });
+}

--- a/frontend/shared/components/src/admins/hooks/useShowInternalAdmins.ts
+++ b/frontend/shared/components/src/admins/hooks/useShowInternalAdmins.ts
@@ -11,7 +11,7 @@ export function useShowInternalAdmins() {
     const organization = useOrganization();
 
     return computed(() => {
-        // No organization means we're in a platform-wide context, where internal admins are always relevant.
-        return organization.value ? organization.value.showInternalAdmins : true;
+        // Without an organization, internal admins are only relevant in platform mode.
+        return organization.value ? organization.value.showInternalAdmins : STAMHOOFD.userMode === 'platform';
     });
 }

--- a/shared/structures/src/Organization.test.ts
+++ b/shared/structures/src/Organization.test.ts
@@ -1,0 +1,37 @@
+import { TestUtils } from '@stamhoofd/test-utils';
+
+import { STPackageStatus, STPackageType } from './billing/STPackage.js';
+import { Organization } from './Organization.js';
+import { OrganizationMetaData, OrganizationPackages } from './OrganizationMetaData.js';
+
+describe('Unit.Organization', () => {
+    describe('showInternalAdmins', () => {
+        function buildOrganization(useMembers: boolean) {
+            const packages = OrganizationPackages.create({});
+            if (useMembers) {
+                packages.packages.set(STPackageType.Members, STPackageStatus.create({
+                    startDate: new Date(0),
+                }));
+            }
+            return Organization.create({
+                name: 'Test',
+                meta: OrganizationMetaData.create({ packages }),
+            });
+        }
+
+        test('It is hidden in organization mode when the members package is not used', () => {
+            TestUtils.setEnvironment('userMode', 'organization');
+            expect(buildOrganization(false).showInternalAdmins).toBe(false);
+        });
+
+        test('It is shown in organization mode when the members package is used', () => {
+            TestUtils.setEnvironment('userMode', 'organization');
+            expect(buildOrganization(true).showInternalAdmins).toBe(true);
+        });
+
+        test('It is always shown in platform mode, even without the members package', () => {
+            TestUtils.setEnvironment('userMode', 'platform');
+            expect(buildOrganization(false).showInternalAdmins).toBe(true);
+        });
+    });
+});

--- a/shared/structures/src/Organization.ts
+++ b/shared/structures/src/Organization.ts
@@ -52,6 +52,14 @@ export class BaseOrganization extends AutoEncoder {
     createdAt = new Date();
 
     /**
+     * Whether internal administrators (members with responsibilities/functions) are relevant for this organization.
+     * In platform mode this is always the case. In organization mode it only makes sense when the members package is used.
+     */
+    get showInternalAdmins() {
+        return this.meta.packages.useMembers || STAMHOOFD.userMode === 'platform';
+    }
+
+    /**
      * Return default locale confiruation
      */
     get i18n() {


### PR DESCRIPTION
In organization mode, organizations that don't use the members package (`useMembers = false`) were still shown the "Interne beheerders" section and the "Functies" button, even though neither is relevant for them.

This adds a reusable `Organization.showInternalAdmins` getter (`true` in platform mode, or when the members package is used in organization mode). When it's `false`:
- the "Functies" button and the internal admins box are hidden;
- a new button to manage admin roles (→ `RolesView`) is shown instead;
- "externe beheerders(rollen)" is renamed to "beheerders(rollen)" everywhere (admins box, roles view, edit admin/API-key/resource-role views). When internal admins are enabled, the "externe" naming is kept.

The terminology switching is centralized in a new `useAdminLabels` hook so it stays consistent across the views.

Added a unit test covering the `showInternalAdmins` getter across organization/platform modes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783862661&installation_id=138085646&pr_number=433&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F433&signature=7fb4d45ba50ac293ed7f3c3bd280083a914826d67e32dada378f911c37573595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->