### PR TITLE
Fix price input 0001

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/discounts/EditProductDiscountView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/discounts/EditProductDiscountView.vue
@@ -207,15 +207,14 @@ function setDiscountType(d: ProductDiscount, type: 'percentageDiscount' | 'disco
     if (type === 'percentageDiscount') {
         p.discounts.addPatch(ProductDiscount.patch({
             id: d.id,
-            percentageDiscount: Math.min(100, getDiscountDiscountPerPiece(d)),
+            percentageDiscount: getDiscountDiscountPerPiece(d) / 100,
             discountPerPiece: 0,
         }));
-    }
-    else {
+    } else {
         p.discounts.addPatch(ProductDiscount.patch({
             id: d.id,
             percentageDiscount: 0,
-            discountPerPiece: Math.max(1, getDiscountPercentageDiscount(d)),
+            discountPerPiece: getDiscountPercentageDiscount(d) * 100,
         }));
     }
     addPatch(p);

--- a/frontend/shared/components/src/inputs/FloatInput.vue
+++ b/frontend/shared/components/src/inputs/FloatInput.vue
@@ -20,7 +20,7 @@
                     @change="updateModelValue()"
                     @input="updateModelValue({ final: false })"
                 >
-                 <div v-if="!text.length" class="placeholder">
+                <div v-if="!text.length" class="placeholder">
                     {{ placeholder }}
                 </div>
                 <div v-else>
@@ -103,17 +103,17 @@ watch(() => model.value, (value) => {
 function setModelValue(value: number | null, {final}: {final: boolean} = { final: true }) {
     if (value !== model.value) {
         model.value = value;
-        return
+        
     }
-    else if (final) {
+    if (final) {
         updateText(value);
     }
 }
 
 function updateText(value: number | null) {
-    text.value = numberInput.numberToString(value, { valueIfNaN: 
-            props.autoFix ? '' : text.value
-         });
+    text.value = numberInput.numberToString(value, { valueIfNaN:
+            props.autoFix ? '' : text.value,
+    });
 }
 
 function step(add: number) {
@@ -124,11 +124,11 @@ function step(add: number) {
     updateText(newValue);
 }
 
-function updateModelValue(options: {final: boolean} = { final: true }) {
+function updateModelValue(options: { final: boolean } = { final: true }) {
     validate(text.value, options);
 }
 
-function validate(value: string, {final}: {final: boolean} = { final: true }) {
+function validate(value: string, { final }: { final: boolean } = { final: true }) {
     let number = numberInput.stringToNumber(value, { valueIfNaN: props.autoFix ? null : NaN });
 
     if (final) {
@@ -144,9 +144,9 @@ function validate(value: string, {final}: {final: boolean} = { final: true }) {
         return;
     }
 
-    const {isValid} = numberInput.validateNumber(number);
+    const { isValid } = numberInput.validateNumber(number);
     if (isValid) {
-        setModelValue(number, {final});
+        setModelValue(number, { final });
     }
 }
 


### PR DESCRIPTION
UI bug -> fixed in FloatInput
bug door hondersten bij percentage en duizendsten bij bedragen -> fixed in EditProductDiscountView.vue

€1 wordt nu omgezet in 1% en vice-versa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785008200&installation_id=138085646&pr_number=535&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F535&signature=e8cfb8647b7b479e16c9fbb4c4bd58c90129236dd37b106cbaa47a8216ad21cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->