### PR TITLE
🐛️ make image-component extend its template

### DIFF
--- a/frontend/shared/scss/base/text-styles-output.scss
+++ b/frontend/shared/scss/base/text-styles-output.scss
@@ -72,6 +72,7 @@
 .style-illustration-img { @extend %style-illustration-img; }
 .illustration-list { @extend %illustration-list; }
 .style-image-with-icon { @extend %style-image-with-icon; }
+.image-component { @extend %image-component; }
 .style-bubble { @extend %style-bubble; }
 .style-strong { @extend %style-strong; }
 .style-pricing-box { @extend %style-pricing-box; }


### PR DESCRIPTION
Fixes STA-1140
Fixes STA-1149
Fixes STA-1139

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784388644&installation_id=138085646&pr_number=494&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F494&signature=1c3710b8f380080f778568539b5a09cbdf5501fc239e6a49a14d3382014afa9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->