### PR TITLE
Backfill balance item relations for migrated v1 items

### DIFF
--- a/backend/app/api/src/helpers/BalanceItemRelationsBackfiller.test.ts
+++ b/backend/app/api/src/helpers/BalanceItemRelationsBackfiller.test.ts
@@ -1,0 +1,174 @@
+import type { Organization, RegistrationPeriod, Webshop } from '@stamhoofd/models';
+import { BalanceItem, BalanceItemFactory, GroupFactory, MemberFactory, OrganizationFactory, OrganizationRegistrationPeriodFactory, Order, RegistrationFactory, RegistrationPeriodFactory, WebshopFactory } from '@stamhoofd/models';
+import { BalanceItemRelation, BalanceItemRelationType, BalanceItemType, OrderData, ReduceablePrice, TranslatedString } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { v4 as uuidv4 } from 'uuid';
+import { backfillBalanceItemRelations } from './BalanceItemRelationsBackfiller.js';
+
+describe('helper.BalanceItemRelationsBackfiller', () => {
+    let period: RegistrationPeriod;
+
+    beforeAll(async () => {
+        period = await new RegistrationPeriodFactory({
+            startDate: new Date(2023, 0, 1),
+            endDate: new Date(2030, 11, 31),
+        }).create();
+    });
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    async function createOrder(organization: Organization, webshop: Webshop) {
+        const order = new Order();
+        order.organizationId = organization.id;
+        order.webshopId = webshop.id;
+        order.data = OrderData.create({});
+        await order.save();
+        return order;
+    }
+
+    it('fills member, group and group price relations for registration balance items', async () => {
+        const organization = await new OrganizationFactory({ period }).create();
+        await new OrganizationRegistrationPeriodFactory({ organization, period }).create();
+
+        const member = await new MemberFactory({ organization, firstName: 'John', lastName: 'Doe' }).create();
+        const group = await new GroupFactory({ organization, period }).create();
+        const registration = await new RegistrationFactory({ member, group }).create();
+
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: organization.id,
+            memberId: member.id,
+            registrationId: registration.id,
+            type: BalanceItemType.Registration,
+            amount: 1,
+            unitPrice: 25_00,
+        }).create();
+
+        expect(balanceItem.relations.size).toBe(0);
+
+        await backfillBalanceItemRelations();
+
+        const updated = await BalanceItem.getByID(balanceItem.id);
+        expect(updated?.relations.get(BalanceItemRelationType.Member)).toMatchObject({ id: member.id });
+        expect(updated?.relations.get(BalanceItemRelationType.Member)?.name.toString()).toBe('John Doe');
+        expect(updated?.relations.get(BalanceItemRelationType.Group)).toMatchObject({ id: group.id });
+        // Only one price configured, so no group price relation
+        expect(updated?.relations.has(BalanceItemRelationType.GroupPrice)).toBe(false);
+    });
+
+    it('fills the group price relation when the group has multiple prices', async () => {
+        const organization = await new OrganizationFactory({ period }).create();
+        await new OrganizationRegistrationPeriodFactory({ organization, period }).create();
+
+        const member = await new MemberFactory({ organization }).create();
+        const group = await new GroupFactory({ organization, period }).create();
+
+        // Add a second price so the relation should be filled
+        group.settings.prices.push(group.settings.prices[0].clone());
+        group.settings.prices[1].id = uuidv4();
+        group.settings.prices[1].name = new TranslatedString('Late price');
+        group.settings.prices[1].price = ReduceablePrice.create({ price: 30_00 });
+        await group.save();
+
+        const registration = await new RegistrationFactory({ member, group, groupPrice: group.settings.prices[1] }).create();
+
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: organization.id,
+            memberId: member.id,
+            registrationId: registration.id,
+            type: BalanceItemType.Registration,
+            amount: 1,
+            unitPrice: 30_00,
+        }).create();
+
+        await backfillBalanceItemRelations();
+
+        const updated = await BalanceItem.getByID(balanceItem.id);
+        expect(updated?.relations.get(BalanceItemRelationType.GroupPrice)).toMatchObject({ id: group.settings.prices[1].id });
+    });
+
+    it('copies the registration period dates onto the balance item', async () => {
+        const organization = await new OrganizationFactory({ period }).create();
+        await new OrganizationRegistrationPeriodFactory({ organization, period }).create();
+
+        const member = await new MemberFactory({ organization }).create();
+        const group = await new GroupFactory({ organization, period }).create();
+        const registration = await new RegistrationFactory({ member, group }).create();
+
+        const startDate = new Date(2024, 7, 1);
+        const endDate = new Date(2025, 6, 31);
+        registration.startDate = startDate;
+        registration.endDate = endDate;
+        await registration.save();
+
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: organization.id,
+            memberId: member.id,
+            registrationId: registration.id,
+            type: BalanceItemType.Registration,
+            amount: 1,
+            unitPrice: 25_00,
+        }).create();
+
+        await backfillBalanceItemRelations();
+
+        const updated = await BalanceItem.getByID(balanceItem.id);
+        expect(updated?.startDate?.getTime()).toBe(startDate.getTime());
+        expect(updated?.endDate?.getTime()).toBe(endDate.getTime());
+    });
+
+    it('fills the webshop relation for order balance items', async () => {
+        const organization = await new OrganizationFactory({ period }).create();
+        const webshop = await new WebshopFactory({ organizationId: organization.id, name: 'My webshop' }).create();
+        const order = await createOrder(organization, webshop);
+
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: organization.id,
+            orderId: order.id,
+            type: BalanceItemType.Order,
+            amount: 1,
+            unitPrice: 12_00,
+        }).create();
+
+        expect(balanceItem.relations.size).toBe(0);
+
+        await backfillBalanceItemRelations();
+
+        const updated = await BalanceItem.getByID(balanceItem.id);
+        expect(updated?.relations.get(BalanceItemRelationType.Webshop)).toMatchObject({ id: webshop.id });
+        expect(updated?.relations.get(BalanceItemRelationType.Webshop)?.name.toString()).toBe('My webshop');
+    });
+
+    it('does not overwrite existing relations', async () => {
+        const organization = await new OrganizationFactory({ period }).create();
+        await new OrganizationRegistrationPeriodFactory({ organization, period }).create();
+
+        const member = await new MemberFactory({ organization }).create();
+        const group = await new GroupFactory({ organization, period }).create();
+        const registration = await new RegistrationFactory({ member, group }).create();
+
+        const existingRelations = new Map([
+            [
+                BalanceItemRelationType.Member,
+                BalanceItemRelation.create({ id: member.id, name: new TranslatedString('Custom name') }),
+            ],
+        ]);
+
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: organization.id,
+            memberId: member.id,
+            registrationId: registration.id,
+            type: BalanceItemType.Registration,
+            amount: 1,
+            unitPrice: 25_00,
+            relations: existingRelations,
+        }).create();
+
+        await backfillBalanceItemRelations();
+
+        const updated = await BalanceItem.getByID(balanceItem.id);
+        expect(updated?.relations.size).toBe(1);
+        expect(updated?.relations.get(BalanceItemRelationType.Member)?.name.toString()).toBe('Custom name');
+    });
+});

--- a/backend/app/api/src/helpers/BalanceItemRelationsBackfiller.ts
+++ b/backend/app/api/src/helpers/BalanceItemRelationsBackfiller.ts
@@ -1,0 +1,163 @@
+import { BalanceItem, Group, Member, Order, Registration, Webshop } from '@stamhoofd/models';
+import { SQL } from '@stamhoofd/sql';
+import { BalanceItemRelation, BalanceItemRelationType, BalanceItemType, TranslatedString } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+import { SeedTools } from './SeedTools.js';
+
+/**
+ * Backfills the `relations` (and registration `startDate`/`endDate`) of legacy v1 balance items.
+ *
+ * V1 balance items were created without relations, so the frontend cannot show the member name, the
+ * registration group, the working year or the webshop name (it falls back to "Onbekende
+ * inschrijvingsgroep" / "Onbekende webshop"). We reconstruct that data from the linked registration or
+ * order.
+ *
+ * Only balance items that still have empty relations are touched, so the migration is idempotent and
+ * never overwrites relations that were already set by the current flows.
+ */
+
+/**
+ * Build the relations for a registration balance item, mirroring RegisterMembersEndpoint.
+ * Returns null when the linked registration/group/member can no longer be resolved.
+ */
+function buildRegistrationRelations(registration: Registration, group: Group, member: Member | undefined): Map<BalanceItemRelationType, BalanceItemRelation> {
+    const relations = new Map<BalanceItemRelationType, BalanceItemRelation>();
+
+    if (member) {
+        relations.set(BalanceItemRelationType.Member, BalanceItemRelation.create({
+            id: member.id,
+            name: new TranslatedString(member.details.name),
+        }));
+    }
+
+    relations.set(BalanceItemRelationType.Group, BalanceItemRelation.create({
+        id: group.id,
+        name: group.settings.name,
+    }));
+
+    // Mirror RegisterMembersEndpoint: only add the group price relation when there are multiple prices.
+    if (group.settings.prices.length > 1 && registration.groupPrice) {
+        relations.set(BalanceItemRelationType.GroupPrice, BalanceItemRelation.create({
+            id: registration.groupPrice.id,
+            name: registration.groupPrice.name,
+        }));
+    }
+
+    return relations;
+}
+
+async function backfillRegistrationBalanceItems(): Promise<number> {
+    let updated = 0;
+
+    await SeedTools.loopBatched({
+        batchSize: 100,
+        query: BalanceItem.select()
+            .whereNot('registrationId', null)
+            .where(SQL.jsonLength(SQL.column('relations'), '$.value'), 0),
+        batchAction: async (items: BalanceItem[]) => {
+            const registrationIds = Formatter.uniqueArray(items.map(i => i.registrationId!).filter(id => !!id));
+            const registrations = await Registration.getByIDs(...registrationIds);
+            const registrationMap = new Map(registrations.map(r => [r.id, r]));
+
+            const groups = await Group.getByIDs(...Formatter.uniqueArray(registrations.map(r => r.groupId)));
+            const groupMap = new Map(groups.map(g => [g.id, g]));
+
+            const members = await Member.getByIDs(...Formatter.uniqueArray(registrations.map(r => r.memberId)));
+            const memberMap = new Map(members.map(m => [m.id, m]));
+
+            for (const item of items) {
+                // A second safety check: never overwrite existing relations.
+                if (item.relations.size > 0) {
+                    continue;
+                }
+
+                const registration = registrationMap.get(item.registrationId!);
+                if (!registration) {
+                    continue;
+                }
+
+                const group = groupMap.get(registration.groupId);
+                if (!group) {
+                    continue;
+                }
+
+                const member = memberMap.get(registration.memberId);
+
+                item.relations = buildRegistrationRelations(registration, group, member);
+
+                // Reconstruct the period (working year) so the frontend can show it.
+                if (item.startDate === null && registration.startDate) {
+                    item.startDate = registration.startDate;
+                }
+                if (item.endDate === null && registration.endDate) {
+                    item.endDate = registration.endDate;
+                }
+
+                await item.save();
+                updated += 1;
+            }
+        },
+    });
+
+    return updated;
+}
+
+async function backfillOrderBalanceItems(): Promise<number> {
+    let updated = 0;
+
+    await SeedTools.loopBatched({
+        batchSize: 100,
+        query: BalanceItem.select()
+            .where('type', BalanceItemType.Order)
+            .whereNot('orderId', null)
+            .where(SQL.jsonLength(SQL.column('relations'), '$.value'), 0),
+        batchAction: async (items: BalanceItem[]) => {
+            const orderIds = Formatter.uniqueArray(items.map(i => i.orderId!).filter(id => !!id));
+            const orders = await Order.getByIDs(...orderIds);
+            const orderMap = new Map(orders.map(o => [o.id, o]));
+
+            const webshops = await Webshop.getByIDs(...Formatter.uniqueArray(orders.map(o => o.webshopId)));
+            const webshopMap = new Map(webshops.map(w => [w.id, w]));
+
+            for (const item of items) {
+                if (item.relations.size > 0) {
+                    continue;
+                }
+
+                const order = orderMap.get(item.orderId!);
+                if (!order) {
+                    continue;
+                }
+
+                const webshop = webshopMap.get(order.webshopId);
+                if (!webshop) {
+                    continue;
+                }
+
+                item.relations = new Map([
+                    [
+                        BalanceItemRelationType.Webshop,
+                        BalanceItemRelation.create({
+                            id: webshop.id,
+                            name: new TranslatedString(webshop.meta.name),
+                        }),
+                    ],
+                ]);
+
+                await item.save();
+                updated += 1;
+            }
+        },
+    });
+
+    return updated;
+}
+
+export async function backfillBalanceItemRelations(): Promise<{ registrations: number; orders: number }> {
+    const registrations = await backfillRegistrationBalanceItems();
+    const orders = await backfillOrderBalanceItems();
+
+    console.log(`[BalanceItemRelationsBackfiller] Updated ${registrations} registration balance items and ${orders} order balance items`);
+
+    return { registrations, orders };
+}

--- a/backend/app/api/src/migrations/1781692342-balance-item-relations.ts
+++ b/backend/app/api/src/migrations/1781692342-balance-item-relations.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@simonbackx/simple-database';
+
+export default new Migration(async () => {
+    if (STAMHOOFD.environment === 'test') {
+        // The backfill is covered directly by BalanceItemRelationsBackfiller.test.ts
+        console.log('skipped in tests');
+        return;
+    }
+
+    // Imported dynamically so the migration loader does not need to resolve the helper at link time.
+    const { backfillBalanceItemRelations } = await import('../helpers/BalanceItemRelationsBackfiller.js');
+    await backfillBalanceItemRelations();
+});


### PR DESCRIPTION
Legacy v1 balance items were migrated without `relations`, so the frontend falls back to "Onbekende inschrijvingsgroep" / "Onbekende webshop" instead of showing the member name, registration group, working year and webshop name.

This adds a migration that backfills, for balance items that still have empty relations:
- **Registration items**: the `Member`, `Group` and (when the group has multiple prices) `GroupPrice` relations, reconstructed from the linked registration/group/member — mirroring `RegisterMembersEndpoint`. Also copies the registration `startDate`/`endDate` onto the item so the period can be shown.
- **Order items**: the `Webshop` relation, reconstructed from the linked order/webshop — mirroring `PlaceOrderEndpoint`.

The backfill lives in `BalanceItemRelationsBackfiller.ts` and is invoked by the migration. It is idempotent: only items with empty relations are touched, so existing relations are never overwritten, and a re-run is a no-op.

Covered by `BalanceItemRelationsBackfiller.test.ts` (member/group/price relations, period dates, webshop relation, and the no-overwrite guard).

Note: tests could not be run in the sandbox (no MySQL/Docker available); typecheck and lint pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784285217&installation_id=138085646&pr_number=487&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F487&signature=6206863fa1a1743d212c952e62bbb7f6ba798117ecb3c9d3aac64f680315507b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->