### PR TITLE
🧑‍💻 remove label `ready if CI succeeds` after PR set to ready

### DIFF
--- a/.github/workflows/auto-ready.yml
+++ b/.github/workflows/auto-ready.yml
@@ -26,8 +26,9 @@ jobs:
             --jq '.workflow_runs[0].conclusion // empty')
 
           if [ "$STATUS" = "success" ]; then
-            gh pr ready "$PR_NUMBER"
-            echo "CI already passed — marked PR #$PR_NUMBER as ready for review"
+            gh pr ready "$PR_NUMBER" || true
+            gh pr edit "$PR_NUMBER" --remove-label "ready if CI succeeds" || true
+            echo "CI already passed — marked PR #$PR_NUMBER as ready for review and removed the label"
           else
             echo "CI has not passed yet for $SHA (conclusion: ${STATUS:-none}). Will convert when CI completes."
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,8 +726,9 @@ jobs:
           IS_DRAFT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft --jq '.isDraft')
           HAS_LABEL=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | contains(["ready if CI succeeds"])')
           if [ "$IS_DRAFT" = "true" ] && [ "$HAS_LABEL" = "true" ]; then
-            gh pr ready "$PR_NUMBER" --repo "$REPO"
-            echo "Marked PR #$PR_NUMBER as ready for review"
+            gh pr ready "$PR_NUMBER" --repo "$REPO" || true
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "ready if CI succeeds" || true
+            echo "Marked PR #$PR_NUMBER as ready for review and removed the label"
           else
             echo "No action (isDraft=$IS_DRAFT, hasLabel=$HAS_LABEL)"
           fi


### PR DESCRIPTION
label weer verwijderen als PR ready is, houdt de lijst met PRs properder

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786103269&installation_id=138085646&pr_number=573&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F573&signature=868eea8b7ad8ffa955182558b98c0c4405796edbfa43f8084f695caf987cca7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->