### PR TITLE
Hide export columns `security code` & `default age groups` in org mode

### DIFF
--- a/frontend/shared/components/src/members/classes/getSelectablePdfData.ts
+++ b/frontend/shared/components/src/members/classes/getSelectablePdfData.ts
@@ -95,13 +95,15 @@ export function getSelectablePdfData({ platform, organization, auth, groupColumn
             // todo: check if this is correct?
             getValue: ({ patchedMember: object }: PlatformMember) => object.details.address?.toString(),
         }),
-        new SelectablePdfData<PlatformMember>({
-            id: 'securityCode',
-            name: $t(`%wE`),
-            enabled: false,
-            description: $t(`%ex`),
-            getValue: ({ patchedMember: object }: PlatformMember) => object.details.securityCode,
-        }),
+        ...(STAMHOOFD.userMode === 'platform'
+            ? [new SelectablePdfData<PlatformMember>({
+                    id: 'securityCode',
+                    name: $t(`%wE`),
+                    enabled: false,
+                    description: $t(`%ex`),
+                    getValue: ({ patchedMember: object }: PlatformMember) => object.details.securityCode,
+                })]
+            : []),
 
         returnNullIfNoAccessRight(new SelectablePdfData<PlatformMember>({
             id: 'requiresFinancialSupport',
@@ -172,37 +174,39 @@ export function getSelectablePdfData({ platform, organization, auth, groupColumn
                             return str;
                         },
                     }),
-                    new SelectablePdfData<PlatformMember>({
-                        id: 'defaultAgeGroup',
-                        name: $t(`%wI`),
-                        enabled: false,
-                        getValue: (member: PlatformMember) => {
-                            const groups = member.filterRegistrations({
-                                currentPeriod: true,
-                                types: [GroupType.Membership],
-                                // todo: check if this is correct
-                                organizationId: undefined,
-                            });
-                            const defaultAgeGroupIds = Formatter.uniqueArray(
-                                groups.filter(o => o.group.defaultAgeGroupId),
-                            );
-                            const defaultAgeGroups = defaultAgeGroupIds.map(
-                                o =>
-                                    Platform.shared.config.defaultAgeGroups.find(
-                                        g => g.id === o.group.defaultAgeGroupId,
-                                    )?.name ?? $t(`%wJ`),
-                            );
-                            const str
-                    = Formatter.joinLast(
-                        Formatter.uniqueArray(defaultAgeGroups).sort(),
-                        ', ',
-                        ' ' + $t(`%M1`) + ' ',
-                    )
-                    || $t('%5D');
+                    ...(platform.config.defaultAgeGroups.length > 0
+                        ? [new SelectablePdfData<PlatformMember>({
+                                id: 'defaultAgeGroup',
+                                name: $t(`%wI`),
+                                enabled: false,
+                                getValue: (member: PlatformMember) => {
+                                    const groups = member.filterRegistrations({
+                                        currentPeriod: true,
+                                        types: [GroupType.Membership],
+                                        // todo: check if this is correct
+                                        organizationId: undefined,
+                                    });
+                                    const defaultAgeGroupIds = Formatter.uniqueArray(
+                                        groups.filter(o => o.group.defaultAgeGroupId),
+                                    );
+                                    const defaultAgeGroups = defaultAgeGroupIds.map(
+                                        o =>
+                                            Platform.shared.config.defaultAgeGroups.find(
+                                                g => g.id === o.group.defaultAgeGroupId,
+                                            )?.name ?? $t(`%wJ`),
+                                    );
+                                    const str
+                            = Formatter.joinLast(
+                                Formatter.uniqueArray(defaultAgeGroups).sort(),
+                                ', ',
+                                ' ' + $t(`%M1`) + ' ',
+                            )
+                            || $t('%5D');
 
-                            return str;
-                        },
-                    }),
+                                    return str;
+                                },
+                            })]
+                        : []),
                 ]
             : []),
 

--- a/frontend/shared/components/src/members/classes/getSelectableWorkbook.ts
+++ b/frontend/shared/components/src/members/classes/getSelectableWorkbook.ts
@@ -71,12 +71,14 @@ export function getSelectableColumns({ platform, organization, auth, groupColumn
             name: $t(`%Cn`),
             description: $t(`%ew`),
         }),
-        new SelectableColumn({
-            id: 'securityCode',
-            name: $t(`%wE`),
-            enabled: false,
-            description: $t(`%ex`),
-        }),
+        ...(STAMHOOFD.userMode === 'platform'
+            ? [new SelectableColumn({
+                    id: 'securityCode',
+                    name: $t(`%wE`),
+                    enabled: false,
+                    description: $t(`%ex`),
+                })]
+            : []),
         returnNullIfNoAccessRight(new SelectableColumn({
             id: 'requiresFinancialSupport',
             name: financialSupportTitle,
@@ -112,11 +114,13 @@ export function getSelectableColumns({ platform, organization, auth, groupColumn
                     }),
                 ]
             : []),
-        new SelectableColumn({
-            id: 'defaultAgeGroup',
-            name: $t(`%wI`),
-            enabled: false,
-        }),
+        ...(platform.config.defaultAgeGroups.length > 0
+            ? [new SelectableColumn({
+                    id: 'defaultAgeGroup',
+                    name: $t(`%wI`),
+                    enabled: false,
+                })]
+            : []),
         new SelectableColumn({
             id: 'group',
             name: $t(`%wH`),

--- a/frontend/shared/components/src/registrations/classes/getSelectableWorkbook.ts
+++ b/frontend/shared/components/src/registrations/classes/getSelectableWorkbook.ts
@@ -116,12 +116,14 @@ export function getSelectableWorkbook(platform: Platform, organization: Organiza
             description: $t(`%ew`),
             enabled: false,
         }),
-        new SelectableColumn({
-            id: 'member.securityCode',
-            name: $t(`%wE`),
-            enabled: false,
-            description: $t(`%ex`),
-        }),
+        ...(STAMHOOFD.userMode === 'platform'
+            ? [new SelectableColumn({
+                    id: 'member.securityCode',
+                    name: $t(`%wE`),
+                    enabled: false,
+                    description: $t(`%ex`),
+                })]
+            : []),
         returnNullIfNoAccessRight(new SelectableColumn({
             id: 'member.requiresFinancialSupport',
             name: financialSupportTitle,
@@ -193,11 +195,13 @@ export function getSelectableWorkbook(platform: Platform, organization: Organiza
             : []),
         ...organization === null || groups.length > 1
             ? [
-                    new SelectableColumn({
-                        id: 'defaultAgeGroup',
-                        name: $t(`%wI`),
-                        enabled: false,
-                    }),
+                    ...(platform.config.defaultAgeGroups.length > 0
+                        ? [new SelectableColumn({
+                                id: 'defaultAgeGroup',
+                                name: $t(`%wI`),
+                                enabled: false,
+                            })]
+                        : []),
                     new SelectableColumn({
                         id: 'group',
                         name: $t(`%wH`),


### PR DESCRIPTION
fixes STA-1234

voor security code heb ik het op basis van userMode gedaan (organization -> verberg)
voor default age groups heb ik het op basis van het aantal default age groups (0 -> verberg)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785060737&installation_id=138085646&pr_number=537&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F537&signature=ec6cf308a830406cca3ea9d39a7eb6f13d7ba8129a970156b4bbcb2570a4e90b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->