### PR TITLE
✨ Added platform filters for organizations with specific documents or specific records

### DIFF
--- a/backend/app/api/src/endpoints/admin/organizations/GetOrganizationsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/admin/organizations/GetOrganizationsEndpoint.test.ts
@@ -1,7 +1,7 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, Token } from '@stamhoofd/models';
-import { OrganizationFactory, STPackageFactory, UserFactory } from '@stamhoofd/models';
-import { LimitedFilteredRequest, OrganizationMetaData, OrganizationType, PermissionLevel, Permissions, STPackageBundle, type StamhoofdFilter, UmbrellaOrganization } from '@stamhoofd/structures';
+import { DocumentTemplateFactory, OrganizationFactory, STPackageFactory, UserFactory } from '@stamhoofd/models';
+import { DocumentStatus, LimitedFilteredRequest, OrganizationMetaData, OrganizationRecordsConfiguration, OrganizationType, PermissionLevel, Permissions, RecordCategory, RecordSettings, RecordType, STPackageBundle, type StamhoofdFilter, TranslatedString, UmbrellaOrganization } from '@stamhoofd/structures';
 import { Country } from '@stamhoofd/types/Country';
 import { TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
@@ -228,5 +228,327 @@ describe('Endpoint.GetOrganizationsEndpoint', () => {
 
         expect(await filter({ createdAt: { $gt: anHourAgo } }, adminToken)).toContain(org.id);
         expect(await filter({ createdAt: { $gt: inAnHour } }, adminToken)).not.toContain(org.id);
+    });
+
+    // Creates an organization with the given record categories (questionnaires) in its records configuration
+    const createOrganizationWithRecordCategories = async (name: string, recordCategories: RecordCategory[]) => {
+        const meta = OrganizationMetaData.create({
+            type: OrganizationType.Other,
+            umbrellaOrganization: null,
+            defaultEndDate: new Date(),
+            defaultStartDate: new Date(),
+            defaultPrices: [],
+            recordsConfiguration: OrganizationRecordsConfiguration.create({
+                recordCategories,
+            }),
+        });
+        return await new OrganizationFactory({ name, meta }).create();
+    };
+
+    const createTextRecord = (nameValue: string) => {
+        return RecordSettings.create({
+            name: TranslatedString.create(nameValue),
+            type: RecordType.Text,
+        });
+    };
+
+    test('Filters organizations by record category name', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const medicalOrg = await createOrganizationWithRecordCategories('Medical Questionnaire Club', [
+            RecordCategory.create({ name: TranslatedString.create('Medische fiche') }),
+        ]);
+        const consentOrg = await createOrganizationWithRecordCategories('Consent Questionnaire Club', [
+            RecordCategory.create({ name: TranslatedString.create('Toestemmingen') }),
+        ]);
+
+        const results = await filter({ recordCategoryName: { $contains: 'Medische' } }, adminToken);
+        expect(results).toContain(medicalOrg.id);
+        expect(results).not.toContain(consentOrg.id);
+    });
+
+    test('Matches questionnaire name regardless of the language of a translated name', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        // A name that is stored as a multi-language object (not a plain string)
+        const org = await createOrganizationWithRecordCategories('Multilingual Questionnaire Club', [
+            RecordCategory.create({
+                name: TranslatedString.create({ nl: 'Gezondheidsvragen', en: 'Health questions' }),
+            }),
+        ]);
+
+        expect(await filter({ recordCategoryName: { $contains: 'Gezondheidsvragen' } }, adminToken)).toContain(org.id);
+        expect(await filter({ recordCategoryName: { $contains: 'Health questions' } }, adminToken)).toContain(org.id);
+    });
+
+    test('Does not match a record name or child category name when filtering on record category name', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const org = await createOrganizationWithRecordCategories('Precise Questionnaire Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Algemeen'),
+                childCategories: [
+                    RecordCategory.create({
+                        name: TranslatedString.create('Subcategorie'),
+                        records: [createTextRecord('Bloedgroep')],
+                    }),
+                ],
+            }),
+        ]);
+
+        // The top-level questionnaire name matches
+        expect(await filter({ recordCategoryName: { $contains: 'Algemeen' } }, adminToken)).toContain(org.id);
+        // A child category name is not a questionnaire
+        expect(await filter({ recordCategoryName: { $contains: 'Subcategorie' } }, adminToken)).not.toContain(org.id);
+        // A record name is not a questionnaire
+        expect(await filter({ recordCategoryName: { $contains: 'Bloedgroep' } }, adminToken)).not.toContain(org.id);
+    });
+
+    test('Filters organizations by a record name in a top-level record categories', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const org = await createOrganizationWithRecordCategories('Direct Question Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Algemeen'),
+                records: [createTextRecord('Bloedgroep')],
+            }),
+        ]);
+        const otherOrg = await createOrganizationWithRecordCategories('Other Question Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Algemeen'),
+                records: [createTextRecord('Schoenmaat')],
+            }),
+        ]);
+
+        const results = await filter({ recordName: { $contains: 'Bloedgroep' } }, adminToken);
+        expect(results).toContain(org.id);
+        expect(results).not.toContain(otherOrg.id);
+    });
+
+    test('Filters organizations by a record name nested in deep child categories', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        // Category -> child -> child -> child, with the record at the deepest level
+        const org = await createOrganizationWithRecordCategories('Deeply Nested Question Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Niveau 0'),
+                childCategories: [
+                    RecordCategory.create({
+                        name: TranslatedString.create('Niveau 1'),
+                        childCategories: [
+                            RecordCategory.create({
+                                name: TranslatedString.create('Niveau 2'),
+                                childCategories: [
+                                    RecordCategory.create({
+                                        name: TranslatedString.create('Niveau 3'),
+                                        records: [createTextRecord('Diepe vraag')],
+                                    }),
+                                ],
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+        ]);
+
+        const noMatchOrg = await createOrganizationWithRecordCategories('Shallow Question Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Niveau 0'),
+                records: [createTextRecord('Oppervlakkige vraag')],
+            }),
+        ]);
+
+        const results = await filter({ recordName: { $contains: 'Diepe vraag' } }, adminToken);
+        expect(results).toContain(org.id);
+        expect(results).not.toContain(noMatchOrg.id);
+    });
+
+    test('Filters organizations by a child (sub)category name', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const org = await createOrganizationWithRecordCategories('Child Category Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Algemeen'),
+                childCategories: [
+                    RecordCategory.create({
+                        name: TranslatedString.create('Medische subcategorie'),
+                        records: [createTextRecord('Bloedgroep')],
+                    }),
+                ],
+            }),
+        ]);
+        const otherOrg = await createOrganizationWithRecordCategories('Other Child Category Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Algemeen'),
+                childCategories: [
+                    RecordCategory.create({
+                        name: TranslatedString.create('Sportieve subcategorie'),
+                        records: [createTextRecord('Bloedgroep')],
+                    }),
+                ],
+            }),
+        ]);
+
+        const results = await filter({ recordChildCategoryName: { $contains: 'Medische subcategorie' } }, adminToken);
+        expect(results).toContain(org.id);
+        expect(results).not.toContain(otherOrg.id);
+    });
+
+    test('Does not match a top-level questionnaire name or record name when filtering on child category name', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const org = await createOrganizationWithRecordCategories('Precise Child Category Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Bovenliggende naam'),
+                childCategories: [
+                    RecordCategory.create({
+                        name: TranslatedString.create('Onderliggende naam'),
+                        records: [createTextRecord('Vraagnaam')],
+                    }),
+                ],
+            }),
+        ]);
+
+        // The child category name matches
+        expect(await filter({ recordChildCategoryName: { $contains: 'Onderliggende naam' } }, adminToken)).toContain(org.id);
+        // A top-level questionnaire name is not a child category
+        expect(await filter({ recordChildCategoryName: { $contains: 'Bovenliggende naam' } }, adminToken)).not.toContain(org.id);
+        // A record name is not a child category
+        expect(await filter({ recordChildCategoryName: { $contains: 'Vraagnaam' } }, adminToken)).not.toContain(org.id);
+    });
+
+    test('Filters organizations by a child category name nested in deep child categories', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        // Category -> child -> child -> child, with the matching child category at the deepest level
+        const org = await createOrganizationWithRecordCategories('Deeply Nested Child Category Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Niveau 0'),
+                childCategories: [
+                    RecordCategory.create({
+                        name: TranslatedString.create('Niveau 1'),
+                        childCategories: [
+                            RecordCategory.create({
+                                name: TranslatedString.create('Niveau 2'),
+                                childCategories: [
+                                    RecordCategory.create({
+                                        name: TranslatedString.create('Diepe subcategorie'),
+                                        records: [createTextRecord('Diepe vraag')],
+                                    }),
+                                ],
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+        ]);
+
+        const noMatchOrg = await createOrganizationWithRecordCategories('Shallow Child Category Club', [
+            RecordCategory.create({
+                name: TranslatedString.create('Niveau 0'),
+                childCategories: [
+                    RecordCategory.create({
+                        name: TranslatedString.create('Oppervlakkige subcategorie'),
+                    }),
+                ],
+            }),
+        ]);
+
+        const results = await filter({ recordChildCategoryName: { $contains: 'Diepe subcategorie' } }, adminToken);
+        expect(results).toContain(org.id);
+        expect(results).not.toContain(noMatchOrg.id);
+    });
+
+    test('Filters organizations by document template type', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const fiscalOrg = await new OrganizationFactory({ name: 'Fiscal Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: fiscalOrg.id, type: 'fiscal' }).create();
+
+        const participationOrg = await new OrganizationFactory({ name: 'Participation Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: participationOrg.id, type: 'participation' }).create();
+
+        const results = await filter({ documentTemplates: { $elemMatch: { type: { $in: ['fiscal'] } } } }, adminToken);
+        expect(results).toContain(fiscalOrg.id);
+        expect(results).not.toContain(participationOrg.id);
+    });
+
+    test('Filters organizations by document template year', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const org2024 = await new OrganizationFactory({ name: 'Document Year 2024 Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: org2024.id, year: 2024 }).create();
+
+        const org2023 = await new OrganizationFactory({ name: 'Document Year 2023 Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: org2023.id, year: 2023 }).create();
+
+        const results = await filter({ documentTemplates: { $elemMatch: { year: { $eq: 2024 } } } }, adminToken);
+        expect(results).toContain(org2024.id);
+        expect(results).not.toContain(org2023.id);
+    });
+
+    test('Filters organizations by document template status', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const publishedOrg = await new OrganizationFactory({ name: 'Published Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: publishedOrg.id, status: DocumentStatus.Published }).create();
+
+        const draftOrg = await new OrganizationFactory({ name: 'Draft Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: draftOrg.id, status: DocumentStatus.Draft }).create();
+
+        const results = await filter({ documentTemplates: { $elemMatch: { status: { $in: [DocumentStatus.Published] } } } }, adminToken);
+        expect(results).toContain(publishedOrg.id);
+        expect(results).not.toContain(draftOrg.id);
+    });
+
+    test('Filters organizations by document template isLocked', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const lockedOrg = await new OrganizationFactory({ name: 'Locked Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: lockedOrg.id, isLocked: true }).create();
+
+        const unlockedOrg = await new OrganizationFactory({ name: 'Unlocked Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: unlockedOrg.id, isLocked: false }).create();
+
+        const results = await filter({ documentTemplates: { $elemMatch: { isLocked: { $eq: true } } } }, adminToken);
+        expect(results).toContain(lockedOrg.id);
+        expect(results).not.toContain(unlockedOrg.id);
+    });
+
+    test('Filters organizations by document template updatesEnabled', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const noUpdatesOrg = await new OrganizationFactory({ name: 'No Updates Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: noUpdatesOrg.id, updatesEnabled: false }).create();
+
+        const updatesOrg = await new OrganizationFactory({ name: 'Updates Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: updatesOrg.id, updatesEnabled: true }).create();
+
+        const results = await filter({ documentTemplates: { $elemMatch: { updatesEnabled: { $eq: false } } } }, adminToken);
+        expect(results).toContain(noUpdatesOrg.id);
+        expect(results).not.toContain(updatesOrg.id);
+    });
+
+    test('Combines multiple document template conditions in a single $elemMatch', async () => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const matchOrg = await new OrganizationFactory({ name: 'Matching Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: matchOrg.id, type: 'fiscal', year: 2025, status: DocumentStatus.Published }).create();
+
+        // Same org, but the conditions are split over two different templates: should not match a single-template $elemMatch
+        const splitOrg = await new OrganizationFactory({ name: 'Split Document Club' }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: splitOrg.id, type: 'fiscal', year: 2020, status: DocumentStatus.Published }).create();
+        await new DocumentTemplateFactory({ groups: [], organizationId: splitOrg.id, type: 'participation', year: 2025, status: DocumentStatus.Published }).create();
+
+        const results = await filter({
+            documentTemplates: {
+                $elemMatch: {
+                    type: { $in: ['fiscal'] },
+                    year: { $eq: 2025 },
+                },
+            },
+        }, adminToken);
+        expect(results).toContain(matchOrg.id);
+        expect(results).not.toContain(splitOrg.id);
     });
 });

--- a/backend/app/api/src/sql-filters/organizations.ts
+++ b/backend/app/api/src/sql-filters/organizations.ts
@@ -69,6 +69,58 @@ export const organizationFilterCompilers: SQLFilterDefinitions = {
         type: SQLValueType.JSONArray,
         nullable: false,
     }),
+    recordCategoryName: createColumnFilter({
+        expression: SQL.jsonExtract(SQL.column('organizations', 'meta'), '$.value.recordsConfiguration.recordCategories[*].name'),
+        type: SQLValueType.JSONArray,
+        nullable: true,
+    }),
+    // Name of a child (sub)category in any record category, at any nesting depth
+    recordChildCategoryName: createColumnFilter({
+        expression: SQL.jsonExtract(SQL.column('organizations', 'meta'), '$.value.recordsConfiguration.recordCategories**.childCategories[*].name'),
+        type: SQLValueType.JSONArray,
+        nullable: true,
+    }),
+    recordName: createColumnFilter({
+        expression: SQL.jsonExtract(SQL.column('organizations', 'meta'), '$.value.recordsConfiguration.recordCategories**.records[*].name'),
+        type: SQLValueType.JSONArray,
+        nullable: true,
+    }),
+    documentTemplates: createExistsFilter(
+        SQL.select()
+            .from(SQL.table('document_templates'))
+            .where(
+                SQL.column('document_templates', 'organizationId'),
+                SQL.column('organizations', 'id'),
+            ),
+        {
+            ...baseSQLFilterCompilers,
+            type: createColumnFilter({
+                expression: SQL.jsonExtract(SQL.column('document_templates', 'privateSettings'), '$.value.templateDefinition.type'),
+                type: SQLValueType.JSONString,
+                nullable: true,
+            }),
+            year: createColumnFilter({
+                expression: SQL.column('document_templates', 'year'),
+                type: SQLValueType.Number,
+                nullable: false,
+            }),
+            status: createColumnFilter({
+                expression: SQL.column('document_templates', 'status'),
+                type: SQLValueType.String,
+                nullable: false,
+            }),
+            isLocked: createColumnFilter({
+                expression: SQL.column('document_templates', 'isLocked'),
+                type: SQLValueType.Boolean,
+                nullable: false,
+            }),
+            updatesEnabled: createColumnFilter({
+                expression: SQL.column('document_templates', 'updatesEnabled'),
+                type: SQLValueType.Boolean,
+                nullable: false,
+            }),
+        },
+    ),
     setupSteps: createExistsFilter(
         SQL.select()
             .from(SQL.table('organization_registration_periods'))

--- a/backend/shared/models/src/factories/DocumentTemplateFactory.ts
+++ b/backend/shared/models/src/factories/DocumentTemplateFactory.ts
@@ -9,6 +9,7 @@ class Options {
     groups: Group[];
     status?: DocumentStatus;
     updatesEnabled?: boolean;
+    isLocked?: boolean;
     minPricePaid?: number | null;
     maxAge?: number | null;
     year?: number | null;
@@ -156,6 +157,11 @@ export class DocumentTemplateFactory extends Factory<Options, DocumentTemplate> 
     async create(): Promise<DocumentTemplate> {
         const documentTemplate = await this.createWithoutSave();
         await documentTemplate.save();
+        if (this.options.isLocked) {
+            // A locked template can no longer be saved normally, so lock it after the initial save.
+            documentTemplate.isLocked = true;
+            await documentTemplate.save({ forceSave: true });
+        }
         return documentTemplate;
     }
 }

--- a/frontend/app/dashboard/src/views/dashboard/documents/DocumentTemplatesView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/documents/DocumentTemplatesView.vue
@@ -78,7 +78,7 @@ import type { StamhoofdFilter } from '@stamhoofd/structures';
 import { DocumentTemplatePrivate, isEmptyFilter, LimitedFilteredRequest } from '@stamhoofd/structures';
 import { FiscalDocumentYearHelper, Formatter } from '@stamhoofd/utility';
 
-import { getDocumentTemplateUIFilterBuilders } from '@stamhoofd/components/filters/filter-builders/document-templates.ts';
+import { useDocumentTemplateUIFilterBuilders } from '@stamhoofd/components/filters/filter-builders/document-templates.ts';
 import type { Ref } from 'vue';
 import { computed, ref, watch, watchEffect } from 'vue';
 
@@ -188,7 +188,7 @@ const yearLabels = tabItems.map((y) => {
 },
 );
 
-const filterBuilders = getDocumentTemplateUIFilterBuilders();
+const filterBuilders = useDocumentTemplateUIFilterBuilders();
 const selectedUIFilter = ref(null) as Ref<null | UIFilter>;
 
 watchEffect(() => {

--- a/frontend/shared/components/src/filters/filter-builders/document-templates.ts
+++ b/frontend/shared/components/src/filters/filter-builders/document-templates.ts
@@ -1,5 +1,6 @@
 import { DocumentStatus, DocumentStatusHelper, FilterWrapperMarker } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
+import { useAppContext } from '#context/appContext.ts';
 import { DateFilterBuilder } from '../DateUIFilter';
 import { GroupUIFilterBuilder } from '../GroupUIFilter';
 import { MultipleChoiceFilterBuilder, MultipleChoiceUIFilterOption } from '../MultipleChoiceUIFilter';
@@ -7,7 +8,9 @@ import { NumberFilterBuilder } from '../NumberUIFilter';
 import { StringFilterBuilder } from '../StringUIFilter';
 import type { UIFilter, UIFilterBuilder } from '../UIFilter';
 
-export function getDocumentTemplateUIFilterBuilders(): UIFilterBuilder<UIFilter>[] {
+export function useDocumentTemplateUIFilterBuilders(): UIFilterBuilder<UIFilter>[] {
+    const app = useAppContext();
+
     const all: UIFilterBuilder<UIFilter>[] = [
         new StringFilterBuilder({
             name: $t(`%1Os`),
@@ -55,7 +58,36 @@ export function getDocumentTemplateUIFilterBuilders(): UIFilterBuilder<UIFilter>
                 },
             },
         }),
+        new MultipleChoiceFilterBuilder({
+            name: $t(`Automatisch bijwerken`),
+            options: [
+                new MultipleChoiceUIFilterOption($t(`Ja`), 1),
+                new MultipleChoiceUIFilterOption($t(`Nee`), 0),
+            ],
+            wrapper: {
+                updatesEnabled: {
+                    $in: FilterWrapperMarker,
+                },
+            },
+        }),
     ];
+
+    if (app === 'admin') {
+        all.push(
+            new MultipleChoiceFilterBuilder({
+                name: $t(`Vergrendeld`),
+                options: [
+                    new MultipleChoiceUIFilterOption($t(`Ja`), 1),
+                    new MultipleChoiceUIFilterOption($t(`Nee`), 0),
+                ],
+                wrapper: {
+                    isLocked: {
+                        $in: FilterWrapperMarker,
+                    },
+                },
+            }),
+        );
+    }
 
     all.unshift(
         new GroupUIFilterBuilder({

--- a/frontend/shared/components/src/filters/filter-builders/organizations.ts
+++ b/frontend/shared/components/src/filters/filter-builders/organizations.ts
@@ -4,6 +4,7 @@ import { Country } from '@stamhoofd/types/Country';
 import { usePlatform } from '#hooks/usePlatform.ts';
 import { useUser } from '#hooks/useUser.ts';
 import { getOrganizationCompanyFilterBuilders } from '../filterBuilders';
+import { useDocumentTemplateUIFilterBuilders } from './document-templates';
 import { DateFilterBuilder } from '../DateUIFilter';
 import { GroupUIFilterBuilder } from '../GroupUIFilter';
 import { MultipleChoiceFilterBuilder, MultipleChoiceUIFilterMode, MultipleChoiceUIFilterOption } from '../MultipleChoiceUIFilter';
@@ -59,6 +60,7 @@ const getOrganizationAdminUIFilterBuilders: () => UIFilterBuilders = () => {
 export function useGetOrganizationUIFilterBuilders(options: { onlyBaseFilters?: boolean } = { onlyBaseFilters: false }) {
     const platform = usePlatform();
     const _user = useUser();
+    const documentTemplateFilterBuilders = useDocumentTemplateUIFilterBuilders();
 
     const setupStepFilterNameMap: Record<SetupStepType, string> = {
         [SetupStepType.Responsibilities]: $t('%7D'),
@@ -310,6 +312,32 @@ export function useGetOrganizationUIFilterBuilders(options: { onlyBaseFilters?: 
                 builders: getOrganizationCompanyFilterBuilders(),
                 wrapper: {
                     companies: {
+                        $elemMatch: FilterWrapperMarker,
+                    },
+                },
+            })),
+
+            ifNotBase(new StringFilterBuilder({
+                name: $t('Naam van een vragenlijst'),
+                key: 'recordCategoryName',
+            })),
+
+            ifNotBase(new StringFilterBuilder({
+                name: $t('Naam van een subcategorie'),
+                key: 'recordChildCategoryName',
+            })),
+
+            ifNotBase(new StringFilterBuilder({
+                name: $t('Naam van een vraag'),
+                key: 'recordName',
+            })),
+
+            ifNotBase(new GroupUIFilterBuilder({
+                name: $t('Documenten'),
+                description: $t('Filter op verenigingen met een documentsjabloon dat aan bepaalde voorwaarden voldoet.'),
+                builders: documentTemplateFilterBuilders,
+                wrapper: {
+                    documentTemplates: {
                         $elemMatch: FilterWrapperMarker,
                     },
                 },


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786025475&installation_id=138085646&pr_number=566&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F566&signature=fb1765e6b6fc50c67bde7fd2d418d9bb0be34f4c4f9965a3db1935341285d9e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->