### PR TITLE
Allow non-registered particapants for events (STA-1238)

### DIFF
--- a/backend/shared/models/src/models/Event.ts
+++ b/backend/shared/models/src/models/Event.ts
@@ -101,18 +101,22 @@ export class Event extends QueryableModel {
         }
 
         if (this.organizationId) {
-            // This is a not-national event, so require the organization
-            group.settings.requireOrganizationIds = [this.organizationId];
+            // This is a not-national event, so require the organization (unless non-members are allowed)
+            group.settings.requireOrganizationIds = this.meta.allowNonMembers ? [] : [this.organizationId];
             group.settings.requireOrganizationTags = [];
             group.settings.requirePlatformMembershipOn = null;
         } else {
-            group.settings.requireOrganizationTags = this.meta.organizationTagIds ?? [];
-
             // Everyone can register
             group.settings.requireOrganizationIds = [];
 
-            // But they need a valid platform membership
-            group.settings.requirePlatformMembershipOn = this.endDate;
+            if (this.meta.allowNonMembers) {
+                group.settings.requireOrganizationTags = [];
+                group.settings.requirePlatformMembershipOn = null;
+            } else {
+                group.settings.requireOrganizationTags = this.meta.organizationTagIds ?? [];
+                // But they need a valid platform membership
+                group.settings.requirePlatformMembershipOn = this.endDate;
+            }
         }
         await group.save();
 

--- a/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
@@ -88,6 +88,20 @@
             </STListItem>
         </STList>
 
+        <STList>
+            <STListItem v-if="STAMHOOFD.userMode === 'organization'" :selectable="true" element-name="label">
+                <template #left>
+                    <Checkbox v-model="blockCreatingNewMembers" />
+                </template>
+                <h3 class="style-title-list">
+                    {{ $t('Blokkeer aanmaken van nieuwe leden') }}
+                </h3>
+                <p class="style-description-small">
+                    {{ $t('Wanneer ingeschakeld kunnen leden of ouders geen nieuwe gezinsleden toevoegen. Ook nieuwe accounts kunnen hierdoor geen leden toevoegen.') }}
+                </p>
+            </STListItem>
+        </STList>
+
         <div v-if="isStamhoofd" key="stamhoofd-settings" class="container">
             <hr><h2>
                 {{ $t('%NU') }}
@@ -206,6 +220,16 @@ const organizationPatch = shallowRef<AutoEncoderPatchType<Organization> & AutoEn
 
 const organization = computed(() => baseOrganization.value.patch(organizationPatch.value));
 const isStamhoofd = computed(() => organizationManager.value.user.email.endsWith('@stamhoofd.be') || organizationManager.value.user.email.endsWith('@stamhoofd.nl'));
+const blockCreatingNewMembers = computed({
+    get: () => organization.value.meta.blockCreatingNewMembers,
+    set: (value: boolean) => {
+        organizationPatch.value = organizationPatch.value.patch({
+            meta: OrganizationMetaData.patch({
+                blockCreatingNewMembers: value,
+            }),
+        });
+    },
+});
 const invoicesEnabled = computed({
     get: () => organization.value.meta.invoicesEnabled ?? false,
     set: (value: boolean) => {

--- a/frontend/shared/components/src/auth/components/GroupTag.vue
+++ b/frontend/shared/components/src/auth/components/GroupTag.vue
@@ -21,5 +21,5 @@ const props = defineProps<{
 const now = useNow();
 const app = useAppContext();
 const organization = useOrganization();
-const tags = computed(() => props.group.getTags({ now: now.value, app, organization: organization.value }));
+const tags = computed(() => props.group.getTags({ now: now.value, app, organization: organization.value, blockCreatingNewMembers: organization.value?.meta.blockCreatingNewMembers }));
 </script>

--- a/frontend/shared/components/src/events/EditEventView.vue
+++ b/frontend/shared/components/src/events/EditEventView.vue
@@ -85,6 +85,9 @@
                 <p class="style-description-small">
                     {{ $t('Deelnemers hoeven geen actieve inschrijving te hebben om zich in te schrijven voor deze activiteit.') }}
                 </p>
+                <p v-if="allowNonMembers && organization?.meta.blockCreatingNewMembers" class="warning-box">
+                    {{ $t('Leden die nog nooit zijn aangemaakt kunnen zichzelf niet registeren. Je kan dit aanpassen via Instellingen > Experimenten.') }}
+                </p>
             </STListItem>
         </STList>
 

--- a/frontend/shared/components/src/events/EditEventView.vue
+++ b/frontend/shared/components/src/events/EditEventView.vue
@@ -73,6 +73,19 @@
                     {{ $t('%7U') }}
                 </h3>
             </STListItem>
+
+            <STListItem :selectable="true" element-name="label">
+                <template #left>
+                    <Checkbox v-model="allowNonMembers" />
+                </template>
+
+                <h3 class="style-title-list">
+                    {{ $t('Toegankelijk voor niet-leden') }}
+                </h3>
+                <p class="style-description-small">
+                    {{ $t('Deelnemers hoeven geen actieve inschrijving te hebben om zich in te schrijven voor deze activiteit.') }}
+                </p>
+            </STListItem>
         </STList>
 
         <template v-if="canSetNationalActivity && externalOrganization">
@@ -559,6 +572,15 @@ const visible = computed({
     set: visible => addPatch({
         meta: EventMeta.patch({
             visible,
+        }),
+    }),
+});
+
+const allowNonMembers = computed({
+    get: () => patched.value.meta.allowNonMembers,
+    set: allowNonMembers => addPatch({
+        meta: EventMeta.patch({
+            allowNonMembers,
         }),
     }),
 });

--- a/frontend/shared/components/src/groups/EditGroupView.vue
+++ b/frontend/shared/components/src/groups/EditGroupView.vue
@@ -137,7 +137,12 @@
                         {{ getGroupStatusName(virtualOpenStatus, registrationStartDate) }}
                     </p>
                 </template>
+
                 <p>{{ $t('%cQ') }}</p>
+
+                <p v-if="blockCreatingNewMembers" class="warning-box">
+                    {{ $t('Leden of ouders kunnen geen nieuwe gezinsleden toevoegen en ook nieuwe accounts kunnen geen leden toevoegen. Je kan dit aanpassen via Instellingen > Experimenten.') }}
+                </p>
 
                 <STList>
                     <STListItem :selectable="true" element-name="label">
@@ -805,6 +810,8 @@ const props = withDefaults(
 
 const platform = usePlatform();
 const organization = useOrganization();
+const blockCreatingNewMembers = computed(() => organization.value?.meta.blockCreatingNewMembers ?? false);
+
 const { patched: patchedPeriod, hasChanges, addPatch, addDependingPatch, patch } = usePatch(props.period);
 if (props.initialPatch) {
     addPatch(props.initialPatch);

--- a/frontend/shared/networking/src/MemberManager.ts
+++ b/frontend/shared/networking/src/MemberManager.ts
@@ -201,7 +201,7 @@ export class MemberManager {
     }
 
     get isAcceptingNewMembers() {
-        return STAMHOOFD.userMode === 'platform' ? true : (this.$context.organization?.isAcceptingNewMembers(this.$context.hasPermissions()) ?? true);
+        return STAMHOOFD.userMode === 'platform' ? true : (this.$context.organization?.isAcceptingNewMembers() ?? true);
     }
 
     async loadMembers() {

--- a/shared/structures/src/Event.ts
+++ b/shared/structures/src/Event.ts
@@ -78,6 +78,9 @@ export class EventMeta extends AutoEncoder {
 
     @field({ decoder: IntegerDecoder, nullable: true, version: 382 })
     maxAge: number | null = null;
+
+    @field({ decoder: BooleanDecoder, ...NextVersion })
+    allowNonMembers = false;
 }
 
 export class Event extends AutoEncoder {

--- a/shared/structures/src/Group.ts
+++ b/shared/structures/src/Group.ts
@@ -456,7 +456,7 @@ export class Group extends AutoEncoder {
         return filter;
     }
 
-    getTags(options: { app: AppType; now?: Date; organization: Organization | null }): GroupTagItem[] {
+    getTags(options: { app: AppType; now?: Date; organization: Organization | null; blockCreatingNewMembers?: boolean }): GroupTagItem[] {
         const tags: GroupTagItem[] = [];
         const now = options.now ?? new Date();
         const remainingStock = this.settings.getRemainingStockIncludingPrices(this);
@@ -528,6 +528,13 @@ export class Group extends AutoEncoder {
                 icon: 'earth',
                 title: $t('%1EN'),
                 style: 'success',
+            });
+        }
+        if (!this.closed && options.app === 'dashboard' && this.type === GroupType.Membership && options.blockCreatingNewMembers) {
+            tags.push({
+                icon: 'disabled',
+                title: $t('Nieuwe leden zijn uitgeschakeld'),
+                style: 'warn',
             });
         }
 

--- a/shared/structures/src/Organization.ts
+++ b/shared/structures/src/Organization.ts
@@ -167,24 +167,8 @@ export class Organization extends BaseOrganization implements ObjectWithRecords 
         return this.getCategoryTree({ admin: true });
     }
 
-    isAcceptingNewMembers(admin: boolean) {
-        const allGroups = this.adminAvailableGroups; // we need to check admin groups because required groups could be restricted to internal groups
-        const groups = this.getCategoryTree({ admin }).getAllGroups();
-
-        for (const group of groups) {
-            if (group.closed && !group.notYetOpen) {
-                continue;
-            }
-            if (group.settings.requireGroupIds.length > 0 && group.settings.requireGroupIds.find(id => !!allGroups.find(g => g.id === id))) {
-                continue;
-            }
-
-            if (group.settings.availableMembers === 0 && !group.waitingList) {
-                continue;
-            }
-            return true;
-        }
-        return false;
+    isAcceptingNewMembers() {
+        return !this.meta.blockCreatingNewMembers;
     }
 
     isAcceptingExistingMembers(admin: boolean) {

--- a/shared/structures/src/OrganizationMetaData.ts
+++ b/shared/structures/src/OrganizationMetaData.ts
@@ -411,6 +411,9 @@ export class OrganizationMetaData extends AutoEncoder {
     @field({ decoder: BooleanDecoder, version: 398, defaultValue: () => false })
     invoicesEnabled: boolean;
 
+    @field({ decoder: BooleanDecoder, ...NextVersion })
+    blockCreatingNewMembers = false;
+
     /**
      * @deprecated Moved to companies
      */


### PR DESCRIPTION
Dit had in essentie geen backend wijzigingen nodig. 

Behalve dat de EventRegistration groepen ook naar de frontend moeten gestuurd worden en gecheckt worden of deze open staan voor inschrijvingen. 

Er is nu nog 1 probleem:
<img width="785" height="229" alt="Screenshot 2026-06-29 at 14 21 30" src="https://github.com/user-attachments/assets/3c4dc6bd-7d60-47ef-9e5e-5b0701eecf51" />
Maar men kan wel inschrijven voor de activiteit... dit los ik op in een aparte PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785327740&installation_id=138085646&pr_number=543&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F543&signature=4f0c09a10b9f13a0569d3ac02cc9554beb81205b030e04e1eb84432a0188b875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->