### PR TITLE
showStockBelow was not replaced due to extra space in translations

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/EditProductView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/EditProductView.vue
@@ -345,7 +345,7 @@
                         </h3>
 
                         <p v-if="useShowStockBelow" class="style-description-small">
-                            {{ $t('%1H3', { showStockBelow: showStockBelow! }) }}
+                            {{ $t('Stamhoofd zal de beschikbare voorraad verbergen als er nog meer dan {showStockBelow} stuks beschikbaar zijn.', { showStockBelow: showStockBelow! }) }}
                         </p>
 
                         <div v-if="useShowStockBelow" class="split-inputs option" @click.stop.prevent>
@@ -448,8 +448,6 @@ import { useSetUitpasEvent } from '@stamhoofd/components/uitpas/useSetUitpasEven
 import { computed, onBeforeUnmount, onMounted } from 'vue';
 
 import WebshopFieldsBox from '../fields/WebshopFieldsBox.vue';
-
-
 
 import OptionMenuSection from './OptionMenuSection.vue';
 import ProductPriceBox from './ProductPriceBox.vue';
@@ -882,15 +880,15 @@ function addOptionMenu() {
     p.optionMenus.addPut(optionMenu);
 
     present(AsyncComponent(() => import('./EditOptionMenuView.vue'), {
-            product: patchedProduct.value.patch(p),
-            optionMenu,
-            isNew: true,
-            saveHandler: (patch: AutoEncoderPatchType<Product>) => {
-                // Merge both patches
-                addProductPatch(p.patch(patch));
-                // TODO: if webshop is saveable: also save it. But maybe that should not happen here but in a special type of emit?
-            },
-        }).setDisplayStyle('popup'))
+        product: patchedProduct.value.patch(p),
+        optionMenu,
+        isNew: true,
+        saveHandler: (patch: AutoEncoderPatchType<Product>) => {
+            // Merge both patches
+            addProductPatch(p.patch(patch));
+            // TODO: if webshop is saveable: also save it. But maybe that should not happen here but in a special type of emit?
+        },
+    }).setDisplayStyle('popup'))
         .catch(console.error);
 }
 


### PR DESCRIPTION
fix voor dit:
<img width="759" height="308" alt="Screenshot 2026-06-18 at 17 42 08" src="https://github.com/user-attachments/assets/ac5a5a47-0266-4fce-bb89-d3d786a4ae5c" />


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784389302&installation_id=138085646&pr_number=496&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F496&signature=e2445de3ba4c8c5056d006c15b7326d05fc043693c039a1bf4deb5b4b6c0547b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->