### PR TITLE
🐛 Don't lock archive period during v1 → v2 migration

### DIFF
--- a/backend/app/api/src/migrations/1752848561-groups-registration-periods.ts
+++ b/backend/app/api/src/migrations/1752848561-groups-registration-periods.ts
@@ -91,7 +91,9 @@ async function migrateGroups({ groups, organization, periodSpan }: { groups: Gro
         // todo: what should be the start date?
         startDate: previousYearStartDate,
         endDate: new Date(periodSpan.startDate.getTime() - 1),
-        locked: true,
+        // Don't lock the archive period: locking requires an extra manual step
+        // after the migration to make archived work years editable again.
+        locked: false,
         organization,
         previousPeriodId: undefined,
         customName: 'Gearchiveerde periodes',


### PR DESCRIPTION
The groups-to-registration-periods migration created the "Gearchiveerde periodes" period with `locked: true`. A locked period can't be edited, so every migrated organization needed an extra manual step to unlock the archived work year afterwards.

This flips the archive period to `locked: false` so no post-migration cleanup is needed. The migration hasn't run yet on the v1 server we're migrating from, so fixing the source migration is sufficient — no follow-up data migration is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784282956&installation_id=138085646&pr_number=484&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F484&signature=4f1f3a92c33bf3cbacb126062279512ca6ab4156e8f2d011320e76169286027d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->