### PR TITLE
🔒️ clearer org scoping in endpoints

### DIFF
--- a/backend/app/api/src/endpoints/global/email-recipients/GetEmailRecipientsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/email-recipients/GetEmailRecipientsCountEndpoint.ts
@@ -36,6 +36,10 @@ export class GetEmailRecipientsCountEndpoint extends Endpoint<Params, Query, Bod
         }
         const query = await GetEmailRecipientsEndpoint.buildQuery(request.query);
 
+        if (organization) {
+            query.where('organizationId', organization.id);
+        }
+
         const count = await query
             .count();
 

--- a/backend/app/api/src/endpoints/global/email-recipients/GetEmailRecipientsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/email-recipients/GetEmailRecipientsEndpoint.test.ts
@@ -1,15 +1,17 @@
-import { STExpect, TestUtils } from '@stamhoofd/test-utils';
-import { GetEmailRecipientsEndpoint } from './GetEmailRecipientsEndpoint.js';
-import { AccessRight, EmailStatus, LimitedFilteredRequest, OrganizationEmail, PermissionLevel, Permissions, PermissionsResourceType, ResourcePermissions } from '@stamhoofd/structures';
+import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, RegistrationPeriod, User } from '@stamhoofd/models';
 import { Email, EmailRecipient, OrganizationFactory, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
-import { Request } from '@simonbackx/simple-endpoints';
+import { AccessRight, CountFilteredRequest, EmailStatus, LimitedFilteredRequest, OrganizationEmail, PermissionLevel, Permissions, PermissionsResourceType, ResourcePermissions } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { GetEmailRecipientsCountEndpoint } from './GetEmailRecipientsCountEndpoint.js';
+import { GetEmailRecipientsEndpoint } from './GetEmailRecipientsEndpoint.js';
 
 const baseUrl = `/email-recipients`;
 
 describe('Endpoint.GetEmailRecipients', () => {
     const endpoint = new GetEmailRecipientsEndpoint();
+    const countEndpoint = new GetEmailRecipientsCountEndpoint();
     let period: RegistrationPeriod;
     let organization: Organization;
     let token: Token;
@@ -111,6 +113,57 @@ describe('Endpoint.GetEmailRecipients', () => {
         expect(result.body.results[0]).toMatchObject({
             id: emailRecipient.id,
         });
+    });
+
+    test('It only counts email recipients of the scoped organization', async () => {
+        const otherOrganization = await new OrganizationFactory({ period }).create();
+        const email = new Email();
+        email.subject = 'test subject';
+        email.status = EmailStatus.Draft;
+        email.text = 'test email';
+        email.html = `<p style="margin: 0; padding: 0; line-height: 1.4;">test email</p>`;
+        email.json = {};
+        email.organizationId = organization.id;
+        email.senderId = sender.id;
+        await email.save();
+
+        const otherEmail = new Email();
+        otherEmail.subject = 'test subject';
+        otherEmail.status = EmailStatus.Draft;
+        otherEmail.text = 'test email';
+        otherEmail.html = `<p style="margin: 0; padding: 0; line-height: 1.4;">test email</p>`;
+        otherEmail.json = {};
+        otherEmail.organizationId = otherOrganization.id;
+        await otherEmail.save();
+
+        const emailRecipient = new EmailRecipient();
+        emailRecipient.email = 'jan.janssens@geenemail.com';
+        emailRecipient.firstName = 'Jan';
+        emailRecipient.lastName = 'Janssens';
+        emailRecipient.emailId = email.id;
+        emailRecipient.organizationId = organization.id;
+        await emailRecipient.save();
+
+        const otherEmailRecipient = new EmailRecipient();
+        otherEmailRecipient.email = 'piet.peeters@geenemail.com';
+        otherEmailRecipient.firstName = 'Piet';
+        otherEmailRecipient.lastName = 'Peeters';
+        otherEmailRecipient.emailId = otherEmail.id;
+        otherEmailRecipient.organizationId = otherOrganization.id;
+        await otherEmailRecipient.save();
+
+        const request = Request.get({
+            path: baseUrl + '/count',
+            host: organization.getApiHost(),
+            query: new CountFilteredRequest({
+                filter: {},
+            }),
+            headers: {
+                authorization: 'Bearer ' + token.accessToken,
+            },
+        });
+        const result = await testServer.test(countEndpoint, request);
+        expect(result.body.count).toBe(1);
     });
 
     test('It can not request all email recipients if not read permission for all senders', async () => {

--- a/backend/app/api/src/endpoints/global/email-recipients/GetEmailRecipientsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/email-recipients/GetEmailRecipientsEndpoint.test.ts
@@ -78,6 +78,11 @@ describe('Endpoint.GetEmailRecipients', () => {
         token2 = await Token.createToken(user2);
     });
 
+    beforeEach(async () => {
+        await EmailRecipient.delete();
+        await Email.delete();
+    });
+
     test('It can request all email recipients if read permission for all senders', async () => {
         const email = new Email();
         email.subject = 'test subject';

--- a/backend/app/api/src/endpoints/global/events/GetEventNotificationsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/events/GetEventNotificationsCountEndpoint.ts
@@ -28,9 +28,13 @@ export class GetEventNotificationsCountEndpoint extends Endpoint<Params, Query, 
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOptionalOrganizationScope();
+        const organization = await Context.setOptionalOrganizationScope();
         await Context.authenticate();
         const query = await GetEventNotificationsEndpoint.buildQuery(request.query);
+
+        if (organization) {
+            query.where('organizationId', organization.id);
+        }
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/global/groups/GetGroupsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/groups/GetGroupsCountEndpoint.ts
@@ -39,6 +39,10 @@ export class GetGroupsCountEndpoint extends Endpoint<Params, Query, Body, Respon
 
         const query = await GetGroupsEndpoint.buildQuery(request.query);
 
+        if (organization) {
+            query.where('organizationId', organization.id);
+        }
+
         const count = await query
             .count();
 

--- a/backend/app/api/src/endpoints/global/members/GetMembersCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersCountEndpoint.ts
@@ -28,9 +28,13 @@ export class GetMembersCountEndpoint extends Endpoint<Params, Query, Body, Respo
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOptionalOrganizationScope();
+        const organization = await Context.setOptionalOrganizationScope();
         await Context.authenticate();
         const query = await GetMembersEndpoint.buildQuery(request.query);
+
+        if (organization && STAMHOOFD.userMode === 'organization') {
+            query.where('organizationId', organization.id);
+        }
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/global/registration-invitations/GetRegistrationInvitationsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration-invitations/GetRegistrationInvitationsCountEndpoint.ts
@@ -28,10 +28,14 @@ export class GetRegistrationInvitationsCountEndpoint extends Endpoint<Params, Qu
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOptionalOrganizationScope();
+        const organization = await Context.setOptionalOrganizationScope();
         await Context.authenticate();
 
         const query = await GetRegistrationInvitationsEndpoint.buildQuery(request.query);
+
+        if (organization) {
+            query.where('organizationId', organization.id);
+        }
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/global/registration-periods/GetRegistrationPeriodsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration-periods/GetRegistrationPeriodsCountEndpoint.ts
@@ -28,8 +28,12 @@ export class GetRegistrationPeriodsCountEndpoint extends Endpoint<Params, Query,
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setUserOrganizationScope();
+        const organization = await Context.setUserOrganizationScope();
         const query = await GetRegistrationPeriodsEndpoint.buildQuery(request.query);
+
+        if (organization) {
+            query.where('organizationId', organization.id);
+        }
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/global/webshops/GetWebshopsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/webshops/GetWebshopsCountEndpoint.ts
@@ -28,10 +28,15 @@ export class GetWebshopsCountEndpoint extends Endpoint<Params, Query, Body, Resp
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOptionalOrganizationScope();
+        const organization = await Context.setOptionalOrganizationScope();
         await Context.authenticate();
 
         const query = await GetWebshopsEndpoint.buildQuery(request.query);
+
+        if (organization) {
+            query.where('organizationId', organization.id);
+        }
+
         const count = await query.count();
 
         return new Response(

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemEndpoint.test.ts
@@ -1,13 +1,15 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import { BalanceItemFactory, OrganizationFactory, Token, UserFactory } from '@stamhoofd/models';
-import { PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { CountFilteredRequest, PermissionLevel, Permissions } from '@stamhoofd/structures';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
 import { GetBalanceItemEndpoint } from './GetBalanceItemEndpoint.js';
+import { GetBalanceItemsCountEndpoint } from './GetBalanceItemsCountEndpoint.js';
 
 describe('Endpoint.GetBalanceItemEndpoint', () => {
     const endpoint = new GetBalanceItemEndpoint();
+    const countEndpoint = new GetBalanceItemsCountEndpoint();
 
     beforeEach(() => {
         TestUtils.setEnvironment('userMode', 'platform');
@@ -32,5 +34,41 @@ describe('Endpoint.GetBalanceItemEndpoint', () => {
         request.headers.authorization = 'Bearer ' + token.accessToken;
 
         await expect(testServer.test(endpoint, request)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+
+    test('should only count balance items from the scoped organization', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+        await new BalanceItemFactory({
+            organizationId: organization.id,
+            userId: user.id,
+            amount: 1,
+            unitPrice: 100,
+        }).create();
+        await new BalanceItemFactory({
+            organizationId: otherOrganization.id,
+            userId: user.id,
+            amount: 1,
+            unitPrice: 100,
+        }).create();
+
+        const request = Request.get({
+            path: '/balance-items/count',
+            host: organization.getApiHost(),
+            query: new CountFilteredRequest({
+                filter: {},
+            }),
+            headers: {
+                authorization: 'Bearer ' + token.accessToken,
+            },
+        });
+
+        const result = await testServer.test(countEndpoint, request);
+        expect(result.body.count).toBe(1);
     });
 });

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemEndpoint.test.ts
@@ -1,0 +1,36 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import { BalanceItemFactory, OrganizationFactory, Token, UserFactory } from '@stamhoofd/models';
+import { PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { GetBalanceItemEndpoint } from './GetBalanceItemEndpoint.js';
+
+describe('Endpoint.GetBalanceItemEndpoint', () => {
+    const endpoint = new GetBalanceItemEndpoint();
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    test('should not get a balance item from another organization', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: otherOrganization.id,
+            userId: user.id,
+            amount: 1,
+            unitPrice: 100,
+        }).create();
+
+        const request = Request.buildJson('GET', '/balance-items/' + balanceItem.id, organization.getApiHost());
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(endpoint, request)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemEndpoint.ts
@@ -34,7 +34,10 @@ export class GetBalanceItemEndpoint extends Endpoint<Params, Query, Body, Respon
             throw Context.auth.error();
         }
 
-        const balanceItem = await BalanceItem.getByID(request.params.id);
+        const balanceItem = await BalanceItem.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
 
         if (!balanceItem || balanceItem.organizationId !== organization.id) {
             throw new SimpleError({

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemsCountEndpoint.ts
@@ -28,9 +28,11 @@ export class GetBalanceItemsCountEndpoint extends Endpoint<Params, Query, Body, 
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOrganizationScope();
+        const organization = await Context.setOrganizationScope();
         await Context.authenticate();
         const query = await GetBalanceItemsEndpoint.buildQuery(request.query);
+
+        query.where('organizationId', organization.id);
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/PatchBalanceItemsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/PatchBalanceItemsEndpoint.ts
@@ -121,7 +121,10 @@ export class PatchBalanceItemsEndpoint extends Endpoint<Params, Query, Body, Res
 
             for (const patch of request.body.getPatches()) {
                 // Create a new balance item
-                const model = await BalanceItem.getByID(patch.id);
+                const model = await BalanceItem.select()
+                    .where('id', patch.id)
+                    .where('organizationId', organization.id)
+                    .first(false);
                 if (!model || !(await Context.auth.canAccessBalanceItems([model], PermissionLevel.Write))) {
                     throw new SimpleError({
                         code: 'invalid_field',

--- a/backend/app/api/src/endpoints/organization/dashboard/documents/GetDocumentTemplateXML.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/documents/GetDocumentTemplateXML.ts
@@ -36,7 +36,10 @@ export class GetDocumentTemplateXMLEndpoint extends Endpoint<Params, Query, Body
             throw Context.auth.error();
         }
 
-        const template = await DocumentTemplate.getByID(request.params.id);
+        const template = await DocumentTemplate.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!template || !await Context.auth.canAccessDocumentTemplate(template)) {
             throw Context.auth.notFoundOrNoAccess($t(`%EK`));
         }

--- a/backend/app/api/src/endpoints/organization/dashboard/documents/GetDocumentTemplatesCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/documents/GetDocumentTemplatesCountEndpoint.ts
@@ -37,6 +37,8 @@ export class GetDocumentTemplatesCountEndpoint extends Endpoint<Params, Query, B
 
         const query = await GetDocumentTemplatesEndpoint.buildQuery(request.query);
 
+        query.where('organizationId', organization.id);
+
         const count = await query
             .count();
 

--- a/backend/app/api/src/endpoints/organization/dashboard/documents/GetDocumentsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/documents/GetDocumentsCountEndpoint.ts
@@ -38,6 +38,8 @@ export class GetDocumentsCountEndpoint extends Endpoint<Params, Query, Body, Res
 
         const query = await GetDocumentsEndpoint.buildQuery(request.query);
 
+        query.where('organizationId', organization.id);
+
         const count = await query
             .count();
 

--- a/backend/app/api/src/endpoints/organization/dashboard/documents/PatchDocumentEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/documents/PatchDocumentEndpoint.ts
@@ -40,7 +40,10 @@ export class PatchDocumentEndpoint extends Endpoint<Params, Query, Body, Respons
         const updatedDocuments: DocumentStruct[] = [];
 
         for (const patch of request.body.getPatches()) {
-            const document = await Document.getByID(patch.id);
+            const document = await Document.select()
+                .where('id', patch.id)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!document || !(await Context.auth.canAccessDocument(document, PermissionLevel.Write))) {
                 throw Context.auth.notFoundOrNoAccess($t(`%EK`));
             }
@@ -83,7 +86,10 @@ export class PatchDocumentEndpoint extends Endpoint<Params, Query, Body, Respons
 
         for (const { put } of request.body.getPuts()) {
             // Create a new document
-            const template = await DocumentTemplate.getByID(put.templateId);
+            const template = await DocumentTemplate.select()
+                .where('id', put.templateId)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!template || !await Context.auth.canAccessDocumentTemplate(template, PermissionLevel.Write)) {
                 throw new SimpleError({
                     code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/dashboard/documents/PatchDocumentTemplatesEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/documents/PatchDocumentTemplatesEndpoint.test.ts
@@ -99,6 +99,29 @@ describe('Endpoint.PatchDocumentTemplatesEndpoint', () => {
     });
 
     describe('patch fiscal document', () => {
+        it('should not patch a document template from another organization', async () => {
+            const otherOrganization = await new OrganizationFactory({ period }).create();
+            const template = await new DocumentTemplateFactory({
+                organizationId: otherOrganization.id,
+                type: 'participation',
+                groups: [],
+                year: 2022,
+            }).create();
+
+            const arr: Body = new PatchableArray();
+            arr.addPatch(DocumentTemplatePrivate.patch({
+                id: template.id,
+                status: DocumentStatus.Published,
+            }));
+
+            const request = Request.buildJson('PATCH', baseUrl, organization.getApiHost(), arr);
+            request.headers.authorization = 'Bearer ' + token.accessToken;
+
+            await expect(testServer.test(endpoint, request))
+                .rejects
+                .toThrow(STExpect.errorWithCode('not_found'));
+        });
+
         describe('change type to fiscal', () => {
             it('should throw if already has fiscal document in year', async () => {
                 // create existing fiscal document in same year

--- a/backend/app/api/src/endpoints/organization/dashboard/documents/PatchDocumentTemplatesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/documents/PatchDocumentTemplatesEndpoint.ts
@@ -67,7 +67,10 @@ export class PatchDocumentTemplatesEndpoint extends Endpoint<Params, Query, Body
         }
 
         for (const patch of request.body.getPatches()) {
-            const template = await DocumentTemplate.getByID(patch.id);
+            const template = await DocumentTemplate.select()
+                .where('id', patch.id)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!template || !await Context.auth.canAccessDocumentTemplate(template, PermissionLevel.Full)) {
                 throw Context.auth.notFoundOrNoAccess($t(`%EP`));
             }
@@ -121,7 +124,10 @@ export class PatchDocumentTemplatesEndpoint extends Endpoint<Params, Query, Body
         }
 
         for (const id of request.body.getDeletes()) {
-            const template = await DocumentTemplate.getByID(id);
+            const template = await DocumentTemplate.select()
+                .where('id', id)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!template || !await Context.auth.canAccessDocumentTemplate(template, PermissionLevel.Full)) {
                 throw new SimpleError({
                     code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.test.ts
@@ -2,9 +2,9 @@ import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray } from '@simonbackx/simple-encoding';
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, RegistrationPeriod } from '@stamhoofd/models';
-import { EmailTemplate, GroupFactory, OrganizationFactory, Platform, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
+import { EmailTemplate, EmailTemplateFactory, GroupFactory, OrganizationFactory, Platform, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
 import { EmailTemplate as EmailTemplateStruct, EmailTemplateType, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions, Version } from '@stamhoofd/structures';
-import { TestUtils } from '@stamhoofd/test-utils';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
 import { PatchEmailTemplatesEndpoint } from './PatchEmailTemplatesEndpoint.js';
 
@@ -86,5 +86,27 @@ describe('Endpoint.PatchEmailTemplatesEndpoint', () => {
             const response = await patchEmailTemplates(body, token);
             expect(response.body).toBeDefined();
         });
+    });
+
+    test('should not patch a template from another organization', async () => {
+        const organization = await new OrganizationFactory({ period }).create();
+        const otherOrganization = await new OrganizationFactory({ period }).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+        const template = await new EmailTemplateFactory({
+            organization: otherOrganization,
+            type: EmailTemplateType.RegistrationConfirmation,
+        }).create();
+
+        const body: PatchableArrayAutoEncoder<EmailTemplateStruct> = new PatchableArray();
+        body.addPatch(EmailTemplateStruct.patch({
+            id: template.id,
+            subject: 'new subject',
+        }));
+
+        await expect(patchEmailTemplates(body, token, organization)).rejects.toThrow(STExpect.errorWithCode('not_found'));
     });
 });

--- a/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.ts
@@ -42,7 +42,12 @@ export class PatchEmailTemplatesEndpoint extends Endpoint<Params, Query, Body, R
 
         // Get all patches
         for (const patch of request.body.getPatches()) {
-            const template = await EmailTemplate.getByID(patch.id);
+            const template = organization
+                ? await EmailTemplate.select()
+                    .where('id', patch.id)
+                    .where('organizationId', organization.id)
+                    .first(false)
+                : await EmailTemplate.getByID(patch.id);
             if (!template || !(await Context.auth.canAccessEmailTemplate(template, PermissionLevel.Write))) {
                 throw Context.auth.notFoundOrNoAccess($t(`%ES`));
             }
@@ -75,7 +80,12 @@ export class PatchEmailTemplatesEndpoint extends Endpoint<Params, Query, Body, R
             template.groupId = struct.groupId;
 
             if (struct.groupId) {
-                const group = await Group.getByID(struct.groupId);
+                const group = organization
+                    ? await Group.select()
+                        .where('id', struct.groupId)
+                        .where('organizationId', organization.id)
+                        .first(false)
+                    : await Group.getByID(struct.groupId);
                 if (!group || !await Context.auth.canAccessGroup(group, PermissionLevel.Full)) {
                     throw Context.auth.error();
                 }
@@ -83,7 +93,12 @@ export class PatchEmailTemplatesEndpoint extends Endpoint<Params, Query, Body, R
             }
 
             if (struct.webshopId) {
-                const webshop = await Webshop.getByID(struct.webshopId);
+                const webshop = organization
+                    ? await Webshop.select()
+                        .where('id', struct.webshopId)
+                        .where('organizationId', organization.id)
+                        .first(false)
+                    : await Webshop.getByID(struct.webshopId);
                 if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Full)) {
                     throw Context.auth.error();
                 }
@@ -108,7 +123,12 @@ export class PatchEmailTemplatesEndpoint extends Endpoint<Params, Query, Body, R
         }
 
         for (const id of request.body.getDeletes()) {
-            const template = await EmailTemplate.getByID(id);
+            const template = organization
+                ? await EmailTemplate.select()
+                    .where('id', id)
+                    .where('organizationId', organization.id)
+                    .first(false)
+                : await EmailTemplate.getByID(id);
             if (!template || !(await Context.auth.canAccessEmailTemplate(template, PermissionLevel.Write))) {
                 throw Context.auth.notFoundOrNoAccess($t(`%EU`));
             }

--- a/backend/app/api/src/endpoints/organization/dashboard/invoices/GetInvoicesCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/invoices/GetInvoicesCountEndpoint.ts
@@ -28,9 +28,11 @@ export class GetInvoicesCountEndpoint extends Endpoint<Params, Query, Body, Resp
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOrganizationScope();
+        const organization = await Context.setOrganizationScope();
         await Context.authenticate();
         const query = await GetInvoicesEndpoint.buildQuery(request.query);
+
+        query.where('organizationId', organization.id);
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/organization/dashboard/organization/PatchOrganizationEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/organization/PatchOrganizationEndpoint.test.ts
@@ -1,7 +1,7 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, User, Webshop } from '@stamhoofd/models';
-import { GroupFactory, OrganizationFactory, OrganizationRegistrationPeriod, RegistrationPeriodFactory, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
-import { AccessRight, MemberResponsibility, OrganizationPrivateMetaData, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, Organization as OrganizationStruct, PermissionLevel, PermissionRoleDetailed, PermissionRoleForResponsibility, Permissions, PermissionsResourceType, ResourcePermissions, Version } from '@stamhoofd/structures';
+import { GroupFactory, OrganizationFactory, OrganizationRegistrationPeriod, RegistrationPeriodFactory, StripeAccount, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
+import { AccessRight, MemberResponsibility, OrganizationPrivateMetaData, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, Organization as OrganizationStruct, PermissionLevel, PermissionRoleDetailed, PermissionRoleForResponsibility, Permissions, PermissionsResourceType, PrivatePaymentConfiguration, ResourcePermissions, Version } from '@stamhoofd/structures';
 
 import type { AutoEncoderPatchType, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray, PatchMap } from '@simonbackx/simple-encoding';
@@ -44,6 +44,35 @@ describe('Endpoint.PatchOrganization', () => {
 
         expect(response.body.id).toEqual(organization.id);
         expect(response.body.name).toEqual('My crazy name');
+    });
+
+    test('should not set registration stripe account from another organization', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({ organization, permissions: Permissions.create({ level: PermissionLevel.Full }) }).create();
+        const token = await Token.createToken(user);
+        const account = new StripeAccount();
+        account.organizationId = otherOrganization.id;
+        account.accountId = 'acct_test';
+        await account.save();
+
+        await expect(patchOrganization({
+            organization,
+            token,
+            patch: OrganizationStruct.patch({
+                id: organization.id,
+                privateMeta: OrganizationPrivateMetaData.patch({
+                    registrationPaymentConfiguration: PrivatePaymentConfiguration.patch({
+                        stripeAccountId: account.id,
+                    }),
+                }),
+            }),
+        })).rejects.toThrow(STExpect.simpleError(
+            {
+                code: 'invalid_field',
+                field: 'registrationPaymentConfiguration.stripeAccountId',
+            },
+        ));
     });
 
     test("Can't change organization as a normal user", async () => {

--- a/backend/app/api/src/endpoints/organization/dashboard/organization/PatchOrganizationEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/organization/PatchOrganizationEndpoint.ts
@@ -242,7 +242,10 @@ export class PatchOrganizationEndpoint extends Endpoint<Params, Query, Body, Res
 
                 if (request.body.privateMeta.registrationPaymentConfiguration?.stripeAccountId !== undefined) {
                     if (request.body.privateMeta.registrationPaymentConfiguration.stripeAccountId !== null) {
-                        const account = await StripeAccount.getByID(request.body.privateMeta.registrationPaymentConfiguration.stripeAccountId);
+                        const account = await StripeAccount.select()
+                            .where('id', request.body.privateMeta.registrationPaymentConfiguration.stripeAccountId)
+                            .where('organizationId', organization.id)
+                            .first(false);
                         if (!account || account.organizationId !== organization.id) {
                             throw new SimpleError({
                                 code: 'invalid_field',
@@ -292,9 +295,12 @@ export class PatchOrganizationEndpoint extends Endpoint<Params, Query, Body, Res
 
                     // check payconiq + mollie
                     if (!organization.privateMeta.mollieOnboarding || !organization.privateMeta.mollieOnboarding.canReceivePayments) {
-                        let stripe: StripeAccount | undefined = undefined;
+                        let stripe: StripeAccount | null = null;
                         if (organization.privateMeta.registrationPaymentConfiguration.stripeAccountId) {
-                            stripe = await StripeAccount.getByID(organization.privateMeta.registrationPaymentConfiguration.stripeAccountId);
+                            stripe = await StripeAccount.select()
+                                .where('id', organization.privateMeta.registrationPaymentConfiguration.stripeAccountId)
+                                .where('organizationId', organization.id)
+                                .first(false);
                         }
 
                         const i = organization.meta.paymentMethods.findIndex((p) => {
@@ -397,7 +403,10 @@ export class PatchOrganizationEndpoint extends Endpoint<Params, Query, Body, Res
             }
 
             if (request.body.period) {
-                const organizationPeriod = await OrganizationRegistrationPeriod.getByID(request.body.period.id);
+                const organizationPeriod = await OrganizationRegistrationPeriod.select()
+                    .where('id', request.body.period.id)
+                    .where('organizationId', organization.id)
+                    .first(false);
                 if (!organizationPeriod || organizationPeriod.organizationId !== organization.id) {
                     throw new SimpleError({
                         code: 'invalid_field',
@@ -606,7 +615,10 @@ export class PatchOrganizationEndpoint extends Endpoint<Params, Query, Body, Res
 
         // Only needed for permissions atm, so no put or delete here
         for (const struct of request.body.webshops.getPatches()) {
-            const model = await Webshop.getByID(struct.id);
+            const model = await Webshop.select()
+                .where('id', struct.id)
+                .where('organizationId', organization.id)
+                .first(false);
 
             if (!model || !await Context.auth.canAccessWebshop(model, PermissionLevel.Full)) {
                 errors.addError(

--- a/backend/app/api/src/endpoints/organization/dashboard/payments/GetPaymentsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/payments/GetPaymentsCountEndpoint.ts
@@ -28,9 +28,11 @@ export class GetPaymentsCountEndpoint extends Endpoint<Params, Query, Body, Resp
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOrganizationScope();
+        const organization = await Context.setOrganizationScope();
         await Context.authenticate();
         const query = await GetPaymentsEndpoint.buildQuery(request.query);
+
+        query.where('organizationId', organization.id);
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/organization/dashboard/payments/PatchPaymentsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/payments/PatchPaymentsEndpoint.test.ts
@@ -2,14 +2,16 @@ import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray } from '@simonbackx/simple-encoding';
 import { Request } from '@simonbackx/simple-endpoints';
 import { BalanceItemFactory, OrganizationFactory, Payment, Token, UserFactory } from '@stamhoofd/models';
-import { BalanceItemPaymentDetailed, PaymentGeneral, PaymentMethod, PaymentStatus, PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { BalanceItemPaymentDetailed, CountFilteredRequest, PaymentGeneral, PaymentMethod, PaymentStatus, PermissionLevel, Permissions } from '@stamhoofd/structures';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { GetPaymentsCountEndpoint } from './GetPaymentsCountEndpoint.js';
 import { PatchPaymentsEndpoint } from './PatchPaymentsEndpoint.js';
 
 describe('Endpoint.PatchPaymentsEndpoint', () => {
     const endpoint = new PatchPaymentsEndpoint();
+    const countEndpoint = new GetPaymentsCountEndpoint();
 
     beforeEach(() => {
         TestUtils.setEnvironment('userMode', 'platform');
@@ -41,6 +43,44 @@ describe('Endpoint.PatchPaymentsEndpoint', () => {
         request.headers.authorization = 'Bearer ' + token.accessToken;
 
         await expect(testServer.test(endpoint, request)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+
+    test('should only count payments from the scoped organization', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.method = PaymentMethod.Transfer;
+        payment.status = PaymentStatus.Created;
+        payment.price = 100;
+        await payment.save();
+
+        const otherPayment = new Payment();
+        otherPayment.organizationId = otherOrganization.id;
+        otherPayment.method = PaymentMethod.Transfer;
+        otherPayment.status = PaymentStatus.Created;
+        otherPayment.price = 100;
+        await otherPayment.save();
+
+        const request = Request.get({
+            path: '/payments/count',
+            host: organization.getApiHost(),
+            query: new CountFilteredRequest({
+                filter: {},
+            }),
+            headers: {
+                authorization: 'Bearer ' + token.accessToken,
+            },
+        });
+
+        const result = await testServer.test(countEndpoint, request);
+        expect(result.body.count).toBe(1);
     });
 
     test('should not create a payment for a balance item from another organization', async () => {

--- a/backend/app/api/src/endpoints/organization/dashboard/payments/PatchPaymentsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/payments/PatchPaymentsEndpoint.test.ts
@@ -1,0 +1,76 @@
+import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
+import { PatchableArray } from '@simonbackx/simple-encoding';
+import { Request } from '@simonbackx/simple-endpoints';
+import { BalanceItemFactory, OrganizationFactory, Payment, Token, UserFactory } from '@stamhoofd/models';
+import { BalanceItemPaymentDetailed, PaymentGeneral, PaymentMethod, PaymentStatus, PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { PatchPaymentsEndpoint } from './PatchPaymentsEndpoint.js';
+
+describe('Endpoint.PatchPaymentsEndpoint', () => {
+    const endpoint = new PatchPaymentsEndpoint();
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    test('should not patch a payment from another organization', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+
+        const payment = new Payment();
+        payment.organizationId = otherOrganization.id;
+        payment.method = PaymentMethod.Transfer;
+        payment.status = PaymentStatus.Created;
+        payment.price = 100;
+        await payment.save();
+
+        const body: PatchableArrayAutoEncoder<PaymentGeneral> = new PatchableArray();
+        body.addPatch(PaymentGeneral.patch({
+            id: payment.id,
+            paidAt: new Date(),
+        }));
+
+        const request = Request.buildJson('PATCH', '/organization/payments', organization.getApiHost(), body);
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(endpoint, request)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+
+    test('should not create a payment for a balance item from another organization', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: otherOrganization.id,
+            userId: user.id,
+            amount: 1,
+            unitPrice: 100,
+        }).create();
+
+        const body: PatchableArrayAutoEncoder<PaymentGeneral> = new PatchableArray();
+        body.addPut(PaymentGeneral.create({
+            method: PaymentMethod.Unknown,
+            status: PaymentStatus.Created,
+            balanceItemPayments: [BalanceItemPaymentDetailed.create({
+                price: 100,
+                balanceItem: balanceItem.getStructure(),
+            })],
+        }));
+
+        const request = Request.buildJson('PATCH', '/organization/payments', organization.getApiHost(), body);
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(endpoint, request)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/payments/PatchPaymentsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/payments/PatchPaymentsEndpoint.ts
@@ -140,7 +140,10 @@ export class PatchPaymentsEndpoint extends Endpoint<Params, Query, Body, Respons
             const balanceItemPayments: BalanceItemPayment[] = [];
 
             for (const item of put.balanceItemPayments) {
-                const balanceItem = await BalanceItem.getByID(item.balanceItem.id);
+                const balanceItem = await BalanceItem.select()
+                    .where('id', item.balanceItem.id)
+                    .where('organizationId', organization.id)
+                    .first(false);
                 if (!balanceItem || balanceItem.organizationId !== organization.id) {
                     throw Context.auth.notFoundOrNoAccess($t(`%Eq`));
                 }
@@ -245,7 +248,10 @@ export class PatchPaymentsEndpoint extends Endpoint<Params, Query, Body, Respons
         // Modify payments
         for (const patch of request.body.getPatches()) {
             await QueueHandler.schedule('payments/' + patch.id, async () => {
-                const payment = await Payment.getByID(patch.id);
+                const payment = await Payment.select()
+                    .where('id', patch.id)
+                    .where('organizationId', organization.id)
+                    .first(false);
                 if (!payment || !(await Context.auth.canAccessPayment(payment, PermissionLevel.Write))) {
                     throw new SimpleError({
                         code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/dashboard/receivable-balances/GetReceivableBalancesCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/receivable-balances/GetReceivableBalancesCountEndpoint.ts
@@ -28,9 +28,11 @@ export class GetReceivableBalancesCountEndpoint extends Endpoint<Params, Query, 
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOrganizationScope();
+        const organization = await Context.setOrganizationScope();
         await Context.authenticate();
         const query = await GetReceivableBalancesEndpoint.buildQuery(request.query);
+
+        query.where('organizationId', organization.id);
 
         const count = await query
             .count();

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts
@@ -91,6 +91,28 @@ describe('Endpoint.PatchOrganizationRegistrationPeriods', () => {
             expect(response.body).toBeDefined();
         });
 
+        test('should not patch organization registration period from another organization', async () => {
+            const organization = await new OrganizationFactory({ }).create();
+            const otherOrganization = await new OrganizationFactory({ }).create();
+            const period = await new RegistrationPeriodFactory({ organization: otherOrganization }).create();
+            const otherOrganizationPeriod = await new OrganizationRegistrationPeriodFactory({ organization: otherOrganization, period }).create();
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({ level: PermissionLevel.Full }),
+            }).create();
+            const token = await Token.createToken(user);
+
+            const patch: PatchableArrayAutoEncoder<OrganizationRegistrationPeriodStruct> = new PatchableArray();
+            patch.addPatch(OrganizationRegistrationPeriodStruct.patch({
+                id: otherOrganizationPeriod.id,
+                groups: new PatchableArray(),
+            }));
+
+            await expect(patchOrganizationRegistrationPeriods({ patch, organization, token })).rejects.toThrow(
+                STExpect.simpleError({ code: 'not_found' }),
+            );
+        });
+
         test('should not be able to create registration periods with global period', async () => {
             const organization = await new OrganizationFactory({ }).create();
 
@@ -115,7 +137,7 @@ describe('Endpoint.PatchOrganizationRegistrationPeriods', () => {
 
             // patch organization registration period should fail
             await expect(patchOrganizationRegistrationPeriods({ patch, organization, token })).rejects.toThrow(
-                STExpect.simpleError({ code: 'invalid_period' }),
+                STExpect.simpleError({ code: 'not_found' }),
             );
         });
 

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
@@ -58,7 +58,10 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
         const forceGroupIds: string[] = [];
 
         for (const patch of request.body.getPatches()) {
-            const organizationPeriod = await OrganizationRegistrationPeriod.getByID(patch.id);
+            const organizationPeriod = await OrganizationRegistrationPeriod.select()
+                .where('id', patch.id)
+                .where('organizationId', organization.id)
+                .first(false);
 
             if (!organizationPeriod || organizationPeriod.organizationId !== organization.id) {
                 throw new SimpleError({
@@ -288,7 +291,12 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
     }
 
     static async createOrganizationPeriod(organization: Organization, struct: OrganizationRegistrationPeriodStruct) {
-        const period = await RegistrationPeriod.getByID(struct.period.id);
+        const period = STAMHOOFD.userMode === 'organization'
+            ? await RegistrationPeriod.select()
+                .where('id', struct.period.id)
+                .where('organizationId', organization.id)
+                .first(false)
+            : await RegistrationPeriod.getByID(struct.period.id);
 
         if (!period) {
             throw new SimpleError({
@@ -296,14 +304,6 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
                 message: 'Period not found',
                 human: $t('%15j'),
                 statusCode: 404,
-            });
-        }
-
-        if (STAMHOOFD.userMode === 'organization' && period.organizationId !== organization.id) {
-            throw new SimpleError({
-                code: 'invalid_period',
-                message: 'Period has different organization id',
-                statusCode: 400,
             });
         }
 

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/SetupStepReviewEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/SetupStepReviewEndpoint.ts
@@ -55,7 +55,10 @@ export class SetupStepReviewEndpoint extends Endpoint<Params, Query, Body, Respo
         const stepType = request.body.type;
         const isReviewed = request.body.isReviewed;
 
-        const organizationPeriod = await OrganizationRegistrationPeriod.getByID(periodId);
+        const organizationPeriod = await OrganizationRegistrationPeriod.select()
+            .where('id', periodId)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!organizationPeriod || organizationPeriod.organizationId !== organization.id) {
             throw new SimpleError({
                 code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/DeleteStripeAccountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/DeleteStripeAccountEndpoint.ts
@@ -38,7 +38,10 @@ export class DeleteStripeAccountEndpoint extends Endpoint<Params, Query, Body, R
         }
 
         // Search account in database
-        const model = await StripeAccount.getByID(request.params.id);
+        const model = await StripeAccount.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!model || model.organizationId !== organization.id || model.status !== 'active') {
             throw Context.auth.notFoundOrNoAccess($t(`%FC`));
         }

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripeAccountLinkEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripeAccountLinkEndpoint.ts
@@ -57,7 +57,10 @@ export class GetStripeAccountLinkEndpoint extends Endpoint<Params, Query, Body, 
         }
 
         // Search account in database
-        const model = await StripeAccount.getByID(request.body.accountId);
+        const model = await StripeAccount.select()
+            .where('id', request.body.accountId)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!model || model.organizationId !== organization.id || model.status !== 'active') {
             throw Context.auth.notFoundOrNoAccess($t(`%FC`));
         }

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripeLoginLinkEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripeLoginLinkEndpoint.test.ts
@@ -1,0 +1,37 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import { OrganizationFactory, StripeAccount, Token, UserFactory } from '@stamhoofd/models';
+import { PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { GetStripeLoginLinkEndpoint } from './GetStripeLoginLinkEndpoint.js';
+
+describe('Endpoint.GetStripeLoginLinkEndpoint', () => {
+    const endpoint = new GetStripeLoginLinkEndpoint();
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    test('should not get a login link for a stripe account from another organization', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+
+        const account = new StripeAccount();
+        account.organizationId = otherOrganization.id;
+        account.accountId = 'acct_test';
+        await account.save();
+
+        const request = Request.buildJson('POST', '/stripe/login-link', organization.getApiHost(), {
+            accountId: account.id,
+        });
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(endpoint, request)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripeLoginLinkEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripeLoginLinkEndpoint.ts
@@ -51,7 +51,10 @@ export class GetStripeLoginLinkEndpoint extends Endpoint<Params, Query, Body, Re
         }
 
         // Search account in database
-        const model = await StripeAccount.getByID(request.body.accountId);
+        const model = await StripeAccount.select()
+            .where('id', request.body.accountId)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!model || model.organizationId !== organization.id || model.status !== 'active') {
             throw new SimpleError({
                 code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/UpdateStripeAccountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/UpdateStripeAccountEndpoint.ts
@@ -37,7 +37,10 @@ export class UpdateStripeAccountEndpoint extends Endpoint<Params, Query, Body, R
         }
 
         // Search account in database
-        const model = await StripeAccount.getByID(request.params.id);
+        const model = await StripeAccount.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!model || model.organizationId !== organization.id) {
             throw Context.auth.notFoundOrNoAccess($t(`%FC`));
         }

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/DeleteWebshopEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/DeleteWebshopEndpoint.ts
@@ -39,7 +39,10 @@ export class DeleteWebshopEndpoint extends Endpoint<Params, Query, Body, Respons
             throw Context.auth.error();
         }
 
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Full)) {
             throw Context.auth.notFoundOrNoAccess();
         }

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/GetDiscountCodesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/GetDiscountCodesEndpoint.ts
@@ -35,7 +35,10 @@ export class GetWebshopDiscountCodesEndpoint extends Endpoint<Params, Query, Bod
             throw Context.auth.error();
         }
 
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Full)) {
             throw Context.auth.notFoundOrNoAccess();
         }

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/GetWebshopOrdersCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/GetWebshopOrdersCountEndpoint.ts
@@ -38,6 +38,8 @@ export class GetWebshopOrdersCountEndpoint extends Endpoint<Params, Query, Body,
 
         const query = await GetWebshopOrdersEndpoint.buildQuery(request.query);
 
+        query.where('organizationId', organization.id);
+
         const count = await query
             .count();
 

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/GetWebshopTicketsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/GetWebshopTicketsCountEndpoint.ts
@@ -38,6 +38,8 @@ export class GetWebshopTicketsCountEndpoint extends Endpoint<Params, Query, Body
 
         const query = await GetWebshopTicketsEndpoint.buildQuery(request.query);
 
+        query.where('organizationId', organization.id);
+
         const count = await query.count();
 
         return new Response(

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/GetWebshopUriAvailabilityEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/GetWebshopUriAvailabilityEndpoint.ts
@@ -45,7 +45,10 @@ export class GetWebshopUriAvailabilityEndpoint extends Endpoint<Params, Query, B
             throw Context.auth.error();
         }
 
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Full)) {
             throw Context.auth.notFoundOrNoAccess();
         }

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchDiscountCodesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchDiscountCodesEndpoint.ts
@@ -39,7 +39,10 @@ export class PatchWebshopDiscountCodesEndpoint extends Endpoint<Params, Query, B
             throw Context.auth.error();
         }
 
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Full)) {
             throw Context.auth.notFoundOrNoAccess();
         }
@@ -77,7 +80,10 @@ export class PatchWebshopDiscountCodesEndpoint extends Endpoint<Params, Query, B
             }
 
             for (const patch of request.body.getPatches()) {
-                const model = await WebshopDiscountCode.getByID(patch.id);
+                const model = await WebshopDiscountCode.select()
+                    .where('id', patch.id)
+                    .where('webshopId', webshop.id)
+                    .first(false);
                 if (!model || model.webshopId !== webshop.id) {
                     throw new SimpleError({
                         code: 'not_found',
@@ -108,7 +114,10 @@ export class PatchWebshopDiscountCodesEndpoint extends Endpoint<Params, Query, B
             }
 
             for (const id of request.body.getDeletes()) {
-                const model = await WebshopDiscountCode.getByID(id);
+                const model = await WebshopDiscountCode.select()
+                    .where('id', id)
+                    .where('webshopId', webshop.id)
+                    .first(false);
                 if (!model || model.webshopId !== webshop.id) {
                     throw new SimpleError({
                         code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopEndpoint.ts
@@ -46,7 +46,10 @@ export class PatchWebshopEndpoint extends Endpoint<Params, Query, Body, Response
 
         // Halt all order placement and validation + pause stock updates
         return await QueueHandler.schedule('webshop-stock/' + request.params.id, async () => {
-            const webshop = await Webshop.getByID(request.params.id);
+            const webshop = await Webshop.select()
+                .where('id', request.params.id)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Full)) {
                 throw Context.auth.notFoundOrNoAccess();
             }

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
@@ -91,7 +91,10 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
 
         // Need to happen in the queue because we are updating the webshop stock
         const orders = await QueueHandler.schedule('webshop-stock/' + request.params.id, async () => {
-            const webshop = await Webshop.getByID(request.params.id);
+            const webshop = await Webshop.select()
+                .where('id', request.params.id)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Write)) {
                 throw Context.auth.notFoundOrNoAccess();
             }
@@ -99,6 +102,7 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
             const orders = body.getPatches().length > 0
                 ? await Order.where({
                         webshopId: webshop.id,
+                        organizationId: organization.id,
                         id: {
                             sign: 'IN',
                             value: body.getPatches().map(o => o.id),

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopTicketsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopTicketsEndpoint.ts
@@ -42,7 +42,10 @@ export class PatchWebshopTicketsEndpoint extends Endpoint<Params, Query, Body, R
             return new Response([]);
         }
 
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || !await Context.auth.canAccessWebshopTickets(webshop, PermissionLevel.Write)) {
             throw Context.auth.notFoundOrNoAccess($t(`%FU`));
         }
@@ -51,7 +54,10 @@ export class PatchWebshopTicketsEndpoint extends Endpoint<Params, Query, Body, R
         const errors = new SimpleErrors();
 
         for (const patch of request.body) {
-            const model = await Ticket.getByID(patch.id);
+            const model = await Ticket.select()
+                .where('id', patch.id)
+                .where('webshopId', webshop.id)
+                .first(false);
             if (!model || model.webshopId !== webshop.id) {
                 errors.addError(new SimpleError({
                     code: 'ticket_not_found',

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/VerifyWebshopDomainEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/VerifyWebshopDomainEndpoint.ts
@@ -40,7 +40,10 @@ export class VerifyWebshopDomainEndpoint extends Endpoint<Params, Query, Body, R
         }
 
         return await QueueHandler.schedule('webshop-stock/' + request.params.id, async () => {
-            const webshop = await Webshop.getByID(request.params.id);
+            const webshop = await Webshop.select()
+                .where('id', request.params.id)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!webshop || !await Context.auth.canAccessWebshop(webshop, PermissionLevel.Full)) {
                 throw Context.auth.notFoundOrNoAccess();
             }

--- a/backend/app/api/src/endpoints/organization/shared/GetPaymentEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/shared/GetPaymentEndpoint.ts
@@ -27,10 +27,15 @@ export class GetPaymentEndpoint extends Endpoint<Params, Query, Body, ResponseBo
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        await Context.setOptionalOrganizationScope();
+        const organization = await Context.setOptionalOrganizationScope();
         await Context.authenticate();
 
-        const payment = await Payment.getByID(request.params.id);
+        const payment = organization
+            ? await Payment.select()
+                .where('id', request.params.id)
+                .where('organizationId', organization.id)
+                .first(false)
+            : await Payment.getByID(request.params.id);
         if (!payment) {
             throw new SimpleError({
                 code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/webshops/CheckWebshopDiscountCodesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/CheckWebshopDiscountCodesEndpoint.ts
@@ -31,7 +31,10 @@ export class CheckWebshopDiscountCodesEndpoint extends Endpoint<Params, Query, B
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
         const organization = await Context.setOrganizationScope({ willAuthenticate: false });
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || webshop.organizationId !== organization.id) {
             throw new SimpleError({
                 code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/webshops/GetOrderByPaymentEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/GetOrderByPaymentEndpoint.ts
@@ -28,7 +28,10 @@ export class GetOrderByPaymentEndpoint extends Endpoint<Params, Query, Body, Res
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
         const organization = await Context.setOrganizationScope({ willAuthenticate: false });
-        const payment = await Payment.getByID(request.params.paymentId);
+        const payment = await Payment.select()
+            .where('id', request.params.paymentId)
+            .where('organizationId', organization.id)
+            .first(false);
 
         if (!payment || payment.organizationId !== organization.id) {
             throw new SimpleError({
@@ -37,7 +40,11 @@ export class GetOrderByPaymentEndpoint extends Endpoint<Params, Query, Body, Res
                 human: $t(`%FY`),
             });
         }
-        const [order] = await Order.where({ paymentId: payment.id }, { limit: 1 });
+        const order = await Order.select()
+            .where('paymentId', payment.id)
+            .where('organizationId', organization.id)
+            .where('webshopId', request.params.id)
+            .first(false);
         if (!order || order.webshopId !== request.params.id || order.organizationId !== organization.id) {
             throw new SimpleError({
                 code: 'not_found',
@@ -46,7 +53,10 @@ export class GetOrderByPaymentEndpoint extends Endpoint<Params, Query, Body, Res
             });
         }
 
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || webshop.organizationId !== organization.id) {
             throw new SimpleError({
                 code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/webshops/GetOrderEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/GetOrderEndpoint.ts
@@ -27,7 +27,10 @@ export class GetOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBody
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
         const organization = await Context.setOrganizationScope({ willAuthenticate: false });
-        const order = await Order.getByID(request.params.orderId);
+        const order = await Order.select()
+            .where('id', request.params.orderId)
+            .where('organizationId', organization.id)
+            .first(false);
 
         if (!order || order.webshopId !== request.params.id || order.organizationId !== organization.id) {
             throw new SimpleError({
@@ -37,7 +40,10 @@ export class GetOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBody
             });
         }
 
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || webshop.organizationId !== organization.id) {
             throw new SimpleError({
                 code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/webshops/GetTicketsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/GetTicketsEndpoint.ts
@@ -46,7 +46,10 @@ export class GetTicketsEndpoint extends Endpoint<Params, Query, Body, ResponseBo
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
         const organization = await Context.setOrganizationScope({ willAuthenticate: false });
-        const webshop = await Webshop.getByID(request.params.id);
+        const webshop = await Webshop.select()
+            .where('id', request.params.id)
+            .where('organizationId', organization.id)
+            .first(false);
         if (!webshop || webshop.organizationId !== organization.id) {
             throw new SimpleError({
                 code: 'not_found',
@@ -70,7 +73,11 @@ export class GetTicketsEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                 });
             }
 
-            const order = await Order.getByID(ticket.orderId);
+            const order = await Order.select()
+                .where('id', ticket.orderId)
+                .where('organizationId', organization.id)
+                .where('webshopId', request.params.id)
+                .first(false);
             if (!order || order.webshopId !== request.params.id || order.organizationId !== organization.id) {
                 console.error('Error: missing order ' + ticket.orderId + ' for ticket ' + ticket.id);
                 throw new SimpleError({
@@ -130,7 +137,11 @@ export class GetTicketsEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                 deletedAt: null,
             });
 
-            const order = await Order.getByID(request.query.orderId);
+            const order = await Order.select()
+                .where('id', request.query.orderId)
+                .where('organizationId', organization.id)
+                .where('webshopId', request.params.id)
+                .first(false);
             if (!order || order.webshopId !== request.params.id || order.organizationId !== organization.id) {
                 throw new SimpleError({
                     code: 'not_found',

--- a/backend/app/api/src/endpoints/organization/webshops/GetWebshopEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/GetWebshopEndpoint.test.ts
@@ -1,9 +1,12 @@
 import { Request } from '@simonbackx/simple-endpoints';
-import { OrganizationFactory, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
-import { PermissionLevel, Permissions, WebshopAuthType, WebshopMetaData } from '@stamhoofd/structures';
+import { Order, OrganizationFactory, Payment, Ticket, Token, UserFactory, WebshopDiscountCode, WebshopFactory } from '@stamhoofd/models';
+import { OrderData, PaymentMethod, PaymentStatus, PermissionLevel, Permissions, WebshopAuthType, WebshopMetaData } from '@stamhoofd/structures';
 
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { CheckWebshopDiscountCodesEndpoint } from './CheckWebshopDiscountCodesEndpoint.js';
+import { GetOrderByPaymentEndpoint } from './GetOrderByPaymentEndpoint.js';
+import { GetTicketsEndpoint } from './GetTicketsEndpoint.js';
 import { GetWebshopEndpoint } from './GetWebshopEndpoint.js';
 
 describe('Endpoint.GetWebshop', () => {
@@ -137,5 +140,90 @@ describe('Endpoint.GetWebshop', () => {
 
         const response = await testServer.test(endpoint, r);
         expect((response.body as any).privateMeta).toBeUndefined();
+    });
+
+    test('Reject discount code check for webshop from different organization', async () => {
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({ organization }).create();
+        const token = await Token.createToken(user);
+        const webshop = await new WebshopFactory({ organizationId: otherOrganization.id }).create();
+
+        const code = new WebshopDiscountCode();
+        code.organizationId = otherOrganization.id;
+        code.webshopId = webshop.id;
+        code.code = 'TEST';
+        await code.save();
+
+        const r = Request.buildJson('POST', '/webshop/' + webshop.id + '/discount-codes', organization.getApiHost(), ['TEST']);
+        r.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(new CheckWebshopDiscountCodesEndpoint(), r)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+
+    test('Reject tickets for webshop from different organization', async () => {
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({ organization }).create();
+        const token = await Token.createToken(user);
+        const webshop = await new WebshopFactory({ organizationId: otherOrganization.id }).create();
+
+        const r = Request.buildJson('GET', '/webshop/' + webshop.id + '/tickets?orderId=unknown', organization.getApiHost());
+        r.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(new GetTicketsEndpoint(), r)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+
+    test('Reject order lookup by payment for order from another webshop', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({ organization }).create();
+        const token = await Token.createToken(user);
+        const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+        const otherWebshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.method = PaymentMethod.Transfer;
+        payment.status = PaymentStatus.Created;
+        payment.price = 0;
+        await payment.save();
+
+        const order = new Order();
+        order.organizationId = organization.id;
+        order.webshopId = otherWebshop.id;
+        order.paymentId = payment.id;
+        order.data = OrderData.create({});
+        await order.save();
+
+        const r = Request.buildJson('GET', '/webshop/' + webshop.id + '/payment/' + payment.id + '/order', organization.getApiHost());
+        r.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(new GetOrderByPaymentEndpoint(), r)).rejects.toThrow(STExpect.errorWithCode('not_found'));
+    });
+
+    test('Reject ticket lookup when ticket order belongs to another webshop', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({ organization }).create();
+        const token = await Token.createToken(user);
+        const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+        const otherWebshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+        const order = new Order();
+        order.organizationId = organization.id;
+        order.webshopId = otherWebshop.id;
+        order.data = OrderData.create({});
+        await order.save();
+
+        const ticket = new Ticket();
+        ticket.organizationId = organization.id;
+        ticket.webshopId = webshop.id;
+        ticket.orderId = order.id;
+        ticket.secret = 'secret-test';
+        await ticket.save();
+
+        const r = Request.buildJson('GET', '/webshop/' + webshop.id + '/tickets?secret=' + ticket.secret, organization.getApiHost());
+        r.headers.authorization = 'Bearer ' + token.accessToken;
+
+        await expect(testServer.test(new GetTicketsEndpoint(), r)).rejects.toThrow(STExpect.errorWithCode('not_found'));
     });
 });

--- a/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
@@ -63,7 +63,10 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
 
         // Read + validate + update stock in one go, to prevent race conditions
         const { webshop, order } = await QueueHandler.schedule('webshop-stock/' + request.params.id, async () => {
-            const webshopWithoutOrganization = await Webshop.getByID(request.params.id);
+            const webshopWithoutOrganization = await Webshop.select()
+                .where('id', request.params.id)
+                .where('organizationId', organization.id)
+                .first(false);
             if (!webshopWithoutOrganization || webshopWithoutOrganization.organizationId !== organization.id) {
                 throw new SimpleError({
                     code: 'not_found',


### PR DESCRIPTION
Fixes STA-1167.

Dit voegt extra `organizationId`-filters toe aan databasequeries, zodat records van andere organisaties al op queryniveau uitgesloten worden. De wijzigingen zijn opgesplitst per risicogroep, van veiligst naar meest aandacht nodig.

## Gebruikten al `Context.setOrganizationScope()`

Deze commits hadden al een `Context.setOptionalOrganizationScope()` dus leek mij vrij duidelijk dat ze een filter toevoegen vanzelfsprekend was?

### Had a direct organizationId check

Deze bestanden hadden na het ophalen van het model al een expliciete `organizationId`-controle. De wijziging verplaatst die controle grotendeels naar de query zelf.

### Relied on auth helper checks

Deze bestanden vertrouwden al op bestaande `Context.auth.canAccess...` controles na het ophalen van het model. De extra queryfilter beperkt de zoekruimte vooraf tot de actieve organisatie.

### Had parent ownership checks

Basically webshop checks waar we eerst de webshop nu ook controleren op organization id en de "child types" controleren op webshopId direct in de query.

## Gebruikten `Context.setOptionalOrganizationScope()`

_Hier is maar 1 commit._

### Had conditional organization scoped lookups

Om hier wat zekerder te zijn heb ik voor de zekerheid enkel de aanpassing gedaan om organizationId WHERE toe te voegen wanneer er een organization was in the auth. Was niet zeker of er soms wel gekeken moest worden naar niet-org items.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784717919&installation_id=138085646&pr_number=505&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F505&signature=e664c8850515cddacc0f2a2e00fc24d4883c976e32a30182f151a333c8ea7460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->