### PR TITLE
🐛️ .st-menu-item only middle should shrink

### DIFF
--- a/frontend/shared/scss/layout/st-menu-modern.scss
+++ b/frontend/shared/scss/layout/st-menu-modern.scss
@@ -116,7 +116,7 @@
                 color: $color-success;
             }
 
-            span:not(.right) {
+            > span:not(.left):not(.right) {
                 min-width: 0;
                 overflow: hidden;
                 text-overflow: ellipsis;
@@ -140,6 +140,7 @@
                 width: 20px;
                 height: 20px;
                 display: block;
+                flex-shrink: 0;
                 overflow: visible !important;
             }
 
@@ -148,7 +149,8 @@
                 font-size: 11px;
                 color: $color-gray-4;
                 font-weight: 500;
-                text-wrap: nowrap;
+                flex-shrink: 0;
+                white-space: nowrap;
             }
         }
 


### PR DESCRIPTION
Fixes STA-1121, follow-up to https://github.com/stamhoofd/stamhoofd/commit/c3e7f45f992c36049f4d1e5a334c20767bc09aa4 which lead to the left shrinking.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784719804&installation_id=138085646&pr_number=506&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F506&signature=9589b61ed05f05fa46113ffc5256fc75d799cc2f61c7f9b1bda7ce5462fd2c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->