### PR TITLE
🐛 first create waiting list before creating groups that depend on it

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.test.ts
@@ -1,7 +1,7 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization } from '@stamhoofd/models';
-import { GroupFactory, OrganizationFactory, OrganizationRegistrationPeriod, OrganizationRegistrationPeriodFactory, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
-import { GroupSettings, Group as GroupStruct, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, PermissionLevel, Permissions, Version } from '@stamhoofd/structures';
+import { Group, GroupFactory, OrganizationFactory, OrganizationRegistrationPeriod, OrganizationRegistrationPeriodFactory, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
+import { GroupCategory, GroupSettings, Group as GroupStruct, GroupType, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, PermissionLevel, Permissions, TranslatedString, Version } from '@stamhoofd/structures';
 
 import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray } from '@simonbackx/simple-encoding';
@@ -151,6 +151,65 @@ describe('Endpoint.PatchOrganizationRegistrationPeriods', () => {
             // patch organization registration period should not fail
             const response = await patchOrganizationRegistrationPeriods({ patch, organization, token });
             expect(response.body).toBeDefined();
+        });
+
+        test('should copy groups that reference a waiting list', async () => {
+            const organization = await new OrganizationFactory({ }).create();
+
+            // create period
+            const startDate = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000);
+            const endDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+            const newPeriod = await new RegistrationPeriodFactory({
+                organization,
+                startDate,
+                endDate,
+            }).create();
+
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({ level: PermissionLevel.Full }),
+            }).create();
+
+            const token = await Token.createToken(user);
+
+            // A waiting list group and a regular group that references it. The regular group is
+            // listed BEFORE the waiting list, reproducing the ordering produced by Group.defaultSort
+            // when duplicating a period (groups with a maxAge sort before waiting lists).
+            const waitingListGroup = GroupStruct.create({
+                type: GroupType.WaitingList,
+                settings: GroupSettings.create({ name: TranslatedString.create('Wachtlijst') }),
+            });
+
+            const regularGroup = GroupStruct.create({
+                type: GroupType.Membership,
+                settings: GroupSettings.create({ name: TranslatedString.create('Kapoenen'), maxAge: 8 }),
+                waitingList: waitingListGroup,
+            });
+
+            const newOrganizationPeriod = OrganizationRegistrationPeriodStruct.create({
+                period: newPeriod.getStructure(),
+            });
+            newOrganizationPeriod.groups.push(regularGroup, waitingListGroup);
+            newOrganizationPeriod.settings.categories = [
+                GroupCategory.create({ id: 'root', groupIds: [regularGroup.id] }),
+            ];
+            newOrganizationPeriod.settings.rootCategoryId = 'root';
+
+            const patch: PatchableArrayAutoEncoder<OrganizationRegistrationPeriodStruct> = new PatchableArray();
+            patch.addPut(newOrganizationPeriod);
+
+            const response = await patchOrganizationRegistrationPeriods({ patch, organization, token });
+            expect(response.body).toBeDefined();
+
+            // Both the regular group and its waiting list should have been created
+            const createdGroups = await Group.getAll(organization.id, newPeriod.id, true, [GroupType.Membership, GroupType.WaitingList]);
+            const regular = createdGroups.find(g => g.id === regularGroup.id);
+            const waitingList = createdGroups.find(g => g.id === waitingListGroup.id);
+
+            expect(waitingList).toBeDefined();
+            expect(regular).toBeDefined();
+            expect(regular!.waitingListId).toBe(waitingListGroup.id);
         });
 
         test('should not be able to patch groups of other organization', async () => {

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
@@ -342,7 +342,20 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
         organizationPeriod.settings = struct.settings;
         await organizationPeriod.save();
 
-        for (const s of struct.groups) {
+        // Create waiting list groups first: a regular group referencing a waiting list requires
+        // that waiting list group to already exist in the same period (see createGroup), otherwise
+        // it fails with 'Waiting list not found' and gets silently skipped below.
+        const sortedGroups = [...struct.groups].sort((a, b) => {
+            if (a.type === GroupType.WaitingList && b.type !== GroupType.WaitingList) {
+                return -1;
+            }
+            if (b.type === GroupType.WaitingList && a.type !== GroupType.WaitingList) {
+                return 1;
+            }
+            return 0;
+        });
+
+        for (const s of sortedGroups) {
             s.settings.registeredMembers = 0;
             s.settings.reservedMembers = 0;
             try {


### PR DESCRIPTION
fixes STA-1314

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786019843&installation_id=138085646&pr_number=561&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F561&signature=9ab3aceacb4cab50863ab082c1e4d7c366b4eb9b460e0f8b8f699b04ee653365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->