### PR TITLE
🐛️ fix caddy to support *.files.stamhoofd

### DIFF
--- a/shared/cli/src/config/caddy-config.test.ts
+++ b/shared/cli/src/config/caddy-config.test.ts
@@ -33,6 +33,18 @@ describe('Caddy config', () => {
         expect(caddyConfig.admin.origins).toEqual([`http://${localhostPort(caddyAdminPort)}`]);
     });
 
+    it('routes wildcard file bucket hosts with TLS coverage', async () => {
+        const config = await writeCaddyConfig(context(rootDir));
+        const caddyConfig = JSON.parse(await fs.readFile(config, 'utf8'));
+        const hosts = routeHosts(caddyConfig);
+        const subjects = caddyConfig.apps.tls.automation.policies[0].subjects;
+
+        expect(hosts).toContain('files.stamhoofd');
+        expect(hosts).toContain('*.files.stamhoofd');
+        expect(subjects).toContain('files.stamhoofd');
+        expect(subjects).toContain('*.files.stamhoofd');
+    });
+
     it('can bind the admin API to the container interface', async () => {
         const config = await writeCaddyConfig(context(rootDir), { adminListenHost: '0.0.0.0' });
         const caddyConfig = JSON.parse(await fs.readFile(config, 'utf8'));

--- a/shared/cli/src/config/caddy-config.ts
+++ b/shared/cli/src/config/caddy-config.ts
@@ -156,6 +156,7 @@ export async function buildCaddyConfig(context: CliContext, options: { setup?: b
     const subjects = [...new Set([
         domains.mail,
         domains.files,
+        `*.${domains.files}`,
         domains.filesConsole,
         domains.sso,
         ...activeManifests.flatMap(manifest => manifest.caddy.tlsSubjects),

--- a/shared/cli/src/config/shared-service-config.ts
+++ b/shared/cli/src/config/shared-service-config.ts
@@ -89,6 +89,10 @@ export function caddyDataDir(): string {
     return path.join(dataHome, 'caddy');
 }
 
+export function caddyRootCaPath(): string {
+    return path.join(caddyDataDir(), 'pki/authorities/local/root.crt');
+}
+
 export function localhostPort(port: number): string {
     return `${localIpv4Host}:${port}`;
 }

--- a/shared/cli/src/runtime/monorepo-runner.test.ts
+++ b/shared/cli/src/runtime/monorepo-runner.test.ts
@@ -1,6 +1,5 @@
-import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { caddyDataDir } from '../config/shared-service-config.js';
+import { caddyRootCaPath } from '../config/shared-service-config.js';
 import { CaddyService } from '../services/definitions/caddy-service.js';
 import * as docker from '../services/docker.js';
 import { startSharedServices } from '../services/shared-services.js';
@@ -44,7 +43,7 @@ describe('monorepo runner', () => {
         expect(playwrightRun).toBeDefined();
         expect(playwrightRun?.[2].env).toMatchObject({
             DB_PORT: '55103',
-            NODE_EXTRA_CA_CERTS: path.join(caddyDataDir(), 'pki/authorities/local/root.crt'),
+            NODE_EXTRA_CA_CERTS: caddyRootCaPath(),
         });
     });
 });

--- a/shared/cli/src/runtime/monorepo-runner.ts
+++ b/shared/cli/src/runtime/monorepo-runner.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { caddyDataDir, localIpv4Host, localhostPortMappingDynamic, mysqlImage, mysqlInternalPort, mysqlRootPassword, mysqlRootUser, mysqlServerArgs } from '../config/shared-service-config.js';
+import { caddyRootCaPath, localIpv4Host, localhostPortMappingDynamic, mysqlImage, mysqlInternalPort, mysqlRootPassword, mysqlRootUser, mysqlServerArgs } from '../config/shared-service-config.js';
 import type { CliContext } from '../context/create-context.js';
 import { buildBackendEnv } from '../config/build-config.js';
 import { CaddyService } from '../services/definitions/caddy-service.js';
@@ -35,7 +35,6 @@ const testMysqlContainer = 'stamhoofd-test-mysql';
 const e2eMysqlContainer = 'stamhoofd-e2e-mysql';
 const e2eMysqlDataVolume = 'stamhoofd-e2e-mysql-data';
 const sharedBuildReadyFile = `.development/cli/generated/shared-build-${process.pid}.ready`;
-const caddyRootCaPath = path.join(caddyDataDir(), 'pki/authorities/local/root.crt');
 
 export async function buildShared(context: CliContext): Promise<void> {
     console.log('\x1B[35m[BUILD]\x1B[0m Building globally shared dependencies...');
@@ -85,7 +84,7 @@ export async function testE2e(context: CliContext, options: { ci: boolean; clear
         await startSharedServices(context);
         shouldRestoreCaddy = true;
         await run('yarn', ['--cwd', 'backend/app/api', '-s', 'build:playwright:pre'], { cwd: context.rootDir, env: { DB_PORT: dbPort }, verbose: context.verbose });
-        await run('yarn', ['--cwd', 'tests/playwright', '-s', 'test', ...(options.ui ? ['--ui'] : []), ...(options.workers === undefined ? [] : ['--workers', String(options.workers)])], { cwd: context.rootDir, env: { NX_DAEMON: 'false', CI: options.ci ? 'true' : undefined, DB_PORT: dbPort, NODE_EXTRA_CA_CERTS: caddyRootCaPath, PLAYWRIGHT_INCLUDE_EXTRA: options.extra ? '1' : undefined, PLAYWRIGHT_WORKER_COUNT: options.workers === undefined ? undefined : String(options.workers) }, verbose: context.verbose });
+        await run('yarn', ['--cwd', 'tests/playwright', '-s', 'test', ...(options.ui ? ['--ui'] : []), ...(options.workers === undefined ? [] : ['--workers', String(options.workers)])], { cwd: context.rootDir, env: { NX_DAEMON: 'false', CI: options.ci ? 'true' : undefined, DB_PORT: dbPort, NODE_EXTRA_CA_CERTS: caddyRootCaPath(), PLAYWRIGHT_INCLUDE_EXTRA: options.extra ? '1' : undefined, PLAYWRIGHT_WORKER_COUNT: options.workers === undefined ? undefined : String(options.workers) }, verbose: context.verbose });
     }
     finally {
         if (shouldRestoreCaddy) {

--- a/shared/cli/src/workflows/setup-machine.ts
+++ b/shared/cli/src/workflows/setup-machine.ts
@@ -4,7 +4,7 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { writeSetupCaddyConfig } from '../config/caddy-config.js';
-import { caddyContainer, caddyDataDir, caddyHttpPort, caddyHttpsPort, caddySetupAdminPort, defaultDomain, localIpv4Host, localhostPort } from '../config/shared-service-config.js';
+import { caddyContainer, caddyDataDir, caddyHttpPort, caddyHttpsPort, caddyRootCaPath, caddySetupAdminPort, defaultDomain, localIpv4Host, localhostPort } from '../config/shared-service-config.js';
 import { buildSharedServiceProfile, SharedServiceDnsSetupKind } from '../config/shared-service-profile.js';
 import type { SharedServiceProfile } from '../config/shared-service-profile.js';
 import type { CliContext } from '../context/create-context.js';
@@ -447,7 +447,7 @@ async function dnsConfigurationCheck(domain: string, profile: SharedServiceProfi
 }
 
 async function certCheck(): Promise<CheckResult> {
-    const certPath = path.join(caddyDataDir(), 'pki/authorities/local/root.crt');
+    const certPath = caddyRootCaPath();
     try {
         await fs.access(certPath);
         return { ok: true, details: certPath };


### PR DESCRIPTION
S3 urls use virtual host paths and caddy doesn't have *.files.stamhoofd added. This was in a previous version added, but got not fully included when making slight changes to some of the caddy routing setup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784389088&installation_id=138085646&pr_number=495&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F495&signature=7b1b2bb641408f681516b0ef2b518ecdc65155e551b749f994b82e146c488f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->