### PR TITLE
✨️ centralise create s3 client creation + automatic creation

### DIFF
--- a/backend/app/api/package.json
+++ b/backend/app/api/package.json
@@ -60,6 +60,7 @@
         "@stamhoofd/backend-env": "*",
         "@stamhoofd/backend-i18n": "*",
         "@stamhoofd/backend-middleware": "*",
+        "@stamhoofd/cli": "*",
         "@stamhoofd/crons": "*",
         "@stamhoofd/email": "*",
         "@stamhoofd/excel-writer": "*",

--- a/backend/app/api/src/services/FileSignService.ts
+++ b/backend/app/api/src/services/FileSignService.ts
@@ -4,6 +4,7 @@ import {
 } from '@aws-sdk/s3-request-presigner';
 import type { DecodedRequest, Request, Response } from '@simonbackx/simple-endpoints';
 import { SimpleError } from '@simonbackx/simple-errors';
+import { createS3Client } from '@stamhoofd/cli';
 import { File } from '@stamhoofd/structures';
 import chalk from 'chalk';
 import * as jose from 'jose';
@@ -15,15 +16,7 @@ export class FileSignService {
     static s3: S3Client;
 
     static async load() {
-        this.s3 = new S3Client({
-            forcePathStyle: false, // Configures to use subdomain/virtual calling format.
-            endpoint: 'https://' + STAMHOOFD.SPACES_ENDPOINT,
-            credentials: {
-                accessKeyId: STAMHOOFD.SPACES_KEY,
-                secretAccessKey: STAMHOOFD.SPACES_SECRET,
-            },
-            region: 'eu-west-1', // Not used, but required by the S3Client
-        });
+        this.s3 = createS3Client(STAMHOOFD);
 
         /**
          * Note the algorithm is only used for signing. For verification the algorithm inside the public keys are used

--- a/backend/app/backup/package.json
+++ b/backend/app/backup/package.json
@@ -29,6 +29,7 @@
         "@stamhoofd/logging": "*",
         "@stamhoofd/queues": "*",
         "@stamhoofd/types": "*",
+        "@stamhoofd/cli": "*",
         "@stamhoofd/utility": "*",
         "chalk": "5.6.2",
         "formidable": "3.5.4",

--- a/backend/app/backup/src/helpers/backup.ts
+++ b/backend/app/backup/src/helpers/backup.ts
@@ -1,6 +1,8 @@
-import { DeleteObjectCommand, HeadObjectCommand, ListObjectsCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'; // ES Modules import
+import type { S3Client } from '@aws-sdk/client-s3';
+import { DeleteObjectCommand, HeadObjectCommand, ListObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3'; // ES Modules import
 import { Database } from '@simonbackx/simple-database';
 import { AutoEncoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import { createS3Client } from '@stamhoofd/cli';
 import { QueueHandler } from '@stamhoofd/queues';
 import { Formatter } from '@stamhoofd/utility';
 import chalk from 'chalk';
@@ -70,8 +72,7 @@ export function getHealth(): BackupHealth {
 
     if (!LAST_BINARY_BACKUP || !LAST_BACKUP) {
         status = 'error';
-    }
-    else {
+    } else {
         if (now.getTime() - LAST_BINARY_BACKUP.date.getTime() > 60 * 10 * 1000) {
             status = 'error';
         }
@@ -123,8 +124,7 @@ export async function cleanBackups() {
                     Bucket: STAMHOOFD.SPACES_BUCKET,
                     Key: file.key,
                 }));
-            }
-            else {
+            } else {
                 if (!lastBackup || lastBackup.key < file.key) {
                     lastBackup = file;
                 }
@@ -239,17 +239,6 @@ export async function diskSpace(): Promise<number> {
     }
     const size = parseInt(parts[1].trim());
     return size;
-}
-
-export function getS3Client() {
-    return new S3Client({
-        endpoint: 'https://' + STAMHOOFD.SPACES_ENDPOINT,
-        region: STAMHOOFD.AWS_REGION,
-        credentials: {
-            accessKeyId: STAMHOOFD.SPACES_KEY,
-            secretAccessKey: STAMHOOFD.SPACES_SECRET,
-        },
-    });
 }
 
 export function getBackupBaseFileName(date: Date) {
@@ -406,7 +395,7 @@ export async function backup() {
         // Upload
 
         // Download last backup file
-        const client = getS3Client();
+        const client = createS3Client(STAMHOOFD);
 
         // Create read stream
         const stream = fs.createReadStream(encryptedFile);
@@ -521,8 +510,7 @@ export async function uploadBinaryLog(binaryLogPath: string, partial: boolean, g
             }));
             console.log('Binary log already exists: ' + uploadedName);
             return;
-        }
-        catch (e) {
+        } catch (e) {
             if (e.name !== 'NotFound') {
                 throw e;
             }
@@ -567,8 +555,7 @@ export async function uploadBinaryLog(binaryLogPath: string, partial: boolean, g
     // Delete encrypted file if it exists
     try {
         await execPromise('rm ' + escapeShellArg(encryptedFile));
-    }
-    catch (e) {
+    } catch (e) {
         if (e.code !== 1) {
             throw e;
         }
@@ -635,8 +622,7 @@ async function deletePartial(client: S3Client, uploadedName: string, binaryLogPa
 
             console.log('Partial binary log deleted');
         }
-    }
-    catch (e) {
+    } catch (e) {
         if (e.name !== 'NotFound') {
             throw e;
         }

--- a/backend/shared/models/package.json
+++ b/backend/shared/models/package.json
@@ -35,6 +35,7 @@
         "@simonbackx/simple-encoding": "2.26.8",
         "@simonbackx/simple-endpoints": "1.21.1",
         "@simonbackx/simple-errors": "1.5.0",
+        "@stamhoofd/cli": "*",
         "argon2": "0.44.0",
         "base-x": "3.0.11",
         "handlebars": "4.7.9",

--- a/backend/shared/models/src/models/Image.ts
+++ b/backend/shared/models/src/models/Image.ts
@@ -2,6 +2,7 @@ import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'; // ES Modules i
 import { column } from '@simonbackx/simple-database';
 import { ArrayDecoder } from '@simonbackx/simple-encoding';
 import { SimpleError } from '@simonbackx/simple-errors';
+import { createS3Client } from '@stamhoofd/cli';
 import { QueryableModel } from '@stamhoofd/sql';
 import type { ResolutionRequest } from '@stamhoofd/structures';
 import { File, Resolution } from '@stamhoofd/structures';
@@ -29,15 +30,7 @@ export class Image extends QueryableModel {
 
     static getS3Client(): S3Client {
         if (!this.s3Client) {
-            this.s3Client = new S3Client({
-                forcePathStyle: false, // Configures to use subdomain/virtual calling format.
-                endpoint: 'https://' + STAMHOOFD.SPACES_ENDPOINT,
-                credentials: {
-                    accessKeyId: STAMHOOFD.SPACES_KEY,
-                    secretAccessKey: STAMHOOFD.SPACES_SECRET,
-                },
-                region: 'eu-west-1', // Not used, but required by the S3Client
-            });
+            this.s3Client = createS3Client(STAMHOOFD);
         }
         return this.s3Client;
     }

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -145,6 +145,8 @@ declare global {
         readonly SPACES_KEY: string;
         readonly SPACES_SECRET: string;
         readonly SPACES_PREFIX?: string;
+        readonly SPACES_FORCE_PATH_STYLE?: boolean;
+        readonly SPACES_PUBLIC_URL?: string;
 
         // Mollie
         readonly MOLLIE_CLIENT_ID: string;
@@ -294,6 +296,7 @@ declare global {
          readonly SPACES_BUCKET: string;
          readonly SPACES_KEY: string;
          readonly SPACES_SECRET: string;
+         readonly SPACES_FORCE_PATH_STYLE?: boolean;
          readonly AWS_REGION: 'eu-west-1' | string; // TODO: add others
          readonly MINIMUM_BACKUP_SIZE?: number; // Expected size (in bytes) of database backup, to detect broken backups
 

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -271,39 +271,39 @@ declare global {
         readonly platformName: string;
     };
 
-     /**
+    /**
      * The environment that is available everywhere: frontend, backend and shared
      */
-     type BackupEnvironment = {
-         /**
+    type BackupEnvironment = {
+        /**
          * We'll map the value of NODE_ENV to the corresponsing value. But staging value isn't valid for NODE_ENV, hence our own variable
          */
-         readonly environment: 'production' | 'development' | 'staging' | 'test';
-         readonly PORT: number;
+        readonly environment: 'production' | 'development' | 'staging' | 'test';
+        readonly PORT: number;
 
-         // Database to backup
-         readonly DB_HOST: string;
-         readonly DB_DATABASE: string;
-         readonly DB_USER: string;
-         readonly DB_PASS: string;
-         readonly CRONS_DISABLED?: boolean;
+        // Database to backup
+        readonly DB_HOST: string;
+        readonly DB_DATABASE: string;
+        readonly DB_USER: string;
+        readonly DB_PASS: string;
+        readonly CRONS_DISABLED?: boolean;
 
-         readonly keyFingerprint: string;
-         readonly objectStoragePath: string;
-         readonly localBackupFolder: string;
+        readonly keyFingerprint: string;
+        readonly objectStoragePath: string;
+        readonly localBackupFolder: string;
 
-         readonly SPACES_ENDPOINT: string;
-         readonly SPACES_BUCKET: string;
-         readonly SPACES_KEY: string;
-         readonly SPACES_SECRET: string;
-         readonly SPACES_FORCE_PATH_STYLE?: boolean;
-         readonly AWS_REGION: 'eu-west-1' | string; // TODO: add others
-         readonly MINIMUM_BACKUP_SIZE?: number; // Expected size (in bytes) of database backup, to detect broken backups
+        readonly SPACES_ENDPOINT: string;
+        readonly SPACES_BUCKET: string;
+        readonly SPACES_KEY: string;
+        readonly SPACES_SECRET: string;
+        readonly SPACES_FORCE_PATH_STYLE?: boolean;
+        readonly AWS_REGION: 'eu-west-1' | string; // TODO: add others
+        readonly MINIMUM_BACKUP_SIZE?: number; // Expected size (in bytes) of database backup, to detect broken backups
 
-         readonly IS_REPLICA?: boolean; // Whether this is a replica server and health checks should also check replica health
+        readonly IS_REPLICA?: boolean; // Whether this is a replica server and health checks should also check replica health
 
-         readonly HEALTH_ACCESS_KEY?: string; // Optional for a little bit of extra security (the health endpoint does not expose any sensitive information)
-     };
+        readonly HEALTH_ACCESS_KEY?: string; // Optional for a little bit of extra security (the health endpoint does not expose any sensitive information)
+    };
 
     type FrontendEnvironment = SharedEnvironment & FrontendSpecificEnvironment;
 }

--- a/shared/cli/package.json
+++ b/shared/cli/package.json
@@ -28,8 +28,10 @@
         "test:coverage": "vitest --coverage"
     },
     "dependencies": {
+        "@aws-sdk/client-s3": "3.1068.0",
         "@inquirer/prompts": "7.10.1",
         "@oclif/core": "4.11.4",
+        "@smithy/node-http-handler": "4.8.0",
         "@stamhoofd/types": "*",
         "chalk": "5.6.2",
         "log-update": "8.0.0",

--- a/shared/cli/src/config/caddy-config.test.ts
+++ b/shared/cli/src/config/caddy-config.test.ts
@@ -33,6 +33,18 @@ describe('Caddy config', () => {
         expect(caddyConfig.admin.origins).toEqual([`http://${localhostPort(caddyAdminPort)}`]);
     });
 
+    it('routes wildcard file bucket hosts with TLS coverage', async () => {
+        const config = await writeCaddyConfig(context(rootDir));
+        const caddyConfig = JSON.parse(await fs.readFile(config, 'utf8'));
+        const hosts = routeHosts(caddyConfig);
+        const subjects = caddyConfig.apps.tls.automation.policies[0].subjects;
+
+        expect(hosts).toContain('files.stamhoofd');
+        expect(hosts).toContain('*.files.stamhoofd');
+        expect(subjects).toContain('files.stamhoofd');
+        expect(subjects).toContain('*.files.stamhoofd');
+    });
+
     it('can bind the admin API to the container interface', async () => {
         const config = await writeCaddyConfig(context(rootDir), { adminListenHost: '0.0.0.0' });
         const caddyConfig = JSON.parse(await fs.readFile(config, 'utf8'));

--- a/shared/cli/src/config/caddy-config.ts
+++ b/shared/cli/src/config/caddy-config.ts
@@ -156,6 +156,7 @@ export async function buildCaddyConfig(context: CliContext, options: { setup?: b
     const subjects = [...new Set([
         domains.mail,
         domains.files,
+        `*.${domains.files}`,
         domains.filesConsole,
         domains.sso,
         ...activeManifests.flatMap(manifest => manifest.caddy.tlsSubjects),

--- a/shared/cli/src/config/development-config.test.ts
+++ b/shared/cli/src/config/development-config.test.ts
@@ -30,7 +30,9 @@ describe('buildDevelopmentConfig', () => {
         expect(config.backendEnv.DB_HOST).toBe(localIpv4Host);
         expect(config.backendEnv.SPACES_KEY).toBe(localFilesAccessKey);
         expect(config.backendEnv.SPACES_SECRET).toBe(localFilesSecretKey);
+        expect(config.backendEnv.SPACES_FORCE_PATH_STYLE).toBe('false');
         expect(config.appEnv.userMode).toBe('organization');
+        expect(config.appEnv.SPACES_FORCE_PATH_STYLE).toBe(false);
         expect(config.appEnv.domains.api).toBe('api.stamhoofd');
         expect(config.appEnv.SMTP_HOST).toBe(localIpv4Host);
         expect(config.appEnv.SMTP_USERNAME).toBe(maildevUsername);

--- a/shared/cli/src/config/development-config.ts
+++ b/shared/cli/src/config/development-config.ts
@@ -77,7 +77,7 @@ export function buildDevelopmentConfig(context: CliContext, service: AppService 
         SPACES_BUCKET: bucket,
         SPACES_KEY: localFilesAccessKey,
         SPACES_SECRET: localFilesSecretKey,
-        SPACES_FORCE_PATH_STYLE: 'true',
+        SPACES_FORCE_PATH_STYLE: 'false',
         SPACES_PUBLIC_URL: `https://${domains.files}/${bucket}`,
     };
 
@@ -163,7 +163,7 @@ function buildAppEnvironment(context: CliContext, domains: DevelopmentDomains, p
         SPACES_KEY: backendEnv.SPACES_KEY!,
         SPACES_SECRET: backendEnv.SPACES_SECRET!,
         SPACES_PREFIX: '',
-        SPACES_FORCE_PATH_STYLE: true,
+        SPACES_FORCE_PATH_STYLE: false,
         SPACES_PUBLIC_URL: backendEnv.SPACES_PUBLIC_URL!,
         MOLLIE_CLIENT_ID: '',
         MOLLIE_SECRET: '',

--- a/shared/cli/src/config/s3-client.test.ts
+++ b/shared/cli/src/config/s3-client.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { createS3Client } from './s3-client.js';
+
+const baseConfig = {
+    SPACES_ENDPOINT: 'files.stamhoofd',
+    SPACES_KEY: 'key',
+    SPACES_SECRET: 'secret',
+};
+
+describe('createS3Client', () => {
+    it('defaults to virtual-host style requests', async () => {
+        const client = createS3Client(baseConfig);
+
+        expect(client.config.forcePathStyle).toBe(false);
+    });
+
+    it('rejects boolean path-style configuration', () => {
+        expect(() => createS3Client({ ...baseConfig, SPACES_FORCE_PATH_STYLE: true })).toThrow('SPACES_FORCE_PATH_STYLE=true is not supported yet');
+    });
+
+    it('rejects string path-style configuration', () => {
+        expect(() => createS3Client({ ...baseConfig, SPACES_FORCE_PATH_STYLE: 'true' })).toThrow('SPACES_FORCE_PATH_STYLE=true is not supported yet');
+    });
+
+    it('allows explicit virtual-host style configuration', () => {
+        const client = createS3Client({ ...baseConfig, SPACES_FORCE_PATH_STYLE: false });
+
+        expect(client.config.forcePathStyle).toBe(false);
+    });
+
+    it('configures a custom CA certificate when provided', () => {
+        const client = createS3Client({ ...baseConfig, SPACES_CA_CERT: 'certificate' });
+
+        expect(client.config.requestHandler).toBeDefined();
+    });
+});

--- a/shared/cli/src/config/s3-client.ts
+++ b/shared/cli/src/config/s3-client.ts
@@ -1,0 +1,46 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import https from 'node:https';
+
+// TODO: split S3 client creation into a smaller shared package. It lives in
+// @stamhoofd/cli for now because @stamhoofd/backend-env imports the CLI in
+// development, so putting it there would create a cyclic dependency.
+
+export type S3ClientEnvironment = {
+    SPACES_ENDPOINT: string;
+    SPACES_KEY: string;
+    SPACES_SECRET: string;
+    AWS_REGION?: string;
+    SPACES_FORCE_PATH_STYLE?: boolean | string;
+    SPACES_CA_CERT?: string | Buffer;
+};
+
+export function createS3Client(config: S3ClientEnvironment): S3Client {
+    if (parseBoolean(config.SPACES_FORCE_PATH_STYLE)) {
+        throw new Error('SPACES_FORCE_PATH_STYLE=true is not supported yet because file URLs currently assume virtual-host style.');
+    }
+
+    return new S3Client({
+        forcePathStyle: false,
+        endpoint: 'https://' + config.SPACES_ENDPOINT,
+        credentials: {
+            accessKeyId: config.SPACES_KEY,
+            secretAccessKey: config.SPACES_SECRET,
+        },
+        region: config.AWS_REGION ?? 'eu-west-1',
+        requestHandler: config.SPACES_CA_CERT
+            ? new NodeHttpHandler({
+                    httpsAgent: new https.Agent({
+                        ca: config.SPACES_CA_CERT,
+                    }),
+                })
+            : undefined,
+    });
+}
+
+function parseBoolean(value: boolean | string | undefined): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    return value === 'true';
+}

--- a/shared/cli/src/config/shared-service-config.ts
+++ b/shared/cli/src/config/shared-service-config.ts
@@ -89,6 +89,10 @@ export function caddyDataDir(): string {
     return path.join(dataHome, 'caddy');
 }
 
+export function caddyRootCaPath(): string {
+    return path.join(caddyDataDir(), 'pki/authorities/local/root.crt');
+}
+
 export function localhostPort(port: number): string {
     return `${localIpv4Host}:${port}`;
 }

--- a/shared/cli/src/index.ts
+++ b/shared/cli/src/index.ts
@@ -1,5 +1,6 @@
 export { run } from '@oclif/core';
 export { buildDevelopmentEnvironment } from './config/development-config.js';
+export { createS3Client, type S3ClientEnvironment } from './config/s3-client.js';
 export { caddyAdminPort, localIpv4Host } from './config/shared-service-config.js';
 export { buildCaddyServiceProfile, buildSharedServiceProfile } from './config/shared-service-profile.js';
 export { createContext } from './context/create-context.js';

--- a/shared/cli/src/runtime/monorepo-runner.test.ts
+++ b/shared/cli/src/runtime/monorepo-runner.test.ts
@@ -1,6 +1,5 @@
-import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { caddyDataDir } from '../config/shared-service-config.js';
+import { caddyRootCaPath } from '../config/shared-service-config.js';
 import { CaddyService } from '../services/definitions/caddy-service.js';
 import * as docker from '../services/docker.js';
 import { startSharedServices } from '../services/shared-services.js';
@@ -44,7 +43,7 @@ describe('monorepo runner', () => {
         expect(playwrightRun).toBeDefined();
         expect(playwrightRun?.[2].env).toMatchObject({
             DB_PORT: '55103',
-            NODE_EXTRA_CA_CERTS: path.join(caddyDataDir(), 'pki/authorities/local/root.crt'),
+            NODE_EXTRA_CA_CERTS: caddyRootCaPath(),
         });
     });
 });

--- a/shared/cli/src/runtime/monorepo-runner.ts
+++ b/shared/cli/src/runtime/monorepo-runner.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { caddyDataDir, localIpv4Host, localhostPortMappingDynamic, mysqlImage, mysqlInternalPort, mysqlRootPassword, mysqlRootUser, mysqlServerArgs } from '../config/shared-service-config.js';
+import { caddyRootCaPath, localIpv4Host, localhostPortMappingDynamic, mysqlImage, mysqlInternalPort, mysqlRootPassword, mysqlRootUser, mysqlServerArgs } from '../config/shared-service-config.js';
 import type { CliContext } from '../context/create-context.js';
 import { buildBackendEnv } from '../config/build-config.js';
 import { CaddyService } from '../services/definitions/caddy-service.js';
@@ -35,7 +35,6 @@ const testMysqlContainer = 'stamhoofd-test-mysql';
 const e2eMysqlContainer = 'stamhoofd-e2e-mysql';
 const e2eMysqlDataVolume = 'stamhoofd-e2e-mysql-data';
 const sharedBuildReadyFile = `.development/cli/generated/shared-build-${process.pid}.ready`;
-const caddyRootCaPath = path.join(caddyDataDir(), 'pki/authorities/local/root.crt');
 
 export async function buildShared(context: CliContext): Promise<void> {
     console.log('\x1B[35m[BUILD]\x1B[0m Building globally shared dependencies...');
@@ -85,7 +84,7 @@ export async function testE2e(context: CliContext, options: { ci: boolean; clear
         await startSharedServices(context);
         shouldRestoreCaddy = true;
         await run('yarn', ['--cwd', 'backend/app/api', '-s', 'build:playwright:pre'], { cwd: context.rootDir, env: { DB_PORT: dbPort }, verbose: context.verbose });
-        await run('yarn', ['--cwd', 'tests/playwright', '-s', 'test', ...(options.ui ? ['--ui'] : []), ...(options.workers === undefined ? [] : ['--workers', String(options.workers)])], { cwd: context.rootDir, env: { NX_DAEMON: 'false', CI: options.ci ? 'true' : undefined, DB_PORT: dbPort, NODE_EXTRA_CA_CERTS: caddyRootCaPath, PLAYWRIGHT_INCLUDE_EXTRA: options.extra ? '1' : undefined, PLAYWRIGHT_WORKER_COUNT: options.workers === undefined ? undefined : String(options.workers) }, verbose: context.verbose });
+        await run('yarn', ['--cwd', 'tests/playwright', '-s', 'test', ...(options.ui ? ['--ui'] : []), ...(options.workers === undefined ? [] : ['--workers', String(options.workers)])], { cwd: context.rootDir, env: { NX_DAEMON: 'false', CI: options.ci ? 'true' : undefined, DB_PORT: dbPort, NODE_EXTRA_CA_CERTS: caddyRootCaPath(), PLAYWRIGHT_INCLUDE_EXTRA: options.extra ? '1' : undefined, PLAYWRIGHT_WORKER_COUNT: options.workers === undefined ? undefined : String(options.workers) }, verbose: context.verbose });
     }
     finally {
         if (shouldRestoreCaddy) {

--- a/shared/cli/src/services/s3-buckets.test.ts
+++ b/shared/cli/src/services/s3-buckets.test.ts
@@ -1,0 +1,77 @@
+import { CreateBucketCommand, HeadBucketCommand, PutBucketPolicyCommand } from '@aws-sdk/client-s3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliContext } from '../context/create-context.js';
+import { localPrimaryBucket } from '../config/shared-service-config.js';
+import { publicBucketPolicy, setupDevelopmentS3Buckets } from './s3-buckets.js';
+
+const send = vi.fn();
+
+vi.mock('../config/s3-client.js', () => ({
+    createS3Client: vi.fn(() => ({ send })),
+}));
+
+function context(partial: Partial<CliContext> = {}): CliContext {
+    return {
+        rootDir: '/repo',
+        generatedDir: '/repo/.development/cli/generated',
+        env: 'stamhoofd',
+        workspace: 'main',
+        verbose: false,
+        instance: {
+            name: 'stamhoofd',
+            prefix: '',
+            primary: true,
+            portOffset: 0,
+        },
+        ...partial,
+    };
+}
+
+describe('setupDevelopmentS3Buckets', () => {
+    beforeEach(() => {
+        send.mockReset();
+        send.mockResolvedValue({});
+    });
+
+    it('creates the bucket from the development config when it is missing', async () => {
+        const notFound = new Error('not found') as Error & { $metadata: { httpStatusCode: number } };
+        notFound.$metadata = { httpStatusCode: 404 };
+        send.mockRejectedValueOnce(notFound).mockResolvedValue({});
+
+        await setupDevelopmentS3Buckets(context());
+
+        expect(send.mock.calls[0][0]).toBeInstanceOf(HeadBucketCommand);
+        expect(send.mock.calls[0][0].input.Bucket).toBe(localPrimaryBucket);
+        expect(send.mock.calls[1][0]).toBeInstanceOf(CreateBucketCommand);
+        expect(send.mock.calls[1][0].input.Bucket).toBe(localPrimaryBucket);
+        expect(send.mock.calls[2][0]).toBeInstanceOf(PutBucketPolicyCommand);
+        expect(send.mock.calls[2][0].input.Bucket).toBe(localPrimaryBucket);
+    });
+
+    it('uses the isolated instance bucket from the development config', async () => {
+        await setupDevelopmentS3Buckets(context({
+            instance: {
+                name: 'stamhoofd-feature-keeo',
+                prefix: 'feature',
+                primary: false,
+                portOffset: 1200,
+            },
+        }));
+
+        expect(send.mock.calls[0][0].input.Bucket).toBe(`${localPrimaryBucket}-stamhoofd-feature-keeo`);
+        expect(send.mock.calls[1][0].input.Policy).toBe(publicBucketPolicy(`${localPrimaryBucket}-stamhoofd-feature-keeo`));
+    });
+
+    it('only grants public access to the public development prefix', () => {
+        const policy = JSON.parse(publicBucketPolicy('example'));
+
+        expect(policy.Statement).toEqual([
+            {
+                Effect: 'Allow',
+                Principal: '*',
+                Action: 's3:GetObject',
+                Resource: 'arn:aws:s3:::example/development/p/*',
+            },
+        ]);
+    });
+});

--- a/shared/cli/src/services/s3-buckets.ts
+++ b/shared/cli/src/services/s3-buckets.ts
@@ -1,0 +1,77 @@
+import { CreateBucketCommand, HeadBucketCommand, PutBucketPolicyCommand } from '@aws-sdk/client-s3';
+import fs from 'node:fs/promises';
+import { buildDevelopmentConfig } from '../config/development-config.js';
+import { createS3Client } from '../config/s3-client.js';
+import { caddyRootCaPath } from '../config/shared-service-config.js';
+import type { CliContext } from '../context/create-context.js';
+
+export async function setupDevelopmentS3Buckets(context: CliContext): Promise<void> {
+    const env = buildDevelopmentConfig(context).backendEnv;
+    const bucket = env.SPACES_BUCKET;
+    const client = createS3Client({
+        SPACES_ENDPOINT: env.SPACES_ENDPOINT!,
+        SPACES_KEY: env.SPACES_KEY!,
+        SPACES_SECRET: env.SPACES_SECRET!,
+        AWS_REGION: env.AWS_REGION,
+        SPACES_FORCE_PATH_STYLE: env.SPACES_FORCE_PATH_STYLE,
+        SPACES_CA_CERT: await readCaddyRootCertificate(),
+    });
+
+    if (!bucket) {
+        throw new Error('Missing SPACES_BUCKET in development config');
+    }
+
+    if (!(await bucketExists(client, bucket))) {
+        await client.send(new CreateBucketCommand({ Bucket: bucket }));
+    }
+
+    await client.send(new PutBucketPolicyCommand({
+        Bucket: bucket,
+        Policy: publicBucketPolicy(bucket),
+    }));
+}
+
+async function readCaddyRootCertificate(): Promise<Buffer | undefined> {
+    try {
+        return await fs.readFile(caddyRootCaPath());
+    }
+    catch {
+        return undefined;
+    }
+}
+
+async function bucketExists(client: ReturnType<typeof createS3Client>, bucket: string): Promise<boolean> {
+    try {
+        await client.send(new HeadBucketCommand({ Bucket: bucket }));
+        return true;
+    }
+    catch (error) {
+        if (isNotFoundError(error)) {
+            return false;
+        }
+        throw error;
+    }
+}
+
+export function publicBucketPolicy(bucket: string): string {
+    return JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [
+            {
+                Effect: 'Allow',
+                Principal: '*',
+                Action: 's3:GetObject',
+                Resource: `arn:aws:s3:::${bucket}/development/p/*`,
+            },
+        ],
+    });
+}
+
+function isNotFoundError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+
+    const metadata = (error as { $metadata?: { httpStatusCode?: number } }).$metadata;
+    return metadata?.httpStatusCode === 404 || error.name === 'NotFound' || error.name === 'NoSuchBucket';
+}

--- a/shared/cli/src/services/s3-buckets.ts
+++ b/shared/cli/src/services/s3-buckets.ts
@@ -34,8 +34,7 @@ export async function setupDevelopmentS3Buckets(context: CliContext): Promise<vo
 async function readCaddyRootCertificate(): Promise<Buffer | undefined> {
     try {
         return await fs.readFile(caddyRootCaPath());
-    }
-    catch {
+    } catch {
         return undefined;
     }
 }
@@ -44,8 +43,7 @@ async function bucketExists(client: ReturnType<typeof createS3Client>, bucket: s
     try {
         await client.send(new HeadBucketCommand({ Bucket: bucket }));
         return true;
-    }
-    catch (error) {
+    } catch (error) {
         if (isNotFoundError(error)) {
             return false;
         }

--- a/shared/cli/src/workflows/setup-machine.ts
+++ b/shared/cli/src/workflows/setup-machine.ts
@@ -4,7 +4,7 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { writeSetupCaddyConfig } from '../config/caddy-config.js';
-import { caddyContainer, caddyDataDir, caddyHttpPort, caddyHttpsPort, caddySetupAdminPort, defaultDomain, localIpv4Host, localhostPort } from '../config/shared-service-config.js';
+import { caddyContainer, caddyDataDir, caddyHttpPort, caddyHttpsPort, caddyRootCaPath, caddySetupAdminPort, defaultDomain, localIpv4Host, localhostPort } from '../config/shared-service-config.js';
 import { buildSharedServiceProfile, SharedServiceDnsSetupKind } from '../config/shared-service-profile.js';
 import type { SharedServiceProfile } from '../config/shared-service-profile.js';
 import type { CliContext } from '../context/create-context.js';
@@ -447,7 +447,7 @@ async function dnsConfigurationCheck(domain: string, profile: SharedServiceProfi
 }
 
 async function certCheck(): Promise<CheckResult> {
-    const certPath = path.join(caddyDataDir(), 'pki/authorities/local/root.crt');
+    const certPath = caddyRootCaPath();
     try {
         await fs.access(certPath);
         return { ok: true, details: certPath };

--- a/shared/cli/src/workflows/start-dev.ts
+++ b/shared/cli/src/workflows/start-dev.ts
@@ -12,6 +12,7 @@ import { openUrl } from '../runtime/ux.js';
 import { CaddyService } from '../services/definitions/caddy-service.js';
 import { startServices, stopServices } from '../services/manager.js';
 import { sharedServiceDefinitions } from '../services/registry.js';
+import { setupDevelopmentS3Buckets } from '../services/s3-buckets.js';
 import { sharedServicesRunning } from '../services/shared-services.js';
 import { startStripe, stopStripe } from '../services/stripe.js';
 import { checkSetup, isSetupReady, printSetupReport } from './setup-machine.js';
@@ -130,6 +131,10 @@ export async function runDev(context: CliContext, target: DevTarget, options: { 
                 output.log('Resolve the shared service issues above, then retry: stam services up');
                 return;
             }
+        }
+
+        if (options.services && target !== DevTarget.Frontend) {
+            await setupDevelopmentS3Buckets(context);
         }
 
         await writeInstanceManifest(context, {

--- a/shared/test-utils/src/env.json
+++ b/shared/test-utils/src/env.json
@@ -1,7 +1,7 @@
 {
     "AWS_ACCESS_KEY_ID": "",
-    "AWS_REGION": "",
-    
+    "AWS_REGION": "eu-west-1",
+
     "AWS_SECRET_ACCESS_KEY": "",
     "DB_DATABASE": "stamhoofd-tests",
     "DB_HOST": "127.0.0.1",

--- a/shared/types/src/Environment.ts
+++ b/shared/types/src/Environment.ts
@@ -82,6 +82,8 @@ export type BackendSpecificEnvironment = {
     readonly SPACES_KEY: string;
     readonly SPACES_SECRET: string;
     readonly SPACES_PREFIX?: string;
+    readonly SPACES_FORCE_PATH_STYLE?: boolean;
+    readonly SPACES_PUBLIC_URL?: string;
 
     // Mollie
     readonly MOLLIE_CLIENT_ID: string;
@@ -231,6 +233,7 @@ export type BackupEnvironment = {
     readonly SPACES_BUCKET: string;
     readonly SPACES_KEY: string;
     readonly SPACES_SECRET: string;
+    readonly SPACES_FORCE_PATH_STYLE?: boolean;
     readonly AWS_REGION: 'eu-west-1' | string; // TODO: add others
     readonly MINIMUM_BACKUP_SIZE?: number; // Expected size (in bytes) of database backup, to detect broken backups
 


### PR DESCRIPTION
1. Centralises the s3 client creation into shared/cli. Ideally we should have this in backend/env or something similar. But that currently doesn't really change because it also has a dependency on shared/cli. We should create a shared/config in the future and this should move there.
2. `stam dev instance` automatically creates the buckets and sets up the policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784296316&installation_id=138085646&pr_number=489&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F489&signature=f5f5d85e98a39eb5eec9481c87889dece68bbaf49c076763c6d333998ee70575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->