### PR TITLE
Stripe payout reports (cron + manual export)

### DIFF
--- a/backend/app/api/src/crons/index.ts
+++ b/backend/app/api/src/crons/index.ts
@@ -11,6 +11,7 @@ import './invoices.js';
 import './service-fees.js';
 import './members-fees.js';
 import './stripe-invoices.js';
+import './stripe-payout-reports.js';
 import './transfer-fees.js';
 import './drip-emails.js';
 import './update-organization-future-events.js';

--- a/backend/app/api/src/crons/stripe-payout-reports.ts
+++ b/backend/app/api/src/crons/stripe-payout-reports.ts
@@ -1,0 +1,69 @@
+import { registerCron } from '@stamhoofd/crons';
+import { Organization, Platform } from '@stamhoofd/models';
+import { Formatter } from '@stamhoofd/utility';
+import { StripePayoutReporter } from '../helpers/StripePayoutReporter.js';
+
+registerCron('stripe-payout-reports', createStripePayoutReports);
+
+let lastStripeReport: Date | null = null;
+
+/**
+ * Sends a monthly report of all Stripe payouts of the previous month, so we can check
+ * whether everything we charged via Stripe application fees was invoiced correctly.
+ */
+async function createStripePayoutReports() {
+    if (STAMHOOFD.environment !== 'production') {
+        return;
+    }
+
+    if (STAMHOOFD.userMode === 'platform') {
+        return;
+    }
+
+    if (STAMHOOFD.STRIPE_CONNECT_METHOD === 'standard') {
+        return;
+    }
+
+    if (new Date().getHours() > 5 || new Date().getHours() < 2) {
+        // Fix for sending emails after deployments
+        return;
+    }
+
+    // Send the report on the 6th day of the month, once
+    const today = new Date();
+    if (today.getDate() !== 6 || (lastStripeReport && Formatter.dateWithoutDay(lastStripeReport) === Formatter.dateWithoutDay(today))) {
+        return;
+    }
+
+    if (!STAMHOOFD.STRIPE_SECRET_KEY) {
+        console.log('No stripe key set');
+        return;
+    }
+
+    const membershipOrganizationId = (await Platform.getShared()).membershipOrganizationId;
+    if (!membershipOrganizationId) {
+        return;
+    }
+
+    const membershipOrganization = await Organization.getByID(membershipOrganizationId, true);
+
+    console.log('Creating Stripe payout report...');
+
+    // Previous month
+    const previousMonthStart = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+    const end = new Date(new Date(today.getFullYear(), today.getMonth(), 1).getTime() - 1000);
+
+    const reporter = new StripePayoutReporter({
+        secretKey: STAMHOOFD.STRIPE_SECRET_KEY,
+        sellingOrganization: membershipOrganization,
+    });
+
+    await reporter.build(previousMonthStart, end);
+    await reporter.sendEmail({
+        to: [{ email: 'simon@stamhoofd.be' }],
+        // Only send the report to the extra (accounting) recipients when it is complete and valid
+        extraRecipientsWhenValid: (STAMHOOFD.STRIPE_PAYOUT_REPORT_EMAILS ?? []).map(email => ({ email })),
+    });
+
+    lastStripeReport = new Date();
+}

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripePayoutsExportStatusEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/GetStripePayoutsExportStatusEndpoint.ts
@@ -1,0 +1,32 @@
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+
+import { PayoutExportStatus, StripePayoutsExportEndpoint } from './StripePayoutsExportEndpoint.js';
+
+type Params = Record<string, never>;
+type Body = undefined;
+type Query = undefined;
+type ResponseBody = PayoutExportStatus[];
+
+export class GetStripePayoutsExportStatusEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'GET') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/stripe/payouts/status', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(_: DecodedRequest<Params, Query, Body>) {
+        await StripePayoutsExportEndpoint.authenticate();
+
+        return new Response(StripePayoutsExportEndpoint.queue.map((item) => {
+            return PayoutExportStatus.create(item);
+        }));
+    }
+}

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/StripePayoutsExportEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/StripePayoutsExportEndpoint.test.ts
@@ -1,0 +1,103 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import { EmailMocker } from '@stamhoofd/email';
+import type { Organization, Token, User } from '@stamhoofd/models';
+import { OrganizationFactory, UserFactory } from '@stamhoofd/models';
+import { Token as TokenModel } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
+import { Company } from '@stamhoofd/structures';
+import { STExpect } from '@stamhoofd/test-utils';
+import nock from 'nock';
+
+import { resetNock } from '../../../../../tests/helpers/resetNock.js';
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { initMembershipOrganization } from '../../../../../tests/init/initMembershipOrganization.js';
+import { initPlatformAdmin } from '../../../../../tests/init/initPlatformAdmin.js';
+import { GetStripePayoutsExportStatusEndpoint } from './GetStripePayoutsExportStatusEndpoint.js';
+import { StripePayoutsExportEndpoint } from './StripePayoutsExportEndpoint.js';
+
+describe('Endpoint.StripePayoutsExport', () => {
+    const endpoint = new StripePayoutsExportEndpoint();
+    const statusEndpoint = new GetStripePayoutsExportStatusEndpoint();
+
+    let membershipOrganization: Organization;
+    let admin: User;
+    let adminToken: Token;
+
+    beforeAll(async () => {
+        membershipOrganization = await initMembershipOrganization();
+        membershipOrganization.meta.companies = [
+            Company.create({
+                name: 'Platform BV',
+                companyNumber: '0700000000',
+                VATNumber: 'BE0700000000',
+            }),
+        ];
+        await membershipOrganization.save();
+
+        ({ admin, adminToken } = await initPlatformAdmin());
+    });
+
+    afterEach(() => {
+        resetNock();
+    });
+
+    const post = async (organization: Organization, token: Token) => {
+        const request = Request.buildJson('POST', '/stripe/payouts', organization.getApiHost(), {
+            start: new Date(2026, 2, 1).getTime(),
+            end: new Date(2026, 3, 1).getTime() - 1000,
+        });
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    const getStatus = async (organization: Organization, token: Token) => {
+        const request = Request.buildJson('GET', '/stripe/payouts/status', organization.getApiHost());
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+        return await testServer.test(statusEndpoint, request);
+    };
+
+    test('A platform admin can export payout reports for the membership organization', async () => {
+        nock('https://api.stripe.com')
+            .get('/v1/payouts')
+            .query(true)
+            .reply(200, { object: 'list', data: [], has_more: false, url: '/v1/payouts' });
+
+        const response = await post(membershipOrganization, adminToken);
+        expect(response.status).toBe(200);
+
+        // Wait for the scheduled report to complete
+        await QueueHandler.awaitAll();
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        const reportEmail = emails.find(e => e.subject.startsWith('Stripe Uitbetalingen'));
+        expect(reportEmail).toBeDefined();
+        expect(reportEmail!.attachments).toHaveLength(1);
+
+        // The report is sent to the user that requested it
+        expect(reportEmail!.to).toContain(admin.email);
+
+        // The queue is empty again
+        const statusResponse = await getStatus(membershipOrganization, adminToken);
+        expect(statusResponse.body).toEqual([]);
+    });
+
+    test('A user without platform full access cannot export payout reports', async () => {
+        const user = await new UserFactory({ organization: membershipOrganization }).create();
+        const token = await TokenModel.createToken(user);
+
+        await expect(post(membershipOrganization, token)).rejects.toThrow(
+            STExpect.simpleError({ code: 'permission_denied' }),
+        );
+        await expect(getStatus(membershipOrganization, token)).rejects.toThrow(
+            STExpect.simpleError({ code: 'permission_denied' }),
+        );
+    });
+
+    test('Payout reports are not available for other organizations', async () => {
+        const otherOrganization = await new OrganizationFactory({}).create();
+
+        await expect(post(otherOrganization, adminToken)).rejects.toThrow(
+            STExpect.simpleError({ code: 'not_available' }),
+        );
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/stripe/StripePayoutsExportEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/stripe/StripePayoutsExportEndpoint.ts
@@ -1,0 +1,125 @@
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { AutoEncoder, DateDecoder, field, IntegerDecoder } from '@simonbackx/simple-encoding';
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { SimpleError } from '@simonbackx/simple-errors';
+import { Platform } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
+
+import { Context } from '../../../../helpers/Context.js';
+import { StripePayoutReporter } from '../../../../helpers/StripePayoutReporter.js';
+
+export class PayoutExportStatus extends AutoEncoder {
+    @field({ decoder: DateDecoder })
+    start: Date;
+
+    @field({ decoder: DateDecoder })
+    end: Date;
+
+    @field({ decoder: IntegerDecoder })
+    count = 0;
+}
+
+type Params = Record<string, never>;
+class Body extends AutoEncoder {
+    @field({ decoder: DateDecoder })
+    start: Date;
+
+    @field({ decoder: DateDecoder })
+    end: Date;
+}
+type Query = undefined;
+type ResponseBody = undefined;
+
+/**
+ * Manually build a Stripe payout report for a given period and email it (to check whether
+ * everything we charged via Stripe application fees was invoiced correctly).
+ */
+export class StripePayoutsExportEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    bodyDecoder = Body as Decoder<Body>;
+
+    static queue: PayoutExportStatus[] = [];
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'POST') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/stripe/payouts', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    static async authenticate() {
+        const organization = await Context.setOrganizationScope();
+        const { user } = await Context.authenticate();
+
+        if (!Context.auth.hasPlatformFullAccess()) {
+            throw Context.auth.error();
+        }
+
+        const platform = await Platform.getShared();
+        if (!platform.membershipOrganizationId || platform.membershipOrganizationId !== organization.id) {
+            throw new SimpleError({
+                code: 'not_available',
+                message: 'Stripe payout exports are only available for the platform membership organization',
+                statusCode: 400,
+            });
+        }
+
+        return { organization, user };
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        const { organization, user } = await StripePayoutsExportEndpoint.authenticate();
+
+        if (!STAMHOOFD.STRIPE_SECRET_KEY) {
+            throw new SimpleError({
+                code: 'not_configured',
+                message: 'Stripe is not configured',
+                statusCode: 400,
+            });
+        }
+        const secretKey = STAMHOOFD.STRIPE_SECRET_KEY;
+
+        const start = request.body.start;
+        const end = request.body.end;
+
+        const item = PayoutExportStatus.create({
+            start,
+            end,
+            count: 0,
+        });
+        StripePayoutsExportEndpoint.queue.push(item);
+
+        // Schedule
+        QueueHandler.schedule('stripe-payout-export', async () => {
+            try {
+                const reporter = new StripePayoutReporter({
+                    secretKey,
+                    sellingOrganization: organization,
+                });
+                let count = 0;
+                reporter.callback = () => {
+                    count++;
+                    item.count = count;
+                };
+
+                await reporter.build(start, end);
+
+                // Send the report to the user that requested it
+                await reporter.sendEmail({
+                    to: [{ email: user.email, name: user.name }],
+                });
+            } finally {
+                // Remove from queue
+                StripePayoutsExportEndpoint.queue.splice(StripePayoutsExportEndpoint.queue.indexOf(item), 1);
+            }
+        }).catch(console.error);
+
+        return new Response(undefined);
+    }
+}

--- a/backend/app/api/src/helpers/StripePayoutExportData.ts
+++ b/backend/app/api/src/helpers/StripePayoutExportData.ts
@@ -1,0 +1,192 @@
+import type { Invoice, Payment } from '@stamhoofd/models';
+
+export enum StripePayoutItemType {
+    Invoice = 'Invoice',
+    StripeFees = 'StripeFees',
+    StripeReserved = 'StripeReserved',
+}
+
+export class StripePayoutItemData {
+    name = '';
+    type = StripePayoutItemType.Invoice;
+
+    /**
+     * In platform price units (1/100 cent)
+     */
+    amount = 0;
+    description = '';
+
+    /**
+     * Stripe account id + payment reference: only set for Invoice items, used to group the same
+     * account/month combination across multiple payouts.
+     */
+    accountId: string | null = null;
+    reference: string | null = null;
+
+    /**
+     * Payments created in the database for these application fees (can be uninvoiced)
+     */
+    payments: Payment[] = [];
+
+    /**
+     * Invoices connected to those payments (only invoices with a number)
+     */
+    invoices: Invoice[] = [];
+
+    constructor(data: Partial<StripePayoutItemData>) {
+        Object.assign(this, data);
+    }
+
+    get paymentsTotal() {
+        return this.payments.reduce((total, payment) => total + payment.price, 0);
+    }
+
+    get hasUninvoicedPayments() {
+        return this.payments.some(p => p.invoiceId === null);
+    }
+}
+
+export class StripePayoutData {
+    id: string;
+    amount: number; // in platform price units (1/100 cent)
+    arrivalDate: Date;
+    statementDescriptor: string;
+
+    constructor(data: { id: string; amount: number; arrivalDate: Date; statementDescriptor: string }) {
+        this.id = data.id;
+        this.amount = data.amount;
+        this.arrivalDate = data.arrivalDate;
+        this.statementDescriptor = data.statementDescriptor;
+    }
+}
+
+export class StripePayoutBreakdownData {
+    payout: StripePayoutData;
+    items: StripePayoutItemData[] = [];
+
+    constructor(data: { payout: StripePayoutData; items?: StripePayoutItemData[] }) {
+        this.payout = data.payout;
+        this.items = data.items ?? [];
+    }
+
+    /**
+     * Whether the payout amount matches the sum of the items
+     */
+    get isValid() {
+        return this.payout.amount === this.items.reduce((total, item) => total + item.amount, 0);
+    }
+
+    isComplete(payoutExport: StripePayoutExportData) {
+        for (const item of this.items) {
+            if (item.type !== StripePayoutItemType.Invoice) {
+                continue;
+            }
+
+            if (!payoutExport.isItemComplete(item)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+export class StripePayoutExportData {
+    /**
+     * All fetched payouts (we need to fetch more payouts than requested in order to complete all information,
+     * because the fees of a given month might have been paid out in other payouts than the requested ones)
+     */
+    payouts: StripePayoutBreakdownData[] = [];
+
+    start: Date;
+    end: Date;
+
+    constructor(data: { start: Date; end: Date }) {
+        this.start = data.start;
+        this.end = data.end;
+    }
+
+    get includedPayouts() {
+        return this.payouts.filter(p => p.payout.arrivalDate >= this.start && p.payout.arrivalDate <= this.end);
+    }
+
+    /**
+     * All payouts for which all application fees have a matching payment that has been invoiced
+     */
+    get completePayouts() {
+        return this.includedPayouts.filter(p => p.isComplete(this));
+    }
+
+    /**
+     * An item is complete if all application fees for the account + month are covered by
+     * created payments, and all of those payments have been invoiced.
+     */
+    isItemComplete(item: StripePayoutItemData) {
+        if (item.type !== StripePayoutItemType.Invoice) {
+            return true;
+        }
+
+        if (item.payments.length === 0) {
+            return false;
+        }
+
+        if (item.hasUninvoicedPayments || item.invoices.length === 0) {
+            return false;
+        }
+
+        // The sum of the application fees across all fetched payouts should equal the total amount
+        // of the created payments for this account + month
+        const totalAcrossPayouts = this.payouts
+            .flatMap(p => p.items)
+            .filter(i => i.accountId === item.accountId && i.reference === item.reference)
+            .reduce((total, i) => total + i.amount, 0);
+
+        return totalAcrossPayouts === item.paymentsTotal;
+    }
+
+    get totalPaidOut() {
+        return this.completePayouts.reduce((total, payout) => total + payout.payout.amount, 0);
+    }
+
+    get totalStripeFees() {
+        return this.completePayouts.reduce((total, payout) => total + payout.items.filter(i => i.type === StripePayoutItemType.StripeFees).reduce((total, item) => total - item.amount, 0), 0);
+    }
+
+    get totalStripeReserved() {
+        return this.completePayouts.reduce((total, payout) => total + payout.items.filter(i => i.type === StripePayoutItemType.StripeReserved).reduce((total, item) => total - item.amount, 0), 0);
+    }
+
+    get totalInvoices() {
+        return this.completePayouts.reduce((total, payout) => total + payout.items.filter(i => i.type === StripePayoutItemType.Invoice).reduce((total, item) => total + item.amount, 0), 0);
+    }
+
+    get totalVAT() {
+        let VAT = 0;
+        for (const payout of this.completePayouts) {
+            for (const item of payout.items) {
+                if (item.type !== StripePayoutItemType.Invoice) {
+                    continue;
+                }
+
+                const invoiceVAT = item.invoices.reduce((total, invoice) => total + invoice.VATTotalAmount, 0);
+                const invoiceTotal = item.invoices.reduce((total, invoice) => total + invoice.totalWithVAT, 0);
+
+                if (invoiceTotal === 0) {
+                    continue;
+                }
+
+                // Estimate applicable VAT based on the VAT rate of the connected invoices
+                // (an invoice can contain more than only these fees, so we apply the rate, not the absolute amount)
+                VAT += invoiceVAT / invoiceTotal * item.amount;
+            }
+        }
+        return Math.round(VAT);
+    }
+
+    get net() {
+        return this.totalPaidOut - this.totalVAT;
+    }
+
+    get isValid() {
+        return this.totalPaidOut === this.totalInvoices - this.totalStripeFees - this.totalStripeReserved && this.completePayouts.length === this.includedPayouts.length;
+    }
+}

--- a/backend/app/api/src/helpers/StripePayoutExportData.ts
+++ b/backend/app/api/src/helpers/StripePayoutExportData.ts
@@ -187,6 +187,9 @@ export class StripePayoutExportData {
     }
 
     get isValid() {
-        return this.totalPaidOut === this.totalInvoices - this.totalStripeFees - this.totalStripeReserved && this.completePayouts.length === this.includedPayouts.length;
+        return this.totalPaidOut === this.totalInvoices - this.totalStripeFees - this.totalStripeReserved
+            // Aggregate totals can mask payout-level mismatches that cancel each other out
+            && this.includedPayouts.every(p => p.isValid)
+            && this.completePayouts.length === this.includedPayouts.length;
     }
 }

--- a/backend/app/api/src/helpers/StripePayoutExportExcel.ts
+++ b/backend/app/api/src/helpers/StripePayoutExportExcel.ts
@@ -1,0 +1,280 @@
+import type { CellValue } from '@stamhoofd/excel-writer';
+import { ArchiverWriterAdapter, XlsxBuiltInNumberFormat, XlsxWriter } from '@stamhoofd/excel-writer';
+import { Sorter } from '@stamhoofd/utility';
+import { Writable } from 'node:stream';
+
+import type { StripePayoutBreakdownData, StripePayoutData, StripePayoutExportData, StripePayoutItemData } from './StripePayoutExportData.js';
+import { StripePayoutItemType } from './StripePayoutExportData.js';
+
+function currencyCell(amount: number | null, width?: number): CellValue {
+    return {
+        value: amount === null ? null : amount / 1_0000,
+        width,
+        style: {
+            numberFormat: {
+                id: XlsxBuiltInNumberFormat.Currency2DecimalWithoutRed,
+            },
+        },
+    };
+}
+
+function dateCell(date: Date | null, width?: number): CellValue {
+    return {
+        value: date,
+        width,
+        style: {
+            numberFormat: {
+                id: XlsxBuiltInNumberFormat.DateSlash,
+            },
+        },
+    };
+}
+
+function textCell(value: string, width?: number): CellValue {
+    return { value, width };
+}
+
+const empty = textCell('');
+
+export class StripePayoutExportExcel {
+    /**
+     * List of all items for every payout
+     */
+    private static async writePayouts(writer: XlsxWriter, sheet: symbol, includedPayouts: StripePayoutBreakdownData[]) {
+        await writer.addRow(sheet, [
+            textCell('Datum', 13),
+            textCell('Uitbetaald bedrag', 16),
+            textCell('Naam', 45),
+            textCell('Bedrag', 13),
+            textCell('Beschrijving', 60),
+        ]);
+
+        for (const breakdown of [...includedPayouts].sort((b, a) => Sorter.byDateValue(a.payout.arrivalDate, b.payout.arrivalDate))) {
+            for (const [index, item] of [...breakdown.items].sort((a, b) => Sorter.byStringValue(a.name, b.name)).entries()) {
+                await writer.addRow(sheet, [
+                    index > 0 ? empty : dateCell(breakdown.payout.arrivalDate),
+                    index > 0 ? empty : currencyCell(breakdown.payout.amount),
+                    textCell(item.name),
+                    currencyCell(item.amount),
+                    textCell(item.description),
+                ]);
+            }
+
+            // Include total line
+            const total = breakdown.items.reduce((total, item) => total + item.amount, 0);
+            await writer.addRow(sheet, [
+                empty,
+                empty,
+                textCell('Totaal'),
+                currencyCell(total),
+                textCell(total === breakdown.payout.amount ? '✓' : 'Klopt niet!'),
+            ]);
+
+            // Empty line
+            await writer.addRow(sheet, []);
+        }
+    }
+
+    /**
+     * Group by account + month (= payment reference): shows the connected payments and invoices
+     */
+    private static async writeInvoices(writer: XlsxWriter, sheet: symbol, includedPayouts: StripePayoutBreakdownData[], allPayouts: StripePayoutBreakdownData[]) {
+        await writer.addRow(sheet, [
+            textCell('Referentie', 22),
+            textCell('Factuur', 35),
+            textCell('Factuurdatum', 14),
+            textCell('Factuurbedrag (incl. BTW)', 22),
+            textCell('Aangerekend bedrag', 18),
+            textCell('Uitbetalingsdatum', 16),
+            textCell('Uitbetaald bedrag', 16),
+            textCell('Opmerking', 25),
+            textCell('Klant', 30),
+            textCell('Ondernemingsnummer', 20),
+            textCell('BTW-nummer', 16),
+            textCell('Adres', 40),
+        ]);
+
+        // Group all data by account + reference
+        const groups = new Map<string, {
+            item: StripePayoutItemData;
+            items: { item: StripePayoutItemData; payout: StripePayoutData }[];
+        }>();
+
+        for (const breakdown of allPayouts) {
+            for (const item of breakdown.items) {
+                if (item.type !== StripePayoutItemType.Invoice) {
+                    continue;
+                }
+
+                const key = (item.accountId ?? '') + '-' + (item.reference ?? '');
+                const group = groups.get(key) ?? {
+                    item,
+                    items: [],
+                };
+                group.items.push({
+                    item,
+                    payout: breakdown.payout,
+                });
+                groups.set(key, group);
+            }
+        }
+
+        const sortedGroups = [...groups.values()].sort((a, b) => Sorter.stack(
+            Sorter.byStringValue(a.item.reference ?? '', b.item.reference ?? ''),
+            Sorter.byStringValue(a.item.description, b.item.description),
+        ));
+
+        for (const group of sortedGroups) {
+            // Skip groups that don't have any payout in the requested period
+            if (!group.items.some(({ payout }) => includedPayouts.some(p => p.payout.id === payout.id))) {
+                continue;
+            }
+
+            const item = group.item;
+            const invoices = item.invoices;
+            const customer = invoices[0]?.customer ?? item.payments[0]?.customer ?? null;
+
+            const invoiceTotal = invoices.reduce((total, invoice) => total + invoice.totalWithVAT, 0);
+            const invoiceDate = invoices[0]?.invoicedAt ?? null;
+
+            for (const [index, { item: payoutItem, payout }] of [...group.items].sort((b, a) => Sorter.byDateValue(a.payout.arrivalDate, b.payout.arrivalDate)).entries()) {
+                await writer.addRow(sheet, [
+                    index > 0 ? empty : textCell(item.reference ?? ''),
+                    index > 0 ? empty : textCell(item.name),
+                    index > 0 ? empty : dateCell(invoiceDate),
+                    index > 0 ? empty : (invoices.length === 0 ? empty : currencyCell(invoiceTotal)),
+                    index > 0 ? empty : (item.payments.length === 0 ? empty : currencyCell(item.paymentsTotal)),
+                    dateCell(payout.arrivalDate),
+                    currencyCell(payoutItem.amount),
+                    empty,
+                    index > 0 ? empty : textCell(customer?.dynamicName ?? item.description),
+                    index > 0 ? empty : textCell(customer?.company?.companyNumber ?? '/'),
+                    index > 0 ? empty : textCell(customer?.company?.VATNumber ?? '/'),
+                    index > 0 ? empty : textCell(customer?.company?.address ? customer.company.address + '' : '/'),
+                ]);
+            }
+
+            // Include total line
+            const total = group.items.reduce((total, { item }) => total + item.amount, 0);
+            let remark = 'Nog geen betaling aangemaakt';
+            if (item.payments.length > 0) {
+                if (total !== item.paymentsTotal) {
+                    remark = 'Nog onvolledig';
+                } else if (item.hasUninvoicedPayments || invoices.length === 0) {
+                    remark = 'Nog niet gefactureerd';
+                } else {
+                    remark = '✓';
+                }
+            }
+
+            await writer.addRow(sheet, [
+                empty,
+                empty,
+                empty,
+                empty,
+                empty,
+                textCell('Totaal'),
+                currencyCell(total),
+                textCell(remark),
+            ]);
+
+            // Empty line
+            await writer.addRow(sheet, []);
+        }
+    }
+
+    /**
+     * Group Stripe fees by month
+     */
+    private static async writeStripeInvoices(writer: XlsxWriter, sheet: symbol, includedPayouts: StripePayoutBreakdownData[], allPayouts: StripePayoutBreakdownData[]) {
+        await writer.addRow(sheet, [
+            textCell('Periode', 25),
+            textCell('Afgehouden bedrag', 18),
+            textCell('Uitbetalingsdatum', 16),
+            textCell('Beschrijving', 25),
+        ]);
+
+        // Group all data by Stripe invoice period
+        const groupedInvoices = new Map<string, { item: StripePayoutItemData; payout: StripePayoutData }[]>();
+
+        for (const breakdown of allPayouts) {
+            for (const item of breakdown.items) {
+                if (item.type !== StripePayoutItemType.StripeFees) {
+                    continue;
+                }
+
+                const groupName = item.description;
+                const list = groupedInvoices.get(groupName) ?? [];
+                groupedInvoices.set(groupName, list);
+                list.push({
+                    item,
+                    payout: breakdown.payout,
+                });
+            }
+        }
+
+        for (const [period, group] of groupedInvoices) {
+            // Do not include invoices that have no payout in the period
+            if (!group.find(g => includedPayouts.find(p => p.payout.id === g.payout.id))) {
+                // Likely not completely fetched: don't include it
+                continue;
+            }
+
+            for (const [index, item] of group.entries()) {
+                await writer.addRow(sheet, [
+                    index > 0 ? empty : textCell(period),
+                    currencyCell(-item.item.amount),
+                    dateCell(item.payout.arrivalDate),
+                    empty,
+                ]);
+            }
+
+            // Include total line
+            const total = -group.reduce((total, item) => total + item.item.amount, 0);
+            await writer.addRow(sheet, [
+                empty,
+                currencyCell(total),
+                empty,
+                textCell('Totaal'),
+            ]);
+
+            // Empty line
+            await writer.addRow(sheet, []);
+        }
+    }
+
+    static async export(e: StripePayoutExportData): Promise<Buffer> {
+        const chunks: Buffer[] = [];
+        const output = new Writable({
+            write(chunk: Buffer, _encoding, callback) {
+                chunks.push(chunk);
+                callback();
+            },
+        });
+        const finishPromise = new Promise<void>((resolve, reject) => {
+            output.on('finish', () => resolve());
+            output.on('error', reject);
+        });
+
+        const zipWriterAdapter = new ArchiverWriterAdapter(output);
+        const writer = new XlsxWriter(zipWriterAdapter);
+
+        const payoutsSheet = await writer.addSheet('Uitbetalingen');
+        const invoicesSheet = await writer.addSheet('Facturen');
+        const stripeInvoicesSheet = await writer.addSheet('Stripe Facturen');
+        await writer.ready();
+
+        try {
+            await this.writePayouts(writer, payoutsSheet, e.includedPayouts);
+            await this.writeInvoices(writer, invoicesSheet, e.includedPayouts, e.payouts);
+            await this.writeStripeInvoices(writer, stripeInvoicesSheet, e.includedPayouts, e.payouts);
+            await writer.close();
+        } catch (error) {
+            await writer.abort();
+            throw error;
+        }
+
+        await finishPromise;
+        return Buffer.concat(chunks);
+    }
+}

--- a/backend/app/api/src/helpers/StripePayoutReporter.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.test.ts
@@ -1,0 +1,292 @@
+import { EmailMocker } from '@stamhoofd/email';
+import type { StripeAccount, Organization } from '@stamhoofd/models';
+import { Invoice, OrganizationFactory, Payment } from '@stamhoofd/models';
+import { Address, Company, PaymentCustomer, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
+import { Country } from '@stamhoofd/types/Country';
+import { Formatter } from '@stamhoofd/utility';
+import nock from 'nock';
+
+import { resetNock } from '../../tests/helpers/resetNock.js';
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import { initMembershipOrganization } from '../../tests/init/initMembershipOrganization.js';
+import { StripeInvoicer } from './StripeInvoicer.js';
+import { StripePayoutItemType } from './StripePayoutExportData.js';
+import { StripePayoutReporter } from './StripePayoutReporter.js';
+
+describe('StripePayoutReporter', () => {
+    let membershipOrganization: Organization;
+    const stripeMocker = new StripeMocker();
+
+    // Report over March 2026 (tests always run in UTC)
+    const month = new Date(2026, 2, 15);
+    const { start: monthStartUnix } = StripeInvoicer.getMonthUnixStartEnd(month);
+    const reference = 'stripe-fees-' + Formatter.dateIso(new Date(monthStartUnix * 1000));
+    const reportStart = new Date(2026, 2, 1);
+    const reportEnd = new Date(new Date(2026, 3, 1).getTime() - 1000);
+
+    const belgianAddress = () => Address.create({
+        street: 'Teststraat',
+        number: '1',
+        postalCode: '9000',
+        city: 'Gent',
+        country: Country.Belgium,
+    });
+
+    beforeAll(async () => {
+        membershipOrganization = await initMembershipOrganization();
+        membershipOrganization.meta.companies = [
+            Company.create({
+                name: 'Platform BV',
+                companyNumber: '0700000000',
+                VATNumber: 'BE0700000000',
+                address: belgianAddress(),
+            }),
+        ];
+        await membershipOrganization.save();
+    });
+
+    afterEach(() => {
+        resetNock();
+    });
+
+    const init = async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const stripeAccount = await stripeMocker.createStripeAccount(organization.id);
+        return { organization, stripeAccount };
+    };
+
+    /**
+     * One payout containing a charge of `chargeCents` with an application fee of `feeCents`,
+     * fully transferred to the connected account. The payout pays out the application fee
+     * minus the Stripe processing fee to the platform.
+     */
+    const mockStripeData = (accountId: string, { feeCents = 250, chargeCents = 10000, stripeFeeCents = 25 } = {}) => {
+        const createdUnix = monthStartUnix + 14 * 24 * 3600;
+        const payout = {
+            id: stripeMocker.createId('po'),
+            object: 'payout',
+            status: 'paid',
+            amount: feeCents - stripeFeeCents,
+            arrival_date: createdUnix + 5 * 24 * 3600,
+            statement_descriptor: 'STAMHOOFD',
+        };
+
+        const transactions = [
+            {
+                id: stripeMocker.createId('txn'),
+                type: 'charge',
+                amount: chargeCents,
+                fee: stripeFeeCents,
+                created: createdUnix,
+                source: { object: 'charge', id: stripeMocker.createId('ch'), amount: chargeCents, on_behalf_of: accountId },
+            },
+            {
+                id: stripeMocker.createId('txn'),
+                type: 'transfer',
+                amount: -chargeCents,
+                fee: 0,
+                created: createdUnix,
+                source: { object: 'transfer', id: stripeMocker.createId('tr'), destination: accountId },
+            },
+            {
+                id: stripeMocker.createId('txn'),
+                type: 'application_fee',
+                amount: feeCents,
+                fee: 0,
+                created: createdUnix,
+                source: { object: 'application_fee', id: stripeMocker.createId('fee'), amount: feeCents, account: accountId },
+            },
+            {
+                id: stripeMocker.createId('txn'),
+                type: 'payout',
+                amount: -(feeCents - stripeFeeCents),
+                fee: 0,
+                created: createdUnix + 5 * 24 * 3600,
+                source: null,
+            },
+        ];
+
+        nock('https://api.stripe.com')
+            .get('/v1/payouts')
+            .query(true)
+            .reply(200, { object: 'list', data: [payout], has_more: false, url: '/v1/payouts' });
+
+        nock('https://api.stripe.com')
+            .get('/v1/balance_transactions')
+            .query(true)
+            .reply(200, { object: 'list', data: transactions, has_more: false, url: '/v1/balance_transactions' });
+
+        return { payout, transactions };
+    };
+
+    const createPayment = async (organization: Organization, stripeAccount: StripeAccount, price: number) => {
+        const payment = new Payment();
+        payment.organizationId = membershipOrganization.id;
+        payment.payingOrganizationId = organization.id;
+        payment.stripeAccountId = stripeAccount.id;
+        payment.reference = reference;
+        payment.method = PaymentMethod.AccountDeductions;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.type = PaymentType.Payment;
+        payment.price = price;
+        payment.paidAt = new Date(monthStartUnix * 1000);
+        payment.customer = PaymentCustomer.create({
+            company: Company.create({
+                name: 'Testvereniging VZW',
+                companyNumber: '0500000000',
+                VATNumber: 'BE0500000000',
+                address: belgianAddress(),
+            }),
+        });
+        await payment.save();
+        return payment;
+    };
+
+    const createInvoice = async (organization: Organization, payment: Payment, { number, totalWithVAT, VATTotalAmount }: { number: string; totalWithVAT: number; VATTotalAmount: number }) => {
+        const invoice = new Invoice();
+        invoice.organizationId = membershipOrganization.id;
+        invoice.payingOrganizationId = organization.id;
+        invoice.number = number;
+        invoice.customer = payment.customer!;
+        invoice.seller = membershipOrganization.meta.companies[0];
+        invoice.totalWithVAT = totalWithVAT;
+        invoice.VATTotalAmount = VATTotalAmount;
+        invoice.totalWithoutVAT = totalWithVAT - VATTotalAmount;
+        invoice.invoicedAt = new Date();
+        await invoice.save();
+
+        payment.invoiceId = invoice.id;
+        await payment.save();
+        return invoice;
+    };
+
+    const buildReport = async () => {
+        const reporter = new StripePayoutReporter({
+            secretKey: STAMHOOFD.STRIPE_SECRET_KEY!,
+            sellingOrganization: membershipOrganization,
+        });
+        await reporter.build(reportStart, reportEnd);
+        return reporter;
+    };
+
+    test('A payment that has been invoiced is reported with its invoice number and makes the report valid', async () => {
+        const { organization, stripeAccount } = await init();
+        mockStripeData(stripeAccount.accountId, { feeCents: 250, stripeFeeCents: 25 });
+
+        // 2.50 euro in platform units (1/100 cent)
+        const payment = await createPayment(organization, stripeAccount, 250_00);
+        await createInvoice(organization, payment, { number: '2026-101', totalWithVAT: 250_00, VATTotalAmount: 4339 });
+
+        const reporter = await buildReport();
+        const payoutExport = reporter.toStructure();
+
+        expect(payoutExport.payouts.length).toBe(1);
+
+        const breakdown = payoutExport.payouts[0];
+        expect(breakdown.payout.amount).toBe(225_00);
+        expect(breakdown.isValid).toBe(true);
+
+        const invoiceItem = breakdown.items.find(i => i.type === StripePayoutItemType.Invoice)!;
+        expect(invoiceItem.name).toBe('Factuur 2026-101');
+        expect(invoiceItem.amount).toBe(250_00);
+        expect(invoiceItem.reference).toBe(reference);
+        expect(invoiceItem.payments.map(p => p.id)).toEqual([payment.id]);
+        expect(invoiceItem.invoices.map(i => i.number)).toEqual(['2026-101']);
+
+        const feesItem = breakdown.items.find(i => i.type === StripePayoutItemType.StripeFees)!;
+        expect(feesItem.amount).toBe(-25_00);
+
+        expect(payoutExport.completePayouts.length).toBe(1);
+        expect(payoutExport.isValid).toBe(true);
+        expect(payoutExport.totalPaidOut).toBe(225_00);
+        expect(payoutExport.totalStripeFees).toBe(25_00);
+        expect(payoutExport.totalInvoices).toBe(250_00);
+        expect(payoutExport.totalVAT).toBe(4339);
+        expect(payoutExport.net).toBe(225_00 - 4339);
+
+        // The report can be exported to Excel
+        const buffer = await reporter.toExcel(payoutExport);
+        expect(buffer.length).toBeGreaterThan(0);
+
+        // Extra recipients receive the report because it is valid
+        await reporter.sendEmail({
+            to: [{ email: 'requester@example.com' }],
+            extraRecipientsWhenValid: [{ email: 'accountant@example.com' }],
+        });
+        const email = (await EmailMocker.transactional.getSucceededEmails()).find(e => e.subject.startsWith('Stripe Uitbetalingen'));
+        expect(email).toBeDefined();
+        expect(email!.to).toContain('requester@example.com');
+        expect(email!.to).toContain('accountant@example.com');
+        expect(email!.text).not.toContain('RAPPORT ONVOLLEDIG');
+    });
+
+    test('A payment that has not been invoiced yet is visible in the report and marks it as incomplete', async () => {
+        const { organization, stripeAccount } = await init();
+        mockStripeData(stripeAccount.accountId, { feeCents: 250, stripeFeeCents: 25 });
+
+        const payment = await createPayment(organization, stripeAccount, 250_00);
+
+        const reporter = await buildReport();
+        const payoutExport = reporter.toStructure();
+
+        const breakdown = payoutExport.payouts[0];
+        expect(breakdown.isValid).toBe(true); // amounts of the payout itself are consistent
+
+        const invoiceItem = breakdown.items.find(i => i.type === StripePayoutItemType.Invoice)!;
+        expect(invoiceItem.name).toBe('Betaling aangemaakt, nog niet gefactureerd');
+        expect(invoiceItem.amount).toBe(250_00);
+        expect(invoiceItem.payments.map(p => p.id)).toEqual([payment.id]);
+        expect(invoiceItem.invoices).toEqual([]);
+
+        // Not invoiced yet: the payout is not complete and the report is invalid
+        expect(payoutExport.completePayouts.length).toBe(0);
+        expect(payoutExport.isValid).toBe(false);
+
+        // Extra recipients are skipped for invalid reports
+        await reporter.sendEmail({
+            to: [{ email: 'requester@example.com' }],
+            extraRecipientsWhenValid: [{ email: 'accountant@example.com' }],
+        });
+        const email = (await EmailMocker.transactional.getSucceededEmails()).find(e => e.subject.startsWith('Stripe Uitbetalingen'));
+        expect(email).toBeDefined();
+        expect(email!.to).toContain('requester@example.com');
+        expect(email!.to).not.toContain('accountant@example.com');
+        expect(email!.text).toContain('RAPPORT ONVOLLEDIG');
+    });
+
+    test('Application fees without a created payment are visible in the report and mark it as incomplete', async () => {
+        const { stripeAccount } = await init();
+        mockStripeData(stripeAccount.accountId, { feeCents: 250, stripeFeeCents: 25 });
+
+        const reporter = await buildReport();
+        const payoutExport = reporter.toStructure();
+
+        const invoiceItem = payoutExport.payouts[0].items.find(i => i.type === StripePayoutItemType.Invoice)!;
+        expect(invoiceItem.name).toBe('Nog geen betaling aangemaakt');
+        expect(invoiceItem.amount).toBe(250_00);
+        expect(invoiceItem.payments).toEqual([]);
+
+        expect(payoutExport.completePayouts.length).toBe(0);
+        expect(payoutExport.isValid).toBe(false);
+    });
+
+    test('An invoiced payment with a different amount than the application fees marks the report as incomplete', async () => {
+        const { organization, stripeAccount } = await init();
+        mockStripeData(stripeAccount.accountId, { feeCents: 250, stripeFeeCents: 25 });
+
+        // Payment of 2 euro, while 2.50 euro of application fees were charged
+        const payment = await createPayment(organization, stripeAccount, 200_00);
+        await createInvoice(organization, payment, { number: '2026-102', totalWithVAT: 200_00, VATTotalAmount: 3471 });
+
+        const reporter = await buildReport();
+        const payoutExport = reporter.toStructure();
+
+        const invoiceItem = payoutExport.payouts[0].items.find(i => i.type === StripePayoutItemType.Invoice)!;
+        expect(invoiceItem.name).toBe('Factuur 2026-102');
+        expect(invoiceItem.amount).toBe(250_00);
+
+        expect(payoutExport.completePayouts.length).toBe(0);
+        expect(payoutExport.isValid).toBe(false);
+    });
+});

--- a/backend/app/api/src/helpers/StripePayoutReporter.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.test.ts
@@ -60,18 +60,18 @@ describe('StripePayoutReporter', () => {
      * fully transferred to the connected account. The payout pays out the application fee
      * minus the Stripe processing fee to the platform.
      */
-    const mockStripeData = (accountId: string, { feeCents = 250, chargeCents = 10000, stripeFeeCents = 25 } = {}) => {
+    const mockStripeData = (accountId: string, { feeCents = 250, chargeCents = 10000, stripeFeeCents = 25, feeRefundCents = 0 } = {}) => {
         const createdUnix = monthStartUnix + 14 * 24 * 3600;
         const payout = {
             id: stripeMocker.createId('po'),
             object: 'payout',
             status: 'paid',
-            amount: feeCents - stripeFeeCents,
+            amount: feeCents - feeRefundCents - stripeFeeCents,
             arrival_date: createdUnix + 5 * 24 * 3600,
             statement_descriptor: 'STAMHOOFD',
         };
 
-        const transactions = [
+        const transactions: unknown[] = [
             {
                 id: stripeMocker.createId('txn'),
                 type: 'charge',
@@ -99,12 +99,28 @@ describe('StripePayoutReporter', () => {
             {
                 id: stripeMocker.createId('txn'),
                 type: 'payout',
-                amount: -(feeCents - stripeFeeCents),
+                amount: -(feeCents - feeRefundCents - stripeFeeCents),
                 fee: 0,
                 created: createdUnix + 5 * 24 * 3600,
                 source: null,
             },
         ];
+
+        if (feeRefundCents > 0) {
+            transactions.push({
+                id: stripeMocker.createId('txn'),
+                type: 'application_fee_refund',
+                amount: -feeRefundCents,
+                fee: 0,
+                created: createdUnix,
+                source: {
+                    object: 'fee_refund',
+                    id: stripeMocker.createId('fr'),
+                    amount: feeRefundCents,
+                    fee: { object: 'application_fee', id: stripeMocker.createId('fee'), amount: feeCents, account: accountId },
+                },
+            });
+        }
 
         nock('https://api.stripe.com')
             .get('/v1/payouts')
@@ -269,6 +285,28 @@ describe('StripePayoutReporter', () => {
 
         expect(payoutExport.completePayouts.length).toBe(0);
         expect(payoutExport.isValid).toBe(false);
+    });
+
+    test('Refunded application fees reduce the amount that should be invoiced', async () => {
+        const { organization, stripeAccount } = await init();
+        mockStripeData(stripeAccount.accountId, { feeCents: 250, feeRefundCents: 50, stripeFeeCents: 25 });
+
+        // 2 euro invoiced: 2.50 euro of fees minus 0.50 euro refunded
+        const payment = await createPayment(organization, stripeAccount, 200_00);
+        await createInvoice(organization, payment, { number: '2026-103', totalWithVAT: 200_00, VATTotalAmount: 3471 });
+
+        const reporter = await buildReport();
+        const payoutExport = reporter.toStructure();
+
+        const breakdown = payoutExport.payouts[0];
+        expect(breakdown.payout.amount).toBe(175_00);
+        expect(breakdown.isValid).toBe(true);
+
+        const invoiceItem = breakdown.items.find(i => i.type === StripePayoutItemType.Invoice)!;
+        expect(invoiceItem.amount).toBe(200_00);
+
+        expect(payoutExport.completePayouts.length).toBe(1);
+        expect(payoutExport.isValid).toBe(true);
     });
 
     test('An invoiced payment with a different amount than the application fees marks the report as incomplete', async () => {

--- a/backend/app/api/src/helpers/StripePayoutReporter.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.test.ts
@@ -60,8 +60,8 @@ describe('StripePayoutReporter', () => {
      * fully transferred to the connected account. The payout pays out the application fee
      * minus the Stripe processing fee to the platform.
      */
-    const mockStripeData = (accountId: string, { feeCents = 250, chargeCents = 10000, stripeFeeCents = 25, feeRefundCents = 0, refundCents = 0 } = {}) => {
-        const createdUnix = monthStartUnix + 14 * 24 * 3600;
+    const mockStripeData = (accountId: string, { feeCents = 250, chargeCents = 10000, stripeFeeCents = 25, feeRefundCents = 0, refundCents = 0, createdOffsetDays = 0 } = {}) => {
+        const createdUnix = monthStartUnix + (14 + createdOffsetDays) * 24 * 3600;
         const payout = {
             id: stripeMocker.createId('po'),
             object: 'payout',
@@ -350,6 +350,23 @@ describe('StripePayoutReporter', () => {
 
         expect(payoutExport.completePayouts.length).toBe(1);
         expect(payoutExport.isValid).toBe(true);
+    });
+
+    test('Payouts outside the requested period are not counted as skipped', async () => {
+        const { stripeAccount } = await init();
+        // The payout is fetched (within the extra month margin), but arrives after the requested period
+        mockStripeData(stripeAccount.accountId, { createdOffsetDays: 20 });
+
+        const reporter = await buildReport();
+        const payoutExport = reporter.toStructure();
+
+        expect(payoutExport.payouts.length).toBe(1);
+        expect(payoutExport.includedPayouts.length).toBe(0);
+        expect(payoutExport.isValid).toBe(true);
+
+        await reporter.sendEmail({ to: [{ email: 'requester@example.com' }] });
+        const email = (await EmailMocker.transactional.getSucceededEmails()).find(e => e.subject.startsWith('Stripe Uitbetalingen'));
+        expect(email!.text).toContain('Overgeslagen uitbetalingen (onvolledig): 0');
     });
 
     test('Payout-level mismatches that cancel each other out still make the report invalid', () => {

--- a/backend/app/api/src/helpers/StripePayoutReporter.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.test.ts
@@ -60,7 +60,7 @@ describe('StripePayoutReporter', () => {
      * fully transferred to the connected account. The payout pays out the application fee
      * minus the Stripe processing fee to the platform.
      */
-    const mockStripeData = (accountId: string, { feeCents = 250, chargeCents = 10000, stripeFeeCents = 25, feeRefundCents = 0 } = {}) => {
+    const mockStripeData = (accountId: string, { feeCents = 250, chargeCents = 10000, stripeFeeCents = 25, feeRefundCents = 0, refundCents = 0 } = {}) => {
         const createdUnix = monthStartUnix + 14 * 24 * 3600;
         const payout = {
             id: stripeMocker.createId('po'),
@@ -105,6 +105,30 @@ describe('StripePayoutReporter', () => {
                 source: null,
             },
         ];
+
+        if (refundCents > 0) {
+            // A customer refund: paid back from the connected account balance via a transfer refund
+            transactions.push({
+                id: stripeMocker.createId('txn'),
+                type: 'refund',
+                amount: -refundCents,
+                fee: 0,
+                created: createdUnix,
+                source: {
+                    object: 'refund',
+                    id: stripeMocker.createId('re'),
+                    amount: refundCents,
+                    charge: { object: 'charge', id: stripeMocker.createId('ch'), amount: chargeCents, on_behalf_of: accountId },
+                },
+            }, {
+                id: stripeMocker.createId('txn'),
+                type: 'transfer_refund',
+                amount: refundCents,
+                fee: 0,
+                created: createdUnix,
+                source: { object: 'transfer', id: stripeMocker.createId('tr'), destination: accountId },
+            });
+        }
 
         if (feeRefundCents > 0) {
             transactions.push({
@@ -304,6 +328,25 @@ describe('StripePayoutReporter', () => {
 
         const invoiceItem = breakdown.items.find(i => i.type === StripePayoutItemType.Invoice)!;
         expect(invoiceItem.amount).toBe(200_00);
+
+        expect(payoutExport.completePayouts.length).toBe(1);
+        expect(payoutExport.isValid).toBe(true);
+    });
+
+    test('A payout containing a customer refund can be reported', async () => {
+        const { organization, stripeAccount } = await init();
+        mockStripeData(stripeAccount.accountId, { feeCents: 250, stripeFeeCents: 25, refundCents: 1000 });
+
+        const payment = await createPayment(organization, stripeAccount, 250_00);
+        await createInvoice(organization, payment, { number: '2026-104', totalWithVAT: 250_00, VATTotalAmount: 4339 });
+
+        const reporter = await buildReport();
+        const payoutExport = reporter.toStructure();
+
+        // The refund and its transfer refund cancel each other out on the payout
+        const breakdown = payoutExport.payouts[0];
+        expect(breakdown.payout.amount).toBe(225_00);
+        expect(breakdown.isValid).toBe(true);
 
         expect(payoutExport.completePayouts.length).toBe(1);
         expect(payoutExport.isValid).toBe(true);

--- a/backend/app/api/src/helpers/StripePayoutReporter.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.test.ts
@@ -10,7 +10,7 @@ import { resetNock } from '../../tests/helpers/resetNock.js';
 import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
 import { initMembershipOrganization } from '../../tests/init/initMembershipOrganization.js';
 import { StripeInvoicer } from './StripeInvoicer.js';
-import { StripePayoutItemType } from './StripePayoutExportData.js';
+import { StripePayoutBreakdownData, StripePayoutData, StripePayoutExportData, StripePayoutItemData, StripePayoutItemType } from './StripePayoutExportData.js';
 import { StripePayoutReporter } from './StripePayoutReporter.js';
 
 describe('StripePayoutReporter', () => {
@@ -350,6 +350,35 @@ describe('StripePayoutReporter', () => {
 
         expect(payoutExport.completePayouts.length).toBe(1);
         expect(payoutExport.isValid).toBe(true);
+    });
+
+    test('Payout-level mismatches that cancel each other out still make the report invalid', () => {
+        const payoutExport = new StripePayoutExportData({ start: reportStart, end: reportEnd });
+
+        const buildBreakdown = (payoutAmount: number, itemAmount: number) => new StripePayoutBreakdownData({
+            payout: new StripePayoutData({
+                id: stripeMocker.createId('po'),
+                amount: payoutAmount,
+                arrivalDate: new Date(2026, 2, 15),
+                statementDescriptor: 'STAMHOOFD',
+            }),
+            items: [
+                new StripePayoutItemData({
+                    name: 'Stripe Factuur',
+                    type: StripePayoutItemType.StripeFees,
+                    amount: itemAmount,
+                }),
+            ],
+        });
+
+        // One payout paid out 1 euro too much and the other 1 euro too little: the aggregate
+        // totals still match, but the report should not be considered valid
+        payoutExport.payouts.push(buildBreakdown(100_00, 200_00), buildBreakdown(300_00, 200_00));
+
+        expect(payoutExport.totalPaidOut).toBe(400_00);
+        expect(payoutExport.completePayouts.length).toBe(2);
+        expect(payoutExport.payouts[0].isValid).toBe(false);
+        expect(payoutExport.isValid).toBe(false);
     });
 
     test('An invoiced payment with a different amount than the application fees marks the report as incomplete', async () => {

--- a/backend/app/api/src/helpers/StripePayoutReporter.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.ts
@@ -1,0 +1,567 @@
+import type { EmailInterfaceRecipient } from '@stamhoofd/email';
+import { Email } from '@stamhoofd/email';
+import { Invoice, Organization, Payment, StripeAccount } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
+import { SQL } from '@stamhoofd/sql';
+import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+import Stripe from 'stripe';
+
+import { StripeInvoicer } from './StripeInvoicer.js';
+import { StripePayoutBreakdownData, StripePayoutData, StripePayoutExportData, StripePayoutItemData, StripePayoutItemType } from './StripePayoutExportData.js';
+import { StripePayoutExportExcel } from './StripePayoutExportExcel.js';
+import { passthroughFetch } from './passthroughFetch.js';
+
+/**
+ * Returns the payment reference for a given balance item date, matching the references
+ * used by StripeInvoicer when creating the payments. So we can group by payment/invoice.
+ */
+function getDateReference(date: Date) {
+    return 'stripe-fees-' + Formatter.dateIso(getDateStartDate(date));
+}
+
+/**
+ * Returns the start of the month for a given balance item date (same boundaries as StripeInvoicer).
+ */
+function getDateStartDate(date: Date) {
+    const { start } = StripeInvoicer.getMonthUnixStartEnd(date);
+    return new Date(start * 1000);
+}
+
+/**
+ * Convert an amount in Stripe cents to the platform price unit (1/100 cent)
+ */
+function fromStripeAmount(amount: number) {
+    return amount * 100;
+}
+
+export class StripeAccountReport {
+    accountId: string;
+    reference: string;
+    sellingOrganization: Organization;
+
+    stripeAccount: StripeAccount | null = null;
+    organization: Organization | null = null;
+    payments: Payment[] = [];
+    invoices: Invoice[] = [];
+
+    constructor(accountId: string, reference: string, sellingOrganization: Organization) {
+        this.accountId = accountId;
+        this.reference = reference;
+        this.sellingOrganization = sellingOrganization;
+    }
+
+    async load() {
+        const stripeAccount = await StripeAccount.select().where('accountId', this.accountId).first(false);
+
+        if (!stripeAccount) {
+            console.error('Stripe account not found for account', this.accountId);
+            return;
+        }
+
+        this.stripeAccount = stripeAccount;
+
+        const organization = await Organization.getByID(stripeAccount.organizationId);
+
+        if (!organization) {
+            console.error('Organization not found for account', this.accountId);
+            return;
+        }
+        this.organization = organization;
+
+        // Load the payments that were created for these application fees (same query as StripeInvoicer uses to check for existing payments)
+        this.payments = await Payment.select()
+            .where('organizationId', this.sellingOrganization.id)
+            .where('payingOrganizationId', organization.id)
+            .where(
+                // required because the same organization can have multiple stripe accounts. Null = legacy
+                SQL.where('stripeAccountId', stripeAccount.id)
+                    .or('stripeAccountId', null),
+            )
+            .where('reference', this.reference)
+            .where('method', PaymentMethod.AccountDeductions)
+            .where('provider', PaymentProvider.Stripe)
+            .where('status', PaymentStatus.Succeeded)
+            .fetch();
+
+        // Load the invoices these payments were grouped in (created later by the invoices cron)
+        const invoiceIds = Formatter.uniqueArray(this.payments.map(p => p.invoiceId).filter(id => id !== null));
+        if (invoiceIds.length > 0) {
+            this.invoices = (await Invoice.select().where('id', invoiceIds).fetch())
+                .filter(i => i.number !== null);
+        }
+    }
+
+    // From platform <-> submerchant (in platform price units, 1/100 cent)
+    applicationFees = 0; // to platform
+    applicationFeesRefunded = 0; // to submerchant
+
+    transfers = 0; // to submerchant
+    transfersRefunded = 0; // to platform
+
+    // Customers <-> platform account
+    charges = 0;
+    refunds = 0;
+    disputes = 0;
+
+    minimumDate: Date | null = null;
+    maximumDate: Date | null = null;
+
+    get toInvoiceAmount() {
+        return this.applicationFees
+            - this.applicationFeesRefunded;
+    }
+
+    get paymentsTotal() {
+        return this.payments.reduce((total, payment) => total + payment.price, 0);
+    }
+
+    /**
+     * Checks whether all charges that are made on the main account were transferred to the submerchant and leaves no balance on the main account
+     */
+    get isValid() {
+        return this.transfers === this.charges && (this.refunds + this.disputes) === this.transfersRefunded;
+    }
+
+    addDate(date: Date) {
+        if (!this.minimumDate || date < this.minimumDate) {
+            this.minimumDate = date;
+        }
+        if (!this.maximumDate || date > this.maximumDate) {
+            this.maximumDate = date;
+        }
+    }
+}
+
+export class StripeMainAccountReport {
+    startDate: Date;
+
+    constructor(startDate: Date) {
+        this.startDate = startDate;
+    }
+
+    get description() {
+        return Formatter.capitalizeFirstLetter(Formatter.dateWithoutDay(this.startDate));
+    }
+
+    fees = 0;
+    reserved = 0;
+}
+
+export class StripeReport {
+    sellingOrganization: Organization;
+    accounts: Map<string, StripeAccountReport> = new Map();
+    mainAccount: Map<string, StripeMainAccountReport> = new Map();
+
+    check = 0;
+
+    constructor(sellingOrganization: Organization) {
+        this.sellingOrganization = sellingOrganization;
+    }
+
+    async getAccountReport(balanceTransaction: Stripe.BalanceTransaction, accountId: string) {
+        const reference = getDateReference(new Date(balanceTransaction.created * 1000));
+        const group = reference + '-' + accountId;
+        let currentAmount = this.accounts.get(group);
+        if (currentAmount === undefined) {
+            currentAmount = new StripeAccountReport(accountId, reference, this.sellingOrganization);
+            await currentAmount.load();
+            this.accounts.set(group, currentAmount);
+        }
+        return currentAmount;
+    }
+
+    getMainAccountReport(balanceTransaction: Stripe.BalanceTransaction) {
+        const monthDate = getDateStartDate(new Date(balanceTransaction.created * 1000));
+        let currentAmount = this.mainAccount.get(Formatter.dateIso(monthDate));
+        if (currentAmount === undefined) {
+            currentAmount = new StripeMainAccountReport(monthDate);
+            this.mainAccount.set(Formatter.dateIso(monthDate), currentAmount);
+        }
+        return currentAmount;
+    }
+
+    async add(balanceTransaction: Stripe.BalanceTransaction) {
+        this.check += fromStripeAmount(balanceTransaction.amount);
+
+        if (balanceTransaction.type === 'application_fee') {
+            const source = balanceTransaction.source as Stripe.ApplicationFee;
+            const account = typeof source.account === 'string' ? source.account : source.account.id;
+
+            if (account) {
+                const currentAmount = await this.getAccountReport(balanceTransaction, account);
+                currentAmount.applicationFees += fromStripeAmount(source.amount);
+                currentAmount.addDate(new Date(balanceTransaction.created * 1000));
+            } else {
+                throw new Error('No account found for application fee ' + balanceTransaction.id);
+            }
+
+            // Handled
+            return;
+        }
+
+        if (balanceTransaction.type === 'application_fee_refund') {
+            const source = balanceTransaction.source as Stripe.ApplicationFee;
+            const account = typeof source.account === 'string' ? source.account : source.account.id;
+
+            if (account) {
+                const currentAmount = await this.getAccountReport(balanceTransaction, account);
+                currentAmount.applicationFeesRefunded += fromStripeAmount(source.amount);
+                currentAmount.addDate(new Date(balanceTransaction.created * 1000));
+            } else {
+                throw new Error('No account found for refunded application fee ' + balanceTransaction.id);
+            }
+
+            // Handled
+            return;
+        }
+
+        // Local payment method = payment, card = charge
+        if (balanceTransaction.type === 'payment' || balanceTransaction.type === 'charge') {
+            const source = balanceTransaction.source;
+            if (typeof source === 'string' || !source) {
+                console.error('Unexpected charge', balanceTransaction);
+                throw new Error('Received unexpanded source for charge ' + balanceTransaction.id);
+            }
+            const charge = source as Stripe.Charge;
+            const account = charge.on_behalf_of ? (typeof charge.on_behalf_of === 'string' ? charge.on_behalf_of : charge.on_behalf_of.id) : null;
+
+            if (account) {
+                const currentAmount = await this.getAccountReport(balanceTransaction, account);
+                currentAmount.charges += fromStripeAmount(charge.amount);
+                currentAmount.addDate(new Date(balanceTransaction.created * 1000));
+                // Costs on main account
+                this.getMainAccountReport(balanceTransaction).fees += fromStripeAmount(balanceTransaction.fee);
+            } else {
+                console.error('Unexpected charge without charge.on_behalf_of', balanceTransaction);
+                throw new Error('No account found for charge ' + balanceTransaction.id);
+            }
+
+            // Handled
+            return;
+        }
+
+        // Local payment method = payment_refund, card = refund
+        if (balanceTransaction.type === 'payment_refund' || balanceTransaction.type === 'refund') {
+            const source = balanceTransaction.source;
+            if (typeof source === 'string' || !source) {
+                console.error('Unexpected refund', balanceTransaction);
+                throw new Error('Received unexpanded source for refund ' + balanceTransaction.id);
+            }
+            const charge = source as Stripe.Charge;
+            const account = charge.on_behalf_of ? (typeof charge.on_behalf_of === 'string' ? charge.on_behalf_of : charge.on_behalf_of.id) : null;
+
+            if (account) {
+                const currentAmount = await this.getAccountReport(balanceTransaction, account);
+                currentAmount.charges += fromStripeAmount(charge.amount);
+                currentAmount.addDate(new Date(balanceTransaction.created * 1000));
+                // Costs on main account
+                this.getMainAccountReport(balanceTransaction).fees += fromStripeAmount(balanceTransaction.fee);
+            } else {
+                console.error('Unexpected refund without charge.on_behalf_of', balanceTransaction);
+                throw new Error('No account found for refund ' + balanceTransaction.id);
+            }
+
+            // Handled
+            return;
+        }
+
+        if (balanceTransaction.type === 'transfer') {
+            // amount is negative here
+            // use source.destination to get related account id
+
+            const source = balanceTransaction.source as Stripe.Transfer;
+
+            if (!source.destination) {
+                // This is a charge on the main account
+                throw new Error('Unexpected transfer on main account without destination account ' + balanceTransaction.id);
+            }
+
+            const account = typeof source.destination === 'string' ? source.destination : source.destination.id;
+
+            if (account) {
+                const currentAmount = await this.getAccountReport(balanceTransaction, account);
+                currentAmount.transfers += fromStripeAmount(-balanceTransaction.amount);
+                currentAmount.addDate(new Date(balanceTransaction.created * 1000));
+            } else {
+                throw new Error('No account found for transfer ' + balanceTransaction.id);
+            }
+
+            // Handled
+            return;
+        }
+
+        if (balanceTransaction.type === 'transfer_cancel' || balanceTransaction.type === 'transfer_failure' || balanceTransaction.type === 'transfer_refund') {
+            const source = balanceTransaction.source as Stripe.Transfer;
+
+            if (!source.destination) {
+                // This is a charge on the main account
+                throw new Error('Unexpected transfer refund on main account without destination account ' + balanceTransaction.id);
+            }
+
+            const account = typeof source.destination === 'string' ? source.destination : source.destination.id;
+
+            if (account) {
+                const currentAmount = await this.getAccountReport(balanceTransaction, account);
+                currentAmount.transfersRefunded += fromStripeAmount(balanceTransaction.amount);
+                currentAmount.addDate(new Date(balanceTransaction.created * 1000));
+            } else {
+                throw new Error('No account found for transfer refund ' + balanceTransaction.id);
+            }
+
+            // Handled
+            return;
+        }
+
+        // Network costs
+        if (balanceTransaction.type === 'stripe_fee' || (balanceTransaction.type as string) === 'network_cost') {
+            this.getMainAccountReport(balanceTransaction).fees += fromStripeAmount(-balanceTransaction.amount);
+            return;
+        }
+
+        // Disputes (adjustment)
+        if (balanceTransaction.type === 'adjustment') {
+            this.getMainAccountReport(balanceTransaction).fees += fromStripeAmount(balanceTransaction.fee);
+            const source = balanceTransaction.source;
+
+            if (typeof source === 'string') {
+                throw new Error('Received unexpanded source for adjustment ' + balanceTransaction.id);
+            }
+
+            if (source && source.object === 'dispute') {
+                console.error('Unexpected dispute without charge or destination ', balanceTransaction);
+                throw new Error('Unexpected dispute without charge or destination ' + balanceTransaction.id);
+            }
+
+            return;
+        }
+
+        if (balanceTransaction.type === 'payout') {
+            // Nothing to process
+            return;
+        }
+
+        if (balanceTransaction.type === 'reserve_transaction') {
+            // temporary blocked funds
+            this.getMainAccountReport(balanceTransaction).reserved += fromStripeAmount(-balanceTransaction.amount);
+            return;
+        }
+
+        // Throw an error for types we don't support yet
+        throw new Error('Unhandled balance transaction type ' + balanceTransaction.type + ' ' + balanceTransaction.id);
+    }
+}
+
+export class StripePayoutReport {
+    payout: Stripe.Payout;
+    sellingOrganization: Organization;
+    report: StripeReport;
+    callback?: () => void;
+
+    constructor(payout: Stripe.Payout, sellingOrganization: Organization) {
+        this.payout = payout;
+        this.sellingOrganization = sellingOrganization;
+        this.report = new StripeReport(sellingOrganization);
+    }
+
+    async build(stripe: Stripe) {
+        const report = new StripeReport(this.sellingOrganization);
+        let c = 0;
+
+        for await (const balanceItem of stripe.balanceTransactions.list({
+            payout: this.payout.id,
+            expand: ['data.source.charge'],
+            limit: 100,
+        })) {
+            await report.add(balanceItem);
+            c += 1;
+
+            if (c % 100 === 0) {
+                console.log('Processed ' + c + ' balance items');
+            }
+
+            if (this.callback) {
+                this.callback();
+            }
+        }
+
+        this.report = report;
+    }
+}
+
+export class StripePayoutReporter {
+    private stripe: Stripe;
+    sellingOrganization: Organization;
+    reports: StripePayoutReport[] = [];
+    startDate: Date = new Date();
+    endDate: Date = new Date();
+    callback?: () => void;
+
+    constructor({ secretKey, sellingOrganization }: { secretKey: string; sellingOrganization: Organization }) {
+        this.stripe = new Stripe(secretKey, {
+            apiVersion: '2024-06-20',
+            typescript: true,
+            maxNetworkRetries: 1,
+            timeout: 10000,
+            httpClient: STAMHOOFD.environment === 'test'
+                ? Stripe.createFetchHttpClient(passthroughFetch)
+                : undefined,
+        });
+        this.sellingOrganization = sellingOrganization;
+    }
+
+    // Loop all payouts
+    async build(start: Date, end: Date) {
+        this.startDate = start;
+        this.endDate = end;
+
+        // Also pull in payouts one month before and after, so we don't have any missing data for the requested payouts
+        const payoutStartDate = new Date(start.getFullYear(), start.getMonth() - 1, 1, 0, 0, 0, 0);
+        const payoutEndDate = new Date(end.getFullYear(), end.getMonth() + 2, 1, 0, 0, 0, 0);
+
+        const params: Stripe.PayoutListParams = {
+            status: 'paid',
+            arrival_date: {
+                gte: Math.floor(payoutStartDate.getTime() / 1000),
+                lte: Math.floor(payoutEndDate.getTime() / 1000),
+            },
+        };
+
+        const pendingPromises: Promise<void>[] = [];
+
+        for await (const payout of this.stripe.payouts.list(params)) {
+            pendingPromises.push(QueueHandler.schedule('stripe-payout-report', async () => {
+                console.log('Building report for payout ' + payout.id);
+                // Create a report for this payout
+                const report = new StripePayoutReport(payout, this.sellingOrganization);
+                report.callback = this.callback;
+                await report.build(this.stripe);
+                this.reports.push(report);
+            }, 10));
+        }
+
+        await Promise.all(pendingPromises);
+    }
+
+    toStructure(): StripePayoutExportData {
+        // Convert report to Stripe payout export
+        const payoutExport = new StripePayoutExportData({
+            start: this.startDate,
+            end: this.endDate,
+        });
+
+        for (const report of this.reports) {
+            const breakdown = new StripePayoutBreakdownData({
+                payout: new StripePayoutData({
+                    id: report.payout.id,
+                    amount: fromStripeAmount(report.payout.amount),
+                    arrivalDate: new Date(report.payout.arrival_date * 1000),
+                    statementDescriptor: report.payout.statement_descriptor ?? '/',
+                }),
+            });
+            payoutExport.payouts.push(breakdown);
+
+            // Add total costs
+            for (const mainAccount of report.report.mainAccount.values()) {
+                if (mainAccount.fees) {
+                    breakdown.items.push(new StripePayoutItemData({
+                        name: 'Stripe Factuur',
+                        type: StripePayoutItemType.StripeFees,
+                        amount: -mainAccount.fees,
+                        description: mainAccount.description,
+                    }));
+                }
+
+                if (mainAccount.reserved) {
+                    breakdown.items.push(new StripePayoutItemData({
+                        name: 'Stripe Gereserveerd',
+                        type: StripePayoutItemType.StripeReserved,
+                        amount: -mainAccount.reserved,
+                        description: mainAccount.description,
+                    }));
+                }
+            }
+
+            // Add each individual account
+            for (const account of report.report.accounts.values()) {
+                if (account.toInvoiceAmount === 0 && account.invoices.length === 0 && account.payments.length === 0) {
+                    continue;
+                }
+                const description = (account.organization?.name ?? 'Onbekende vereniging') + ' - ' + (account.minimumDate ? Formatter.dateTime(account.minimumDate) : '?') + ' tot ' + (account.maximumDate ? Formatter.dateTime(account.maximumDate) : '?');
+
+                breakdown.items.push(new StripePayoutItemData({
+                    name: this.getAccountItemName(account),
+                    type: StripePayoutItemType.Invoice,
+                    amount: account.toInvoiceAmount,
+                    description,
+                    accountId: account.accountId,
+                    reference: account.reference,
+                    payments: account.payments,
+                    invoices: account.invoices,
+                }));
+            }
+        }
+
+        return payoutExport;
+    }
+
+    private getAccountItemName(account: StripeAccountReport) {
+        if (account.payments.length === 0) {
+            return 'Nog geen betaling aangemaakt';
+        }
+
+        const numbers = account.invoices.map(i => i.number).filter(n => n !== null);
+        if (numbers.length === 0) {
+            return 'Betaling aangemaakt, nog niet gefactureerd';
+        }
+
+        const name = 'Factuur ' + numbers.join(', ');
+        if (account.payments.some(p => p.invoiceId === null)) {
+            return name + ' (deels nog niet gefactureerd)';
+        }
+        return name;
+    }
+
+    async toExcel(pExport?: StripePayoutExportData) {
+        // Convert report to Stripe payout export
+        const payoutExport = pExport ?? this.toStructure();
+        const buffer = await StripePayoutExportExcel.export(payoutExport);
+        return buffer;
+    }
+
+    async sendEmail({ to, extraRecipientsWhenValid }: { to: EmailInterfaceRecipient[]; extraRecipientsWhenValid?: EmailInterfaceRecipient[] }): Promise<void> {
+        // E-mail the report excel
+        const payoutExport = this.toStructure();
+        const buffer = await this.toExcel(payoutExport);
+        const startMonth = Formatter.dateWithoutDay(this.startDate, { timezone: 'UTC' });
+        const endMonth = Formatter.dateWithoutDay(this.endDate, { timezone: 'UTC' });
+        const subject = 'Stripe Uitbetalingen ' + startMonth + ((endMonth !== startMonth) ? (' - ' + endMonth) : '');
+
+        const completePayouts = payoutExport.completePayouts;
+        const sellerName = this.sellingOrganization.meta.companies[0]?.name ?? this.sellingOrganization.name;
+
+        Email.send({
+            from: Email.getWebmasterFromEmail(),
+            to: payoutExport.isValid
+                ? [...to, ...(extraRecipientsWhenValid ?? [])]
+                : to,
+            subject: subject,
+            text: 'In bijlage het overzicht van de Stripe uitbetalingen van ' + Formatter.dateTime(this.startDate) + ' tot ' + Formatter.dateTime(this.endDate) + ' voor ' + sellerName + '.\n'
+                + (payoutExport.isValid ? '' : ('\nRAPPORT ONVOLLEDIG!\n'))
+                + '\nTotaal uitbetaald: ' + Formatter.price(payoutExport.totalPaidOut) + ` (${completePayouts.length} uitbetalingen)`
+                + '\nTotaal Stripe Kosten: ' + Formatter.price(payoutExport.totalStripeFees)
+                + '\nTotaal doorgefactureerd aan klanten: ' + Formatter.price(payoutExport.totalInvoices) + ' (incl. BTW)'
+                + '\nGeschatte BTW terug te betalen: ' + Formatter.price(payoutExport.totalVAT)
+                + '\nGeschatte winst: ' + Formatter.price(payoutExport.net)
+                + '\n\nOvergeslagen uitbetalingen (onvolledig): ' + (payoutExport.payouts.length - completePayouts.length) + '\n',
+            type: 'transactional',
+            attachments: [
+                {
+                    filename: Formatter.fileSlug(subject) + '.xlsx',
+                    content: buffer,
+                    contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                },
+            ],
+        });
+    }
+}

--- a/backend/app/api/src/helpers/StripePayoutReporter.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.ts
@@ -570,7 +570,8 @@ export class StripePayoutReporter {
                 + '\nTotaal doorgefactureerd aan klanten: ' + Formatter.price(payoutExport.totalInvoices) + ' (incl. BTW)'
                 + '\nGeschatte BTW terug te betalen: ' + Formatter.price(payoutExport.totalVAT)
                 + '\nGeschatte winst: ' + Formatter.price(payoutExport.net)
-                + '\n\nOvergeslagen uitbetalingen (onvolledig): ' + (payoutExport.payouts.length - completePayouts.length) + '\n',
+                // Only count the payouts in the requested period: extra payouts are fetched around it to complete the data
+                + '\n\nOvergeslagen uitbetalingen (onvolledig): ' + (payoutExport.includedPayouts.length - completePayouts.length) + '\n',
             type: 'transactional',
             attachments: [
                 {

--- a/backend/app/api/src/helpers/StripePayoutReporter.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.ts
@@ -201,8 +201,15 @@ export class StripeReport {
         }
 
         if (balanceTransaction.type === 'application_fee_refund') {
-            const source = balanceTransaction.source as Stripe.ApplicationFee;
-            const account = typeof source.account === 'string' ? source.account : source.account.id;
+            // The source is a fee refund: the connected account is stored on the refunded application fee itself
+            const source = balanceTransaction.source as Stripe.FeeRefund;
+            const fee = typeof source.fee === 'string' || !source.fee ? null : source.fee;
+
+            if (!fee) {
+                throw new Error('Received unexpanded fee for refunded application fee ' + balanceTransaction.id);
+            }
+
+            const account = typeof fee.account === 'string' ? fee.account : fee.account.id;
 
             if (account) {
                 const currentAmount = await this.getAccountReport(balanceTransaction, account);
@@ -370,7 +377,8 @@ export class StripePayoutReport {
 
         for await (const balanceItem of stripe.balanceTransactions.list({
             payout: this.payout.id,
-            expand: ['data.source.charge'],
+            // charge = for refunds, fee = for application fee refunds
+            expand: ['data.source.charge', 'data.source.fee'],
             limit: 100,
         })) {
             await report.add(balanceItem);

--- a/backend/app/api/src/helpers/StripePayoutReporter.ts
+++ b/backend/app/api/src/helpers/StripePayoutReporter.ts
@@ -255,12 +255,21 @@ export class StripeReport {
                 console.error('Unexpected refund', balanceTransaction);
                 throw new Error('Received unexpanded source for refund ' + balanceTransaction.id);
             }
-            const charge = source as Stripe.Charge;
+
+            // The source is a refund: the connected account is stored on the refunded charge
+            const refund = source as Stripe.Refund;
+            const charge = typeof refund.charge === 'string' || !refund.charge ? null : refund.charge;
+
+            if (!charge) {
+                console.error('Unexpected refund', balanceTransaction);
+                throw new Error('Received unexpanded charge for refund ' + balanceTransaction.id);
+            }
+
             const account = charge.on_behalf_of ? (typeof charge.on_behalf_of === 'string' ? charge.on_behalf_of : charge.on_behalf_of.id) : null;
 
             if (account) {
                 const currentAmount = await this.getAccountReport(balanceTransaction, account);
-                currentAmount.charges += fromStripeAmount(charge.amount);
+                currentAmount.refunds += fromStripeAmount(refund.amount);
                 currentAmount.addDate(new Date(balanceTransaction.created * 1000));
                 // Costs on main account
                 this.getMainAccountReport(balanceTransaction).fees += fromStripeAmount(balanceTransaction.fee);

--- a/backend/app/api/tests/vitest.setup.ts
+++ b/backend/app/api/tests/vitest.setup.ts
@@ -60,11 +60,13 @@ beforeAll(async () => {
     // cascade below, so it has to be cleared first
     await Database.delete('DELETE FROM `invoiced_balance_items`');
     await Database.delete('DELETE FROM `invoices`');
+
+    // payments restrict deleting stripe accounts (which cascade from organizations), and a payment
+    // can reference a stripe account of a different organization, so payments have to be cleared first
+    await Database.delete('DELETE FROM `payments`');
     await Database.update('UPDATE registration_periods set organizationId = null, customName = ? where organizationId is not null', ['delete']);
     await Database.delete('DELETE FROM `organizations`');
     await Database.delete('DELETE FROM `registration_periods` where customName = ?', ['delete']);
-
-    await Database.delete('DELETE FROM `payments`');
     await Database.delete('OPTIMIZE TABLE organizations;'); // fix breaking of indexes due to deletes (mysql bug?)
 
     // Use random file keys in tests

--- a/frontend/app/dashboard/src/views/dashboard/settings/FinancesView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/FinancesView.vue
@@ -74,6 +74,21 @@
                         </template>
                     </STListItem>
 
+                    <STListItem v-if="canExportStripePayouts" :selectable="true" class="left-center" @click="$navigate(Routes.StripePayouts)">
+                        <template #left>
+                            <img src="@stamhoofd/assets/images/illustrations/bank.svg">
+                        </template>
+                        <h2 class="style-title-list">
+                            {{ $t('Stripe uitbetalingen exporteren') }}
+                        </h2>
+                        <p class="style-description">
+                            {{ $t('Ontvang een rapport via e-mail om te controleren of alle aangerekende Stripe kosten correct werden gefactureerd.') }}
+                        </p>
+                        <template #right>
+                            <span class="icon arrow-right-small gray" />
+                        </template>
+                    </STListItem>
+
                     <STListItem v-if="STAMHOOFD.environment === 'development' && auth.hasAccessRight(AccessRight.OrganizationFinanceDirector)" :selectable="true" class="left-center" @click="$navigate(Routes.BalanceItems)">
                         <template #left>
                             <img src="@stamhoofd/assets/images/illustrations/box.svg">
@@ -189,11 +204,12 @@ import { useAuth } from '@stamhoofd/components/hooks/useAuth.ts';
 import { useContext } from '@stamhoofd/components/hooks/useContext.ts';
 import { useGlobalEventListener } from '@stamhoofd/components/hooks/useGlobalEventListener';
 import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
+import { usePlatform } from '@stamhoofd/components/hooks/usePlatform.ts';
 import { LocalizedDomains } from '@stamhoofd/frontend-i18n/LocalizedDomains';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import { AccessRight, BalanceItem, DetailedPayableBalance, DetailedPayableBalanceCollection, PaymentMethod, PaymentStatus } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import BillingWarningBox from './packages/BillingWarningBox.vue';
 
@@ -207,6 +223,7 @@ enum Routes {
     PayableBalance = 'PayableBalance',
     ReceivableBalance = 'ReceivableBalance',
     Packages = 'pakketten',
+    StripePayouts = 'StripePayouts',
 }
 
 const isPlatform = STAMHOOFD.userMode === 'platform';
@@ -355,6 +372,13 @@ if (!isPlatform) {
         present: 'popup' as const,
         component: async () => (await import('./packages/PackageSettingsView.vue')).default,
     });
+
+    defineRoute({
+        name: Routes.StripePayouts,
+        url: 'stripe-uitbetalingen',
+        present: 'popup',
+        component: async () => (await import('./administration/StripePayoutExportView.vue')).default,
+    });
 }
 
 const auth = useAuth();
@@ -363,7 +387,16 @@ const owner = useRequestOwner();
 const context = useContext();
 const errors = useErrors();
 const organization = useOrganization();
+const platform = usePlatform();
 const outstandingBalance = ref(null) as Ref<DetailedPayableBalanceCollection | null>;
+
+// Manual Stripe payout reports: only for the platform membership organization itself
+const canExportStripePayouts = computed(() => {
+    return !isPlatform
+        && !!platform.value.membershipOrganizationId
+        && organization.value?.id === platform.value.membershipOrganizationId
+        && auth.hasPlatformFullAccess();
+});
 
 const balancePromise = updateBalance().catch(console.error);
 

--- a/frontend/app/dashboard/src/views/dashboard/settings/administration/StripePayoutExportView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/administration/StripePayoutExportView.vue
@@ -1,0 +1,259 @@
+<template>
+    <SaveView :loading="saving" :title="$t('Uitbetalingen exporteren')" :save-text="$t('Exporteren')" @save="save">
+        <h1>
+            {{ $t('Stripe uitbetalingen exporteren') }}
+        </h1>
+        <p>{{ $t('Je ontvangt het rapport via e-mail zodra het klaar is. Zo kunnen we controleren of alle aangerekende Stripe kosten correct werden gefactureerd.') }}</p>
+
+        <STErrorsDefault :error-box="errorBox" />
+
+        <div class="split-inputs">
+            <STInputBox error-fields="startDate" :error-box="errorBox" :title="$t('%5M')">
+                <DateSelection v-model="startDate" />
+            </STInputBox>
+
+            <STInputBox error-fields="endDate" :error-box="errorBox" :title="$t('%3w')">
+                <DateSelection v-model="endDate" />
+            </STInputBox>
+        </div>
+
+        <p class="style-description-small">
+            {{ $t('%P0') }}: <span v-for="(suggestion, index) in dateRangeSuggestions" :key="suggestion.name">
+                <button type="button" class="inline-link" :class="isSuggestionSelected(suggestion) ? {secundary: false} : {secundary: true}" @click="selectSuggestion(suggestion)">
+                    {{ suggestion.name }}
+                </button><template v-if="index < dateRangeSuggestions.length - 1">, </template>
+            </span>
+        </p>
+
+        <hr><h2>{{ $t('%P1') }}</h2>
+        <STList>
+            <STListItem :selectable="true" element-name="label">
+                <template #left>
+                    <Checkbox v-model="useUTCTimezone" />
+                </template>
+                <h3 class="style-title-list">
+                    {{ $t('%P2') }}
+                </h3>
+                <p class="style-description-small">
+                    {{ $t('%P3') }}
+                </p>
+            </STListItem>
+        </STList>
+
+        <div v-if="runningJobs.length" class="container">
+            <hr><h2>{{ $t('Lopende rapporten') }}</h2>
+            <STList>
+                <STListItem v-for="(runningJob, index) in runningJobs" :key="index">
+                    <h3 class="style-title-list">
+                        {{ $t('Van {start} tot {end}', {start: formatDateTime(runningJob.start), end: formatDateTime(runningJob.end)}) }}
+                    </h3>
+                    <p v-if="runningJob.count" class="style-description-small">
+                        {{ $t('Al {count} transacties verwerkt', {count: runningJob.count.toString()}) }}
+                    </p>
+                </STListItem>
+            </STList>
+        </div>
+    </SaveView>
+</template>
+
+<script lang="ts" setup>
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { ArrayDecoder, AutoEncoder, DateDecoder, field, IntegerDecoder } from '@simonbackx/simple-encoding';
+import { Request } from '@simonbackx/simple-networking';
+import { usePop } from '@simonbackx/vue-app-navigation';
+import { ErrorBox } from '@stamhoofd/components/errors/ErrorBox.ts';
+import STErrorsDefault from '@stamhoofd/components/errors/STErrorsDefault.vue';
+import { useContext } from '@stamhoofd/components/hooks/useContext.ts';
+import Checkbox from '@stamhoofd/components/inputs/Checkbox.vue';
+import DateSelection from '@stamhoofd/components/inputs/DateSelection.vue';
+import STInputBox from '@stamhoofd/components/inputs/STInputBox.vue';
+import STList from '@stamhoofd/components/layout/STList.vue';
+import STListItem from '@stamhoofd/components/layout/STListItem.vue';
+import SaveView from '@stamhoofd/components/navigation/SaveView.vue';
+import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
+import { Formatter } from '@stamhoofd/utility';
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue';
+
+class PayoutExportStatus extends AutoEncoder {
+    @field({ decoder: DateDecoder })
+    start: Date;
+
+    @field({ decoder: DateDecoder })
+    end: Date;
+
+    @field({ decoder: IntegerDecoder })
+    count = 0;
+}
+
+class DateRangeSuggestion {
+    name: string;
+    startDate: Date;
+    endDate: Date;
+
+    constructor({ name, startDate, endDate }: { name: string; startDate: Date; endDate: Date }) {
+        this.name = name;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}
+
+const context = useContext();
+const pop = usePop();
+const requestOwner = {};
+const errorBox = ref<ErrorBox | null>(null);
+const saving = ref(false);
+const internalStartDate = ref(new Date());
+const internalEndDate = ref(new Date());
+const useUTCTimezone = ref(true);
+const dateRangeSuggestions = shallowRef<DateRangeSuggestion[]>([]);
+const runningJobs = shallowRef<PayoutExportStatus[]>([]);
+let loadingJobs = false;
+let interval: ReturnType<typeof setInterval> | null = null;
+
+const startDate = computed({
+    get: () => internalStartDate.value,
+    set: (value: Date) => {
+        internalStartDate.value = new Date(value.getTime());
+        internalStartDate.value.setHours(0, 0, 0, 0);
+    },
+});
+const endDate = computed({
+    get: () => internalEndDate.value,
+    set: (value: Date) => {
+        internalEndDate.value = new Date(value.getTime());
+        internalEndDate.value.setHours(23, 59, 59, 0);
+    },
+});
+const correctedStartDate = computed(() => {
+    if (!useUTCTimezone.value) {
+        return startDate.value;
+    }
+    const date = new Date();
+    date.setUTCFullYear(startDate.value.getFullYear(), startDate.value.getMonth(), startDate.value.getDate());
+    date.setUTCHours(0, 0, 0, 0);
+    return date;
+});
+const correctedEndDate = computed(() => {
+    if (!useUTCTimezone.value) {
+        return endDate.value;
+    }
+    const date = new Date();
+    date.setUTCFullYear(endDate.value.getFullYear(), endDate.value.getMonth(), endDate.value.getDate());
+    date.setUTCHours(23, 59, 59, 0);
+    return date;
+});
+
+onMounted(() => {
+    buildSuggestions();
+    selectSuggestion(dateRangeSuggestions.value[0]!);
+
+    loadJobs().catch(console.error);
+    interval = setInterval(() => {
+        loadJobs().catch(console.error);
+    }, 1000);
+});
+
+onBeforeUnmount(() => {
+    if (interval) {
+        clearInterval(interval);
+        interval = null;
+    }
+    Request.cancelAll(requestOwner);
+});
+
+function formatDateTime(date: Date) {
+    return Formatter.dateTime(date);
+}
+
+async function loadJobs() {
+    if (loadingJobs) {
+        return;
+    }
+    loadingJobs = true;
+
+    try {
+        const response = await context.value.authenticatedServer.request({
+            method: 'GET',
+            path: '/stripe/payouts/status',
+            decoder: new ArrayDecoder(PayoutExportStatus as Decoder<PayoutExportStatus>),
+            shouldRetry: false,
+            owner: requestOwner,
+        });
+        runningJobs.value = response.data;
+    } catch (e) {
+        if (!Request.isAbortError(e)) {
+            console.error(e);
+        }
+    }
+    loadingJobs = false;
+}
+
+function buildSuggestions() {
+    dateRangeSuggestions.value = [
+        new DateRangeSuggestion({
+            name: Formatter.month(Formatter.luxon().startOf('month').toJSDate()),
+            startDate: Formatter.luxon().startOf('month').toJSDate(),
+            endDate: Formatter.luxon().endOf('month').toJSDate(),
+        }),
+        new DateRangeSuggestion({
+            name: Formatter.month(Formatter.luxon().minus({ month: 1 }).startOf('month').toJSDate()),
+            startDate: Formatter.luxon().minus({ month: 1 }).startOf('month').toJSDate(),
+            endDate: Formatter.luxon().minus({ month: 1 }).endOf('month').toJSDate(),
+        }),
+        new DateRangeSuggestion({
+            name: Formatter.month(Formatter.luxon().minus({ month: 2 }).startOf('month').toJSDate()),
+            startDate: Formatter.luxon().minus({ month: 2 }).startOf('month').toJSDate(),
+            endDate: Formatter.luxon().minus({ month: 2 }).endOf('month').toJSDate(),
+        }),
+        new DateRangeSuggestion({
+            name: Formatter.month(Formatter.luxon().minus({ month: 3 }).startOf('month').toJSDate()),
+            startDate: Formatter.luxon().minus({ month: 3 }).startOf('month').toJSDate(),
+            endDate: Formatter.luxon().minus({ month: 3 }).endOf('month').toJSDate(),
+        }),
+        new DateRangeSuggestion({
+            name: Formatter.year(Formatter.luxon().startOf('year').toJSDate()).toString(),
+            startDate: Formatter.luxon().startOf('year').toJSDate(),
+            endDate: Formatter.luxon().endOf('year').toJSDate(),
+        }),
+        new DateRangeSuggestion({
+            name: Formatter.year(Formatter.luxon().minus({ year: 1 }).startOf('year').toJSDate()).toString(),
+            startDate: Formatter.luxon().minus({ year: 1 }).startOf('year').toJSDate(),
+            endDate: Formatter.luxon().minus({ year: 1 }).endOf('year').toJSDate(),
+        }),
+    ];
+}
+
+function selectSuggestion(suggestion: DateRangeSuggestion) {
+    startDate.value = suggestion.startDate;
+    endDate.value = suggestion.endDate;
+}
+
+function isSuggestionSelected(suggestion: DateRangeSuggestion) {
+    return Formatter.dateIso(startDate.value) === Formatter.dateIso(suggestion.startDate)
+        && Formatter.dateIso(endDate.value) === Formatter.dateIso(suggestion.endDate);
+}
+
+async function save() {
+    if (saving.value) {
+        return;
+    }
+
+    saving.value = true;
+    try {
+        await context.value.authenticatedServer.request({
+            method: 'POST',
+            path: '/stripe/payouts',
+            body: {
+                start: correctedStartDate.value.getTime(),
+                end: correctedEndDate.value.getTime(),
+            },
+            owner: requestOwner,
+        });
+        new Toast($t('Je ontvangt een e-mail met de uitbetalingen zodra het rapport klaar is'), 'success').show();
+        await pop({ force: true });
+    } catch (e) {
+        errorBox.value = new ErrorBox(e as Error);
+    }
+    saving.value = false;
+}
+</script>

--- a/shared/types/src/Environment.ts
+++ b/shared/types/src/Environment.ts
@@ -105,6 +105,9 @@ export type BackendSpecificEnvironment = {
     readonly STRIPE_ENDPOINT_SECRET?: string;
     readonly STRIPE_CONNECT_METHOD?: 'express' | 'standard';
 
+    // Extra recipients of the automatic monthly Stripe payout report (only added when the report is valid)
+    readonly STRIPE_PAYOUT_REPORT_EMAILS?: string[];
+
     // Communication with other internal services
     readonly INTERNAL_SECRET_KEY: string;
 


### PR DESCRIPTION
## Summary

Ports the `StripePayoutReporter` from the legacy admin backend, adapted to the new payments/invoices model. The report checks whether everything we charged via Stripe application fees was invoiced correctly — required for our finances.

### Reporter (`backend/app/api/src/helpers/`)
- Groups application fees per Stripe account per month and matches them against the payments created by `StripeInvoicer` (reference `stripe-fees-*`, scoped to the platform membership organization), and the invoices those payments were grouped in by the invoices cron.
- Three visible states per account/month: invoiced (`Factuur <number>` with invoice details), payment created but not yet invoiced, and no payment created at all. Only fully invoiced fees count as complete; incomplete payouts flag the report with `RAPPORT ONVOLLEDIG!`.
- Amounts use the platform price unit (Stripe cents × 100); month boundaries reuse `StripeInvoicer.getMonthUnixStartEnd` so grouping always matches the invoicer.
- Excel export (Uitbetalingen / Facturen / Stripe Facturen sheets) rewritten on `@stamhoofd/excel-writer`; report data classes are backend-local (the legacy `StripePayoutExport` structures in `@stamhoofd/structures` are left untouched).

### Cron
- `stripe-payout-reports`: sends the previous month's report on the 6th of each month (production, non-platform userMode, express connect only). Extra recipients (accounting) via the new optional `STRIPE_PAYOUT_REPORT_EMAILS` environment variable — only added when the report is valid.

### Manual export
- `POST /stripe/payouts` + `GET /stripe/payouts/status`, requires full platform access and the platform membership organization scope. The report is emailed to the requesting user.
- Dashboard: new "Stripe uitbetalingen exporteren" item in the finances settings (only visible for the membership organization to users with full platform access), with date range suggestions, UTC toggle and running-jobs status — ported from the legacy admin `StripePayoutExporterView`.

### Test setup fix
- `vitest.setup.ts`: payments are now cleared before organizations — a payment can reference a Stripe account of a different organization (exactly what this feature creates) and `payments.stripeAccountId` is a RESTRICT foreign key, so the old order broke the cleanup cascade.

## Tests
- `StripePayoutReporter.test.ts`: invoiced / payment-not-invoiced / no payment / amount mismatch scenarios against nock-mocked Stripe payouts, plus email recipient behavior for valid vs incomplete reports.
- `StripePayoutsExportEndpoint.test.ts`: happy path (report emailed to requester with attachment), permission denied without platform full access, rejected for non-membership organizations.
- Full api suite green (82 test files passed, 2 pre-existing skips); dashboard `vue-tsc` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786109705&installation_id=138085646&pr_number=577&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F577&signature=d4704d0e85ddfc595344fc51b61c453de39d95aa649344bf8d7c200a27dc4a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->