### PR TITLE
🐛 don't show same category step twice in member portal

### DIFF
--- a/shared/structures/src/members/PlatformMember.test.ts
+++ b/shared/structures/src/members/PlatformMember.test.ts
@@ -1,9 +1,13 @@
-import { MemberWithRegistrationsBlob } from './MemberWithRegistrationsBlob.js';
+import { MembersBlob, MemberWithRegistrationsBlob } from './MemberWithRegistrationsBlob.js';
 import { MemberPlatformMembership } from './MemberPlatformMembership.js';
 import { Platform } from '../Platform.js';
 import { Organization } from '../Organization.js';
+import { OrganizationMetaData } from '../OrganizationMetaData.js';
 import { MemberDetails } from './MemberDetails.js';
 import { ContinuousMembershipStatus } from './MembershipStatus.js';
+import { OrganizationRecordsConfiguration } from './OrganizationRecordsConfiguration.js';
+import { RecordCategory } from './records/RecordCategory.js';
+import { TranslatedString } from '../TranslatedString.js';
 import {
     PlatformFamily,
     PlatformMember,
@@ -249,6 +253,38 @@ describe('PlatformMember', () => {
                 // assert
                 expect(status).toBe(ContinuousMembershipStatus.Full);
             }
+        });
+    });
+
+    describe('getAllRecordCategories', () => {
+        test('does not return the same record category twice when the member belongs to the scoped organization', () => {
+            const categoryA = RecordCategory.create({ name: new TranslatedString('Category A') });
+            const categoryB = RecordCategory.create({ name: new TranslatedString('Category B') });
+
+            const organization = Organization.create({
+                meta: OrganizationMetaData.create({
+                    recordsConfiguration: OrganizationRecordsConfiguration.create({
+                        recordCategories: [categoryA, categoryB],
+                    }),
+                }),
+            });
+
+            const blob = MembersBlob.create({
+                organizations: [organization],
+                members: [
+                    MemberWithRegistrationsBlob.create({
+                        organizationId: organization.id,
+                        details: MemberDetails.create({}),
+                    }),
+                ],
+            });
+
+            const family = PlatformFamily.create(blob, { platform: Platform.create({}), contextOrganization: organization });
+            const member = family.members[0];
+
+            const categories = member.getAllRecordCategories({ scopeOrganization: organization });
+
+            expect(categories.map(c => c.id)).toEqual([categoryA.id, categoryB.id]);
         });
     });
 });

--- a/shared/structures/src/members/PlatformMember.ts
+++ b/shared/structures/src/members/PlatformMember.ts
@@ -1363,7 +1363,8 @@ export class PlatformMember implements ObjectWithRecords {
             }
         }
 
-        return categories;
+        // Deduplicate by id
+        return [...new Map(categories.map(c => [c.id, c])).values()];
     }
 
     getEnabledRecordCategories(options: { checkPermissions?: { user: UserWithMembers; level: PermissionLevel } | null;


### PR DESCRIPTION
fixes STA-1301

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786103237&installation_id=138085646&pr_number=572&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F572&signature=25712de8be7e563955212bb69b93632f9700cf93106920faa88b7ad422a83c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->