### PR TITLE
🐛️ require domains to be explicitly configured + fix sgv config

### DIFF
--- a/environment.d.ts
+++ b/environment.d.ts
@@ -35,27 +35,32 @@ declare global {
 
     type LocalizedDomain = Localized<string>;
 
-    type StamhoofdDomains = {
+    // Use `field: type | undefined` instead of `field?: type` to require setting
+    // each field. This ensures fields are explicitly set to undefined, not
+    // forgotten to be added.
+    export type StamhoofdDomains = {
         dashboard: string; // requires both www + non-www DNS record
-        registration?: LocalizedDomain; // Optional. Set to undefined for platforms. requires wildcard prefix DNS
+        registration: LocalizedDomain | undefined; // Optional. Set to undefined for platforms. requires wildcard prefix DNS
         marketing: LocalizedDomain; // main landing page (used for linking back to website, documentation...)
-        documentation?: LocalizedDomain; // main landing page (used for linking back to website, documentation...)
-        webshop?: LocalizedDomain; // E.g. shop.stamhoofd.be
-        legacyWebshop?: string; // In the past, webshops were hosted on a subdomain. This is deprecated, but the links should still work. E.g. stamhoofd.shop for *.stamhoofd.shop
+        documentation: LocalizedDomain | undefined; // main landing page (used for linking back to website, documentation...)
+        webshop: LocalizedDomain | undefined; // E.g. shop.stamhoofd.be
+        legacyWebshop: string | undefined; // In the past, webshops were hosted on a subdomain. This is deprecated, but the links should still work. E.g. stamhoofd.shop for *.stamhoofd.shop
         api: string; // requires wildcard prefix DNS
         rendererApi: string;
-        sgvLoginUrl?: string;
-        sgvAdminUrl?: string;
+
+        // Scouts & Gidsen Vlaanderen
+        sgvLoginUrl: string | undefined;
+        sgvAdminUrl: string | undefined;
 
         // MX + SPF (both for email) + A record for webshops
-        webshopCname?: string;
+        webshopCname: string | undefined;
 
         // MX + SPF (both for email) + A record for registration
         registrationCname: LocalizedDomain;
 
         // Default email domain for emails sent from organizations
-        defaultTransactionalEmail?: LocalizedDomain;
-        defaultBroadcastEmail?: LocalizedDomain;
+        defaultTransactionalEmail: LocalizedDomain | undefined;
+        defaultBroadcastEmail: LocalizedDomain | undefined;
     };
 
     /**

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -53,12 +53,6 @@ declare global {
          */
         admin?: string;
 
-        /**
-         * @deprecated
-         * Removed in v2
-         */
-        adminApi?: string;
-
         // MX + SPF (both for email) + A record for webshops
         webshopCname?: string;
 
@@ -269,38 +263,38 @@ declare global {
         readonly platformName: string;
     };
 
-     /**
+    /**
      * The environment that is available everywhere: frontend, backend and shared
      */
-     type BackupEnvironment = {
-         /**
+    type BackupEnvironment = {
+        /**
          * We'll map the value of NODE_ENV to the corresponsing value. But staging value isn't valid for NODE_ENV, hence our own variable
          */
-         readonly environment: 'production' | 'development' | 'staging' | 'test';
-         readonly PORT: number;
+        readonly environment: 'production' | 'development' | 'staging' | 'test';
+        readonly PORT: number;
 
-         // Database to backup
-         readonly DB_HOST: string;
-         readonly DB_DATABASE: string;
-         readonly DB_USER: string;
-         readonly DB_PASS: string;
-         readonly CRONS_DISABLED?: boolean;
+        // Database to backup
+        readonly DB_HOST: string;
+        readonly DB_DATABASE: string;
+        readonly DB_USER: string;
+        readonly DB_PASS: string;
+        readonly CRONS_DISABLED?: boolean;
 
-         readonly keyFingerprint: string;
-         readonly objectStoragePath: string;
-         readonly localBackupFolder: string;
+        readonly keyFingerprint: string;
+        readonly objectStoragePath: string;
+        readonly localBackupFolder: string;
 
-         readonly SPACES_ENDPOINT: string;
-         readonly SPACES_BUCKET: string;
-         readonly SPACES_KEY: string;
-         readonly SPACES_SECRET: string;
-         readonly AWS_REGION: 'eu-west-1' | string; // TODO: add others
-         readonly MINIMUM_BACKUP_SIZE?: number; // Expected size (in bytes) of database backup, to detect broken backups
+        readonly SPACES_ENDPOINT: string;
+        readonly SPACES_BUCKET: string;
+        readonly SPACES_KEY: string;
+        readonly SPACES_SECRET: string;
+        readonly AWS_REGION: 'eu-west-1' | string; // TODO: add others
+        readonly MINIMUM_BACKUP_SIZE?: number; // Expected size (in bytes) of database backup, to detect broken backups
 
-         readonly IS_REPLICA?: boolean; // Whether this is a replica server and health checks should also check replica health
+        readonly IS_REPLICA?: boolean; // Whether this is a replica server and health checks should also check replica health
 
-         readonly HEALTH_ACCESS_KEY?: string; // Optional for a little bit of extra security (the health endpoint does not expose any sensitive information)
-     };
+        readonly HEALTH_ACCESS_KEY?: string; // Optional for a little bit of extra security (the health endpoint does not expose any sensitive information)
+    };
 
     type FrontendEnvironment = SharedEnvironment & FrontendSpecificEnvironment;
 }

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -38,7 +38,7 @@ declare global {
     // Use `field: type | undefined` instead of `field?: type` to require setting
     // each field. This ensures fields are explicitly set to undefined, not
     // forgotten to be added.
-    export type StamhoofdDomains = {
+    type StamhoofdDomains = {
         dashboard: string; // requires both www + non-www DNS record
         registration: LocalizedDomain | undefined; // Optional. Set to undefined for platforms. requires wildcard prefix DNS
         marketing: LocalizedDomain; // main landing page (used for linking back to website, documentation...)

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -47,12 +47,6 @@ declare global {
         sgvLoginUrl?: string;
         sgvAdminUrl?: string;
 
-        /**
-         * @deprecated
-         * Removed in v2
-         */
-        admin?: string;
-
         // MX + SPF (both for email) + A record for webshops
         webshopCname?: string;
 

--- a/shared/cli/src/config/development-config.test.ts
+++ b/shared/cli/src/config/development-config.test.ts
@@ -32,6 +32,8 @@ describe('buildDevelopmentConfig', () => {
         expect(config.backendEnv.SPACES_SECRET).toBe(localFilesSecretKey);
         expect(config.appEnv.userMode).toBe('organization');
         expect(config.appEnv.domains.api).toBe('api.stamhoofd');
+        expect(config.appEnv.domains.sgvLoginUrl).toBe('https://login.sgv.stamhoofd');
+        expect(config.appEnv.domains.sgvAdminUrl).toBe('https://admin.sgv.stamhoofd');
         expect(config.appEnv.SMTP_HOST).toBe(localIpv4Host);
         expect(config.appEnv.SMTP_USERNAME).toBe(maildevUsername);
         expect(config.appEnv.SMTP_PASSWORD).toBe(maildevPassword);
@@ -84,6 +86,8 @@ describe('buildDevelopmentConfig', () => {
         expect(config.backendEnv.STAMHOOFD_PORT_OFFSET_LOCKED).toBe('1');
         expect(config.appEnv.userMode).toBe('platform');
         expect(config.appEnv.translationNamespace).toBe('keeo');
+        expect(config.appEnv.domains.sgvLoginUrl).toBe('https://login.sgv.keeo.stamhoofd');
+        expect(config.appEnv.domains.sgvAdminUrl).toBe('https://admin.sgv.keeo.stamhoofd');
     });
 
     it('assigns the resolved frontend port to dashboard apps', () => {

--- a/shared/cli/src/config/development-config.ts
+++ b/shared/cli/src/config/development-config.ts
@@ -1,6 +1,6 @@
 import type { BackendEnvironment, FrontendEnvironment, SharedEnvironment } from '@stamhoofd/types/Environment';
-import type { StamhoofdDomains } from '@stamhoofd/types/StamhoofdDomains';
 import { MemberNumberAlgorithm } from '@stamhoofd/types/MemberNumberAlgorithm';
+import type { StamhoofdDomains } from '@stamhoofd/types/StamhoofdDomains';
 import path from 'node:path';
 import type { CliContext } from '../context/create-context.js';
 import { createContext } from '../context/create-context.js';
@@ -203,18 +203,31 @@ function frontendPort(service: FrontendAppService['frontend'], ports: ReturnType
 }
 
 function buildStamhoofdDomains(domains: DevelopmentDomains, preset: EnvironmentPreset): StamhoofdDomains {
+    const sgvDomainPrefix = preset.platformName === 'stamhoofd' ? '' : `${preset.platformName}.`;
+
     return {
         dashboard: domains.dashboard,
         registration: preset.userMode === 'organization' ? { '': domains.registration, 'BE': domains.registration, 'NL': domains.registration } : undefined,
         marketing: { '': 'www.stamhoofd.be' },
+        documentation: preset.documentation ? { '': preset.documentation } : undefined,
         webshop: { '': domains.webshop, 'BE': domains.webshop, 'NL': domains.webshop },
+        legacyWebshop: undefined,
         api: domains.api,
         rendererApi: domains.renderer,
+
+        // Scouts & Gidsen Vlaanderen
+        sgvLoginUrl: `https://login.sgv.${sgvDomainPrefix}stamhoofd`,
+        sgvAdminUrl: `https://admin.sgv.${sgvDomainPrefix}stamhoofd`,
+
+        // MX + SPF (both for email) + A record for webshops
         webshopCname: domains.webshop,
+
+        // MX + SPF (both for email) + A record for registration
         registrationCname: { '': domains.registration },
+
+        // Default email domain for emails sent from organizations
         defaultTransactionalEmail: { '': 'stamhoofd.be', 'NL': 'stamhoofd.nl' },
         defaultBroadcastEmail: { '': 'stamhoofd.email' },
-        documentation: preset.documentation ? { '': preset.documentation } : undefined,
     };
 }
 

--- a/shared/types/src/StamhoofdDomains.ts
+++ b/shared/types/src/StamhoofdDomains.ts
@@ -1,24 +1,29 @@
 import type { LocalizedDomain } from './Localized.js';
 
+// Use `field: type | undefined` instead of `field?: type` to require setting
+// each field. This ensures fields are explicitly set to undefined, not
+// forgotten to be added.
 export type StamhoofdDomains = {
     dashboard: string; // requires both www + non-www DNS record
-    registration?: LocalizedDomain; // Optional. Set to undefined for platforms. requires wildcard prefix DNS
+    registration: LocalizedDomain | undefined; // Optional. Set to undefined for platforms. requires wildcard prefix DNS
     marketing: LocalizedDomain; // main landing page (used for linking back to website, documentation...)
-    documentation?: LocalizedDomain; // main landing page (used for linking back to website, documentation...)
-    webshop?: LocalizedDomain; // E.g. shop.stamhoofd.be
-    legacyWebshop?: string; // In the past, webshops were hosted on a subdomain. This is deprecated, but the links should still work. E.g. stamhoofd.shop for *.stamhoofd.shop
+    documentation: LocalizedDomain | undefined; // main landing page (used for linking back to website, documentation...)
+    webshop: LocalizedDomain | undefined; // E.g. shop.stamhoofd.be
+    legacyWebshop: string | undefined; // In the past, webshops were hosted on a subdomain. This is deprecated, but the links should still work. E.g. stamhoofd.shop for *.stamhoofd.shop
     api: string; // requires wildcard prefix DNS
     rendererApi: string;
-    sgvLoginUrl?: string;
-    sgvAdminUrl?: string;
+
+    // Scouts & Gidsen Vlaanderen
+    sgvLoginUrl: string | undefined;
+    sgvAdminUrl: string | undefined;
 
     // MX + SPF (both for email) + A record for webshops
-    webshopCname?: string;
+    webshopCname: string | undefined;
 
     // MX + SPF (both for email) + A record for registration
     registrationCname: LocalizedDomain;
 
     // Default email domain for emails sent from organizations
-    defaultTransactionalEmail?: LocalizedDomain;
-    defaultBroadcastEmail?: LocalizedDomain;
+    defaultTransactionalEmail: LocalizedDomain | undefined;
+    defaultBroadcastEmail: LocalizedDomain | undefined;
 };

--- a/shared/types/src/StamhoofdDomains.ts
+++ b/shared/types/src/StamhoofdDomains.ts
@@ -12,12 +12,6 @@ export type StamhoofdDomains = {
     sgvLoginUrl?: string;
     sgvAdminUrl?: string;
 
-    /**
-     * @deprecated
-     * Removed in v2
-     */
-    admin?: string;
-
     // MX + SPF (both for email) + A record for webshops
     webshopCname?: string;
 

--- a/shared/types/src/StamhoofdDomains.ts
+++ b/shared/types/src/StamhoofdDomains.ts
@@ -18,12 +18,6 @@ export type StamhoofdDomains = {
      */
     admin?: string;
 
-    /**
-     * @deprecated
-     * Removed in v2
-     */
-    adminApi?: string;
-
     // MX + SPF (both for email) + A record for webshops
     webshopCname?: string;
 

--- a/tests/playwright/src/setup/helpers/WorkerHelper.ts
+++ b/tests/playwright/src/setup/helpers/WorkerHelper.ts
@@ -141,6 +141,10 @@ class WorkerHelperInstance {
                 registrationCname: {
                     '': CaddyConfigHelper.getDomain('registration', WorkerData.id),
                 },
+                documentation: undefined,
+                legacyWebshop: undefined,
+                sgvLoginUrl: undefined,
+                sgvAdminUrl: undefined,
             },
             translationNamespace: 'stamhoofd',
             platformName: 'stamhoofd',


### PR DESCRIPTION
1. Require StamhoofdDomains to be explicitly configured in each field. This makes sure that we don't forget to configure something.
2. Fix forgetting to configure sgvAdminUrl and sgvLoginUrl in shared/cli.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784741304&installation_id=138085646&pr_number=514&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F514&signature=ff9763864afba4cb76824a00bd2d81039f5c7b9dbf6f8f65d54edc560f52430d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->