### PR TITLE
🐛️ new waiting list inside new group no longer errors

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts
@@ -1,7 +1,7 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization } from '@stamhoofd/models';
-import { GroupFactory, OrganizationFactory, OrganizationRegistrationPeriod, OrganizationRegistrationPeriodFactory, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
-import { GroupSettings, Group as GroupStruct, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, PermissionLevel, Permissions, Version } from '@stamhoofd/structures';
+import { Group, GroupFactory, OrganizationFactory, OrganizationRegistrationPeriod, OrganizationRegistrationPeriodFactory, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
+import { GroupSettings, Group as GroupStruct, GroupType, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, PermissionLevel, Permissions, TranslatedString, Version } from '@stamhoofd/structures';
 
 import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray } from '@simonbackx/simple-encoding';
@@ -151,6 +151,53 @@ describe('Endpoint.PatchOrganizationRegistrationPeriods', () => {
             // patch organization registration period should not fail
             const response = await patchOrganizationRegistrationPeriods({ patch, organization, token });
             expect(response.body).toBeDefined();
+        });
+
+        test('should be able to create a group with a nested waiting list', async () => {
+            const organization = await new OrganizationFactory({ }).create();
+            const period = await new RegistrationPeriodFactory({ organization }).create();
+            const organizationPeriod = await new OrganizationRegistrationPeriodFactory({
+                organization,
+                period,
+            }).create();
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({ level: PermissionLevel.Full }),
+            }).create();
+            const token = await Token.createToken(user);
+
+            const waitingList = GroupStruct.create({
+                organizationId: organization.id,
+                periodId: period.id,
+                type: GroupType.WaitingList,
+                settings: GroupSettings.create({
+                    name: TranslatedString.create('Waiting list'),
+                }),
+            });
+            const group = GroupStruct.create({
+                organizationId: organization.id,
+                periodId: period.id,
+                waitingList,
+                settings: GroupSettings.create({
+                    name: TranslatedString.create('Group with waiting list'),
+                }),
+            });
+            const groupsPatch: PatchableArrayAutoEncoder<GroupStruct> = new PatchableArray();
+            groupsPatch.addPut(group);
+            const patch: PatchableArrayAutoEncoder<OrganizationRegistrationPeriodStruct> = new PatchableArray();
+            patch.addPatch(OrganizationRegistrationPeriodStruct.patch({
+                id: organizationPeriod.id,
+                groups: groupsPatch,
+            }));
+
+            const response = await patchOrganizationRegistrationPeriods({ patch, organization, token });
+
+            expect(response.body).toBeDefined();
+            const createdGroup = await Group.getByID(group.id);
+            const createdWaitingList = await Group.getByID(waitingList.id);
+            expect(createdGroup).toBeDefined();
+            expect(createdWaitingList).toBeDefined();
+            expect(createdGroup!.waitingListId).toBe(waitingList.id);
         });
 
         test('should not be able to patch groups of other organization', async () => {

--- a/frontend/shared/components/src/groups/EditGroupView.vue
+++ b/frontend/shared/components/src/groups/EditGroupView.vue
@@ -781,8 +781,8 @@ import { useFinancialSupportSettings } from '#groups/hooks/useFinancialSupportSe
 import ImageInput from '#inputs/ImageInput.vue';
 import CategorizedBox from '#layout/categorized-view/CategorizedBox.vue';
 import CategorizedView from '#layout/categorized-view/CategorizedView.vue';
-import { LocalizedDomains } from '@stamhoofd/frontend-i18n/LocalizedDomains';
 import { useOrganizationRegistrationRecordSettingsRoute } from '@stamhoofd/components/records/useOrganizationRegistrationRecordSettingsRoute.ts';
+import { LocalizedDomains } from '@stamhoofd/frontend-i18n/LocalizedDomains';
 
 const props = withDefaults(
     defineProps<{
@@ -1572,7 +1572,9 @@ async function addWaitingList() {
 
     const groups: PatchableArrayAutoEncoder<Group> = new PatchableArray();
     groups.addPut(waitingList);
-    const basePatch = OrganizationRegistrationPeriod.patch({ groups });
+    const basePatch = OrganizationRegistrationPeriod.patch({
+        groups,
+    });
 
     // Edit the group
     await present({
@@ -1584,7 +1586,24 @@ async function addWaitingList() {
                 showToasts: false,
                 organizationHint: externalOrganization.value,
                 saveHandler: (patch: AutoEncoderPatchType<OrganizationRegistrationPeriod>) => {
-                    addPatch(basePatch.patch(patch));
+                    // Save the waiting list under the parent group creation,
+                    // it will take care of creating the nested waiting list.
+                    // Otherwise it'll try to create the waiting list twice.
+                    const updatedPeriod = patchedPeriod.value.patch(patch);
+                    const updatedWaitingList = updatedPeriod.groups
+                        .find(g => g.id === waitingList.id)
+                        // This fallback should actually never happen but there's no easy way to return an error.
+                        ?? waitingList;
+
+                    const groups: PatchableArrayAutoEncoder<Group> = new PatchableArray();
+                    groups.addPatch(Group.patch({
+                        id: props.groupId,
+                        waitingList: updatedWaitingList,
+                    }));
+
+                    addPatch(OrganizationRegistrationPeriod.patch({
+                        groups,
+                    }));
                 },
             }),
         ],


### PR DESCRIPTION
This errored because it was trying to create a waiting group as part of the parent group and then once more itself. Added a test to confirm this behaviour on the backend and then change the implementation on the frontend to make it use the right path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784219294&installation_id=138085646&pr_number=480&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F480&signature=41263ac70c8be7f99ab7e293d44b37c724603f5075cd88248800d082c89cbe96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->