### PR TITLE
✨ filter payments on registration or webshop order (STA-1232)

### DIFF
--- a/backend/app/api/src/sql-filters/balance-item-payments.ts
+++ b/backend/app/api/src/sql-filters/balance-item-payments.ts
@@ -1,5 +1,5 @@
 import type { SQLFilterDefinitions } from '@stamhoofd/sql';
-import { baseSQLFilterCompilers, createColumnFilter, SQL, SQLValueType } from '@stamhoofd/sql';
+import { baseSQLFilterCompilers, createColumnFilter, createExistsFilter, SQL, SQLValueType } from '@stamhoofd/sql';
 
 export const balanceItemPaymentsCompilers: SQLFilterDefinitions = {
     ...baseSQLFilterCompilers,
@@ -30,5 +30,37 @@ export const balanceItemPaymentsCompilers: SQLFilterDefinitions = {
             type: SQLValueType.String,
             nullable: true,
         }),
+        registration: createExistsFilter(
+            SQL.select()
+                .from(SQL.table('registrations'))
+                .where(
+                    SQL.column('registrations', 'id'),
+                    SQL.column('balance_items', 'registrationId'),
+                ),
+            {
+                ...baseSQLFilterCompilers,
+                groupId: createColumnFilter({
+                    expression: SQL.column('registrations', 'groupId'),
+                    type: SQLValueType.String,
+                    nullable: false,
+                }),
+            },
+        ),
+        order: createExistsFilter(
+            SQL.select()
+                .from(SQL.table('webshop_orders'))
+                .where(
+                    SQL.column('webshop_orders', 'id'),
+                    SQL.column('balance_items', 'orderId'),
+                ),
+            {
+                ...baseSQLFilterCompilers,
+                webshopId: createColumnFilter({
+                    expression: SQL.column('webshop_orders', 'webshopId'),
+                    type: SQLValueType.String,
+                    nullable: false,
+                }),
+            },
+        ),
     },
 };

--- a/backend/app/api/src/sql-filters/balance-item-payments.ts
+++ b/backend/app/api/src/sql-filters/balance-item-payments.ts
@@ -30,6 +30,11 @@ export const balanceItemPaymentsCompilers: SQLFilterDefinitions = {
             type: SQLValueType.String,
             nullable: true,
         }),
+        type: createColumnFilter({
+            expression: SQL.column('balance_items', 'type'),
+            type: SQLValueType.String,
+            nullable: false,
+        }),
         registration: createExistsFilter(
             SQL.select()
                 .from(SQL.table('registrations'))

--- a/frontend/shared/components/src/filters/RelationUIFilter.ts
+++ b/frontend/shared/components/src/filters/RelationUIFilter.ts
@@ -93,8 +93,26 @@ export class RelationUIFilter<T extends string | number | Date | null | boolean>
                 style: '',
             },
             {
-                text: ` ${$t('%1G1')} `,
-                style: 'gray',
+                text: '',
+                style: '',
+                choices: [
+                    {
+                        id: 'is',
+                        text: $t('%1q'),
+                        action: () => {
+                            this.isInverted = false;
+                        },
+                        isSelected: () => !this.isInverted,
+                    },
+                    {
+                        id: 'is not',
+                        text: $t('%bT'),
+                        action: () => {
+                            this.isInverted = true;
+                        },
+                        isSelected: () => this.isInverted,
+                    },
+                ],
             },
             {
                 text: this.valuesToString,
@@ -179,7 +197,7 @@ export class RelationFilterBuilder<T extends string | number | Date | null | boo
     }
 
     fromFilter(filter: StamhoofdFilter): UIFilter | null {
-        const { markerValue: unwrapped, isInverted } = unwrapFilterForBuilder(this, filter);
+        const { markerValue: unwrapped, isInverted } = unwrapFilterForBuilder(this, filter, true);
         if (!unwrapped || typeof unwrapped !== 'object') {
             return null;
         }

--- a/frontend/shared/components/src/filters/filter-builders/payments.ts
+++ b/frontend/shared/components/src/filters/filter-builders/payments.ts
@@ -1,7 +1,7 @@
 import { NumberFilterFormat } from '#filters/NumberFilterFormat.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import type { WrapperFilter } from '@stamhoofd/structures';
-import { FilterWrapperMarker, GroupType, PaymentMethod, PaymentMethodHelper, PaymentStatus, PaymentStatusHelper, PaymentType, PaymentTypeHelper } from '@stamhoofd/structures';
+import { BalanceItemType, FilterWrapperMarker, GroupType, PaymentMethod, PaymentMethodHelper, PaymentStatus, PaymentStatusHelper, PaymentType, PaymentTypeHelper, getBalanceItemTypeName } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { DateFilterBuilder } from '../DateUIFilter';
 import { getCustomerUIFilterBuilders } from '../filterBuilders';
@@ -129,6 +129,17 @@ export function usePaymentsUIFilterBuilders() {
     };
 
     const balanceItemBuilders: UIFilterBuilders = [
+        new MultipleChoiceFilterBuilder({
+            name: $t('%1B'),
+            options: Object.values(BalanceItemType).map(type => new MultipleChoiceUIFilterOption(getBalanceItemTypeName(type), type)),
+            wrapper: {
+                balanceItem: {
+                    type: {
+                        $in: FilterWrapperMarker,
+                    },
+                },
+            },
+        }),
         new RelationFilterBuilder({
             name: $t('%14Z'),
             type: GroupType.Membership,

--- a/frontend/shared/components/src/filters/filter-builders/payments.ts
+++ b/frontend/shared/components/src/filters/filter-builders/payments.ts
@@ -1,14 +1,19 @@
 import { NumberFilterFormat } from '#filters/NumberFilterFormat.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
-import { FilterWrapperMarker, PaymentMethod, PaymentMethodHelper, PaymentStatus, PaymentStatusHelper, PaymentType, PaymentTypeHelper } from '@stamhoofd/structures';
+import type { WrapperFilter } from '@stamhoofd/structures';
+import { FilterWrapperMarker, GroupType, PaymentMethod, PaymentMethodHelper, PaymentStatus, PaymentStatusHelper, PaymentType, PaymentTypeHelper } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { DateFilterBuilder } from '../DateUIFilter';
 import { getCustomerUIFilterBuilders } from '../filterBuilders';
 import { GroupUIFilterBuilder } from '../GroupUIFilter';
 import { MultipleChoiceFilterBuilder, MultipleChoiceUIFilterOption } from '../MultipleChoiceUIFilter';
 import { NumberFilterBuilder } from '../NumberUIFilter';
+import { RelationFilterBuilder } from '../RelationUIFilter';
 import { StringFilterBuilder } from '../StringUIFilter';
 import type { UIFilterBuilders } from '../UIFilter';
+import { useEventGroupsRelationFetcher } from '../relation-fetchers/event-groups';
+import { useGroupsRelationFetcher } from '../relation-fetchers/groups';
+import { useWebshopsRelationFetcher } from '../relation-fetchers/webshops';
 import { usePlatform } from '#hooks/usePlatform.ts';
 
 export class PaymentFilterBuilders {
@@ -113,6 +118,17 @@ export class PaymentFilterBuilders {
 export function usePaymentsUIFilterBuilders() {
     const organization = useOrganization();
     const platform = usePlatform();
+    const groupsRelationFetcher = useGroupsRelationFetcher();
+    const eventGroupsRelationFetcher = useEventGroupsRelationFetcher();
+    const webshopsRelationFetcher = useWebshopsRelationFetcher();
+
+    const balanceItemRegistrationWrapper: WrapperFilter = {
+        balanceItemPayments: {
+            balanceItem: {
+                registration: FilterWrapperMarker,
+            },
+        },
+    };
 
     const builders: UIFilterBuilders = [
         (!organization.value || organization.value.id === platform.value.membershipOrganizationId) && STAMHOOFD.userMode === 'organization' ? PaymentFilterBuilders.methodForMembershipOrganization : PaymentFilterBuilders.method,
@@ -123,6 +139,32 @@ export function usePaymentsUIFilterBuilders() {
         PaymentFilterBuilders.createdAt,
         PaymentFilterBuilders.transferDescription,
         getCustomerUIFilterBuilders()[0],
+        new RelationFilterBuilder({
+            name: $t('%14Z'),
+            type: GroupType.Membership,
+            key: 'groupId',
+            wrapper: balanceItemRegistrationWrapper,
+            relationFetcher: groupsRelationFetcher({ type: GroupType.Membership }),
+        }),
+        new RelationFilterBuilder({
+            name: $t('%1IR'),
+            type: GroupType.EventRegistration,
+            key: 'groupId',
+            wrapper: balanceItemRegistrationWrapper,
+            relationFetcher: eventGroupsRelationFetcher(),
+        }),
+        new RelationFilterBuilder({
+            name: $t('Webshop'),
+            key: 'webshopId',
+            wrapper: {
+                balanceItemPayments: {
+                    balanceItem: {
+                        order: FilterWrapperMarker,
+                    },
+                },
+            },
+            relationFetcher: webshopsRelationFetcher,
+        }),
     ];
 
     if (organization.value && organization.value.meta.invoicesEnabled) {

--- a/frontend/shared/components/src/filters/filter-builders/payments.ts
+++ b/frontend/shared/components/src/filters/filter-builders/payments.ts
@@ -123,22 +123,12 @@ export function usePaymentsUIFilterBuilders() {
     const webshopsRelationFetcher = useWebshopsRelationFetcher();
 
     const balanceItemRegistrationWrapper: WrapperFilter = {
-        balanceItemPayments: {
-            balanceItem: {
-                registration: FilterWrapperMarker,
-            },
+        balanceItem: {
+            registration: FilterWrapperMarker,
         },
     };
 
-    const builders: UIFilterBuilders = [
-        (!organization.value || organization.value.id === platform.value.membershipOrganizationId) && STAMHOOFD.userMode === 'organization' ? PaymentFilterBuilders.methodForMembershipOrganization : PaymentFilterBuilders.method,
-        PaymentFilterBuilders.status,
-        PaymentFilterBuilders.type,
-        PaymentFilterBuilders.price,
-        PaymentFilterBuilders.paidAt,
-        PaymentFilterBuilders.createdAt,
-        PaymentFilterBuilders.transferDescription,
-        getCustomerUIFilterBuilders()[0],
+    const balanceItemBuilders: UIFilterBuilders = [
         new RelationFilterBuilder({
             name: $t('%14Z'),
             type: GroupType.Membership,
@@ -156,14 +146,27 @@ export function usePaymentsUIFilterBuilders() {
         new RelationFilterBuilder({
             name: $t('Webshop'),
             key: 'webshopId',
-            wrapper: {
-                balanceItemPayments: {
-                    balanceItem: {
-                        order: FilterWrapperMarker,
-                    },
-                },
-            },
+            wrapper: { balanceItem: { order: FilterWrapperMarker } } as WrapperFilter,
             relationFetcher: webshopsRelationFetcher,
+        }),
+    ];
+
+    balanceItemBuilders.unshift(new GroupUIFilterBuilder({ builders: balanceItemBuilders }));
+
+    const builders: UIFilterBuilders = [
+        (!organization.value || organization.value.id === platform.value.membershipOrganizationId) && STAMHOOFD.userMode === 'organization' ? PaymentFilterBuilders.methodForMembershipOrganization : PaymentFilterBuilders.method,
+        PaymentFilterBuilders.status,
+        PaymentFilterBuilders.type,
+        PaymentFilterBuilders.price,
+        PaymentFilterBuilders.paidAt,
+        PaymentFilterBuilders.createdAt,
+        PaymentFilterBuilders.transferDescription,
+        getCustomerUIFilterBuilders()[0],
+        new GroupUIFilterBuilder({
+            name: $t('Betaallijnen'),
+            description: $t('Een betaling kan voor meerdere items tegelijk zijn. Filter op betalingen die een item hebben die aan deze voorwaarden voldoet.'),
+            builders: balanceItemBuilders,
+            wrapper: { balanceItemPayments: FilterWrapperMarker } as WrapperFilter,
         }),
     ];
 

--- a/frontend/shared/components/src/filters/relation-fetchers/webshops.ts
+++ b/frontend/shared/components/src/filters/relation-fetchers/webshops.ts
@@ -1,0 +1,14 @@
+import { SortItemDirection } from '@stamhoofd/structures';
+import { useWebshopsObjectFetcher } from '../../fetchers/useWebshopsObjectFetcher';
+import { RelationFetcher } from '../RelationUIFilter';
+
+export function useWebshopsRelationFetcher() {
+    const fetcher = useWebshopsObjectFetcher();
+
+    return new RelationFetcher({
+        fetcher,
+        getName: w => w.webshop.meta.name,
+        getValue: w => w.id,
+        sort: [{ key: 'name', order: SortItemDirection.ASC }],
+    });
+}

--- a/shared/locales/src/machine-en.json
+++ b/shared/locales/src/machine-en.json
@@ -14468,7 +14468,7 @@
     "translation": "Export"
   },
   "%Oz": {
-    "original": "Cijfers exporteren",
+    "original": "Betalingen exporteren",
     "translation": "Export figures"
   },
   "%P0": {

--- a/shared/locales/src/machine-fr.json
+++ b/shared/locales/src/machine-fr.json
@@ -14632,7 +14632,7 @@
     "translation": "Exporter"
   },
   "%Oz": {
-    "original": "Cijfers exporteren",
+    "original": "Betalingen exporteren",
     "translation": "Exporter les chiffres"
   },
   "%P0": {

--- a/shared/locales/src/nl.json
+++ b/shared/locales/src/nl.json
@@ -1498,7 +1498,7 @@
   "%Ow": "Stuur automatisch e-mails naar leden als hun openstaand bedrag stijgt of als betaalherinnering.",
   "%Ox": "Geef 25 euro en krijg zelf ook een tegoed",
   "%Oy": "Exporteren",
-  "%Oz": "Cijfers exporteren",
+  "%Oz": "Betalingen exporteren",
   "%P0": "Snel selecteren",
   "%P1": "Tijdzone",
   "%P2": "Gebruik UTC-tijdzone",


### PR DESCRIPTION
Voorlopig staan de 3 nieuwe filters nog als top level filter, maar dit zou eigenlijk onder "items" (goede naam?) moeten komen. 

Je filtert namelijk niet rechtstreeks op betalingen, maar op de balance-items die aan de betaling hangen: 2 verschillend ingestelde filters kunnen dezelfde betaling terug geven. 

Hoe zou ik dit best duidelijk maken?

<img width="291" height="485" alt="Screenshot 2026-06-25 at 09 55 19" src="https://github.com/user-attachments/assets/990ead5a-2f6f-470f-af3c-c432d1c50ea3" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784966272&installation_id=138085646&pr_number=529&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F529&signature=7e4e6e450a64b78801fb9af811bfe8411c3c070118e1df8fb6c7aa2d67568a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->