### PR TITLE
fix migrations in platform mode not in prod

### DIFF
--- a/backend/shared/models/src/migrations/1720080975-convert-charset.ts
+++ b/backend/shared/models/src/migrations/1720080975-convert-charset.ts
@@ -4,7 +4,7 @@ import { LoggingTools } from '@stamhoofd/utility';
 export default new Migration(async () => {
     process.stdout.write('\n');
 
-    if (STAMHOOFD.userMode === 'platform' && STAMHOOFD.environment === 'production') {
+    if (STAMHOOFD.userMode === 'platform' && (STAMHOOFD.environment === 'production' || STAMHOOFD.environment === 'staging')) {
         console.log('Skipped convert charset for userMode platform in production.');
         return;
     }

--- a/backend/shared/models/src/migrations/1720080975-convert-charset.ts
+++ b/backend/shared/models/src/migrations/1720080975-convert-charset.ts
@@ -4,8 +4,8 @@ import { LoggingTools } from '@stamhoofd/utility';
 export default new Migration(async () => {
     process.stdout.write('\n');
 
-    if (STAMHOOFD.userMode === 'platform') {
-        console.log('Skipped convert charset for userMode platform.');
+    if (STAMHOOFD.userMode === 'platform' && STAMHOOFD.environment === 'production') {
+        console.log('Skipped convert charset for userMode platform in production.');
         return;
     }
 

--- a/backend/shared/models/src/migrations/1720080976-convert-charset-leads.ts
+++ b/backend/shared/models/src/migrations/1720080976-convert-charset-leads.ts
@@ -3,14 +3,14 @@ import { Database, Migration } from '@simonbackx/simple-database';
 /**
  * If the charset of the leads table is not converted this results
  * in foreign keys constraint errors in other migrations.
- * 
+ *
  * todo: will we keep the leads table after the migration?
  */
 export default new Migration(async () => {
     process.stdout.write('\n');
 
-    if (STAMHOOFD.userMode === 'platform') {
-        console.log('Skipped update leads charset for userMode platform.')
+    if (STAMHOOFD.userMode === 'platform' && STAMHOOFD.environment === 'production') {
+        console.log('Skipped update leads charset for userMode platform in production.');
         return Promise.resolve();
     }
 
@@ -22,7 +22,7 @@ export default new Migration(async () => {
             'set foreign_key_checks=0;',
             'ALTER TABLE `leads` CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;',
             'ALTER TABLE `leads` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;',
-            'set foreign_key_checks=1;'
+            'set foreign_key_checks=1;',
         ].join('');
 
         console.log('Start updating charset of leads table.');
@@ -40,7 +40,7 @@ async function tableExists(tableName: string): Promise<boolean> {
         WHERE table_schema = DATABASE()
         AND table_name = ?
         `,
-        [tableName]
+        [tableName],
     );
 
     const count = rows[0]['']['count'];

--- a/backend/shared/models/src/migrations/1720080976-convert-charset-leads.ts
+++ b/backend/shared/models/src/migrations/1720080976-convert-charset-leads.ts
@@ -9,7 +9,7 @@ import { Database, Migration } from '@simonbackx/simple-database';
 export default new Migration(async () => {
     process.stdout.write('\n');
 
-    if (STAMHOOFD.userMode === 'platform' && STAMHOOFD.environment === 'production') {
+    if (STAMHOOFD.userMode === 'platform' && (STAMHOOFD.environment === 'production' || STAMHOOFD.environment === 'staging')) {
         console.log('Skipped update leads charset for userMode platform in production.');
         return Promise.resolve();
     }


### PR DESCRIPTION
migrations are skipped to avoid being run on prod servers, but leads to errors for fresh setups

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784129450&installation_id=138085646&pr_number=471&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F471&signature=ac7885982fb1ded5702b02c7eb8eadf00eeac9a603c75ed0224143a463822459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->