### PR TITLE
Limit context menu on group category row based on permissions

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupCategoryRow.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupCategoryRow.vue
@@ -1,5 +1,5 @@
 <template>
-    <STListItem v-long-press="(e: any) => showContextMenu(e)" :selectable="true" class="right-stack" @click="editCategory()" @contextmenu.prevent="showContextMenu">
+    <STListItem v-long-press="(e: any) => canShowMenu && showContextMenu(e)" :selectable="true" class="right-stack" @click="canManage && editCategory()" @contextmenu.prevent="canShowMenu && showContextMenu($event)">
         <h2 class="style-title-list">
             {{ category.settings.name }}
         </h2>
@@ -8,7 +8,7 @@
         </p>
 
         <template #right>
-            <button type="button" class="button icon more gray hide-smartphone" @click.stop.prevent="showContextMenu" @contextmenu.stop />
+            <button v-if="canShowMenu" type="button" class="button icon more gray hide-smartphone" @click.stop.prevent="showContextMenu" @contextmenu.stop />
             <span class="button icon drag gray" @click.stop @contextmenu.stop />
             <span class="icon arrow-right-small gray" />
         </template>
@@ -32,7 +32,7 @@ const emit = defineEmits<{
     (e: 'patch:periods', value: PatchableArrayAutoEncoder<OrganizationRegistrationPeriod>): void;
 }>();
 
-const { showMenu: showContextMenu, editCategory } = useGroupCategoryActions(
+const { showMenu: showContextMenu, editCategory, canShowMenu, canManage } = useGroupCategoryActions(
     (patch: PatchableArrayAutoEncoder<OrganizationRegistrationPeriod>) => emit('patch:periods', patch),
 )(props);
 

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupRow.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupRow.vue
@@ -1,5 +1,5 @@
 <template>
-    <STListItem v-long-press="(e: any) => showContextMenu(e)" :selectable="true" class="right-stack" @click="editGroup()" @contextmenu.prevent="showContextMenu">
+    <STListItem v-long-press="(e: any) => canShowMenu && showContextMenu(e)" :selectable="true" class="right-stack" @click="canShowMenu && editGroup()" @contextmenu.prevent="canShowMenu && showContextMenu($event)">
         <template #left>
             <GroupAvatar :group="group" />
         </template>
@@ -8,7 +8,7 @@
             {{ group.settings.name }}
         </h2>
         <template #right>
-            <button type="button" class="button icon more gray hide-smartphone" @click.stop.prevent="showContextMenu" @contextmenu.stop />
+            <button v-if="canShowMenu" type="button" class="button icon more gray hide-smartphone" @click.stop.prevent="showContextMenu" @contextmenu.stop />
             <span class="button icon drag gray" @click.stop @contextmenu.stop />
             <span class="icon arrow-right-small gray" />
         </template>
@@ -33,7 +33,7 @@ const emit = defineEmits<{
     (e: 'patch:periods', value: PatchableArrayAutoEncoder<OrganizationRegistrationPeriod>): void;
 }>();
 
-const { showMenu: showContextMenu, editGroup } = useGroupActions(
+const { showMenu: showContextMenu, editGroup, canShowMenu } = useGroupActions(
     patch => emit('patch:periods', patch),
 )(props);
 </script>

--- a/frontend/app/dashboard/src/views/members/GroupCategoryBox.vue
+++ b/frontend/app/dashboard/src/views/members/GroupCategoryBox.vue
@@ -7,7 +7,7 @@
         :title="subcategory.settings.name"
         :selected="checkRoute(Routes.Category, {properties: {category: subcategory, period}})"
         @open="navigate(Routes.Category, {properties: {category: subcategory, period}})"
-        @contextmenu.prevent="getCategoryActions({period, category: subcategory}).showMenu($event)"
+        @contextmenu="getCategoryActions({period, category: subcategory}).showMenu($event)"
     >
         <GroupCategoryBox
             :category="subcategory"

--- a/frontend/app/dashboard/src/views/members/GroupCategoryMenuBox.vue
+++ b/frontend/app/dashboard/src/views/members/GroupCategoryMenuBox.vue
@@ -7,7 +7,7 @@
         type="members"
         :selected="checkRoute(Routes.Category, {properties: {category, period}})"
         @open="$navigate(Routes.Category, {properties: {category, period}})"
-        @contextmenu.prevent="getCategoryActions({period, category}).showMenu($event)"
+        @contextmenu="getCategoryActions({period, category}).showMenu($event)"
     >
         <GroupCategoryBox
             :category="category"

--- a/frontend/app/dashboard/src/views/members/GroupCategoryMoreButton.vue
+++ b/frontend/app/dashboard/src/views/members/GroupCategoryMoreButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <span class="icon button small right more-in-circle" @click.stop="showMenu" />
+    <span v-if="canShowMenu" class="icon button small right more-in-circle" @click.stop="showMenu" />
 </template>
 
 <script setup lang="ts">
@@ -16,6 +16,6 @@ const props = withDefaults(
     },
 );
 
-const { showMenu } = useGroupCategoryActions()(props);
+const { showMenu, canShowMenu } = useGroupCategoryActions()(props);
 
 </script>

--- a/frontend/app/dashboard/src/views/members/useGroupActions.ts
+++ b/frontend/app/dashboard/src/views/members/useGroupActions.ts
@@ -2,13 +2,13 @@ import type { AutoEncoderPatchType, PatchableArrayAutoEncoder } from '@simonback
 import { PatchableArray } from '@simonbackx/simple-encoding';
 import { usePresent } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '@stamhoofd/components/containers/AsyncComponent.ts';
-
+import { useAuth } from '@stamhoofd/components/hooks/useAuth.ts';
 import { CenteredMessage } from '@stamhoofd/components/overlays/CenteredMessage.ts';
 import { ContextMenu, ContextMenuItem } from '@stamhoofd/components/overlays/ContextMenu';
 import { Toast } from '@stamhoofd/components/overlays/Toast';
 import { useLoadRecentPeriods } from '@stamhoofd/networking/hooks/useLoadRecentPeriods';
 import { usePatchOrganizationPeriods } from '@stamhoofd/networking/hooks/usePatchOrganizationPeriods';
-import { Group, GroupCategory, GroupSettings, GroupStatus, OrganizationRegistrationPeriod, OrganizationRegistrationPeriodSettings, TranslatedString } from '@stamhoofd/structures';
+import { Group, GroupCategory, GroupSettings, GroupStatus, OrganizationRegistrationPeriod, OrganizationRegistrationPeriodSettings, PermissionLevel, TranslatedString } from '@stamhoofd/structures';
 import { v4 as uuidv4 } from 'uuid';
 
 /**
@@ -19,6 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
  */
 export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<OrganizationRegistrationPeriod>) => Promise<void> | void) {
     const present = usePresent();
+    const auth = useAuth();
     const patchOrganizationPeriods = usePatchOrganizationPeriods();
     const getPeriods = useLoadRecentPeriods();
 
@@ -30,6 +31,9 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
          */
         periods?: OrganizationRegistrationPeriod[];
     }) {
+        const canManage = auth.hasFullAccess();
+        const canEdit = canManage || auth.canAccessGroup(props.group, PermissionLevel.Write);
+
         function getParentCategory() {
             return props.group.getParentCategories(props.period.settings.categories)[0];
         }
@@ -110,7 +114,12 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
             const settings = OrganizationRegistrationPeriodSettings.patch({});
             settings.categories.addPatch(GroupCategory.patch({ id: parentCategory.id, groupIds: reorder }));
 
-            await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            try {
+                await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+            }
         }
 
         async function moveTo(category: GroupCategory, period: OrganizationRegistrationPeriod) {
@@ -135,12 +144,18 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
             pp.groupIds.addDelete(props.group.id);
             settings.categories.addPatch(pp);
 
-            await save([
-                OrganizationRegistrationPeriod.patch({
-                    id: props.period.id,
-                    settings,
-                }),
-            ], [props.period]);
+            try {
+                await save([
+                    OrganizationRegistrationPeriod.patch({
+                        id: props.period.id,
+                        settings,
+                    }),
+                ], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return;
+            }
 
             showSuccessToast($t('%1cM', {
                 groupName: props.group.settings.name.toString(),
@@ -244,7 +259,13 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
             });
             periodPatch.groups.addPut(duplicated);
 
-            await save([periodPatch], [props.period]);
+            try {
+                await save([periodPatch], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return;
+            }
 
             showSuccessToast($t('%1bK', {
                 groupName: props.group.settings.name.toString(),
@@ -282,7 +303,13 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
             });
             periodPatch.groups.addDelete(props.group.id);
 
-            await save([periodPatch], [props.period]);
+            try {
+                await save([periodPatch], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return false;
+            }
 
             showSuccessToast($t('%1Z8', {
                 groupName: props.group.settings.name.toString(),
@@ -323,7 +350,13 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
             const periodPatch = OrganizationRegistrationPeriod.patch({ id: props.period.id });
             periodPatch.groups.addPatch(groupPatch);
 
-            await save([periodPatch], [props.period]);
+            try {
+                await save([periodPatch], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return false;
+            }
 
             showSuccessToast($t('%1WV'));
 
@@ -348,7 +381,13 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
                 status: GroupStatus.Closed,
             }));
 
-            await save([periodPatch], [props.period]);
+            try {
+                await save([periodPatch], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return false;
+            }
 
             showSuccessToast($t('%b4'));
 
@@ -401,7 +440,11 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
                 });
             });
 
-            const menu = new ContextMenu([
+            if (!canEdit) {
+                return;
+            }
+
+            const sections: ContextMenuItem[][] = [
                 [
                     new ContextMenuItem({
                         name: $t('%f9'),
@@ -412,7 +455,10 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
                         },
                     }),
                 ],
-                [
+            ];
+
+            if (canManage) {
+                sections.push([
                     new ContextMenuItem({
                         name: $t('%11f'),
                         icon: 'arrow-up',
@@ -429,8 +475,12 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
                             return true;
                         },
                     }),
-                ],
-                [
+                ]);
+            }
+
+            const managementActions: ContextMenuItem[] = [];
+            if (canManage) {
+                managementActions.push(
                     new ContextMenuItem({
                         icon: 'folder',
                         name: $t('%122'),
@@ -456,7 +506,6 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
                             ],
                         ]),
                     }),
-
                     new ContextMenuItem({
                         name: $t('%KK'),
                         icon: 'copy',
@@ -465,21 +514,27 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
                             return true;
                         },
                     }),
+                );
+            }
 
-                    new ContextMenuItem({
-                        name: props.group.closed ? $t('%Lh') : $t('%1Vi'),
-                        icon: props.group.closed ? 'unlock' : 'lock',
-                        destructive: !props.group.closed,
-                        action: async () => {
-                            if (props.group.closed) {
-                                await openGroup();
-                            } else {
-                                await closeGroup();
-                            }
-                            return true;
-                        },
-                    }),
+            managementActions.push(
+                new ContextMenuItem({
+                    name: props.group.closed ? $t('%Lh') : $t('%1Vi'),
+                    icon: props.group.closed ? 'unlock' : 'lock',
+                    destructive: !props.group.closed,
+                    action: async () => {
+                        if (props.group.closed) {
+                            await openGroup();
+                        } else {
+                            await closeGroup();
+                        }
+                        return true;
+                    },
+                }),
+            );
 
+            if (canManage) {
+                managementActions.push(
                     new ContextMenuItem({
                         name: $t('%CJ'),
                         destructive: true,
@@ -489,8 +544,12 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
                             return true;
                         },
                     }),
-                ],
-            ]);
+                );
+            }
+
+            sections.push(managementActions);
+
+            const menu = new ContextMenu(sections);
 
             if (event.type === 'contextmenu') {
                 // show at mouse
@@ -505,6 +564,6 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
             });
         }
 
-        return { showMenu, editGroup, openGroup, closeGroup, deleteGroup };
+        return { showMenu, editGroup, openGroup, closeGroup, deleteGroup, canShowMenu: canEdit };
     };
 }

--- a/frontend/app/dashboard/src/views/members/useGroupCategoryActions.ts
+++ b/frontend/app/dashboard/src/views/members/useGroupCategoryActions.ts
@@ -403,6 +403,11 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
         }
 
         async function showMenu(event: MouseEvent) {
+            if (!canShowMenu) {
+                return;
+            }
+            event.preventDefault();
+
             const parentCategory = getParentCategory();
             const grandParentCategory = getGrandParentCategory();
             const subCategories = getSubCategories();
@@ -593,6 +598,7 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
             });
         }
 
-        return { showMenu, editCategory, canManage, canShowMenu: canManage || canCreate };
+        const canShowMenu = canManage || (canCreate && props.category.categoryIds.length === 0);
+        return { showMenu, editCategory, canManage, canShowMenu };
     };
 }

--- a/frontend/app/dashboard/src/views/members/useGroupCategoryActions.ts
+++ b/frontend/app/dashboard/src/views/members/useGroupCategoryActions.ts
@@ -34,6 +34,7 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
         }
         : undefined);
     const isPlatformAdmin = auth.hasFullPlatformAccess();
+    const canManage = auth.hasFullAccess();
 
     return function getFor(props: {
         period: OrganizationRegistrationPeriod;
@@ -95,6 +96,7 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
         }
 
         const canDeleteOrRename = props.category.settings.locked !== true || isPlatformAdmin;
+        const canCreate = auth.canCreateGroupInCategory(props.category);
 
         async function save(patches: AutoEncoderPatchType<OrganizationRegistrationPeriod>[], periods: OrganizationRegistrationPeriod[]) {
             const arr = new PatchableArray() as PatchableArrayAutoEncoder<OrganizationRegistrationPeriod>;
@@ -171,7 +173,12 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
             const settings = OrganizationRegistrationPeriodSettings.patch({});
             settings.categories.addPatch(GroupCategory.patch({ id: parentCategory.id, categoryIds: reorder }));
 
-            await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            try {
+                await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+            }
         }
 
         async function moveTo(category: GroupCategory) {
@@ -196,7 +203,13 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
             pp.categoryIds.addDelete(props.category.id);
             settings.categories.addPatch(pp);
 
-            await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            try {
+                await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return;
+            }
 
             showSuccessToast($t('%1YP', {
                 categoryName: props.category.getName(props.period),
@@ -330,7 +343,13 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
             pp.categoryIds.addDelete(props.category.id);
             settings.categories.addPatch(pp);
 
-            await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            try {
+                await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return;
+            }
 
             showSuccessToast($t('%1YI', {
                 categoryName: props.category.getName(props.period),
@@ -355,7 +374,13 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
             pp.categoryIds.addDelete(props.category.id);
             settings.categories.addPatch(pp);
 
-            await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            try {
+                await save([OrganizationRegistrationPeriod.patch({ id: props.period.id, settings })], [props.period]);
+            } catch (e) {
+                console.error(e);
+                Toast.fromError(e).show();
+                return;
+            }
 
             showSuccessToast($t('%1XK', {
                 categoryName: props.category.getName(props.period),
@@ -425,8 +450,10 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
                 });
             });
 
-            const sections: ContextMenuItem[][] = [
-                [
+            const sections: ContextMenuItem[][] = [];
+
+            if (canManage) {
+                sections.push([
                     new ContextMenuItem({
                         icon: 'settings',
                         name: $t('%1cI'),
@@ -435,11 +462,11 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
                             return true;
                         },
                     }),
-                ],
-            ];
+                ]);
+            }
 
             const createActions: ContextMenuItem[] = [];
-            if (props.category.groupIds.length === 0) {
+            if (canManage && props.category.groupIds.length === 0) {
                 createActions.push(new ContextMenuItem({
                     icon: 'folder-add',
                     name: $t('%LN'),
@@ -449,7 +476,7 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
                     },
                 }));
             }
-            if (props.category.categoryIds.length === 0) {
+            if (canCreate && props.category.categoryIds.length === 0) {
                 createActions.push(new ContextMenuItem({
                     icon: 'add',
                     name: $t('%LD'),
@@ -463,87 +490,93 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
                 sections.push(createActions);
             }
 
-            sections.push([
-                new ContextMenuItem({
-                    name: $t('%11f'),
-                    icon: 'arrow-up',
-                    action: async () => {
-                        await move(-1);
-                        return true;
-                    },
-                }),
-                new ContextMenuItem({
-                    name: $t('%11g'),
-                    icon: 'arrow-down',
-                    action: async () => {
-                        await move(1);
-                        return true;
-                    },
-                }),
-            ]);
+            if (canManage) {
+                sections.push([
+                    new ContextMenuItem({
+                        name: $t('%11f'),
+                        icon: 'arrow-up',
+                        action: async () => {
+                            await move(-1);
+                            return true;
+                        },
+                    }),
+                    new ContextMenuItem({
+                        name: $t('%11g'),
+                        icon: 'arrow-down',
+                        action: async () => {
+                            await move(1);
+                            return true;
+                        },
+                    }),
+                ]);
 
-            sections.push([
-                new ContextMenuItem({
-                    icon: 'folder',
-                    name: $t('%122'),
-                    childMenu: new ContextMenu([
-                        [
-                            new ContextMenuItem({
-                                icon: 'folder',
-                                name: $t('%1cr'),
-                                description: grandParentCategory?.getName(props.period),
-                                disabled: !grandParentCategory,
-                                action: async () => {
-                                    await moveTo(grandParentCategory!);
-                                    return true;
-                                },
-                            }),
-                        ],
-                        subCategories.map(cat =>
-                            new ContextMenuItem({
-                                icon: 'folder',
-                                name: cat.getName(props.period),
-                                disabled: cat.groupIds.length > 0,
-                                action: async () => {
-                                    await moveTo(cat);
-                                    return true;
-                                },
-                            }),
-                        ),
-                        [
-                            new ContextMenuItem({
-                                name: $t('%1HU'),
-                                childMenu: new ContextMenu([
-                                    moveToPeriodOptions,
-                                ]),
-                                disabled: !canDeleteOrRename || moveToPeriodOptions.filter(p => !p.disabled).length === 0,
-                            }),
-                        ],
-                    ]),
-                }),
-                new ContextMenuItem({
-                    icon: 'unbox',
-                    name: $t('%1dQ'),
-                    destructive: true,
-                    disabled: !canDeleteOrRename || (props.category.groupIds.length === 0 && props.category.categoryIds.length === 0),
-                    childMenu: new ContextMenu([
-                        [
-                            createMergeContextMenuItem(parentCategory),
-                        ],
-                        subCategories.map(cat => createMergeContextMenuItem(cat)),
-                    ]),
-                }),
-                new ContextMenuItem({
-                    name: $t('%CJ'),
-                    destructive: true,
-                    icon: 'trash',
-                    disabled: !canDeleteOrRename,
-                    action: async () => {
-                        await deleteMe();
-                        return true;
-                    },
-                }),
-            ]);
+                sections.push([
+                    new ContextMenuItem({
+                        icon: 'folder',
+                        name: $t('%122'),
+                        childMenu: new ContextMenu([
+                            [
+                                new ContextMenuItem({
+                                    icon: 'folder',
+                                    name: $t('%1cr'),
+                                    description: grandParentCategory?.getName(props.period),
+                                    disabled: !grandParentCategory,
+                                    action: async () => {
+                                        await moveTo(grandParentCategory!);
+                                        return true;
+                                    },
+                                }),
+                            ],
+                            subCategories.map(cat =>
+                                new ContextMenuItem({
+                                    icon: 'folder',
+                                    name: cat.getName(props.period),
+                                    disabled: cat.groupIds.length > 0,
+                                    action: async () => {
+                                        await moveTo(cat);
+                                        return true;
+                                    },
+                                }),
+                            ),
+                            [
+                                new ContextMenuItem({
+                                    name: $t('%1HU'),
+                                    childMenu: new ContextMenu([
+                                        moveToPeriodOptions,
+                                    ]),
+                                    disabled: !canDeleteOrRename || moveToPeriodOptions.filter(p => !p.disabled).length === 0,
+                                }),
+                            ],
+                        ]),
+                    }),
+                    new ContextMenuItem({
+                        icon: 'unbox',
+                        name: $t('%1dQ'),
+                        destructive: true,
+                        disabled: !canDeleteOrRename || (props.category.groupIds.length === 0 && props.category.categoryIds.length === 0),
+                        childMenu: new ContextMenu([
+                            [
+                                createMergeContextMenuItem(parentCategory),
+                            ],
+                            subCategories.map(cat => createMergeContextMenuItem(cat)),
+                        ]),
+                    }),
+                    new ContextMenuItem({
+                        name: $t('%CJ'),
+                        destructive: true,
+                        icon: 'trash',
+                        disabled: !canDeleteOrRename,
+                        action: async () => {
+                            await deleteMe();
+                            return true;
+                        },
+                    }),
+                ]);
+            }
+
+            if (sections.length === 0) {
+                return;
+            }
 
             const menu = new ContextMenu(sections);
 
@@ -560,6 +593,6 @@ export function useGroupCategoryActions(saveHandler?: (patch: PatchableArrayAuto
             });
         }
 
-        return { showMenu, editCategory };
+        return { showMenu, editCategory, canManage, canShowMenu: canManage || canCreate };
     };
 }


### PR DESCRIPTION
Op dit moment moet je voor bijna alles full admin zijn van de org...

In de toekomst misschien veranderen dat users met full rights tot 1 categorie ook wat meer mogen (reorders, sub-categorieën toevoegen, ...). Maar hiervoor zijn backend changes nodig.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785006197&installation_id=138085646&pr_number=534&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F534&signature=0a7fadae43a33eb27356472c50e3fd6767053a15dbab4ded7732beb45b6d9785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->