### PR TITLE
🐛 sgv: ignore previous work years (STA-1179)

### DIFF
--- a/frontend/shared/components/src/members/components/view/ViewMemberWarningsBox.vue
+++ b/frontend/shared/components/src/members/components/view/ViewMemberWarningsBox.vue
@@ -16,16 +16,16 @@
 </template>
 
 <script setup lang="ts">
+import { useDataPermissionSettings } from '#groups/hooks/useDataPermissionSettings.ts';
+import { useFinancialSupportSettings } from '#groups/hooks/useFinancialSupportSettings.ts';
+import { useAuth } from '#hooks/useAuth.ts';
+import { useOrganization } from '#hooks/useOrganization.ts';
 import { isMemberManaged } from '@stamhoofd/sgv-frontend/SGVSyncReport';
 import { useSGVSync } from '@stamhoofd/sgv-frontend/useSGVSync';
 import type { MemberPlatformMembership, PlatformMember } from '@stamhoofd/structures';
 import { MembershipStatus, PermissionLevel, RecordAnswer, RecordWarning, RecordWarningType, SGVSyncStatus, TranslatedString } from '@stamhoofd/structures';
 import { Formatter, Sorter } from '@stamhoofd/utility';
 import { computed } from 'vue';
-import { useDataPermissionSettings } from '#groups/hooks/useDataPermissionSettings.ts';
-import { useFinancialSupportSettings } from '#groups/hooks/useFinancialSupportSettings.ts';
-import { useAuth } from '#hooks/useAuth.ts';
-import { useOrganization } from '#hooks/useOrganization.ts';
 import { useIsPropertyEnabled } from '../../hooks/useIsPropertyRequired';
 
 defineOptions({
@@ -149,7 +149,7 @@ const warnings = computed(() => {
     }
 
     if (organization.value?.isSGVSyncOrganization && isMemberManaged(props.member.member, organization.value)) {
-        const status = props.member.member.getSGVSyncStatus({ periodId: organization.value?.period.period.id ?? null });
+        const status = props.member.member.getSGVSyncStatus({ organization: organization.value });
         const actionText = auth.hasFullAccess() ? $t('%1Z6') : $t('%1b9');
 
         if (status === SGVSyncStatus.Never) {
@@ -195,7 +195,7 @@ function handleWarningClick(warning: RecordWarning) {
         return;
     }
 
-    const status = props.member.member.getSGVSyncStatus({ periodId: organization.value?.period.period.id ?? null });
+    const status = props.member.member.getSGVSyncStatus({ organization: organization.value });
     if (status === SGVSyncStatus.Never || status === SGVSyncStatus.Outdated || status === SGVSyncStatus.Changed) {
         const text = warning.text.toString();
         if (text.includes('groepsadministratie') || text.includes('synchronisatie')) {

--- a/frontend/shared/sgv/src/SGVGroupAdministration.ts
+++ b/frontend/shared/sgv/src/SGVGroupAdministration.ts
@@ -5,9 +5,8 @@ import type {
     RequestResult,
 } from '@simonbackx/simple-networking';
 import { Request, Server } from '@simonbackx/simple-networking';
-import type { PushOptions } from '@simonbackx/vue-app-navigation';
+import type { ComponentWithProperties, PushOptions } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '@stamhoofd/components/containers/AsyncComponent.ts';
-import type { ComponentWithProperties } from '@simonbackx/vue-app-navigation';
 import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 import type { MemberManager } from '@stamhoofd/networking/MemberManager';
 import type { OrganizationManager } from '@stamhoofd/networking/OrganizationManager';
@@ -625,7 +624,7 @@ export class SGVGroupAdministration implements RequestMiddleware {
             try {
                 // If updatedAt close to lastsynced at (5 seconds)
                 if (match.stamhoofd.getSGVSyncStatus({
-                    periodId: organization.period.period.id,
+                    organization: organization,
                 }) === SGVSyncStatus.Ok) {
                     // report.addWarning(match.stamhoofd.details.firstName+" "+match.stamhoofd.details.lastName+" werd overgeslagen: geen wijzigingen sinds laatste synchronisatie");
                     report.markSkipped(match.stamhoofd);

--- a/frontend/shared/sgv/src/SGVSyncReport.test.ts
+++ b/frontend/shared/sgv/src/SGVSyncReport.test.ts
@@ -57,4 +57,12 @@ describe('SGVSyncReport.isMemberManaged', () => {
 
         expect(isMemberManaged(createMember({ group: createGroup(GroupType.Membership, 'other-period') }), organization)).toBe(false);
     });
+
+    test('ignores registrations from previous active work years', () => {
+        const organization = createOrganization();
+        organization.period.period.startDate = new Date();
+        organization.period.period.previousPeriodId = 'previous-period';
+
+        expect(isMemberManaged(createMember({ group: createGroup(GroupType.Membership, 'previous-period') }), organization)).toBe(false);
+    });
 });

--- a/frontend/shared/sgv/src/useSGVSync.test.ts
+++ b/frontend/shared/sgv/src/useSGVSync.test.ts
@@ -195,4 +195,23 @@ describe('useSGVSync.getSGVSyncWarning', () => {
 
         expect(warning).toBeNull();
     });
+
+    test('ignores registrations from previous active work years', () => {
+        const organization = createOrganization();
+        organization.period.period.startDate = new Date();
+        organization.period.period.previousPeriodId = 'previous-period';
+
+        const warning = getSGVSyncWarning(
+            [
+                createMember({
+                    lastExternalSync: null,
+                    group: createGroup(GroupType.Membership, 'previous-period'),
+                }),
+            ],
+            organization,
+            true,
+        );
+
+        expect(warning).toBeNull();
+    });
 });

--- a/frontend/shared/sgv/src/useSGVSync.ts
+++ b/frontend/shared/sgv/src/useSGVSync.ts
@@ -63,9 +63,9 @@ export function useSGVSync(
         propsToParams: props => ({
             query: props.code && props.state
                 ? new URLSearchParams([
-                    ['code', props.code],
-                    ['state', props.state],
-                ])
+                        ['code', props.code],
+                        ['state', props.state],
+                    ])
                 : null,
         }),
     });
@@ -116,7 +116,7 @@ export function getSGVSyncWarning(
         }
 
         const status = member.getSGVSyncStatus({
-            periodId: organization.period.period.id,
+            organization,
         });
         if (
             status === SGVSyncStatus.Never

--- a/shared/structures/src/members/MemberWithRegistrationsBlob.test.ts
+++ b/shared/structures/src/members/MemberWithRegistrationsBlob.test.ts
@@ -1,6 +1,8 @@
 import { Group } from '../Group.js';
 import { GroupPrice } from '../GroupSettings.js';
 import { GroupType } from '../GroupType.js';
+import { Organization } from '../Organization.js';
+import { OrganizationRegistrationPeriod, RegistrationPeriod } from '../RegistrationPeriod.js';
 import { MemberDetails } from './MemberDetails.js';
 import { MemberWithRegistrationsBlob, SGVSyncStatus } from './MemberWithRegistrationsBlob.js';
 import { Registration } from './Registration.js';
@@ -13,6 +15,14 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
             id,
             type,
             periodId,
+        });
+    }
+
+    function createOrganization(periodId = 'period-id') {
+        return Organization.create({
+            period: OrganizationRegistrationPeriod.create({
+                period: RegistrationPeriod.create({ id: periodId }),
+            }),
         });
     }
 
@@ -43,7 +53,7 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
 
     test('returns never without last external sync', () => {
         const member = createMember({ lastExternalSync: null });
-        expect(member.getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Never);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Never);
     });
 
     test('returns outdated when a current registration is newer than the last sync', () => {
@@ -52,7 +62,7 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
             registeredAt: new Date(now.getTime() - 1000 * 60),
         });
 
-        expect(member.getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Outdated);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Outdated);
     });
 
     test('returns outdated when the last sync is older than nine months', () => {
@@ -63,7 +73,7 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
             registeredAt: new Date(lastExternalSync.getTime() - 1000),
         });
 
-        expect(member.getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Outdated);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Outdated);
     });
 
     test('returns ok when the member update time is close to the last sync', () => {
@@ -73,7 +83,7 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
             updatedAt: new Date(lastExternalSync.getTime() + 1000),
         });
 
-        expect(member.getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Ok);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Ok);
     });
 
     test('returns changed when member details changed after the last sync', () => {
@@ -83,18 +93,27 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
             updatedAt: new Date(lastExternalSync.getTime() + 1000 * 60),
         });
 
-        expect(member.getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Changed);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Changed);
     });
 
-    test('ignores registrations from other periods when a period id is provided', () => {
+    test('ignores registrations from periods other than the organization default period', () => {
         const member = createMember({
             lastExternalSync: new Date(now.getTime() - 1000 * 60 * 2),
             registeredAt: new Date(now.getTime() - 1000 * 60),
             group: createGroup(GroupType.Membership, 'other-period'),
         });
 
-        expect(member.getSGVSyncStatus({ now, periodId: 'period-id' })).toBe(SGVSyncStatus.Ok);
-        expect(member.getSGVSyncStatus({ now, periodId: 'other-period' })).toBe(SGVSyncStatus.Outdated);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization('period-id') })).toBe(SGVSyncStatus.Ok);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization('other-period') })).toBe(SGVSyncStatus.Outdated);
+    });
+
+    test('returns ok when registrations only exist in another period', () => {
+        const member = createMember({
+            lastExternalSync: null,
+            group: createGroup(GroupType.Membership, 'other-period'),
+        });
+
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization('period-id') })).toBe(SGVSyncStatus.Ok);
     });
 
     test('ignores deactivated registrations when determining outdated status', () => {
@@ -106,7 +125,7 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
         });
         member.registrations[0].deactivatedAt = now;
 
-        expect(member.getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Ok);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Ok);
     });
 
     test('does not mark registrations at the exact sync time as outdated', () => {
@@ -117,7 +136,7 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
             registeredAt: lastExternalSync,
         });
 
-        expect(member.getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Ok);
+        expect(member.getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Ok);
     });
 
     test('uses the update tolerance around the last sync time', () => {
@@ -126,12 +145,12 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
         expect(createMember({
             lastExternalSync,
             updatedAt: new Date(lastExternalSync.getTime() + 1000 * 5 - 1),
-        }).getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Ok);
+        }).getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Ok);
 
         expect(createMember({
             lastExternalSync,
             updatedAt: new Date(lastExternalSync.getTime() + 1000 * 5),
-        }).getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Changed);
+        }).getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Changed);
     });
 
     test('marks syncs older than nine months as outdated', () => {
@@ -143,13 +162,12 @@ describe('MemberWithRegistrationsBlob SGV sync helpers', () => {
             lastExternalSync: justRecentEnough,
             updatedAt: justRecentEnough,
             registeredAt: new Date(justRecentEnough.getTime() - 1000),
-        }).getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Ok);
+        }).getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Ok);
 
         expect(createMember({
             lastExternalSync: tooOld,
             updatedAt: tooOld,
             registeredAt: new Date(tooOld.getTime() - 1000),
-        }).getSGVSyncStatus({ now })).toBe(SGVSyncStatus.Outdated);
+        }).getSGVSyncStatus({ now, organization: createOrganization() })).toBe(SGVSyncStatus.Outdated);
     });
-
 });

--- a/shared/structures/src/members/MemberWithRegistrationsBlob.ts
+++ b/shared/structures/src/members/MemberWithRegistrationsBlob.ts
@@ -166,17 +166,22 @@ export class MemberWithRegistrationsBlob extends Member implements Filterable {
      * Determines whether a member still reflects the latest SGV sync.
      * New membership registrations and old sync timestamps become outdated, while local edits after sync become changed.
      */
-    getSGVSyncStatus(options: { now?: Date; periodId?: string | null } = {}): SGVSyncStatus {
+    getSGVSyncStatus(options: {
+        organization: Organization;
+        now?: Date;
+    }): SGVSyncStatus {
+        const activeRegistrations = this.registrations.filter(registration => registration.group.periodId === options.organization.period.period.id);
+
+        if (activeRegistrations.length === 0) {
+            return SGVSyncStatus.Ok;
+        }
+
         const lastExternalSync = this.details.lastExternalSync;
         if (!lastExternalSync) {
             return SGVSyncStatus.Never;
         }
 
-        for (const registration of this.registrations) {
-            if (options.periodId && registration.group.periodId !== options.periodId) {
-                continue;
-            }
-
+        for (const registration of activeRegistrations) {
             if (registration.group.type !== GroupType.Membership || registration.deactivatedAt !== null || registration.registeredAt === null) {
                 continue;
             }


### PR DESCRIPTION
When getting the sync status, return ok when there are no registrations in the active period of the organization.

STA-1179

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784741124&installation_id=138085646&pr_number=513&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F513&signature=5e85f4ec8fc71f944131aaf1ed0b7c4c4fedcd140c1e9c79140a0273735e0d4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->