### PR TITLE
Faster routing e2e tests

### DIFF
--- a/tests/playwright/src/tests/routing.spec.ts
+++ b/tests/playwright/src/tests/routing.spec.ts
@@ -72,17 +72,14 @@ async function testRoute({ page, ...options }: {
         throw new Error('Invaid usage NOT expectedSwitcher with expectedSwitchOptions');
     }
 
-    await page.goto(options.url);
+    await page.goto(options.url + '?initial=true'); // nav framework should remove this param
 
     // Settings view should be visible
     await expect(page.locator(options.expectedLocator)).toBeVisible();
     await checkScopedTo({ page, organization: options.expectedScope });
 
-    // Url will only get updated after a certain timeout
-    await page.waitForTimeout(5_000);
-
-    // Url should be the same
-    await expect(page).toHaveURL(options.expectedUrl);
+    // Wait until URL is as expected, or time-out after 5 seconds
+    await expect(page).toHaveURL(options.expectedUrl, { timeout: 5_000 });
 
     if (options.expectedSwitcher === undefined) {
         return;


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784117390&installation_id=138085646&pr_number=468&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F468&signature=773e24ed6059b1111e2e6ea329f4875ea070b66dac432f407d5d3e6b18af3dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->