### PR TITLE
Enable sensible default personal data settings on the platform

### DIFF
--- a/backend/app/api/src/migrations/1781784820-platform-records-defaults.ts
+++ b/backend/app/api/src/migrations/1781784820-platform-records-defaults.ts
@@ -1,0 +1,41 @@
+import { Migration } from '@simonbackx/simple-database';
+import { Platform } from '@stamhoofd/models';
+import { RecordConfigurationFactory } from '@stamhoofd/structures';
+
+export default new Migration(async () => {
+    if (STAMHOOFD.environment === 'test') {
+        console.log('skipped in tests');
+        return;
+    }
+
+    // Only the platform itself (e.g. Stamhoofd) needs default personal data settings.
+    // In organization mode the platform config is merged into every organization, which would
+    // override their own settings, so we skip it there.
+    if (STAMHOOFD.userMode !== 'platform') {
+        console.log('skipped: only runs in platform mode');
+        return;
+    }
+
+    const platform = await Platform.getForEditing();
+    const config = platform.config.recordsConfiguration;
+    const defaults = RecordConfigurationFactory.createPlatformDefault();
+
+    // Only fill in fields that have not been configured yet, so we don't override manual changes.
+    const fields = ['birthDay', 'gender', 'phone', 'emailAddress', 'address', 'parents', 'emergencyContacts'] as const;
+    let changed = false;
+
+    for (const field of fields) {
+        if (config[field] === null && defaults[field] !== null) {
+            config[field] = defaults[field];
+            changed = true;
+        }
+    }
+
+    if (!changed) {
+        console.log('Platform records configuration already set, skipping');
+        return;
+    }
+
+    await platform.save();
+    console.log('Set default personal data settings on the platform');
+});

--- a/shared/structures/src/members/records/RecordConfigurationFactory.test.ts
+++ b/shared/structures/src/members/records/RecordConfigurationFactory.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+import { RecordConfigurationFactory } from './RecordConfigurationFactory.js';
+
+describe('RecordConfigurationFactory.createPlatformDefault', () => {
+    test('enables the birth date for everyone', () => {
+        const config = RecordConfigurationFactory.createPlatformDefault();
+        expect(config.birthDay).not.toBeNull();
+        expect(config.birthDay!.enabledWhen).toBeNull();
+    });
+
+    test('asks the email address based on age', () => {
+        const config = RecordConfigurationFactory.createPlatformDefault();
+        expect(config.emailAddress).not.toBeNull();
+        expect(config.emailAddress!.enabledWhen).not.toBeNull();
+    });
+
+    test('asks the parents based on age', () => {
+        const config = RecordConfigurationFactory.createPlatformDefault();
+        expect(config.parents).not.toBeNull();
+        expect(config.parents!.enabledWhen).not.toBeNull();
+    });
+
+    test('does not add record categories', () => {
+        const config = RecordConfigurationFactory.createPlatformDefault();
+        expect(config.recordCategories).toHaveLength(0);
+    });
+});

--- a/shared/structures/src/members/records/RecordConfigurationFactory.ts
+++ b/shared/structures/src/members/records/RecordConfigurationFactory.ts
@@ -22,6 +22,21 @@ export class RecordConfigurationFactory {
     }
 
     /**
+     * Default built-in field configuration for the platform itself (e.g. Stamhoofd).
+     * Enables the birth date and asks email, phone, parents and emergency contacts based on the member's age.
+     * Record categories are managed separately on the platform, so they are not included here.
+     */
+    static createPlatformDefault(): OrganizationRecordsConfiguration {
+        const configuration = OrganizationRecordsConfiguration.create({});
+
+        this.setDefaultBuiltInFields(configuration, OrganizationType.Youth);
+        this.setDefaultParents(configuration, OrganizationType.Youth);
+        this.setDefaultEmergencyContacts(configuration, OrganizationType.Youth);
+
+        return configuration;
+    }
+
+    /**
      * Set default email, phone, partents, ... configuration
      * Except emergency contacts
      */


### PR DESCRIPTION
The platform config (e.g. Stamhoofd itself, in platform mode) shipped with an empty records configuration, so birth date, parents and email address weren't asked by default. Organizations already get sensible defaults via `RecordConfigurationFactory` at signup, but the platform never did.

- Added `RecordConfigurationFactory.createPlatformDefault()` which reuses the existing youth-style built-in field defaults (birth date enabled for everyone, email/phone/parents/emergency contacts asked based on age). Record categories are managed separately on the platform, so they're not included.
- Added a migration (platform mode only) that fills in any still-`null` built-in fields on the existing platform config, so manual configuration is never overwritten. It's skipped in organization mode, where the platform config is merged into every organization.

Added unit tests for the new factory method.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784377403&installation_id=138085646&pr_number=493&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F493&signature=4a4fa88f758a9195b8cef69a6a49a8c79408185b79c693598ae771fe7c1bb15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->