### PR TITLE
🐛 .st-menu-item.right disable text wrap (STA-1121)

### DIFF
--- a/frontend/shared/scss/layout/st-menu-modern.scss
+++ b/frontend/shared/scss/layout/st-menu-modern.scss
@@ -7,7 +7,7 @@
     @media (min-width: 300px) {
         --st-horizontal-padding: 18px;
     }
-    
+
     > main {
         --left-offset: 0px;
         --item-padding: 10px;
@@ -25,7 +25,7 @@
             }
         }
 
-        
+
 
         .footer {
             margin-top: auto;
@@ -148,6 +148,7 @@
                 font-size: 11px;
                 color: $color-gray-4;
                 font-weight: 500;
+                text-wrap: nowrap;
             }
         }
 
@@ -166,7 +167,7 @@
             font-weight: 500;
             min-width: 0;
             flex-shrink: 100;
-            
+
             > span {
                 min-width: 0;
                 overflow: hidden;


### PR DESCRIPTION
Fixes STA-1121

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784389778&installation_id=138085646&pr_number=497&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F497&signature=c22c57bbc9a9c18f86c35f72880964ec9a8ee9df368bdbcc8f487dd7f163c327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->