### PR TITLE
🐛️ end/close global database after migrations

### DIFF
--- a/backend/app/api/src/migrate.ts
+++ b/backend/app/api/src/migrate.ts
@@ -8,10 +8,10 @@ Column.setJSONVersion(Version);
 process.env.TZ = 'UTC';
 
 // Polyfill require.resolve, since import.meta.resolve is not supported by vitest
-import { createRequire } from 'node:module';
-import { GlobalHelper } from './helpers/GlobalHelper.js';
 import { I18n } from '@stamhoofd/backend-i18n/I18n';
 import { QueryableModel } from '@stamhoofd/sql';
+import { createRequire } from 'node:module';
+import { GlobalHelper } from './helpers/GlobalHelper.js';
 const require = createRequire(import.meta.url);
 
 const emailPath = require.resolve('@stamhoofd/email');
@@ -50,34 +50,37 @@ const start = async () => {
         database: null,
     });
 
-    await globalDatabase.statement(query);
+    try {
+        await globalDatabase.statement(query);
 
-    // External migrations
-    if (!await Migration.runAll(path.dirname(modelsPath) + '/migrations')) {
-        throw new Error('Migrations failed');
+        // External migrations
+        if (!await Migration.runAll(path.dirname(modelsPath) + '/migrations')) {
+            throw new Error('Migrations failed');
+        }
+        if (!await Migration.runAll(path.dirname(emailPath) + '/../migrations')) {
+            throw new Error('Email migrations failed');
+        }
+
+        // Internal
+        await I18n.load();
+        GlobalHelper.loadGlobalTranslateFunction();
+
+        if (!await Migration.runAll(import.meta.dirname + '/migrations')) {
+            throw new Error('Internal migrations failed');
+        }
+
+        if (killSignalReceived) {
+            console.error(chalk.red('Killing process due to received signal during migration'));
+            process.exit(1);
+        }
+
+        // Reload database to prevent connection state leakage
+        await Database.reload({});
+    } finally {
+        await globalDatabase.end();
+        process.off('SIGTERM', handler);
+        process.off('SIGINT', handler);
     }
-    if (!await Migration.runAll(path.dirname(emailPath) + '/../migrations')) {
-        throw new Error('Email migrations failed');
-    }
-
-    // Internal
-    await I18n.load();
-    GlobalHelper.loadGlobalTranslateFunction();
-
-    if (!await Migration.runAll(import.meta.dirname + '/migrations')) {
-        throw new Error('Internal migrations failed');
-    }
-
-    if (killSignalReceived) {
-        console.error(chalk.red('Killing process due to received signal during migration'));
-        process.exit(1);
-    }
-
-    // Reload database to prevent connection state leakage
-    await Database.reload({});
-
-    process.off('SIGTERM', handler);
-    process.off('SIGINT', handler);
 };
 
 export async function run() {


### PR DESCRIPTION
Always run `await globalDatabase.end();` at the end of migrations. `vitest` would be prevented from exiting and then time out after 10 seconds , adding a needless 10 seconds after running migrations in tests. This makes it so we always close the database. It just wraps it all in a try-finally and adds `globalDatabase.end()`.

Example of logs:
```
✓ src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts (5 tests) 1409ms
   ✓ Endpoint.PatchOrganizationRegistrationPeriods (5)
     ✓ userMode organization (5)
       ✓ should not be able to patch registration periods with global period 137ms
       ✓ should be able to patch registration periods 105ms
       ✓ should not be able to create registration periods with global period 94ms
       ✓ should be able to create registration periods 103ms
       ✓ should not be able to patch groups of other organization 127ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  15:42:31
   Duration  34.53s (transform 1.57s, setup 1.94s, import 59ms, tests 1.41s, environment 0ms)

close timed out after 10000ms
Tests closed successfully but something prevents Vite server from exiting
You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/guide/reporters.html#hanging-process-reporter

————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 Lerna (powered by Nx)   Successfully ran target test for project @stamhoofd/backend (45s)

      With additional flags:
        src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts 
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784712166&installation_id=138085646&pr_number=504&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F504&signature=354b0ce11c29e1332b34d199aeb0126b505d3d1b68ec70d90fca6579577932d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->