### PR TITLE
Fix Formatter import

### DIFF
--- a/shared/structures/src/billing/STPackageBundle.ts
+++ b/shared/structures/src/billing/STPackageBundle.ts
@@ -1,4 +1,4 @@
-import { Formatter } from '../../../utility/dist/Formatter.js';
+import { Formatter } from '@stamhoofd/utility';
 import { STPackage, STPackageMeta, STPackageType, STPricingType } from './STPackage.js';
 
 /**


### PR DESCRIPTION
Bij het gebruik van @stamhoofd/structures in een andere applicatie, wordt er een fout geworpen bij het builden.

Ik vermoed dat dit komt door een import die niet juist was.

```
17.06 ■  Nuxt build error: RollupError: Could not resolve "../../../utility/dist/Formatter.js" from "node_modules/.pnpm/@stamhoofd+structures@2.121.0_@simonbackx+simple-errors@1.5.0_uuid@11.0.3/node_modules/@stamhoofd/structures/dist/billing/STPackageBundle.js"
17.06 │  file: /app/node_modules/.pnpm/@stamhoofd+structures@2.121.0_@simonbackx+simple-errors@1.5.0_uuid@11.0.3/node_modules/@stamhoofd/structures/dist/billing/STPackageBundle.js
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783937210&installation_id=138085646&pr_number=459&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F459&signature=ae8f7e08430f6ee9843fdd6c114100bc54b7cca744411c64166e31ceb7ed8e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->