### PR TITLE
🐛 fix event groups not being able to be created in org mode

### DIFF
--- a/backend/app/api/src/endpoints/global/events/PatchEventsEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/events/PatchEventsEndpoint.ts
@@ -34,8 +34,18 @@ export class PatchEventsEndpoint extends Endpoint<Params, Query, Body, ResponseB
         return [false];
     }
 
-    async putEventGroup(event: Event, putGroup: GroupStruct) {
-        const period = await RegistrationPeriod.getByDate(event.startDate, event.organizationId);
+    async putEventGroup(putEvent: Event, putGroup: GroupStruct) {
+        const event = await Event.getByID(putEvent.id);
+        if (!event) {
+            throw new SimpleError({
+                code: 'invalid_event',
+                message: 'Event does not exist',
+                human: Context.i18n.$t('%DU'),
+                field: 'id',
+            });
+        }
+
+        const period = await RegistrationPeriod.getByDate(putEvent.startDate, event.organizationId);
 
         if (!period) {
             throw new SimpleError({


### PR DESCRIPTION
When creating an event, you couldn't create its group because the frontend is not sending `event.organizationId`. Let's just get the event to validate it exists and then use that onwards. We're not using the event information besides the ID.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784394225&installation_id=138085646&pr_number=498&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F498&signature=378454f90964d8b5ef007190a833e20ffe400dc4d9e195538825d9b1b8412d13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->