### PR TITLE
🐛 Fix double-counting of Stripe transfer fee in settlement checker

### DIFF
--- a/backend/app/api/src/helpers/StripePayoutChecker.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutChecker.test.ts
@@ -1,0 +1,123 @@
+import { Payment } from '@stamhoofd/models';
+import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import nock from 'nock';
+import { resetNock } from '../../tests/helpers/resetNock.js';
+import { StripePayoutChecker } from './StripePayoutChecker.js';
+
+describe('StripePayoutChecker', () => {
+    afterEach(() => {
+        resetNock();
+    });
+
+    async function createPayment(props: { price: number; serviceFeePayout?: number }) {
+        const payment = new Payment();
+        payment.method = PaymentMethod.iDEAL;
+        payment.status = PaymentStatus.Succeeded;
+        payment.provider = PaymentProvider.Stripe;
+        payment.price = props.price;
+        payment.serviceFeePayout = props.serviceFeePayout ?? 0;
+        await payment.save();
+        return payment;
+    }
+
+    /**
+     * Mock the two Stripe list endpoints the checker walks:
+     * - GET /v1/payouts (status=paid)
+     * - GET /v1/balance_transactions (filtered by payout)
+     */
+    function mockStripe({ payout, balanceTransaction }: { payout: any; balanceTransaction: any }) {
+        nock('https://api.stripe.com')
+            .get(/v1\/payouts.*/)
+            .reply(200, {
+                object: 'list',
+                has_more: false,
+                data: [payout],
+            });
+
+        nock('https://api.stripe.com')
+            .get(/v1\/balance_transactions.*/)
+            .reply(200, {
+                object: 'list',
+                has_more: false,
+                data: [balanceTransaction],
+            });
+    }
+
+    it('does not double-count the application fee in the transfer fee', async () => {
+        // A € 10,00 payment. Stripe withholds € 0,35 in total fees from the connected
+        // account (already including the application fee Stripe lists in fee_details).
+        const payment = await createPayment({ price: 10_00_00 });
+
+        const payout = {
+            id: 'po_' + payment.id,
+            object: 'payout',
+            amount: 9_65, // cents
+            arrival_date: Math.floor(Date.now() / 1000),
+            statement_descriptor: 'PAYOUT',
+        };
+
+        const balanceTransaction = {
+            id: 'txn_1',
+            object: 'balance_transaction',
+            type: 'charge',
+            amount: 10_00, // cents (matches payment.price / 100)
+            // Total fee withheld from the connected account, already includes the application fee.
+            fee: 35, // cents
+            source: {
+                id: 'ch_1',
+                object: 'charge',
+                metadata: { payment: payment.id },
+                // Stripe also exposes the application fee separately, but it is a SUBSET of `fee`.
+                application_fee_amount: 30,
+            },
+        };
+
+        mockStripe({ payout, balanceTransaction });
+
+        const checker = new StripePayoutChecker({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+        await checker.checkSettlements();
+
+        const updated = (await Payment.getByID(payment.id))!;
+
+        // transferFee should equal the total fee (€ 0,35), not fee + applicationFee (€ 0,65).
+        expect(updated.transferFee).toBe(35 * 100);
+        expect(updated.settlement?.fee).toBe(35 * 100);
+    });
+
+    it('subtracts the service fee payout from the transfer fee', async () => {
+        const payment = await createPayment({ price: 10_00_00, serviceFeePayout: 10 * 100 });
+
+        const payout = {
+            id: 'po_' + payment.id,
+            object: 'payout',
+            amount: 9_65,
+            arrival_date: Math.floor(Date.now() / 1000),
+            statement_descriptor: 'PAYOUT',
+        };
+
+        const balanceTransaction = {
+            id: 'txn_2',
+            object: 'balance_transaction',
+            type: 'charge',
+            amount: 10_00,
+            fee: 35, // total fee € 0,35, of which € 0,10 is our service fee
+            source: {
+                id: 'ch_2',
+                object: 'charge',
+                metadata: { payment: payment.id },
+                application_fee_amount: 30,
+            },
+        };
+
+        mockStripe({ payout, balanceTransaction });
+
+        const checker = new StripePayoutChecker({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+        await checker.checkSettlements();
+
+        const updated = (await Payment.getByID(payment.id))!;
+
+        // € 0,35 total fee - € 0,10 service fee payout = € 0,25 transfer fee
+        expect(updated.transferFee).toBe(35 * 100 - 10 * 100);
+        expect(updated.settlement?.fee).toBe(35 * 100);
+    });
+});

--- a/backend/app/api/src/helpers/StripePayoutChecker.ts
+++ b/backend/app/api/src/helpers/StripePayoutChecker.ts
@@ -154,9 +154,10 @@ export class StripePayoutChecker {
             return;
         }
 
-        const applicationFee = balanceItem.source.application_fee_amount;
-        const otherFees = balanceItem.fee;
-        const totalFees = otherFees + (applicationFee ?? 0);
+        // balanceItem.fee is the total fee withheld from the connected account for this charge.
+        // It already includes the application fee (Stripe lists it in fee_details), so we must
+        // NOT add application_fee_amount on top of it again — doing so double-counts the fee.
+        const totalFees = balanceItem.fee;
 
         // Cool, we can store this in the database now.
 


### PR DESCRIPTION
When `StripePayoutChecker` processes a settled payout, `balanceItem.fee` is the total fee Stripe withheld from the connected account for that charge — and that total **already includes the application fee** (Stripe lists it in `fee_details`). The checker was adding `application_fee_amount` on top of it again, so the stored `transferFee` (and `settlement.fee`) came out roughly twice as high as the actual fee.

The fix uses `balanceItem.fee` as the total fee, consistent with the per-charge webhook path in `StripeHelper.saveChargeInfo`, which already computed `transferFee = balance_transaction.fee - serviceFeePayout`.

Added unit tests covering the fee computation (no doubling, and correct subtraction of the service fee payout).

Note: the test is an integration test against the MySQL test DB, which couldn't run in my sandbox (no Docker/MySQL available) — it will run in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785077875&installation_id=138085646&pr_number=540&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F540&signature=8a55f9f2f2a4cb24ea289d20eacfee6bdad4562fc75c8c4103be436ffe737f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->