### PR TITLE
Fill payment customer on a best-effort basis

### DIFF
--- a/backend/app/api/src/helpers/PaymentCustomerResolver.test.ts
+++ b/backend/app/api/src/helpers/PaymentCustomerResolver.test.ts
@@ -1,5 +1,5 @@
 import { BalanceItem, Member, Order, Organization, Payment, User } from '@stamhoofd/models';
-import { Address, Company, Country, MemberDetails, OrderData, Parent, ParentType } from '@stamhoofd/structures';
+import { Company, MemberDetails, OrderData, Parent, ParentType } from '@stamhoofd/structures';
 import { determinePaymentCustomer } from './PaymentCustomerResolver.js';
 
 describe('PaymentCustomerResolver', () => {
@@ -45,12 +45,16 @@ describe('PaymentCustomerResolver', () => {
         payingOrganizations: [] as Organization[],
     };
 
-    it('returns the company of the paying organization', () => {
+    function createOrganization(id: string, companyName: string): Organization {
         const organization = new Organization();
-        organization.id = 'org-1';
-        organization.name = 'My Organization';
-        organization.address = Address.createDefault(Country.Belgium);
-        organization.meta = { companies: [] } as any;
+        organization.id = id;
+        organization.name = companyName;
+        organization.meta = { companies: [Company.create({ name: companyName })] } as any;
+        return organization;
+    }
+
+    it('returns the company of the paying organization', () => {
+        const organization = createOrganization('org-1', 'My Organization');
 
         const payment = createPayment({ payingOrganizationId: 'org-1' });
 
@@ -167,11 +171,7 @@ describe('PaymentCustomerResolver', () => {
     });
 
     it('prefers the paying organization over a linked member', () => {
-        const organization = new Organization();
-        organization.id = 'org-1';
-        organization.name = 'My Organization';
-        organization.address = Address.createDefault(Country.Belgium);
-        organization.meta = { companies: [Company.create({ name: 'My Company' })] } as any;
+        const organization = createOrganization('org-1', 'My Company');
 
         const payment = createPayment({ payingOrganizationId: 'org-1' });
         const details = MemberDetails.create({ firstName: 'Jane', lastName: 'Smith', email: 'jane@example.com', birthDay: new Date(1990, 0, 1) });

--- a/backend/app/api/src/helpers/PaymentCustomerResolver.test.ts
+++ b/backend/app/api/src/helpers/PaymentCustomerResolver.test.ts
@@ -1,0 +1,203 @@
+import { BalanceItem, Member, Order, Organization, Payment, User } from '@stamhoofd/models';
+import { Address, Company, Country, MemberDetails, OrderData, Parent, ParentType } from '@stamhoofd/structures';
+import { determinePaymentCustomer } from './PaymentCustomerResolver.js';
+
+describe('PaymentCustomerResolver', () => {
+    function createPayment(props: Partial<Pick<Payment, 'payingUserId' | 'payingOrganizationId'>> = {}): Payment {
+        const payment = new Payment();
+        payment.id = 'payment-1';
+        payment.payingUserId = props.payingUserId ?? null;
+        payment.payingOrganizationId = props.payingOrganizationId ?? null;
+        return payment;
+    }
+
+    function createBalanceItem(props: Partial<Pick<BalanceItem, 'id' | 'memberId' | 'userId' | 'orderId' | 'payingOrganizationId'>>): BalanceItem {
+        const balanceItem = new BalanceItem();
+        balanceItem.id = props.id ?? 'balance-item-1';
+        balanceItem.memberId = props.memberId ?? null;
+        balanceItem.userId = props.userId ?? null;
+        balanceItem.orderId = props.orderId ?? null;
+        balanceItem.payingOrganizationId = props.payingOrganizationId ?? null;
+        return balanceItem;
+    }
+
+    function createUser(props: { id: string; firstName?: string | null; lastName?: string | null; email: string }): User {
+        const user = new User();
+        user.id = props.id;
+        user.firstName = props.firstName ?? null;
+        user.lastName = props.lastName ?? null;
+        user.email = props.email;
+        return user;
+    }
+
+    function createMember(id: string, details: MemberDetails): Member {
+        const member = new Member();
+        member.id = id;
+        member.details = details;
+        return member;
+    }
+
+    const emptyRelations = {
+        balanceItems: [] as BalanceItem[],
+        members: [] as Member[],
+        users: [] as User[],
+        orders: [] as Order[],
+        payingOrganizations: [] as Organization[],
+    };
+
+    it('returns the company of the paying organization', () => {
+        const organization = new Organization();
+        organization.id = 'org-1';
+        organization.name = 'My Organization';
+        organization.address = Address.createDefault(Country.Belgium);
+        organization.meta = { companies: [] } as any;
+
+        const payment = createPayment({ payingOrganizationId: 'org-1' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            payingOrganizations: [organization],
+        });
+
+        expect(customer).not.toBeNull();
+        expect(customer!.company).not.toBeNull();
+        expect(customer!.company!.name).toBe('My Organization');
+    });
+
+    it('returns the paying user', () => {
+        const payment = createPayment({ payingUserId: 'user-1' });
+        const user = createUser({ id: 'user-1', firstName: 'John', lastName: 'Doe', email: 'john@example.com' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            users: [user],
+        });
+
+        expect(customer).not.toBeNull();
+        expect(customer!.firstName).toBe('John');
+        expect(customer!.lastName).toBe('Doe');
+        expect(customer!.email).toBe('john@example.com');
+    });
+
+    it('falls back to a member linked to a balance item', () => {
+        const payment = createPayment();
+        const details = MemberDetails.create({
+            firstName: 'Jane',
+            lastName: 'Smith',
+            email: 'jane@example.com',
+            birthDay: new Date(1990, 0, 1),
+        });
+        const member = createMember('member-1', details);
+        const balanceItem = createBalanceItem({ id: 'b1', memberId: 'member-1' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            balanceItems: [balanceItem],
+            members: [member],
+        });
+
+        expect(customer).not.toBeNull();
+        expect(customer!.firstName).toBe('Jane');
+        expect(customer!.lastName).toBe('Smith');
+        expect(customer!.email).toBe('jane@example.com');
+    });
+
+    it('uses the parent of a young member', () => {
+        const payment = createPayment();
+        const details = MemberDetails.create({
+            firstName: 'Kid',
+            lastName: 'Smith',
+            birthDay: new Date(2020, 0, 1),
+            parents: [
+                Parent.create({
+                    type: ParentType.Mother,
+                    firstName: 'Mom',
+                    lastName: 'Smith',
+                    email: 'mom@example.com',
+                }),
+            ],
+        });
+        const member = createMember('member-1', details);
+        const balanceItem = createBalanceItem({ id: 'b1', memberId: 'member-1' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            balanceItems: [balanceItem],
+            members: [member],
+        });
+
+        expect(customer).not.toBeNull();
+        expect(customer!.firstName).toBe('Mom');
+        expect(customer!.email).toBe('mom@example.com');
+    });
+
+    it('falls back to a user linked to a balance item', () => {
+        const payment = createPayment();
+        const user = createUser({ id: 'user-2', firstName: 'Linked', lastName: 'User', email: 'linked@example.com' });
+        const balanceItem = createBalanceItem({ id: 'b1', userId: 'user-2' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            balanceItems: [balanceItem],
+            users: [user],
+        });
+
+        expect(customer).not.toBeNull();
+        expect(customer!.email).toBe('linked@example.com');
+    });
+
+    it('falls back to the customer of a linked order', () => {
+        const payment = createPayment();
+        const order = new Order();
+        order.id = 'order-1';
+        order.data = OrderData.create({});
+        order.data.customer.firstName = 'Order';
+        order.data.customer.lastName = 'Customer';
+        order.data.customer.email = 'order@example.com';
+        const balanceItem = createBalanceItem({ id: 'b1', orderId: 'order-1' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            balanceItems: [balanceItem],
+            orders: [order],
+        });
+
+        expect(customer).not.toBeNull();
+        expect(customer!.email).toBe('order@example.com');
+    });
+
+    it('prefers the paying organization over a linked member', () => {
+        const organization = new Organization();
+        organization.id = 'org-1';
+        organization.name = 'My Organization';
+        organization.address = Address.createDefault(Country.Belgium);
+        organization.meta = { companies: [Company.create({ name: 'My Company' })] } as any;
+
+        const payment = createPayment({ payingOrganizationId: 'org-1' });
+        const details = MemberDetails.create({ firstName: 'Jane', lastName: 'Smith', email: 'jane@example.com', birthDay: new Date(1990, 0, 1) });
+        const member = createMember('member-1', details);
+        const balanceItem = createBalanceItem({ id: 'b1', memberId: 'member-1' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            balanceItems: [balanceItem],
+            members: [member],
+            payingOrganizations: [organization],
+        });
+
+        expect(customer).not.toBeNull();
+        expect(customer!.company!.name).toBe('My Company');
+    });
+
+    it('returns null when no information is available', () => {
+        const payment = createPayment();
+        const balanceItem = createBalanceItem({ id: 'b1' });
+
+        const customer = determinePaymentCustomer(payment, {
+            ...emptyRelations,
+            balanceItems: [balanceItem],
+        });
+
+        expect(customer).toBeNull();
+    });
+});

--- a/backend/app/api/src/helpers/PaymentCustomerResolver.ts
+++ b/backend/app/api/src/helpers/PaymentCustomerResolver.ts
@@ -1,0 +1,147 @@
+import { PaymentCustomer } from '@stamhoofd/structures';
+import type { BalanceItem, Member, Order, Organization, Payment, User } from '@stamhoofd/models';
+
+/**
+ * The related models that are needed to determine the customer of a payment on a best-effort basis.
+ */
+export type PaymentCustomerRelations = {
+    /**
+     * The balance items linked to the payment (via balance item payments).
+     */
+    balanceItems: BalanceItem[];
+    members: Member[];
+    users: User[];
+    orders: Order[];
+    payingOrganizations: Organization[];
+};
+
+/**
+ * Determines the customer that paid a payment on a best-effort basis.
+ *
+ * In our v1 code payments had no customer. To fill in the missing data we try to figure out who paid
+ * by inspecting the balance items linked to the payment and their related members, users and orders, in
+ * addition to the paying organization/user stored directly on the payment.
+ *
+ * Priority (most reliable source first):
+ * 1. The paying organization (payingOrganizationId) → company customer
+ * 2. The paying user (payingUserId)
+ * 3. A member linked to one of the balance items
+ * 4. A user linked to one of the balance items
+ * 5. The customer of an order linked to one of the balance items
+ *
+ * Returns null when we could not find any usable information.
+ */
+export function determinePaymentCustomer(payment: Payment, relations: PaymentCustomerRelations): PaymentCustomer | null {
+    const { balanceItems, members, users, orders, payingOrganizations } = relations;
+
+    // 1. Paid by an organization
+    if (payment.payingOrganizationId) {
+        const organization = payingOrganizations.find(o => o.id === payment.payingOrganizationId);
+        if (organization) {
+            return PaymentCustomer.create({
+                company: organization.defaultCompanies[0] ?? null,
+            });
+        }
+    }
+
+    // 2. Paid by a known user
+    if (payment.payingUserId) {
+        const user = users.find(u => u.id === payment.payingUserId);
+        const customer = user ? customerFromUser(user) : null;
+        if (customer) {
+            return customer;
+        }
+    }
+
+    // The balance items linked to this payment, used to find members/users/orders.
+    const linkedMemberIds = unique(balanceItems.map(b => b.memberId).filter((id): id is string => id !== null));
+    const linkedUserIds = unique(balanceItems.map(b => b.userId).filter((id): id is string => id !== null));
+    const linkedOrderIds = unique(balanceItems.map(b => b.orderId).filter((id): id is string => id !== null));
+    const linkedPayingOrganizationIds = unique(balanceItems.map(b => b.payingOrganizationId).filter((id): id is string => id !== null));
+
+    // 3. A member linked to the balance items
+    for (const memberId of linkedMemberIds) {
+        const member = members.find(m => m.id === memberId);
+        if (member) {
+            const customer = customerFromMember(member);
+            if (customer) {
+                return customer;
+            }
+        }
+    }
+
+    // 4. A user linked to the balance items
+    for (const userId of linkedUserIds) {
+        const user = users.find(u => u.id === userId);
+        if (user) {
+            const customer = customerFromUser(user);
+            if (customer) {
+                return customer;
+            }
+        }
+    }
+
+    // 5. The customer data of an order linked to the balance items
+    for (const orderId of linkedOrderIds) {
+        const order = orders.find(o => o.id === orderId);
+        if (order && (order.data.customer.email || order.data.customer.name)) {
+            return order.data.customer.toPaymentCustomer();
+        }
+    }
+
+    // 6. A paying organization referenced by a balance item (fallback)
+    for (const organizationId of linkedPayingOrganizationIds) {
+        const organization = payingOrganizations.find(o => o.id === organizationId);
+        if (organization) {
+            return PaymentCustomer.create({
+                company: organization.defaultCompanies[0] ?? null,
+            });
+        }
+    }
+
+    return null;
+}
+
+function customerFromUser(user: User): PaymentCustomer | null {
+    if (!user.firstName && !user.lastName && !user.email) {
+        return null;
+    }
+    return PaymentCustomer.create({
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+    });
+}
+
+function customerFromMember(member: Member): PaymentCustomer | null {
+    const details = member.details;
+
+    // For young members the parents are the ones who pay, mirroring the logic used elsewhere
+    // (e.g. ReceivableBalance customers).
+    const useParents = (details.calculatedParentsHaveAccess || details.getMemberEmails().length === 0) && details.parents.length > 0;
+
+    if (useParents) {
+        const parent = details.parents[0];
+        return PaymentCustomer.create({
+            firstName: parent.firstName ?? null,
+            lastName: parent.lastName ?? null,
+            email: parent.getEmails()[0] ?? null,
+            phone: parent.phone,
+        });
+    }
+
+    if (!details.firstName && !details.lastName && details.getMemberEmails().length === 0) {
+        return null;
+    }
+
+    return PaymentCustomer.create({
+        firstName: details.firstName ?? null,
+        lastName: details.lastName ?? null,
+        email: details.getMemberEmails()[0] ?? null,
+        phone: details.phone,
+    });
+}
+
+function unique(ids: string[]): string[] {
+    return [...new Set(ids)];
+}

--- a/backend/app/api/src/helpers/PaymentCustomerResolver.ts
+++ b/backend/app/api/src/helpers/PaymentCustomerResolver.ts
@@ -1,4 +1,5 @@
 import { PaymentCustomer } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
 import type { BalanceItem, Member, Order, Organization, Payment, User } from '@stamhoofd/models';
 
 /**
@@ -54,10 +55,10 @@ export function determinePaymentCustomer(payment: Payment, relations: PaymentCus
     }
 
     // The balance items linked to this payment, used to find members/users/orders.
-    const linkedMemberIds = unique(balanceItems.map(b => b.memberId).filter((id): id is string => id !== null));
-    const linkedUserIds = unique(balanceItems.map(b => b.userId).filter((id): id is string => id !== null));
-    const linkedOrderIds = unique(balanceItems.map(b => b.orderId).filter((id): id is string => id !== null));
-    const linkedPayingOrganizationIds = unique(balanceItems.map(b => b.payingOrganizationId).filter((id): id is string => id !== null));
+    const linkedMemberIds = Formatter.uniqueArray(balanceItems.map(b => b.memberId).filter((id): id is string => id !== null));
+    const linkedUserIds = Formatter.uniqueArray(balanceItems.map(b => b.userId).filter((id): id is string => id !== null));
+    const linkedOrderIds = Formatter.uniqueArray(balanceItems.map(b => b.orderId).filter((id): id is string => id !== null));
+    const linkedPayingOrganizationIds = Formatter.uniqueArray(balanceItems.map(b => b.payingOrganizationId).filter((id): id is string => id !== null));
 
     // 3. A member linked to the balance items
     for (const memberId of linkedMemberIds) {
@@ -140,8 +141,4 @@ function customerFromMember(member: Member): PaymentCustomer | null {
         email: details.getMemberEmails()[0] ?? null,
         phone: details.phone,
     });
-}
-
-function unique(ids: string[]): string[] {
-    return [...new Set(ids)];
 }

--- a/backend/app/api/src/seeds/1780915001-fill-payment-customer.ts
+++ b/backend/app/api/src/seeds/1780915001-fill-payment-customer.ts
@@ -1,0 +1,70 @@
+import { Migration } from '@simonbackx/simple-database';
+import { Member, Order, Organization, Payment, User } from '@stamhoofd/models';
+import { Formatter } from '@stamhoofd/utility';
+import { SeedTools } from '../helpers/SeedTools.js';
+import { determinePaymentCustomer } from '../helpers/PaymentCustomerResolver.js';
+
+export default new Migration(async () => {
+    if (STAMHOOFD.environment === 'test') {
+        // The customer determination is covered directly by PaymentCustomerResolver.test.ts
+        console.log('skipped in tests');
+        return;
+    }
+
+    if (STAMHOOFD.platformName !== 'stamhoofd') {
+        // In v1 only the Stamhoofd platform stored payments without a customer.
+        return;
+    }
+
+    console.log('Start filling in payment customers.');
+
+    let filled = 0;
+
+    const result = await SeedTools.loopBatched({
+        query: Payment.select().where('customer', null),
+        batchSize: 1000,
+        batchAction: async (payments: Payment[]) => {
+            // Load all the related data needed to determine the customers in bulk.
+            const { balanceItemPayments, balanceItems } = await Payment.loadBalanceItems(payments);
+            const { payingOrganizations } = await Payment.loadPayingOrganizations(payments);
+
+            const memberIds = Formatter.uniqueArray(balanceItems.map(b => b.memberId).filter((id): id is string => id !== null));
+            const userIds = Formatter.uniqueArray([
+                ...payments.map(p => p.payingUserId),
+                ...balanceItems.map(b => b.userId),
+            ].filter((id): id is string => id !== null));
+            const orderIds = Formatter.uniqueArray(balanceItems.map(b => b.orderId).filter((id): id is string => id !== null));
+            const balanceItemPayingOrganizationIds = Formatter.uniqueArray(balanceItems.map(b => b.payingOrganizationId).filter((id): id is string => id !== null));
+
+            const members = memberIds.length ? await Member.getByIDs(...memberIds) : [];
+            const users = userIds.length ? await User.getByIDs(...userIds) : [];
+            const orders = orderIds.length ? await Order.getByIDs(...orderIds) : [];
+            const extraOrganizations = balanceItemPayingOrganizationIds.length ? await Organization.getByIDs(...balanceItemPayingOrganizationIds) : [];
+            const allPayingOrganizations = [...payingOrganizations, ...extraOrganizations.filter(o => !payingOrganizations.some(p => p.id === o.id))];
+
+            for (const payment of payments) {
+                const paymentBalanceItemIds = balanceItemPayments.filter(bip => bip.paymentId === payment.id).map(bip => bip.balanceItemId);
+                const paymentBalanceItems = balanceItems.filter(b => paymentBalanceItemIds.includes(b.id));
+
+                const customer = determinePaymentCustomer(payment, {
+                    balanceItems: paymentBalanceItems,
+                    members,
+                    users,
+                    orders,
+                    payingOrganizations: allPayingOrganizations,
+                });
+
+                if (customer) {
+                    payment.customer = customer;
+                    await payment.save({
+                        skipMarkSaved: true,
+                        skipSendEvents: true,
+                    });
+                    filled++;
+                }
+            }
+        },
+    });
+
+    console.log(`Finished filling in payment customers: set ${filled} of ${result.total} payments.`);
+});


### PR DESCRIPTION
In v1 payments had no `customer`, so many existing payments still lack one. This adds a seed (Stamhoofd-platform only) that loops all payments without a customer and tries to figure out who paid.

The customer is determined best-effort from the payment and its linked balance items, in priority order:
1. The paying organization (`payingOrganizationId`) → company customer
2. The paying user (`payingUserId`)
3. A member linked to a balance item (parents for young members, mirroring the receivable-balance logic)
4. A user linked to a balance item
5. The customer of an order linked to a balance item
6. A paying organization referenced by a balance item

The resolution logic lives in `PaymentCustomerResolver` (pure function) and is covered by unit tests. The seed (`1780915001-fill-payment-customer`) loads the related models in bulk per batch and only saves payments where a customer could be determined.

Note: the DB-backed test suite couldn't be run in this environment (no MySQL/docker), but typecheck, build and lint pass and the resolver is covered by unit tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784283872&installation_id=138085646&pr_number=486&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F486&signature=93860c5467138f7727c8a429d3642f2a3c1c0bfa2e0c803e374defc9a42fab02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->