### PR TITLE
🔒 Block drastic member name & birth date changes for non-full-permission users (STA-1081)

### DIFF
--- a/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.test.ts
@@ -156,7 +156,9 @@ describe('Endpoint.PatchOrganizationMembersEndpoint', () => {
             }).create();
 
             const memberToPatch = await new MemberFactory({
-                firstName: 'otherName',
+                // A typo of the existing member's first name, so correcting it (below) is allowed
+                // and still triggers the duplicate detection
+                firstName: firstName + 'n',
                 lastName,
                 birthDay,
                 generateData: true,
@@ -618,7 +620,8 @@ describe('Endpoint.PatchOrganizationMembersEndpoint', () => {
             const patch = MemberWithRegistrationsBlob.patch({
                 id: member.id,
                 details: MemberDetails.patch({
-                    firstName: 'Changed',
+                    // Changing the last name is always allowed; it proves the registration grants write access
+                    lastName: 'Changed',
                 }),
             });
             arr.addPatch(patch);
@@ -639,7 +642,7 @@ describe('Endpoint.PatchOrganizationMembersEndpoint', () => {
             expect(response.body.members.length).toBe(1);
             const memberStruct = response.body.members[0];
             expect(memberStruct.details).toMatchObject({
-                firstName: 'Changed',
+                lastName: 'Changed',
             });
         });
 
@@ -798,6 +801,74 @@ describe('Endpoint.PatchOrganizationMembersEndpoint', () => {
             expect(memberStruct.details).toMatchObject({
                 firstName: 'Changed',
             });
+        });
+    });
+
+    describe('Name and birth date changes', () => {
+        test('A non-full admin cannot drastically change the first name of a member', async () => {
+            const organization = await new OrganizationFactory({}).create();
+
+            const group = await new GroupFactory({ organization }).create();
+            const resources = new Map();
+            resources.set(
+                PermissionsResourceType.Groups, new Map([[
+                    group.id,
+                    ResourcePermissions.create({ level: PermissionLevel.Write }),
+                ]]),
+            );
+
+            const user = await new UserFactory({
+                permissions: Permissions.create({ level: PermissionLevel.None, resources }),
+                organization,
+            }).create();
+
+            const member = await new MemberFactory({ firstName, lastName, birthDay, generateData: false }).create();
+            await new RegistrationFactory({ member, group }).create();
+
+            const token = await Token.createToken(user);
+
+            const arr: Body = new PatchableArray();
+            arr.addPatch(MemberWithRegistrationsBlob.patch({
+                id: member.id,
+                details: MemberDetails.patch({ firstName: 'Michael' }),
+            }));
+
+            const request = Request.buildJson('PATCH', baseUrl, organization.getApiHost(), arr);
+            request.headers.authorization = 'Bearer ' + token.accessToken;
+            await expect(testServer.test(endpoint, request))
+                .rejects
+                .toThrow(STExpect.errorWithCode('not_allowed'));
+        });
+
+        test('A full admin can drastically change the name and birth date of a member', async () => {
+            const organization = await new OrganizationFactory({}).create();
+
+            const user = await new UserFactory({
+                permissions: Permissions.create({ level: PermissionLevel.Full }),
+                organization,
+            }).create();
+
+            const member = await new MemberFactory({ firstName, lastName, birthDay, generateData: false }).create();
+            await new RegistrationFactory({ member, organization }).create();
+
+            const token = await Token.createToken(user);
+
+            const base = member.details.birthDay!;
+            const newBirthDay = new Date(base.getFullYear() + 5, base.getMonth() + 4, base.getDate() + 6);
+
+            const arr: Body = new PatchableArray();
+            arr.addPatch(MemberWithRegistrationsBlob.patch({
+                id: member.id,
+                details: MemberDetails.patch({ firstName: 'Michael', birthDay: newBirthDay }),
+            }));
+
+            const request = Request.buildJson('PATCH', baseUrl, organization.getApiHost(), arr);
+            request.headers.authorization = 'Bearer ' + token.accessToken;
+            const response = await testServer.test(endpoint, request);
+
+            expect(response.status).toBe(200);
+            expect(response.body.members[0].details.firstName).toBe('Michael');
+            expect(response.body.members[0].details.birthDay?.getFullYear()).toBe(base.getFullYear() + 5);
         });
     });
 

--- a/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.ts
@@ -23,6 +23,7 @@ import { MemberNumberService } from '../../../services/MemberNumberService.js';
 import { PlatformMembershipService } from '../../../services/PlatformMembershipService.js';
 import { RegistrationService } from '../../../services/RegistrationService.js';
 import { shouldCheckIfMemberIsDuplicateForPatch } from './shouldCheckIfMemberIsDuplicate.js';
+import { throwIfDrasticMemberDetailsChange } from './throwIfDrasticMemberDetailsChange.js';
 import { mergeTwoMembers } from '../../../helpers/MemberMerger.js';
 
 type Params = Record<string, never>;
@@ -211,6 +212,11 @@ export class PatchOrganizationMembersEndpoint extends Endpoint<Params, Query, Bo
                 }
 
                 shouldCheckDuplicate = shouldCheckIfMemberIsDuplicateForPatch(patch, originalDetails);
+
+                // Only full-permission admins may drastically change the name or birth date of an existing member
+                if (!await Context.auth.canAccessMember(member, PermissionLevel.Full)) {
+                    throwIfDrasticMemberDetailsChange(patch.details, originalDetails);
+                }
 
                 const wasReduced = member.details.shouldApplyReducedPrice;
 

--- a/backend/app/api/src/endpoints/global/members/throwIfDrasticMemberDetailsChange.test.ts
+++ b/backend/app/api/src/endpoints/global/members/throwIfDrasticMemberDetailsChange.test.ts
@@ -1,0 +1,95 @@
+import { isSimpleError } from '@simonbackx/simple-errors';
+import { MemberDetails } from '@stamhoofd/structures';
+import { throwIfDrasticMemberDetailsChange } from './throwIfDrasticMemberDetailsChange.js';
+
+/**
+ * Runs the check and returns the thrown SimpleError (as { code, field }), or null when nothing was thrown.
+ */
+function runCheck(patch: ReturnType<typeof MemberDetails.patch>, original: MemberDetails): { code: string; field?: string } | null {
+    try {
+        throwIfDrasticMemberDetailsChange(patch, original);
+        return null;
+    } catch (e) {
+        if (isSimpleError(e)) {
+            return { code: e.code, field: e.field };
+        }
+        throw e;
+    }
+}
+
+describe('throwIfDrasticMemberDetailsChange', () => {
+    const original = MemberDetails.create({
+        firstName: 'Thomas',
+        lastName: 'Peeters',
+        birthDay: new Date(2010, 4, 15), // 15 May 2010
+    });
+
+    describe('First name', () => {
+        test('An unchanged first name is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ firstName: 'Thomas' }), original)).toBeNull();
+        });
+
+        test('A case-only change is allowed (normalized)', () => {
+            expect(runCheck(MemberDetails.patch({ firstName: 'thomas' }), original)).toBeNull();
+        });
+
+        test('Fixing a typo is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ firstName: 'Tomas' }), original)).toBeNull();
+        });
+
+        test('A short name with a single typo is allowed', () => {
+            const jan = MemberDetails.create({ firstName: 'Jan', lastName: 'Peeters', birthDay: new Date(2010, 4, 15) });
+            expect(runCheck(MemberDetails.patch({ firstName: 'Jana' }), jan)).toBeNull();
+        });
+
+        test('Completely changing the first name is not allowed', () => {
+            expect(runCheck(MemberDetails.patch({ firstName: 'Wannes' }), original)).toMatchObject({ code: 'not_allowed', field: 'firstName' });
+        });
+
+        test('Swapping a short first name for a different one is not allowed', () => {
+            const jan = MemberDetails.create({ firstName: 'Jan', lastName: 'Peeters', birthDay: new Date(2010, 4, 15) });
+            expect(runCheck(MemberDetails.patch({ firstName: 'Tom' }), jan)).toMatchObject({ code: 'not_allowed', field: 'firstName' });
+        });
+    });
+
+    describe('Last name', () => {
+        test('Completely changing the last name is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ lastName: 'Janssens' }), original)).toBeNull();
+        });
+    });
+
+    describe('Birth date', () => {
+        test('Changing only the year is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ birthDay: new Date(2011, 4, 15) }), original)).toBeNull();
+        });
+
+        test('Changing only the day is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ birthDay: new Date(2010, 4, 16) }), original)).toBeNull();
+        });
+
+        test('Changing only the month is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ birthDay: new Date(2010, 5, 15) }), original)).toBeNull();
+        });
+
+        test('Changing two components is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ birthDay: new Date(2010, 5, 16) }), original)).toBeNull();
+        });
+
+        test('Changing day, month and year all at once is not allowed', () => {
+            expect(runCheck(MemberDetails.patch({ birthDay: new Date(2012, 7, 20) }), original)).toMatchObject({ code: 'not_allowed', field: 'birthDay' });
+        });
+
+        test('Setting a birth date for the first time is allowed', () => {
+            const noBirthDay = MemberDetails.create({ firstName: 'Thomas', lastName: 'Peeters', birthDay: null });
+            expect(runCheck(MemberDetails.patch({ birthDay: new Date(2012, 7, 20) }), noBirthDay)).toBeNull();
+        });
+
+        test('Clearing the birth date is allowed', () => {
+            expect(runCheck(MemberDetails.patch({ birthDay: null }), original)).toBeNull();
+        });
+    });
+
+    test('An unrelated patch is allowed', () => {
+        expect(runCheck(MemberDetails.patch({ email: 'someone@example.com' }), original)).toBeNull();
+    });
+});

--- a/backend/app/api/src/endpoints/global/members/throwIfDrasticMemberDetailsChange.test.ts
+++ b/backend/app/api/src/endpoints/global/members/throwIfDrasticMemberDetailsChange.test.ts
@@ -1,3 +1,4 @@
+import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { isSimpleError } from '@simonbackx/simple-errors';
 import { MemberDetails } from '@stamhoofd/structures';
 import { throwIfDrasticMemberDetailsChange } from './throwIfDrasticMemberDetailsChange.js';
@@ -5,7 +6,7 @@ import { throwIfDrasticMemberDetailsChange } from './throwIfDrasticMemberDetails
 /**
  * Runs the check and returns the thrown SimpleError (as { code, field }), or null when nothing was thrown.
  */
-function runCheck(patch: ReturnType<typeof MemberDetails.patch>, original: MemberDetails): { code: string; field?: string } | null {
+function runCheck(patch: AutoEncoderPatchType<MemberDetails>, original: MemberDetails): { code: string; field?: string } | null {
     try {
         throwIfDrasticMemberDetailsChange(patch, original);
         return null;

--- a/backend/app/api/src/endpoints/global/members/throwIfDrasticMemberDetailsChange.ts
+++ b/backend/app/api/src/endpoints/global/members/throwIfDrasticMemberDetailsChange.ts
@@ -1,0 +1,58 @@
+import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
+import { SimpleError } from '@simonbackx/simple-errors';
+import type { MemberDetails } from '@stamhoofd/structures';
+import { StringCompare } from '@stamhoofd/utility';
+
+/**
+ * Prevents non platform-admins from drastically changing the identity of an existing member.
+ *
+ * Fully overwriting the name or birth date of a member can be abused to 'merge' a member into
+ * another one (e.g. a parent changing the data of one child so it becomes identical to a sibling),
+ * which is hard to undo afterwards.
+ *
+ * Allowed changes (that do NOT throw):
+ * - Fixing a typo in the first name (small edit distance)
+ * - Changing the last name (fully allowed, e.g. after a marriage or a spelling correction)
+ * - A small correction to the birth date: changing the day, month or year, but not all three at once
+ *
+ * Platform admins with full access are not restricted; callers should only run this check when the
+ * user does not have platform full access.
+ */
+export function throwIfDrasticMemberDetailsChange(patch: MemberDetails | AutoEncoderPatchType<MemberDetails>, originalDetails: MemberDetails) {
+    // First name: only allow typo-level corrections. A completely different first name is not allowed.
+    if (patch.firstName !== undefined && patch.firstName !== originalDetails.firstName) {
+        const typoCount = StringCompare.typoCount(originalDetails.firstName, patch.firstName);
+
+        // Allow a change of at most ~40% of the (shortest) name, with a minimum of one character,
+        // so short names can still have a typo corrected.
+        const maxTypos = Math.max(1, Math.floor(0.4 * Math.min(originalDetails.firstName.length, patch.firstName.length)));
+
+        if (typoCount > maxTypos) {
+            throw new SimpleError({
+                code: 'not_allowed',
+                message: 'Drastic first name change is not allowed',
+                human: $t(`Je kan de voornaam van een bestaand lid niet volledig wijzigen, enkel een typfout verbeteren. Neem contact op met een hoofdbeheerder als dit toch nodig is.`),
+                field: 'firstName',
+            });
+        }
+    }
+
+    // Birth date: only allow a small correction. Changing the day, month and year all at once is not allowed.
+    const originalBirthDay = originalDetails.birthDay;
+    const newBirthDay = patch.birthDay;
+
+    if (newBirthDay !== undefined && newBirthDay !== null && originalBirthDay !== null) {
+        const dayChanged = newBirthDay.getDate() !== originalBirthDay.getDate();
+        const monthChanged = newBirthDay.getMonth() !== originalBirthDay.getMonth();
+        const yearChanged = newBirthDay.getFullYear() !== originalBirthDay.getFullYear();
+
+        if (dayChanged && monthChanged && yearChanged) {
+            throw new SimpleError({
+                code: 'not_allowed',
+                message: 'Drastic birth date change is not allowed',
+                human: $t(`Je kan de geboortedatum van een bestaand lid enkel beperkt corrigeren, niet de dag, maand én jaar tegelijk wijzigen. Neem contact op met een hoofdbeheerder als dit toch nodig is.`),
+                field: 'birthDay',
+            });
+        }
+    }
+}

--- a/backend/app/api/src/endpoints/global/registration/PatchUserMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/registration/PatchUserMembersEndpoint.test.ts
@@ -1,4 +1,5 @@
 import { Database } from '@simonbackx/simple-database';
+import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { PatchableArray, PatchMap } from '@simonbackx/simple-encoding';
 import type { Endpoint } from '@simonbackx/simple-endpoints';
 import { Request } from '@simonbackx/simple-endpoints';
@@ -1215,7 +1216,7 @@ describe('Endpoint.PatchUserMembersEndpoint', () => {
             return { organization, user, member, token };
         }
 
-        async function patchMember(organization: Awaited<ReturnType<typeof createOwnedMember>>['organization'], token: Awaited<ReturnType<typeof createOwnedMember>>['token'], memberId: string, details: ReturnType<typeof MemberDetails.patch>) {
+        async function patchMember(organization: Awaited<ReturnType<typeof createOwnedMember>>['organization'], token: Awaited<ReturnType<typeof createOwnedMember>>['token'], memberId: string, details: AutoEncoderPatchType<MemberDetails>) {
             const arr: Body = new PatchableArray();
             arr.addPatch(MemberWithRegistrationsBlob.patch({
                 id: memberId,

--- a/backend/app/api/src/endpoints/global/registration/PatchUserMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/registration/PatchUserMembersEndpoint.test.ts
@@ -1198,4 +1198,71 @@ describe('Endpoint.PatchUserMembersEndpoint', () => {
             });
         });
     });
+
+    describe('Name and birth date changes', () => {
+        async function createOwnedMember() {
+            const organization = await new OrganizationFactory({}).create();
+            const user = await new UserFactory({}).create();
+            const member = await new MemberFactory({
+                firstName,
+                lastName,
+                birthDay,
+                generateData: false,
+                // Give user access to this member
+                user,
+            }).create();
+            const token = await Token.createToken(user);
+            return { organization, user, member, token };
+        }
+
+        async function patchMember(organization: Awaited<ReturnType<typeof createOwnedMember>>['organization'], token: Awaited<ReturnType<typeof createOwnedMember>>['token'], memberId: string, details: ReturnType<typeof MemberDetails.patch>) {
+            const arr: Body = new PatchableArray();
+            arr.addPatch(MemberWithRegistrationsBlob.patch({
+                id: memberId,
+                details,
+            }));
+            const request = Request.buildJson('PATCH', baseUrl, organization.getApiHost(), arr);
+            request.headers.authorization = 'Bearer ' + token.accessToken;
+            return await testServer.test(endpoint, request);
+        }
+
+        test('A user cannot drastically change the first name of their member', async () => {
+            const { organization, member, token } = await createOwnedMember();
+            await expect(patchMember(organization, token, member.id, MemberDetails.patch({ firstName: 'Michael' })))
+                .rejects
+                .toThrow(STExpect.errorWithCode('not_allowed'));
+        });
+
+        test('A user can fix a typo in the first name', async () => {
+            const { organization, member, token } = await createOwnedMember();
+            const response = await patchMember(organization, token, member.id, MemberDetails.patch({ firstName: 'Jon' }));
+            expect(response.status).toBe(200);
+            expect(response.body.members[0].details.firstName).toBe('Jon');
+        });
+
+        test('A user can change the last name', async () => {
+            const { organization, member, token } = await createOwnedMember();
+            const response = await patchMember(organization, token, member.id, MemberDetails.patch({ lastName: 'Smith' }));
+            expect(response.status).toBe(200);
+            expect(response.body.members[0].details.lastName).toBe('Smith');
+        });
+
+        test('A user cannot change the day, month and year of the birth date all at once', async () => {
+            const { organization, member, token } = await createOwnedMember();
+            const base = member.details.birthDay!;
+            const newBirthDay = new Date(base.getFullYear() + 2, base.getMonth() + 3, base.getDate() + 5);
+            await expect(patchMember(organization, token, member.id, MemberDetails.patch({ birthDay: newBirthDay })))
+                .rejects
+                .toThrow(STExpect.errorWithCode('not_allowed'));
+        });
+
+        test('A user can correct a single part of the birth date', async () => {
+            const { organization, member, token } = await createOwnedMember();
+            const base = member.details.birthDay!;
+            const newBirthDay = new Date(base.getFullYear() + 1, base.getMonth(), base.getDate());
+            const response = await patchMember(organization, token, member.id, MemberDetails.patch({ birthDay: newBirthDay }));
+            expect(response.status).toBe(200);
+            expect(response.body.members[0].details.birthDay?.getFullYear()).toBe(base.getFullYear() + 1);
+        });
+    });
 });

--- a/backend/app/api/src/endpoints/global/registration/PatchUserMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration/PatchUserMembersEndpoint.ts
@@ -6,7 +6,7 @@ import { SimpleError } from '@simonbackx/simple-errors';
 import type { Group, Registration } from '@stamhoofd/models';
 import { Document, Member, RateLimiter } from '@stamhoofd/models';
 import type { MemberDetails, MembersBlob } from '@stamhoofd/structures';
-import { BooleanStatus, MemberWithRegistrationsBlob } from '@stamhoofd/structures';
+import { BooleanStatus, MemberWithRegistrationsBlob, PermissionLevel } from '@stamhoofd/structures';
 
 import type { OneToManyRelation } from '@simonbackx/simple-database';
 import { AuthenticatedStructures } from '../../../helpers/AuthenticatedStructures.js';
@@ -15,6 +15,7 @@ import { MemberUserSyncer } from '../../../helpers/MemberUserSyncer.js';
 import { didUitpasReviewChange, updateMemberDetailsUitpasNumber, updateMemberDetailsUitpasNumberForPatch } from '../../../helpers/updateMemberDetailsUitpasNumber.js';
 import { PatchOrganizationMembersEndpoint } from '../../global/members/PatchOrganizationMembersEndpoint.js';
 import { shouldCheckIfMemberIsDuplicateForPatch } from '../members/shouldCheckIfMemberIsDuplicate.js';
+import { throwIfDrasticMemberDetailsChange } from '../members/throwIfDrasticMemberDetailsChange.js';
 type Params = Record<string, never>;
 type Query = undefined;
 type Body = PatchableArrayAutoEncoder<MemberWithRegistrationsBlob>;
@@ -108,6 +109,11 @@ export class PatchUserMembersEndpoint extends Endpoint<Params, Query, Body, Resp
                 }
 
                 shouldCheckDuplicate = shouldCheckIfMemberIsDuplicateForPatch(struct, member.details);
+
+                // Only full-permission admins may drastically change the name or birth date of an existing member
+                if (!await Context.auth.canAccessMember(member, PermissionLevel.Full)) {
+                    throwIfDrasticMemberDetailsChange(struct.details, member.details);
+                }
 
                 const previousUitpasNumber = member.details.uitpasNumberDetails?.uitpasNumber ?? null;
 

--- a/backend/app/api/tests/e2e/documents.test.ts
+++ b/backend/app/api/tests/e2e/documents.test.ts
@@ -301,13 +301,15 @@ describe('E2E.Documents', () => {
         await assertNoDocument(registration);
 
         // Change age as user (different endpoint, but should also have the same side effect)
+        // A user may only make a small birth date correction, so we only change the year (the
+        // member was born on 2000-01-01 above) to make them young again.
         await patchUserMember({
             organization,
             user,
             patch: MemberWithRegistrationsBlob.patch({
                 id: member.id,
                 details: MemberDetails.patch({
-                    birthDay: new Date(),
+                    birthDay: new Date(new Date().getFullYear(), 0, 1),
                 }),
             }),
         });


### PR DESCRIPTION
## Summary

Fixes [STA-1081](https://linear.app/stamhoofd/issue/STA-1081). Prevents users from drastically overwriting an existing member's identity — which could accidentally or maliciously "merge" a member into another one (e.g. a parent changing one child's data so it becomes identical to a sibling).

Only **full-permission admins** (platform full access, or full access to the member's organization) may drastically change an existing member's name or birth date. Everyone else — self-service parents and limited admins — may still make legitimate corrections:

- ✅ Fix a typo in the first name (via `StringCompare.typoCount`, threshold relative to name length)
- ✅ Change the last name (fully allowed, e.g. after a marriage or spelling correction)
- ✅ Correct a single part of the birth date (change the day, month **or** year, but not all three at once)
- ❌ Completely replace the first name
- ❌ Change day, month **and** year of the birth date all at once

## Implementation

- New pure helper `throwIfDrasticMemberDetailsChange(patch, originalDetails)` that throws a `SimpleError` (`not_allowed`) on a drastic change.
- Called in both member patch endpoints (`PatchOrganizationMembersEndpoint` and `PatchUserMembersEndpoint`), guarded by `!canAccessMember(member, PermissionLevel.Full)` so full-permission admins are exempt.

## Tests

- Unit tests for the helper covering all first-name / last-name / birth-date branches.
- Integration tests in both endpoints (self-service user + org admin), including the full-admin exemption.
- Updated two existing duplicate-detection tests whose mechanism (a non-full admin renaming a member to match another) is exactly the flow this change now restricts — reworked to keep testing their original intent (typo-fix rename / last-name change) without tripping the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786103930&installation_id=138085646&pr_number=574&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F574&signature=d7e82f3afa6b226cf8ea7460448bd8f1591634b40f1ba4e7408dd84ac1c184d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->