### PR TITLE
🐛 Support decoding $lte and $gte number filters

### DIFF
--- a/frontend/shared/components/src/filters/NumberUIFilter.test.ts
+++ b/frontend/shared/components/src/filters/NumberUIFilter.test.ts
@@ -1,0 +1,46 @@
+import type { StamhoofdFilter } from '@stamhoofd/structures';
+import { describe, expect, test } from 'vitest';
+import { NumberFilterBuilder, NumberUIFilter } from './NumberUIFilter';
+import { UINumberFilterMode } from './UINumberFilterMode.ts';
+
+describe('NumberUIFilter', () => {
+    const builder = new NumberFilterBuilder({
+        key: 'amount',
+        name: 'Amount',
+    });
+
+    test('builds and decodes all modes round-trip', () => {
+        const cases: { mode: UINumberFilterMode; expected: StamhoofdFilter }[] = [
+            { mode: UINumberFilterMode.Equals, expected: { amount: { $eq: 5 } } },
+            { mode: UINumberFilterMode.NotEquals, expected: { $not: { amount: { $eq: 5 } } } },
+            { mode: UINumberFilterMode.GreaterThan, expected: { amount: { $gt: 5 } } },
+            { mode: UINumberFilterMode.GreaterThanOrEqual, expected: { amount: { $gte: 5 } } },
+            { mode: UINumberFilterMode.LessThan, expected: { amount: { $lt: 5 } } },
+            { mode: UINumberFilterMode.LessThanOrEqual, expected: { amount: { $lte: 5 } } },
+        ];
+
+        for (const { mode, expected } of cases) {
+            const filter = new NumberUIFilter({ builder, value: 5, mode });
+            expect(filter.build()).toEqual(expected);
+
+            const decoded = builder.fromFilter(expected);
+            expect(decoded).not.toBeNull();
+            expect((decoded as NumberUIFilter).mode).toBe(mode);
+            expect((decoded as NumberUIFilter).value).toBe(5);
+        }
+    });
+
+    test('decodes $gte filter (regression for STA-1101)', () => {
+        const decoded = builder.fromFilter({ amount: { $gte: 10 } });
+        expect(decoded).not.toBeNull();
+        expect((decoded as NumberUIFilter).mode).toBe(UINumberFilterMode.GreaterThanOrEqual);
+        expect((decoded as NumberUIFilter).value).toBe(10);
+    });
+
+    test('decodes $lte filter (regression for STA-1101)', () => {
+        const decoded = builder.fromFilter({ amount: { $lte: 10 } });
+        expect(decoded).not.toBeNull();
+        expect((decoded as NumberUIFilter).mode).toBe(UINumberFilterMode.LessThanOrEqual);
+        expect((decoded as NumberUIFilter).value).toBe(10);
+    });
+});

--- a/frontend/shared/components/src/filters/NumberUIFilter.ts
+++ b/frontend/shared/components/src/filters/NumberUIFilter.ts
@@ -1,4 +1,4 @@
-import { ComponentWithProperties } from '@simonbackx/vue-app-navigation';
+import type { ComponentWithProperties } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '#containers/AsyncComponent.ts';
 import type { StamhoofdFilter, WrapperFilter } from '@stamhoofd/structures';
 import { unwrapFilterByPath } from '@stamhoofd/structures';
@@ -40,9 +40,21 @@ export class NumberUIFilter extends UIFilter<NumberFilterBuilder> {
                 },
             };
 
+            case UINumberFilterMode.GreaterThanOrEqual: return {
+                [this.builder.key]: {
+                    $gte: this.value,
+                },
+            };
+
             case UINumberFilterMode.LessThan: return {
                 [this.builder.key]: {
                     $lt: this.value,
+                },
+            };
+
+            case UINumberFilterMode.LessThanOrEqual: return {
+                [this.builder.key]: {
+                    $lte: this.value,
                 },
             };
         }
@@ -57,7 +69,9 @@ export class NumberUIFilter extends UIFilter<NumberFilterBuilder> {
     get combinationWord(): string {
         switch (this.mode) {
             case UINumberFilterMode.GreaterThan: return $t(`%bE`);
+            case UINumberFilterMode.GreaterThanOrEqual: return $t(`is groter dan of gelijk aan`);
             case UINumberFilterMode.LessThan: return $t(`%bF`);
+            case UINumberFilterMode.LessThanOrEqual: return $t(`is kleiner dan of gelijk aan`);
             case UINumberFilterMode.Equals: return $t(`%bG`);
             case UINumberFilterMode.NotEquals: return $t(`%bH`);
         }
@@ -91,8 +105,6 @@ export class NumberUIFilter extends UIFilter<NumberFilterBuilder> {
         }
     }
 }
-
-
 
 export class NumberFilterBuilder implements UIFilterBuilder<NumberUIFilter> {
     key = '';
@@ -156,6 +168,16 @@ export class NumberFilterBuilder implements UIFilterBuilder<NumberUIFilter> {
             }, { isInverted });
         }
 
+        const lessThanOrEqual = unwrapFilterByPath(unwrapped, [this.key, '$lte']);
+
+        if (typeof lessThanOrEqual === 'number') {
+            return new NumberUIFilter({
+                builder: this,
+                value: lessThanOrEqual,
+                mode: UINumberFilterMode.LessThanOrEqual,
+            }, { isInverted });
+        }
+
         const greaterThan = unwrapFilterByPath(unwrapped, [this.key, '$gt']);
 
         if (typeof greaterThan === 'number') {
@@ -163,6 +185,16 @@ export class NumberFilterBuilder implements UIFilterBuilder<NumberUIFilter> {
                 builder: this,
                 value: greaterThan,
                 mode: UINumberFilterMode.GreaterThan,
+            }, { isInverted });
+        }
+
+        const greaterThanOrEqual = unwrapFilterByPath(unwrapped, [this.key, '$gte']);
+
+        if (typeof greaterThanOrEqual === 'number') {
+            return new NumberUIFilter({
+                builder: this,
+                value: greaterThanOrEqual,
+                mode: UINumberFilterMode.GreaterThanOrEqual,
             }, { isInverted });
         }
 

--- a/frontend/shared/components/src/filters/NumberUIFilterView.vue
+++ b/frontend/shared/components/src/filters/NumberUIFilterView.vue
@@ -35,6 +35,17 @@
 
         <STListItem :selectable="true" element-name="label">
             <template #left>
+                <Radio v-model="filter.mode" :name="filter.id" :value="UINumberFilterMode.GreaterThanOrEqual" @change="onChange" />
+            </template>
+            <p class="style-title-list">
+                {{ $t('Groter dan of gelijk aan...') }}
+            </p>
+
+            <component :is="inputComponent" v-if="filter.mode === UINumberFilterMode.GreaterThanOrEqual" ref="input" v-model="filter.value" :min="null" :max="null" :floating-point="floatingPoint" :stepper="!floatingPoint" class="option" :placeholder="$t(`%bV`)" />
+        </STListItem>
+
+        <STListItem :selectable="true" element-name="label">
+            <template #left>
                 <Radio v-model="filter.mode" :name="filter.id" :value="UINumberFilterMode.LessThan" @change="onChange" />
             </template>
             <p class="style-title-list">
@@ -42,6 +53,17 @@
             </p>
 
             <component :is="inputComponent" v-if="filter.mode === UINumberFilterMode.LessThan" ref="input" v-model="filter.value" :min="null" :max="null" :floating-point="floatingPoint" :stepper="!floatingPoint" class="option" :placeholder="$t(`%bV`)" />
+        </STListItem>
+
+        <STListItem :selectable="true" element-name="label">
+            <template #left>
+                <Radio v-model="filter.mode" :name="filter.id" :value="UINumberFilterMode.LessThanOrEqual" @change="onChange" />
+            </template>
+            <p class="style-title-list">
+                {{ $t('Kleiner dan of gelijk aan...') }}
+            </p>
+
+            <component :is="inputComponent" v-if="filter.mode === UINumberFilterMode.LessThanOrEqual" ref="input" v-model="filter.value" :min="null" :max="null" :floating-point="floatingPoint" :stepper="!floatingPoint" class="option" :placeholder="$t(`%bV`)" />
         </STListItem>
     </STList>
 </template>

--- a/frontend/shared/components/src/filters/UINumberFilterMode.ts
+++ b/frontend/shared/components/src/filters/UINumberFilterMode.ts
@@ -1,6 +1,8 @@
 export enum UINumberFilterMode {
     GreaterThan = 'GreaterThan',
+    GreaterThanOrEqual = 'GreaterThanOrEqual',
     LessThan = 'LessThan',
+    LessThanOrEqual = 'LessThanOrEqual',
     Equals = 'Equals',
     NotEquals = 'NotEquals',
 }


### PR DESCRIPTION
`NumberUIFilter` could only build/decode `$gt` and `$lt` number filters, so any saved filter using `$gte`/`$lte` failed to decode back into a UI filter and showed "niet ondersteunde filter".

This adds two new modes — `GreaterThanOrEqual` (`$gte`) and `LessThanOrEqual` (`$lte`) — covering both the build and decode paths, plus radio options in `NumberUIFilterView.vue`.

Added `NumberUIFilter.test.ts` covering round-trip build/decode for all modes and a regression check for `$gte`/`$lte`.

Note: the test couldn't be run locally — the `components` package uses browser-mode Vitest, which can't launch in this sandbox (missing `libnspr4.so`, no sudo). Typecheck and lint pass; the test runs in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784283798&installation_id=138085646&pr_number=485&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F485&signature=5026384990e544d85331800e2cf777694943ce311408e0ed2da5c68cd4a22a8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->