### PR TITLE
🐛️ make period id reactive in MembersTableView + tableobjectfilter reset fix

### DIFF
--- a/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
+++ b/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
@@ -222,19 +222,19 @@ defineRoute({
     name: Routes.All,
     show: 'detail',
     component: async () => (await import('@stamhoofd/components/members/MembersTableView.vue')).default,
-    defaultProperties: () => {
-        return {
-            periodId: period.value.period.id,
-        };
-    },
+    defaultProperties: () => getAllMembersRouteProperties(),
     isDefault: showAll.value
         ? {
-                properties: {
-                    periodId: period.value.period.id,
-                },
+                properties: getAllMembersRouteProperties(),
             }
         : undefined,
 });
+
+function getAllMembersRouteProperties() {
+    return {
+        periodId: computed(() => period.value.period.id),
+    };
+}
 
 const checkRoute = useCheckRoute();
 const fetchPeriods = useFetchOrganizationRegistrationPeriods();

--- a/frontend/shared/components/src/fetchers/useMembersObjectFetcher.ts
+++ b/frontend/shared/components/src/fetchers/useMembersObjectFetcher.ts
@@ -1,9 +1,9 @@
-import type { CountFilteredRequest, PlatformMember, SortList } from '@stamhoofd/structures';
-import { assertSort, CountResponse, LimitedFilteredRequest, MembersBlob, PaginatedResponseDecoder, PlatformFamily, SortItemDirection } from '@stamhoofd/structures';
-import type { ObjectFetcher } from '#tables/classes/ObjectFetcher.ts';
-import type { Decoder } from '@simonbackx/simple-encoding';
 import { useContext } from '#hooks/useContext.ts';
 import { usePlatform } from '#hooks/usePlatform.ts';
+import type { ObjectFetcher } from '#tables/classes/ObjectFetcher.ts';
+import type { Decoder } from '@simonbackx/simple-encoding';
+import type { CountFilteredRequest, PlatformMember, SortList } from '@stamhoofd/structures';
+import { assertSort, CountResponse, LimitedFilteredRequest, MembersBlob, PaginatedResponseDecoder, PlatformFamily, SortItemDirection } from '@stamhoofd/structures';
 
 type ObjectType = PlatformMember;
 
@@ -78,5 +78,9 @@ export function useMembersObjectFetcher(overrides?: Partial<ObjectFetcher<Object
         },
 
         ...overrides,
+
+        get requiredFilter() {
+            return overrides?.requiredFilter ?? null;
+        },
     };
 }

--- a/frontend/shared/components/src/members/MembersTableView.vue
+++ b/frontend/shared/components/src/members/MembersTableView.vue
@@ -2,7 +2,6 @@
     <LoadingViewTransition :loading="isLoading">
         <ModernTableView
             v-if="!isLoading"
-            :key="filterPeriodId"
             ref="modernTableView"
             :table-object-fetcher="tableObjectFetcher"
             :filter-builders="filterBuilders"

--- a/frontend/shared/components/src/members/MembersTableView.vue
+++ b/frontend/shared/components/src/members/MembersTableView.vue
@@ -2,6 +2,7 @@
     <LoadingViewTransition :loading="isLoading">
         <ModernTableView
             v-if="!isLoading"
+            :key="filterPeriodId"
             ref="modernTableView"
             :table-object-fetcher="tableObjectFetcher"
             :filter-builders="filterBuilders"
@@ -39,7 +40,9 @@ import { useGlobalEventListener } from '#hooks/useGlobalEventListener.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import { usePlatform } from '#hooks/usePlatform.ts';
 import { useChooseOrganizationMembersForGroup } from '#members/checkout/useCheckoutRegisterItem.ts';
+import { getMemberColumns } from '#members/helpers/getMemberColumns.ts';
 import { useRequiredRegistrationsFilter } from '#registrations/classes/getRequiredRegistrationsFilter.ts';
+import { useRegistrationInvitationEventListener } from '#registrations/classes/useRegistrationInvitationEventListener.ts';
 import type { TableAction } from '#tables/classes/TableAction.ts';
 import { InMemoryTableAction } from '#tables/classes/TableAction.ts';
 import { useTableObjectFetcher } from '#tables/classes/TableObjectFetcher.ts';
@@ -49,13 +52,10 @@ import { useSGVSync } from '@stamhoofd/sgv-frontend/useSGVSync';
 import type { Group, GroupCategoryTree, MemberResponsibility, PlatformMember, StamhoofdFilter } from '@stamhoofd/structures';
 import { AccessRight, GroupType, SGVSyncStatus } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useMembersObjectFetcher } from '../fetchers/useMembersObjectFetcher';
 import { useAdvancedMemberWithRegistrationsBlobUIFilterBuilders } from '../filters/filter-builders/members';
-import { useRegistrationInvitationEventListener } from '#registrations/classes/useRegistrationInvitationEventListener.ts';
 import { useDirectMemberActions } from './classes/MemberActionBuilder';
-import { getMemberColumns } from '#members/helpers/getMemberColumns.ts';
-import MemberSegmentedView from './MemberSegmentedView.vue';
 
 type ObjectType = PlatformMember;
 
@@ -116,7 +116,7 @@ const modernTableView = ref(null) as Ref<null | ComponentExposed<typeof ModernTa
 const auth = useAuth();
 const organization = useOrganization();
 const platform = usePlatform();
-const filterPeriodId = props.periodId ?? props.group?.periodId ?? organization?.value?.period?.period?.id ?? platform.value.period.id;
+const filterPeriodId = computed(() => props.periodId ?? props.group?.periodId ?? organization?.value?.period?.period?.id ?? platform.value.period.id);
 const isPlatform = STAMHOOFD.userMode === 'platform';
 const defaultFilter = isPlatform && app === 'admin' && !props.group && !props.customFilter
     ? {
@@ -131,7 +131,7 @@ const defaultFilter = isPlatform && app === 'admin' && !props.group && !props.cu
     : null;
 
 const organizationRegistrationPeriod = computed(() => {
-    const periodId = filterPeriodId;
+    const periodId = filterPeriodId.value;
 
     return organization.value?.periods?.organizationPeriods?.find(p => p.period.id === periodId);
 });
@@ -187,14 +187,16 @@ function getRequiredFilter(): StamhoofdFilter | null {
     }
 
     if (!props.group && !props.category) {
-        if (organization.value && props.periodId) {
+        const periodId = filterPeriodId.value;
+
+        if (organization.value && periodId) {
             // Only show members that are registered in the current period AND in this group
             // (avoid showing old members that moved to other groups)
             return {
                 registrations: {
                     $elemMatch: {
                         organizationId: organization.value.id,
-                        periodId: props.periodId,
+                        periodId,
                         group: {
                             // Do not show members that are only registered for a waiting list or event
                             type: GroupType.Membership,
@@ -204,11 +206,11 @@ function getRequiredFilter(): StamhoofdFilter | null {
             };
         }
 
-        if (props.periodId) {
+        if (periodId) {
             return {
                 registrations: {
                     $elemMatch: {
-                        periodId: props.periodId,
+                        periodId,
                     },
                 },
             };
@@ -218,7 +220,7 @@ function getRequiredFilter(): StamhoofdFilter | null {
 
     const extra: StamhoofdFilter[] = getRequiredRegistrationsFilter({
         group: props.group ?? undefined,
-        periodId: props.periodId ?? undefined,
+        periodId: filterPeriodId.value,
     });
 
     return [
@@ -240,10 +242,15 @@ function getRequiredFilter(): StamhoofdFilter | null {
 }
 
 const objectFetcher = useMembersObjectFetcher({
-    requiredFilter: getRequiredFilter(),
+    get requiredFilter() {
+        return getRequiredFilter();
+    },
 });
 
 const tableObjectFetcher = useTableObjectFetcher<ObjectType>(objectFetcher);
+watch(filterPeriodId, () => {
+    tableObjectFetcher.reset(true, true);
+});
 const { sgvSyncOpen, sgvSyncWarning } = useSGVSync(computed(() => tableObjectFetcher.objects.map(member => member.member)));
 
 const allColumns = getMemberColumns({
@@ -253,7 +260,7 @@ const allColumns = getMemberColumns({
     category: props.category,
     organization: organization.value,
     groups,
-    filterPeriodId,
+    filterPeriodId: filterPeriodId.value,
     auth,
     app,
     waitingList: waitingList.value,

--- a/frontend/shared/components/src/tables/classes/TableObjectFetcher.ts
+++ b/frontend/shared/components/src/tables/classes/TableObjectFetcher.ts
@@ -132,6 +132,11 @@ export class TableObjectFetcher<O extends { id: string }> {
         }
 
         this.objects = [];
+        // The visible range belongs to the previous object list. After clearing the
+        // list, the table can report the same range again; resetting this state
+        // makes that next visibility update trigger a fresh fetch.
+        this.currentStartIndex = 0;
+        this.currentEndIndex = 0;
 
         if (total) {
             this.totalCount = null;


### PR DESCRIPTION
Fixes STA-1153 by making the period id reactive in MembersTableView. There was an additional bug when resetting the object fetcher. If the visible range remains the same between resets, we don't update. So to make sure we always update, set the visible range to 0..0. The only time it might not update then, is when it's already empty but then it doesn't require an update anyhow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784729429&installation_id=138085646&pr_number=508&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F508&signature=06fd489084d12e8a0dd49c967ff6b50067e44ce8138b9fe4017e80062ae121c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->