### PR TITLE
✨ Ask for birth day, address and gender of webshop customers

### DIFF
--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: self-review
+description: Spin up a dedicated review sub-agent to critique Claude's own pending changes or recent commits, following the adjustable methodology in this skill. Use when the user asks to review your changes, review the diff, review the last commit(s), do a self-review, or types /self-review. Optional argument = the scope to review (e.g. a commit ref, a range, "last 2 commits", "staged").
+---
+
+# Self-review
+
+Delegate a critical review of the current changes to a **fresh sub-agent**, so the
+review isn't biased by the context that produced the code, then report its findings
+back to the user.
+
+## 1. Determine the review scope
+
+Use the argument passed to the skill if there is one. Otherwise auto-detect, in this order:
+
+1. **Uncommitted work** — if `git status --porcelain` is non-empty, review the working
+   tree: staged + unstaged + untracked. Reproduce it with `git diff HEAD` and list
+   untracked files via `git status --porcelain`.
+2. **Branch commits** — otherwise review commits on this branch that aren't on `main`:
+   `git log --oneline main..HEAD` and `git diff main...HEAD`.
+3. If both are empty, tell the user there's nothing to review and stop.
+
+Interpret natural-language arguments sensibly: "last commit" → `HEAD~1..HEAD`,
+"staged" → `git diff --cached`, a PR number → `gh pr diff <n>`, an explicit ref/range → use it directly.
+
+## 2. Spawn the review sub-agent
+
+Launch **one** sub-agent with the Agent tool (`subagent_type: general-purpose`,
+description like "Review current diff"). Its prompt must contain:
+
+- The exact scope you resolved (the git command(s) that reproduce the diff, or the branch/range).
+- This instruction, verbatim:
+  > Read `.claude/skills/self-review/methodology.md` and follow it exactly. Review **only**
+  > the changes in the scope below. Do not modify any files and do not spawn further agents.
+  > Return your findings in the format the methodology specifies.
+- The scope details.
+
+Do **not** review the code yourself in the main thread — the whole point is a fresh pair of eyes.
+
+## 3. Relay the findings
+
+Summarize the sub-agent's report for the user: lead with the verdict and any blocking
+issues, then the rest grouped by severity, keeping `file:line` references clickable.
+Don't silently drop findings. Offer to fix them, but don't start fixing unless asked.

--- a/.claude/skills/self-review/methodology.md
+++ b/.claude/skills/self-review/methodology.md
@@ -1,0 +1,165 @@
+# Review methodology
+
+> **This file is the knob.** Edit it to change how `/self-review` reviews code — the
+> criteria, the severity bar, the output format, whether it runs tooling. The review
+> sub-agent reads this file and follows it verbatim, so changes take effect on the next
+> run with no other edits needed.
+
+## Settings
+
+- **Depth:** balanced — surface real problems, don't nitpick style the linter already catches.
+- **Run tooling:** off by default (static review only). Flip to *on* to have the reviewer
+  run `yarn typecheck` / `yarn lint` / the relevant `yarn stam test ...` and fold failures
+  into the findings.
+- **Findings:** no hard cap, but merge duplicates and lead with what matters.
+
+## What to check
+
+Review the changes in scope against these, most important first:
+
+1. **Correctness & bugs** — logic errors, off-by-one, null/undefined,
+   unhandled errors, missed edge cases, race conditions, incorrect types. Trace the actual
+   data flow; don't assume the code does what its names imply.
+2. **Project rules** (from `CLAUDE.md` / `AGENTS.md`):
+   - `@stamhoofd/structures` changed without respecting versioning — new fields must be
+     additive via `...NextVersion`, never edit `Version.ts`. Flag any change that could break old clients.
+   - User-facing strings must be Dutch and wrapped in `$t(...)`. `SimpleError.message` stays
+     plain English; `SimpleError.human` uses `$t`.
+   - Backend endpoint changes need unit + integration tests; bugfixes need a regression test
+     that fails before the fix.
+   - Scope creep — the change should touch only the files the task needs.
+   - Import style: modern `#`/package exports, no barrel files.
+3. **Tests** — are the new/changed behaviors actually covered, and would the tests fail
+   *without* the change? Missing or tautological tests are a finding.
+4. **Reuse, simplification and maintainability ** — duplicated logic, something that already exists in the
+   codebase, needlessly complex code, dead code. Also check the 'Maintainability' section below.
+5. **Security** — injection, missing authz/permission checks, leaking data across
+   organizations/tenants, unsafe input handling.
+6. **Performance** — N+1 queries, work repeated in loops, oversized payloads — only when
+   it's a real concern, not speculative.
+
+## Maintainability
+
+Maintainable code practices
+
+### 1. Optimize for clarity
+
+Code is read far more often than it is written.
+
+Prefer:
+
+- Clear names over abbreviations
+- Straightforward control flow over clever one-liners
+- Small, focused functions
+- Explicit assumptions and constraints
+- Consistent patterns across the codebase
+
+A function or class should ideally answer one question or perform one responsibility.
+
+### 2. Keep abstractions proportional to the problem
+
+Avoid both extremes:
+
+- Duplicating complex logic everywhere
+- Creating abstractions before there is a clear need
+
+A useful rule is to tolerate small duplication until the shared concept is understood. Similar-looking code does not always represent the same responsibility.
+
+Ask:
+
+- Does this abstraction make the calling code easier to understand?
+- Does it hide unnecessary detail?
+- Can it evolve without accumulating flags and special cases?
+
+### 3. Separate responsibilities
+
+Keep business logic separate from:
+
+- Database access
+- HTTP or UI concerns
+- Framework-specific code
+- Logging and monitoring
+- Serialization
+- External integrations
+
+This makes the important behavior easier to test and reduces the impact of infrastructure changes.
+
+### 4. Design clear interfaces
+
+Modules, functions, APIs, and classes should have:
+
+- A narrow purpose
+- Minimal inputs
+- Predictable outputs
+- Explicit failure behavior
+- Limited side effects
+
+Avoid functions that both calculate values and unexpectedly mutate unrelated state.
+
+### 5. Write tests around behavior
+
+Tests should protect important behavior, not mirror the implementation line by line.
+
+Include:
+
+- Normal behavior
+- Boundary conditions
+- Failure cases
+- Regression tests for fixed bugs
+- Authorization and security-sensitive cases
+- Integration tests where components interact
+- Important edge cases that might break the code or are hard to reason about
+
+A test suite should make refactoring safer rather than preventing refactoring.
+
+### 6. Keep dependencies and coupling under control
+
+Each new dependency increases maintenance, security, upgrade, and operational costs.
+
+Before adding one, ask:
+
+- Is the problem substantial enough to justify it?
+- Is the project actively maintained?
+- Is the API stable?
+- Could a small local implementation be clearer?
+- What is the dependency’s security and licensing impact?
+
+### 7. Document decisions, not obvious syntax
+
+Comments should explain:
+
+- Why a non-obvious approach was chosen
+- Important constraints
+- Trade-offs
+- Workarounds and when they can be removed
+- External-system behavior that is not visible in the code
+
+Comments that merely restate the code tend to become outdated.
+
+For significant architectural decisions, use short architecture decision records or equivalent documentation.
+
+### 8. Keep changes small and focused
+
+Smaller PRs are easier to understand and review accurately.
+
+Avoid mixing:
+
+- Functional changes
+- Large refactors
+- Formatting changes
+- Dependency upgrades
+- Unrelated cleanup
+
+Sometimes a preparatory refactor should be a separate PR before the behavioral change.
+
+## Output format
+
+Return a concise report:
+
+- **Verdict:** one line — `Ship it`, `Ship with nits`, or `Needs changes`.
+- **Blocking** — must fix before merge (correctness, broken project rules, missing required tests).
+- **Non-blocking** — recommended doing but not required.
+- **Nits** — minor / optional.
+
+For each finding: the `file:line`, a one-sentence explanation, and a concrete suggested
+change. Omit any section that has no findings. Don't pad the report.

--- a/frontend/app/dashboard/src/classes/OrdersExcelExport.ts
+++ b/frontend/app/dashboard/src/classes/OrdersExcelExport.ts
@@ -1,7 +1,7 @@
 import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 import { AppManager } from '@stamhoofd/networking/AppManager';
 import type { PrivateOrder, Webshop } from '@stamhoofd/structures';
-import { CartItem, CartItemOption, CheckoutMethodType, OrderStatusHelper, PaymentMethodHelper, ProductType, ReservedSeat } from '@stamhoofd/structures';
+import { CartItem, CartItemOption, CheckoutMethodType, Gender, getGenderName, OrderStatusHelper, PaymentMethodHelper, ProductType, ReservedSeat } from '@stamhoofd/structures';
 import { Formatter, Sorter } from '@stamhoofd/utility';
 import XLSX from 'xlsx';
 
@@ -22,6 +22,27 @@ function cartItemGroupingString(item: CartItem) {
 }
 
 export class OrdersExcelExport {
+    /**
+     * Extra customer columns (birth day, gender, address) shown after the phone number.
+     */
+    private static get customerColumnHeaders(): RowValue[] {
+        return [$t(`Geboortedatum`), $t(`Geslacht`), $t(`Adres klant`)];
+    }
+
+    private static customerColumnValues(order: PrivateOrder): RowValue[] {
+        const customer = order.data.customer;
+        return [
+            customer.birthDay
+                ? {
+                        value: customer.birthDay,
+                        format: 'dd/mm/yyyy',
+                    }
+                : '',
+            customer.gender === Gender.Other ? '' : getGenderName(customer.gender),
+            customer.address ? customer.address.toString() : '',
+        ];
+    }
+
     /**
      * List of all products for every order
      */
@@ -162,6 +183,7 @@ export class OrdersExcelExport {
                 $t(`%1MU`),
                 $t(`%xB`),
                 $t(`%18Z`),
+                ...this.customerColumnHeaders,
                 ...answerNames,
                 $t(`%Ve`),
                 $t(`%M4`),
@@ -288,6 +310,7 @@ export class OrdersExcelExport {
                     showDetails ? order.data.customer.lastName : '',
                     showDetails ? order.data.customer.email : '',
                     showDetails ? order.data.customer.phone : '',
+                    ...(showDetails ? OrdersExcelExport.customerColumnValues(order) : ['', '', '']),
                     ...answers,
                     showDetails ? order.data.comments : '',
                     {
@@ -432,6 +455,7 @@ export class OrdersExcelExport {
                 $t(`%1MU`),
                 $t(`%xB`),
                 $t(`%18Z`),
+                ...this.customerColumnHeaders,
                 ...answerNames,
                 $t(`%Ve`),
                 $t(`%xE`),
@@ -507,6 +531,7 @@ export class OrdersExcelExport {
                 order.data.customer.lastName,
                 order.data.customer.email,
                 order.data.customer.phone,
+                ...OrdersExcelExport.customerColumnValues(order),
                 ...answers,
                 order.data.comments,
                 checkoutType,

--- a/frontend/app/dashboard/src/classes/OrdersExcelExport.ts
+++ b/frontend/app/dashboard/src/classes/OrdersExcelExport.ts
@@ -26,7 +26,7 @@ export class OrdersExcelExport {
      * Extra customer columns (birth day, gender, address) shown after the phone number.
      */
     private static get customerColumnHeaders(): RowValue[] {
-        return [$t(`Geboortedatum`), $t(`Geslacht`), $t(`Adres klant`)];
+        return [$t(`Geboortedatum`), $t(`Gender`), $t(`Adres klant`)];
     }
 
     private static customerColumnValues(order: PrivateOrder): RowValue[] {
@@ -310,7 +310,7 @@ export class OrdersExcelExport {
                     showDetails ? order.data.customer.lastName : '',
                     showDetails ? order.data.customer.email : '',
                     showDetails ? order.data.customer.phone : '',
-                    ...(showDetails ? OrdersExcelExport.customerColumnValues(order) : ['', '', '']),
+                    ...(showDetails ? OrdersExcelExport.customerColumnValues(order) : OrdersExcelExport.customerColumnHeaders.map(() => '')),
                     ...answers,
                     showDetails ? order.data.comments : '',
                     {

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopRecordSettingsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopRecordSettingsView.vue
@@ -46,6 +46,30 @@
                     {{ $t('%2k') }}
                 </p>
             </STListItem>
+            <STListItem element-name="label" :selectable="true">
+                <template #left>
+                    <Checkbox v-model="birthDayEnabled" />
+                </template>
+                <p class="style-title-list">
+                    {{ $t('Geboortedatum') }}
+                </p>
+            </STListItem>
+            <STListItem element-name="label" :selectable="true">
+                <template #left>
+                    <Checkbox v-model="addressEnabled" />
+                </template>
+                <p class="style-title-list">
+                    {{ $t('Adres') }}
+                </p>
+            </STListItem>
+            <STListItem element-name="label" :selectable="true">
+                <template #left>
+                    <Checkbox v-model="genderEnabled" />
+                </template>
+                <p class="style-title-list">
+                    {{ $t('Geslacht') }}
+                </p>
+            </STListItem>
         </STList>
 
         <hr>
@@ -89,6 +113,39 @@ const phoneEnabled = computed({
         addPatch(PrivateWebshop.patch({
             meta: WebshopMetaData.patch({
                 phoneEnabled,
+            }),
+        }));
+    },
+});
+
+const birthDayEnabled = computed({
+    get: () => webshop.value.meta.birthDayEnabled,
+    set: (birthDayEnabled: boolean) => {
+        addPatch(PrivateWebshop.patch({
+            meta: WebshopMetaData.patch({
+                birthDayEnabled,
+            }),
+        }));
+    },
+});
+
+const addressEnabled = computed({
+    get: () => webshop.value.meta.addressEnabled,
+    set: (addressEnabled: boolean) => {
+        addPatch(PrivateWebshop.patch({
+            meta: WebshopMetaData.patch({
+                addressEnabled,
+            }),
+        }));
+    },
+});
+
+const genderEnabled = computed({
+    get: () => webshop.value.meta.genderEnabled,
+    set: (genderEnabled: boolean) => {
+        addPatch(PrivateWebshop.patch({
+            meta: WebshopMetaData.patch({
+                genderEnabled,
             }),
         }));
     },

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopRecordSettingsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopRecordSettingsView.vue
@@ -67,7 +67,7 @@
                     <Checkbox v-model="genderEnabled" />
                 </template>
                 <p class="style-title-list">
-                    {{ $t('Geslacht') }}
+                    {{ $t('Gender') }}
                 </p>
             </STListItem>
         </STList>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/orders/EditOrderView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/orders/EditOrderView.vue
@@ -32,7 +32,7 @@
 
             <BirthDayInput v-if="customerBirthDay || birthDayEnabled" v-model="customerBirthDay" :title="$t(`Geboortedatum`)" :validator="errors.validator" :required="false" />
 
-            <STInputBox v-if="customerGender !== 'Other' || genderEnabled" error-fields="gender" :error-box="errors.errorBox" :title="$t(`Geslacht`)">
+            <STInputBox v-if="customerGender !== Gender.Other || genderEnabled" error-fields="gender" :error-box="errors.errorBox" :title="$t(`Gender`)">
                 <RadioGroup>
                     <Radio v-model="customerGender" :value="Gender.Male" autocomplete="sex" name="customer-sex">
                         {{ $t('%XK') }}
@@ -46,7 +46,7 @@
                 </RadioGroup>
             </STInputBox>
 
-            <AddressInput v-if="(customerAddress || addressEnabled) && selectedMethod?.type !== 'Delivery'" v-model="customerAddress" :required="false" :validator="errors.validator" :validate-server="server" :title="$t(`%Cn`)" />
+            <AddressInput v-if="(customerAddress || addressEnabled) && selectedMethod?.type !== CheckoutMethodType.Delivery" v-model="customerAddress" :required="false" :validator="errors.validator" :validate-server="server" :title="$t(`%Cn`)" />
 
             <FieldBox v-for="field in fields" :key="field.id" :with-title="false" :field="field" :answers="answersClone" :error-box="errors.errorBox" />
 

--- a/frontend/app/dashboard/src/views/dashboard/webshop/orders/EditOrderView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/orders/EditOrderView.vue
@@ -30,6 +30,24 @@
 
             <PhoneInput v-if="phone || phoneEnabed" v-model="phone" :title="$t('%2k' )" name="mobile" :validator="errors.validator" autocomplete="tel" :required="false" :placeholder="$t(`%Uz`)" />
 
+            <BirthDayInput v-if="customerBirthDay || birthDayEnabled" v-model="customerBirthDay" :title="$t(`Geboortedatum`)" :validator="errors.validator" :required="false" />
+
+            <STInputBox v-if="customerGender !== 'Other' || genderEnabled" error-fields="gender" :error-box="errors.errorBox" :title="$t(`Geslacht`)">
+                <RadioGroup>
+                    <Radio v-model="customerGender" :value="Gender.Male" autocomplete="sex" name="customer-sex">
+                        {{ $t('%XK') }}
+                    </Radio>
+                    <Radio v-model="customerGender" :value="Gender.Female" autocomplete="sex" name="customer-sex">
+                        {{ $t('%XM') }}
+                    </Radio>
+                    <Radio v-model="customerGender" :value="Gender.Other" autocomplete="sex" name="customer-sex">
+                        {{ $t('%1JG') }}
+                    </Radio>
+                </RadioGroup>
+            </STInputBox>
+
+            <AddressInput v-if="(customerAddress || addressEnabled) && selectedMethod?.type !== 'Delivery'" v-model="customerAddress" :required="false" :validator="errors.validator" :validate-server="server" :title="$t(`%Cn`)" />
+
             <FieldBox v-for="field in fields" :key="field.id" :with-title="false" :field="field" :answers="answersClone" :error-box="errors.errorBox" />
 
             <div v-for="category in recordCategories.filter(c => c.isEnabled(patchedOrder.data))" :key="category.id" class="container">
@@ -166,9 +184,11 @@ import { useErrors } from '@stamhoofd/components/errors/useErrors.ts';
 import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
 import { usePatch } from '@stamhoofd/components/hooks/usePatch.ts';
 import AddressInput from '@stamhoofd/components/inputs/AddressInput.vue';
+import BirthDayInput from '@stamhoofd/components/inputs/BirthDayInput.vue';
 import EmailInput from '@stamhoofd/components/inputs/EmailInput.vue';
 import PhoneInput from '@stamhoofd/components/inputs/PhoneInput.vue';
 import Radio from '@stamhoofd/components/inputs/Radio.vue';
+import RadioGroup from '@stamhoofd/components/inputs/RadioGroup.vue';
 import STInputBox from '@stamhoofd/components/inputs/STInputBox.vue';
 import STList from '@stamhoofd/components/layout/STList.vue';
 import STListItem from '@stamhoofd/components/layout/STListItem.vue';
@@ -183,8 +203,8 @@ import PaymentSelectionList from '@stamhoofd/components/views/PaymentSelectionLi
 import PriceBreakdownBox from '@stamhoofd/components/views/PriceBreakdownBox.vue';
 import { I18nController } from '@stamhoofd/frontend-i18n/I18nController';
 import { NetworkManager } from '@stamhoofd/networking/NetworkManager';
-import type { CartItem, CheckoutMethod, DiscountCode, PatchAnswers, ValidatedAddress, WebshopOnSiteMethod, WebshopTakeoutMethod } from '@stamhoofd/structures';
-import { CheckoutMethodType, Customer, OrderData, PaymentConfiguration, PaymentMethod, PrivateOrder, RecordCategory, Version, WebshopTicketType, WebshopTimeSlot } from '@stamhoofd/structures';
+import type { Address, CartItem, CheckoutMethod, DiscountCode, PatchAnswers, ValidatedAddress, WebshopOnSiteMethod, WebshopTakeoutMethod } from '@stamhoofd/structures';
+import { CheckoutMethodType, Customer, Gender, OrderData, PaymentConfiguration, PaymentMethod, PrivateOrder, RecordCategory, Version, WebshopTicketType, WebshopTimeSlot } from '@stamhoofd/structures';
 
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import type { WebshopManager } from '../WebshopManager';
@@ -255,6 +275,10 @@ const recordCategories = computed(() => {
 const phoneEnabed = computed(() => {
     return webshop.meta.phoneEnabled;
 });
+
+const birthDayEnabled = computed(() => webshop.meta.birthDayEnabled);
+const addressEnabled = computed(() => webshop.meta.addressEnabled);
+const genderEnabled = computed(() => webshop.meta.genderEnabled);
 
 const emailPlaceholder = computed(() => {
     if (webshop.meta.ticketType !== WebshopTicketType.None) {
@@ -338,6 +362,45 @@ const phone = computed({
             data: OrderData.patch({
                 customer: Customer.patch({
                     phone: phone ?? '',
+                }),
+            }),
+        });
+    },
+});
+
+const customerBirthDay = computed({
+    get: () => patchedOrder.value.data.customer.birthDay,
+    set: (birthDay: Date | null) => {
+        addPatch({
+            data: OrderData.patch({
+                customer: Customer.patch({
+                    birthDay,
+                }),
+            }),
+        });
+    },
+});
+
+const customerGender = computed({
+    get: () => patchedOrder.value.data.customer.gender,
+    set: (gender: Gender) => {
+        addPatch({
+            data: OrderData.patch({
+                customer: Customer.patch({
+                    gender,
+                }),
+            }),
+        });
+    },
+});
+
+const customerAddress = computed({
+    get: () => patchedOrder.value.data.customer.address,
+    set: (address: Address | ValidatedAddress | null) => {
+        addPatch({
+            data: OrderData.patch({
+                customer: Customer.patch({
+                    address,
                 }),
             }),
         });

--- a/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderView.vue
@@ -236,6 +236,33 @@
                     </p>
                 </STListItem>
 
+                <STListItem v-if="order.data.customer.birthDay">
+                    <h3 class="style-definition-label">
+                        {{ $t('Geboortedatum') }}
+                    </h3>
+                    <p class="style-definition-text">
+                        {{ formatDate(order.data.customer.birthDay) }}
+                    </p>
+                </STListItem>
+
+                <STListItem v-if="order.data.customer.gender !== 'Other'">
+                    <h3 class="style-definition-label">
+                        {{ $t('Geslacht') }}
+                    </h3>
+                    <p class="style-definition-text">
+                        {{ getGenderName(order.data.customer.gender) }}
+                    </p>
+                </STListItem>
+
+                <STListItem v-if="order.data.customer.address && !order.data.address">
+                    <h3 class="style-definition-label">
+                        {{ $t('%Cn') }}
+                    </h3>
+                    <p class="style-definition-text">
+                        {{ order.data.customer.address }}
+                    </p>
+                </STListItem>
+
                 <STListItem v-for="a in order.data.fieldAnswers" :key="a.field.id">
                     <h3 class="style-definition-label">
                         {{ a.field.name }}
@@ -311,7 +338,7 @@ import type { TableActionSelection } from '@stamhoofd/components/tables/classes/
 import CartItemRow from '@stamhoofd/components/views/CartItemRow.vue';
 import PriceBreakdownBox from '@stamhoofd/components/views/PriceBreakdownBox.vue';
 import type { BalanceItemWithPrivatePayments, PrivateOrder, PrivateOrderWithTickets, PrivatePayment, TicketPrivate, WebshopTakeoutMethod } from '@stamhoofd/structures';
-import { AccessRight, LimitedFilteredRequest, OrderStatus, OrderStatusHelper, PaymentGeneral, PaymentMethod, PaymentMethodHelper, PaymentProvider, PaymentStatus, PaymentType, PermissionLevel, ProductType, RecordCategory, RecordWarning, WebshopTicketType } from '@stamhoofd/structures';
+import { AccessRight, getGenderName, LimitedFilteredRequest, OrderStatus, OrderStatusHelper, PaymentGeneral, PaymentMethod, PaymentMethodHelper, PaymentProvider, PaymentStatus, PaymentType, PermissionLevel, ProductType, RecordCategory, RecordWarning, WebshopTicketType } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 
 import { useOrganizationManager } from '@stamhoofd/networking/OrganizationManager';

--- a/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderView.vue
@@ -213,8 +213,10 @@
                     <h3 class="style-definition-label">
                         {{ $t('%1Os') }}
                     </h3>
-                    <p class="style-definition-text">
-                        {{ order.data.customer.name }}
+                    <p class="style-definition-text with-icons">
+                        <span>{{ order.data.customer.name }}</span>
+                        <span v-if="order.data.customer.gender === Gender.Male" v-tooltip="$t('%XK')" class="icon male blue" />
+                        <span v-if="order.data.customer.gender === Gender.Female" v-tooltip="$t('%XM')" class="icon female pink" />
                     </p>
                 </STListItem>
 
@@ -242,15 +244,6 @@
                     </h3>
                     <p class="style-definition-text">
                         {{ formatDate(order.data.customer.birthDay) }}
-                    </p>
-                </STListItem>
-
-                <STListItem v-if="order.data.customer.gender !== 'Other'">
-                    <h3 class="style-definition-label">
-                        {{ $t('Geslacht') }}
-                    </h3>
-                    <p class="style-definition-text">
-                        {{ getGenderName(order.data.customer.gender) }}
                     </p>
                 </STListItem>
 
@@ -338,7 +331,7 @@ import type { TableActionSelection } from '@stamhoofd/components/tables/classes/
 import CartItemRow from '@stamhoofd/components/views/CartItemRow.vue';
 import PriceBreakdownBox from '@stamhoofd/components/views/PriceBreakdownBox.vue';
 import type { BalanceItemWithPrivatePayments, PrivateOrder, PrivateOrderWithTickets, PrivatePayment, TicketPrivate, WebshopTakeoutMethod } from '@stamhoofd/structures';
-import { AccessRight, getGenderName, LimitedFilteredRequest, OrderStatus, OrderStatusHelper, PaymentGeneral, PaymentMethod, PaymentMethodHelper, PaymentProvider, PaymentStatus, PaymentType, PermissionLevel, ProductType, RecordCategory, RecordWarning, WebshopTicketType } from '@stamhoofd/structures';
+import { AccessRight, Gender, LimitedFilteredRequest, OrderStatus, OrderStatusHelper, PaymentGeneral, PaymentMethod, PaymentMethodHelper, PaymentProvider, PaymentStatus, PaymentType, PermissionLevel, ProductType, RecordCategory, RecordWarning, WebshopTicketType } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 
 import { useOrganizationManager } from '@stamhoofd/networking/OrganizationManager';

--- a/frontend/app/webshop/src/views/checkout/AddressSelectionView.vue
+++ b/frontend/app/webshop/src/views/checkout/AddressSelectionView.vue
@@ -1,5 +1,5 @@
 <template>
-    <SaveView :loading="loading" save-icon-right="arrow-right" :save-text="$t('%16p')" data-submit-last-field :title="$t(`%Xn`)" @save="goNext">
+    <SaveView :loading="loading" save-icon-right="arrow-right" :save-text="$t('%16p')" data-submit-last-field data-testid="address-step" :title="$t(`%Xn`)" @save="goNext">
         <h1>{{ $t('%Xn') }}</h1>
         <div v-if="deliveryMethod && deliveryMethod.price.minimumPrice !== null && deliveryMethod.price.discountPrice !== checkout.deliveryPrice" class="info-box">
             {{ $t('%Ut', {min: formatPrice(deliveryMethod.price.minimumPrice), price: formatPrice(deliveryMethod.price.discountPrice)}) }}

--- a/frontend/app/webshop/src/views/checkout/CheckoutStepsManager.ts
+++ b/frontend/app/webshop/src/views/checkout/CheckoutStepsManager.ts
@@ -157,10 +157,14 @@ export class CheckoutStepsManager {
         const loggedIn = this.$context.isComplete() ?? false;
         const user = loggedIn ? (this.$context.user ?? null) : null;
 
+        // When a delivery method is chosen, the address is collected in the Address step, so we don't
+        // need to ask for the customer address again.
+        const hasDeliveryAddress = checkoutMethod !== null && checkoutMethod.type === CheckoutMethodType.Delivery;
+
         steps.push(new CheckoutStep({
             id: CheckoutStepType.Customer,
             url: '/checkout/' + CheckoutStepType.Customer.toLowerCase(),
-            active: !loggedIn || webshop.meta.phoneEnabled || !user?.firstName || !user?.lastName,
+            active: !loggedIn || webshop.meta.phoneEnabled || webshop.meta.birthDayEnabled || webshop.meta.genderEnabled || (webshop.meta.addressEnabled && !hasDeliveryAddress) || !user?.firstName || !user?.lastName,
             getComponent: () => import(/* webpackChunkName: "Checkout", webpackPrefetch: true */ './CustomerView.vue').then(m => new ComponentWithProperties(m.default, {})),
             validate: (checkout, webshop, organizationMeta) => checkout.validateCustomer(webshop, organizationMeta, I18nController.i18n, false, loggedIn ? (this.$context.user ?? null) : null),
         }));

--- a/frontend/app/webshop/src/views/checkout/CustomerView.vue
+++ b/frontend/app/webshop/src/views/checkout/CustomerView.vue
@@ -24,7 +24,7 @@
 
         <BirthDayInput v-if="birthDayEnabled" v-model="birthDay" :title="$t(`Geboortedatum`)" :validator="errors.validator" :required="true" />
 
-        <STInputBox v-if="genderEnabled" error-fields="gender" :error-box="errors.errorBox" :title="$t(`Geslacht`)">
+        <STInputBox v-if="genderEnabled" error-fields="gender" :error-box="errors.errorBox" :title="$t(`Gender`)">
             <RadioGroup>
                 <Radio v-model="gender" :value="Gender.Male" autocomplete="sex" name="sex">
                     {{ $t('%XK') }}

--- a/frontend/app/webshop/src/views/checkout/CustomerView.vue
+++ b/frontend/app/webshop/src/views/checkout/CustomerView.vue
@@ -22,22 +22,45 @@
 
         <PhoneInput v-if="phoneEnabled" v-model="phone" :title="$t('%2k' )" name="mobile" :validator="errors.validator" autocomplete="tel" :placeholder="$t(`%Xu`)" />
 
+        <BirthDayInput v-if="birthDayEnabled" v-model="birthDay" :title="$t(`Geboortedatum`)" :validator="errors.validator" :required="true" />
+
+        <STInputBox v-if="genderEnabled" error-fields="gender" :error-box="errors.errorBox" :title="$t(`Geslacht`)">
+            <RadioGroup>
+                <Radio v-model="gender" :value="Gender.Male" autocomplete="sex" name="sex">
+                    {{ $t('%XK') }}
+                </Radio>
+                <Radio v-model="gender" :value="Gender.Female" autocomplete="sex" name="sex">
+                    {{ $t('%XM') }}
+                </Radio>
+                <Radio v-model="gender" :value="Gender.Other" autocomplete="sex" name="sex">
+                    {{ $t('%1JG') }}
+                </Radio>
+            </RadioGroup>
+        </STInputBox>
+
+        <AddressInput v-if="addressEnabled && !hasDeliveryAddress" v-model="address" :required="true" :validator="errors.validator" :validate-server="unscopedServer" :title="$t(`%Cn`)" />
+
         <FieldBox v-for="field in fields" :key="field.id" :with-title="false" :field="field" :answers="checkoutManager.checkout.fieldAnswers" :error-box="errors.errorBox" />
     </SaveView>
 </template>
 
 <script lang="ts" setup>
+import AddressInput from '@stamhoofd/components/inputs/AddressInput.vue';
+import BirthDayInput from '@stamhoofd/components/inputs/BirthDayInput.vue';
 import EmailInput from '@stamhoofd/components/inputs/EmailInput.vue';
 import { ErrorBox } from '@stamhoofd/components/errors/ErrorBox.ts';
 import FieldBox from '@stamhoofd/components/views/FieldBox.vue';
 import PhoneInput from '@stamhoofd/components/inputs/PhoneInput.vue';
+import Radio from '@stamhoofd/components/inputs/Radio.vue';
+import RadioGroup from '@stamhoofd/components/inputs/RadioGroup.vue';
 import SaveView from '@stamhoofd/components/navigation/SaveView.vue';
 import STErrorsDefault from '@stamhoofd/components/errors/STErrorsDefault.vue';
 import STInputBox from '@stamhoofd/components/inputs/STInputBox.vue';
 import { useContext } from '@stamhoofd/components/hooks/useContext.ts';
 import { useErrors } from '@stamhoofd/components/errors/useErrors.ts';
 import { useNavigationActions } from '@stamhoofd/components/types/NavigationActions.ts';
-import { WebshopTicketType } from '@stamhoofd/structures';
+import type { Address, ValidatedAddress } from '@stamhoofd/structures';
+import { Gender, WebshopTicketType } from '@stamhoofd/structures';
 
 import { computed, ref } from 'vue';
 import { useCheckoutManager } from '../../composables/useCheckoutManager';
@@ -53,7 +76,15 @@ const context = useContext();
 const webshop = computed(() => webshopManager.webshop);
 const navigationActions = useNavigationActions();
 const phoneEnabled = computed(() => webshop.value.meta.phoneEnabled);
+const birthDayEnabled = computed(() => webshop.value.meta.birthDayEnabled);
+const addressEnabled = computed(() => webshop.value.meta.addressEnabled);
+const genderEnabled = computed(() => webshop.value.meta.genderEnabled);
 const isLoggedIn = computed(() => context.value.isComplete() ?? false);
+const unscopedServer = computed(() => webshopManager.unscopedServer);
+
+// When a delivery method is chosen, its address is already collected in a separate step
+// and stored on the customer, so we don't ask for the address a second time.
+const hasDeliveryAddress = computed(() => checkoutManager.checkout.deliveryMethod !== null);
 
 const emailPlaceholder = computed(() => {
     if (webshop.value.meta.ticketType !== WebshopTicketType.None) {
@@ -99,6 +130,30 @@ const phone = computed({
     get: () => checkoutManager.checkout.customer.phone,
     set: (phone: string) => {
         checkoutManager.checkout.customer.phone = phone;
+        checkoutManager.saveCheckout();
+    },
+});
+
+const birthDay = computed({
+    get: () => checkoutManager.checkout.customer.birthDay,
+    set: (birthDay: Date | null) => {
+        checkoutManager.checkout.customer.birthDay = birthDay;
+        checkoutManager.saveCheckout();
+    },
+});
+
+const gender = computed({
+    get: () => checkoutManager.checkout.customer.gender,
+    set: (gender: Gender) => {
+        checkoutManager.checkout.customer.gender = gender;
+        checkoutManager.saveCheckout();
+    },
+});
+
+const address = computed({
+    get: () => checkoutManager.checkout.customer.address,
+    set: (address: Address | ValidatedAddress | null) => {
+        checkoutManager.checkout.customer.address = address;
         checkoutManager.saveCheckout();
     },
 });

--- a/frontend/app/webshop/src/views/orders/OrderView.vue
+++ b/frontend/app/webshop/src/views/orders/OrderView.vue
@@ -161,6 +161,33 @@
                                     {{ order.data.customer.email }}
                                 </p>
                             </STListItem>
+                            <STListItem v-if="order.data.customer.birthDay" class="right-description">
+                                <h3 class="style-definition-label">
+                                    {{ $t('Geboortedatum') }}
+                                </h3>
+
+                                <p class="style-definition-text">
+                                    {{ formatDate(order.data.customer.birthDay) }}
+                                </p>
+                            </STListItem>
+                            <STListItem v-if="order.data.customer.gender !== 'Other'" class="right-description">
+                                <h3 class="style-definition-label">
+                                    {{ $t('Geslacht') }}
+                                </h3>
+
+                                <p class="style-definition-text">
+                                    {{ getGenderName(order.data.customer.gender) }}
+                                </p>
+                            </STListItem>
+                            <STListItem v-if="order.data.customer.address && !order.data.address" class="right-description">
+                                <h3 class="style-definition-label">
+                                    {{ $t('%Cn') }}
+                                </h3>
+
+                                <p class="style-definition-text">
+                                    {{ order.data.customer.address }}
+                                </p>
+                            </STListItem>
                             <STListItem v-for="(payment, index) in order.payments" :key="payment.id" class="right-description right-stack" :selectable="isPaymentTransfer(payment)" @click="openTransferView(payment)">
                                 <h3 class="style-definition-label">
                                     {{ payment.price >= 0 ? 'Betaling' : 'Terugbetaling' }} {{ order.payments.length > 1 ? index + 1 : '' }}
@@ -357,7 +384,7 @@ import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 
 import ViewRecordCategoryAnswersBox from '@stamhoofd/components/records/components/ViewRecordCategoryAnswersBox.vue';
 import type { Payment } from '@stamhoofd/structures';
-import { Order, OrderStatus, OrderStatusHelper, PaymentMethod, PaymentMethodHelper, PaymentStatus, ProductType, RecordCategory, TicketOrder, TicketPublic, WebshopTicketType } from '@stamhoofd/structures';
+import { getGenderName, Order, OrderStatus, OrderStatusHelper, PaymentMethod, PaymentMethodHelper, PaymentStatus, ProductType, RecordCategory, TicketOrder, TicketPublic, WebshopTicketType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { computed, onMounted, ref, watch } from 'vue';
 

--- a/frontend/app/webshop/src/views/orders/OrderView.vue
+++ b/frontend/app/webshop/src/views/orders/OrderView.vue
@@ -170,9 +170,9 @@
                                     {{ formatDate(order.data.customer.birthDay) }}
                                 </p>
                             </STListItem>
-                            <STListItem v-if="order.data.customer.gender !== 'Other'" class="right-description">
+                            <STListItem v-if="order.data.customer.gender !== Gender.Other" class="right-description">
                                 <h3 class="style-definition-label">
-                                    {{ $t('Geslacht') }}
+                                    {{ $t('Gender') }}
                                 </h3>
 
                                 <p class="style-definition-text">
@@ -384,7 +384,7 @@ import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 
 import ViewRecordCategoryAnswersBox from '@stamhoofd/components/records/components/ViewRecordCategoryAnswersBox.vue';
 import type { Payment } from '@stamhoofd/structures';
-import { getGenderName, Order, OrderStatus, OrderStatusHelper, PaymentMethod, PaymentMethodHelper, PaymentStatus, ProductType, RecordCategory, TicketOrder, TicketPublic, WebshopTicketType } from '@stamhoofd/structures';
+import { Gender, getGenderName, Order, OrderStatus, OrderStatusHelper, PaymentMethod, PaymentMethodHelper, PaymentStatus, ProductType, RecordCategory, TicketOrder, TicketPublic, WebshopTicketType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { computed, onMounted, ref, watch } from 'vue';
 

--- a/shared/structures/src/webshops/Checkout.test.ts
+++ b/shared/structures/src/webshops/Checkout.test.ts
@@ -1,0 +1,133 @@
+import { Country } from '@stamhoofd/types/Country';
+import { describe, expect, it } from 'vitest';
+
+import { ValidatedAddress } from '../addresses/Address.js';
+import type { I18n } from '../I18nInterface.js';
+import { Gender } from '../members/Gender.js';
+import { OrganizationMetaData } from '../OrganizationMetaData.js';
+import { Cart } from './Cart.js';
+import { Checkout } from './Checkout.js';
+import { Customer } from './Customer.js';
+import { Webshop } from './Webshop.js';
+import { WebshopDeliveryMethod, WebshopMetaData } from './WebshopMetaData.js';
+
+const i18n = { t: (key: string) => key } as unknown as I18n;
+const organizationMeta = OrganizationMetaData.create({});
+
+function createWebshop(meta: Partial<Record<'phoneEnabled' | 'birthDayEnabled' | 'addressEnabled' | 'genderEnabled', boolean>>) {
+    return Webshop.create({
+        meta: WebshopMetaData.create({
+            phoneEnabled: false,
+            ...meta,
+        }),
+    });
+}
+
+function createValidCustomer() {
+    return Customer.create({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+    });
+}
+
+function createAddress() {
+    return ValidatedAddress.create({
+        street: 'Teststraat',
+        number: '1',
+        postalCode: '9000',
+        city: 'Gent',
+        country: Country.Belgium,
+        cityId: 'city-1',
+        parentCityId: null,
+        provinceId: 'province-1',
+    });
+}
+
+describe('Checkout.validateCustomer', () => {
+    it('requires a birth day when birthDayEnabled', () => {
+        const webshop = createWebshop({ birthDayEnabled: true });
+        const checkout = Checkout.create({ customer: createValidCustomer() });
+
+        expect(() => checkout.validateCustomer(webshop, organizationMeta, i18n, false)).toThrow(/birth day/i);
+
+        checkout.customer.birthDay = new Date('2000-01-01');
+        expect(() => checkout.validateCustomer(webshop, organizationMeta, i18n, false)).not.toThrow();
+    });
+
+    it('does not require a birth day for admins', () => {
+        const webshop = createWebshop({ birthDayEnabled: true });
+        const checkout = Checkout.create({ customer: createValidCustomer() });
+
+        expect(() => checkout.validateCustomer(webshop, organizationMeta, i18n, true)).not.toThrow();
+    });
+
+    it('clears the birth day when birthDayEnabled is false', () => {
+        const webshop = createWebshop({ birthDayEnabled: false });
+        const customer = createValidCustomer();
+        customer.birthDay = new Date('2000-01-01');
+        const checkout = Checkout.create({ customer });
+
+        checkout.validateCustomer(webshop, organizationMeta, i18n, false);
+        expect(checkout.customer.birthDay).toBeNull();
+    });
+
+    it('requires an address when addressEnabled', () => {
+        const webshop = createWebshop({ addressEnabled: true });
+        const checkout = Checkout.create({ customer: createValidCustomer() });
+
+        expect(() => checkout.validateCustomer(webshop, organizationMeta, i18n, false)).toThrow(/address/i);
+
+        checkout.customer.address = createAddress();
+        expect(() => checkout.validateCustomer(webshop, organizationMeta, i18n, false)).not.toThrow();
+    });
+
+    it('clears the customer address when addressEnabled is false and there is no delivery address', () => {
+        const webshop = createWebshop({ addressEnabled: false });
+        const customer = createValidCustomer();
+        customer.address = createAddress();
+        const checkout = Checkout.create({ customer });
+
+        checkout.validateCustomer(webshop, organizationMeta, i18n, false);
+        expect(checkout.customer.address).toBeNull();
+    });
+
+    it('resets the gender when genderEnabled is false', () => {
+        const webshop = createWebshop({ genderEnabled: false });
+        const customer = createValidCustomer();
+        customer.gender = Gender.Female;
+        const checkout = Checkout.create({ customer });
+
+        checkout.validateCustomer(webshop, organizationMeta, i18n, false);
+        expect(checkout.customer.gender).toBe(Gender.Other);
+    });
+
+    it('keeps the gender when genderEnabled is true', () => {
+        const webshop = createWebshop({ genderEnabled: true });
+        const customer = createValidCustomer();
+        customer.gender = Gender.Female;
+        const checkout = Checkout.create({ customer });
+
+        checkout.validateCustomer(webshop, organizationMeta, i18n, false);
+        expect(checkout.customer.gender).toBe(Gender.Female);
+    });
+});
+
+describe('Checkout.validateDeliveryAddress', () => {
+    it('copies the delivery address to the customer even when addressEnabled is false', () => {
+        const address = createAddress();
+        const checkoutMethod = WebshopDeliveryMethod.create({
+            countries: [address.country],
+        });
+        const webshop = createWebshop({ addressEnabled: false });
+        const checkout = Checkout.create({
+            customer: createValidCustomer(),
+            checkoutMethod,
+            address,
+            cart: Cart.create({}),
+        });
+
+        checkout.validateDeliveryAddress(webshop, organizationMeta);
+        expect(checkout.customer.address).toStrictEqual(address);
+    });
+});

--- a/shared/structures/src/webshops/Checkout.test.ts
+++ b/shared/structures/src/webshops/Checkout.test.ts
@@ -130,4 +130,26 @@ describe('Checkout.validateDeliveryAddress', () => {
         checkout.validateDeliveryAddress(webshop, organizationMeta);
         expect(checkout.customer.address).toStrictEqual(address);
     });
+
+    it('keeps the delivery address as the customer address when addressEnabled and does not re-require it', () => {
+        // validateCustomer relies on validateDeliveryAddress having run first: the delivery
+        // address is copied onto the customer, so the addressEnabled check must not throw even
+        // though the customer never filled in a separate address.
+        const address = createAddress();
+        const checkoutMethod = WebshopDeliveryMethod.create({
+            countries: [address.country],
+        });
+        const webshop = createWebshop({ addressEnabled: true });
+        const checkout = Checkout.create({
+            customer: createValidCustomer(),
+            checkoutMethod,
+            address,
+            cart: Cart.create({}),
+        });
+
+        // Same order as Checkout.validate()
+        checkout.validateDeliveryAddress(webshop, organizationMeta);
+        expect(() => checkout.validateCustomer(webshop, organizationMeta, i18n, false)).not.toThrow();
+        expect(checkout.customer.address).toStrictEqual(address);
+    });
 });

--- a/shared/structures/src/webshops/Checkout.ts
+++ b/shared/structures/src/webshops/Checkout.ts
@@ -7,6 +7,7 @@ import { compileToInMemoryFilter } from '../filters/InMemoryFilter.js';
 import { checkoutInMemoryFilterCompilers } from '../filters/inMemoryFilterDefinitions.js';
 import type { StamhoofdFilter } from '../filters/StamhoofdFilter.js';
 import type { I18n } from '../I18nInterface.js';
+import { Gender } from '../members/Gender.js';
 import type { ObjectWithRecords, PatchAnswers } from '../members/ObjectWithRecords.js';
 import type { RecordAnswer } from '../members/records/RecordAnswer.js';
 import { RecordAnswerDecoder, RecordAnswerMapDecoder } from '../members/records/RecordAnswer.js';
@@ -354,6 +355,10 @@ export class Checkout extends AutoEncoder implements ObjectWithRecords {
             });
         }
 
+        // Always store the delivery address on the customer too (even if addressEnabled is false),
+        // so we don't ask for the same address twice.
+        this.customer.address = this.address;
+
         // Check country
         if (this.checkoutMethod.countries.includes(this.address.country)) {
             return;
@@ -480,6 +485,38 @@ export class Checkout extends AutoEncoder implements ObjectWithRecords {
             }
         } else {
             this.customer.phone = '';
+        }
+
+        if (webshop.meta.birthDayEnabled) {
+            if (!this.customer.birthDay && !asAdmin) {
+                throw new SimpleError({
+                    code: 'invalid_birth_day',
+                    message: 'Invalid birth day',
+                    human: $t(`Vul de geboortedatum in`),
+                    field: 'customer.birthDay',
+                });
+            }
+        } else {
+            this.customer.birthDay = null;
+        }
+
+        if (webshop.meta.addressEnabled) {
+            if (!this.customer.address && !asAdmin) {
+                throw new SimpleError({
+                    code: 'invalid_address',
+                    message: 'Invalid address',
+                    human: $t(`Vul het adres in`),
+                    field: 'customer.address',
+                });
+            }
+        } else if (!this.address) {
+            // Only clear the customer address when there is no delivery address:
+            // a delivery address is always stored on the customer.
+            this.customer.address = null;
+        }
+
+        if (!webshop.meta.genderEnabled) {
+            this.customer.gender = Gender.Other;
         }
 
         const regex = /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i;

--- a/shared/structures/src/webshops/Customer.ts
+++ b/shared/structures/src/webshops/Customer.ts
@@ -1,4 +1,6 @@
-import { AutoEncoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import { AutoEncoder, DateDecoder, EnumDecoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import { Address } from '../addresses/Address.js';
+import { Gender } from '../members/Gender.js';
 import { PaymentCustomer } from '../PaymentCustomer.js';
 
 export class Customer extends AutoEncoder {
@@ -13,6 +15,15 @@ export class Customer extends AutoEncoder {
 
     @field({ decoder: StringDecoder })
     phone = '';
+
+    @field({ decoder: DateDecoder, nullable: true, ...NextVersion })
+    birthDay: Date | null = null;
+
+    @field({ decoder: Address, nullable: true, ...NextVersion })
+    address: Address | null = null;
+
+    @field({ decoder: new EnumDecoder(Gender), defaultValue: () => Gender.Other, isDefaultValue: v => v === Gender.Other, ...NextVersion })
+    gender: Gender = Gender.Other;
 
     get name() {
         if (this.lastName === '') {

--- a/shared/structures/src/webshops/WebshopMetaData.ts
+++ b/shared/structures/src/webshops/WebshopMetaData.ts
@@ -449,6 +449,15 @@ export class WebshopMetaData extends AutoEncoder {
     @field({ decoder: BooleanDecoder, optional: true })
     phoneEnabled = true;
 
+    @field({ decoder: BooleanDecoder, ...NextVersion })
+    birthDayEnabled = false;
+
+    @field({ decoder: BooleanDecoder, ...NextVersion })
+    addressEnabled = false;
+
+    @field({ decoder: BooleanDecoder, ...NextVersion })
+    genderEnabled = false;
+
     @field({ decoder: BooleanDecoder, version: 242 })
     allowDiscountCodeEntry = false;
 

--- a/tests/playwright/src/flows/WebshopOrderFlow.ts
+++ b/tests/playwright/src/flows/WebshopOrderFlow.ts
@@ -1,5 +1,21 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
+
+export interface TestAddress {
+    street: string;
+    number: string;
+    postalCode: string;
+    city: string;
+    /** ISO country code, e.g. 'FR' (non BE/NL avoids the postal-code database lookup) */
+    country: string;
+}
+
+export interface TestBirthDay {
+    day: number;
+    /** 1-12 */
+    month: number;
+    year: number;
+}
 
 /**
  * Drives the public webshop SPA through a complete order: adding products (with optional seats),
@@ -75,13 +91,70 @@ export class WebshopOrderFlow {
         await expect(this.page.getByTestId('customer-step')).toBeVisible({ timeout: 15000 });
     }
 
-    async fillCustomer(options: { firstName?: string; lastName?: string; email?: string } = {}) {
-        const { firstName = 'John', lastName = 'Doe', email = 'john.doe@test.be' } = options;
+    async fillCustomer(options: { firstName?: string; lastName?: string; email?: string; birthDay?: TestBirthDay; gender?: 'Male' | 'Female' | 'Other'; address?: TestAddress } = {}) {
+        const { firstName = 'John', lastName = 'Doe', email = 'john.doe@test.be', birthDay, gender, address } = options;
         const step = this.page.getByTestId('customer-step');
         await step.locator('input[name="fname"]').fill(firstName);
         await step.locator('input[name="lname"]').fill(lastName);
         await step.locator('input[name="email"]').fill(email);
+
+        if (birthDay) {
+            await this.fillBirthDay(step, birthDay);
+        }
+        if (gender) {
+            await this.selectGender(step, gender, 'sex');
+        }
+        if (address) {
+            await this.fillAddressInputs(step, address);
+        }
+
         await step.getByTestId('save-button').click();
+    }
+
+    /**
+     * Assert the customer step is showing (or hiding) the birth day, gender and address inputs.
+     */
+    async expectCustomerFields(fields: { birthDay: boolean; gender: boolean; address: boolean }) {
+        const step = this.page.getByTestId('customer-step');
+        await expect(step).toBeVisible({ timeout: 15000 });
+        await expect(step.getByTestId('day-select')).toHaveCount(fields.birthDay ? 1 : 0);
+        await expect(step.locator('input[name="sex"]')).toHaveCount(fields.gender ? 3 : 0);
+        await expect(step.locator('input[name="street-address"]')).toHaveCount(fields.address ? 1 : 0);
+    }
+
+    /**
+     * Delivery flow: open the checkout and fill the (separate) delivery address step, which comes
+     * before the customer step. Returns once the customer step is visible.
+     */
+    async fillDeliveryAddressStep(address: TestAddress) {
+        if (this.cartEnabled) {
+            await this.page.getByTestId('cart-checkout-button').click();
+        }
+        const step = this.page.getByTestId('address-step');
+        await expect(step).toBeVisible({ timeout: 15000 });
+        await this.fillAddressInputs(step, address);
+        await step.getByTestId('save-button').click();
+        await expect(this.page.getByTestId('customer-step')).toBeVisible({ timeout: 15000 });
+    }
+
+    private async fillBirthDay(scope: Locator, birthDay: TestBirthDay) {
+        await scope.getByTestId('day-select').selectOption({ label: String(birthDay.day) });
+        // Option index 0 is the placeholder, so month M is at index M
+        await scope.getByTestId('month-select').selectOption({ index: birthDay.month });
+        await scope.getByTestId('year-select').selectOption({ label: String(birthDay.year) });
+    }
+
+    private async selectGender(scope: Locator, gender: 'Male' | 'Female' | 'Other', name: string) {
+        await scope.locator('label.radio', { has: this.page.locator(`input[name="${name}"][value="${gender}"]`) }).click();
+    }
+
+    private async fillAddressInputs(scope: Locator, address: TestAddress) {
+        await scope.locator('select[name="country"]').selectOption(address.country);
+        await scope.locator('input[name="street-address"]').fill(`${address.street} ${address.number}`);
+        await scope.locator('input[name="postal-code"]').fill(address.postalCode);
+        await scope.locator('input[name="city"]').fill(address.city);
+        // Blur to let the address validate before the step is submitted
+        await scope.locator('input[name="city"]').blur();
     }
 
     async selectPaymentMethod(name: string) {

--- a/tests/playwright/src/helpers/page/webshop/EditOrderView.ts
+++ b/tests/playwright/src/helpers/page/webshop/EditOrderView.ts
@@ -1,12 +1,17 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import type { PaymentMethod, Product } from '@stamhoofd/structures';
 import { ProductType } from '@stamhoofd/structures';
+import type { TestAddress, TestBirthDay } from '../../../flows/WebshopOrderFlow.js';
 
 export class EditOrderView {
     constructor(public readonly page: Page) {
     }
 
-    async fillCustomerData({firstName, lastName, email, phone}: Partial<{firstName: string, lastName: string, email: string, phone: string}>) {
+    private get view(): Locator {
+        return this.page.getByTestId('edit-order-view');
+    }
+
+    async fillCustomerData({ firstName, lastName, email, phone, birthDay, gender, address }: Partial<{ firstName: string; lastName: string; email: string; phone: string; birthDay: TestBirthDay; gender: 'Male' | 'Female' | 'Other'; address: TestAddress }>) {
         if (firstName) {
             await this.fillFirstName(firstName);
         }
@@ -21,6 +26,24 @@ export class EditOrderView {
 
         if (phone) {
             await this.phone(phone);
+        }
+
+        if (birthDay) {
+            await this.view.getByTestId('day-select').selectOption({ label: String(birthDay.day) });
+            await this.view.getByTestId('month-select').selectOption({ index: birthDay.month });
+            await this.view.getByTestId('year-select').selectOption({ label: String(birthDay.year) });
+        }
+
+        if (gender) {
+            await this.view.locator('label.radio', { has: this.page.locator(`input[name="customer-sex"][value="${gender}"]`) }).click();
+        }
+
+        if (address) {
+            await this.view.locator('select[name="country"]').selectOption(address.country);
+            await this.view.locator('input[name="street-address"]').fill(`${address.street} ${address.number}`);
+            await this.view.locator('input[name="postal-code"]').fill(address.postalCode);
+            await this.view.locator('input[name="city"]').fill(address.city);
+            await this.view.locator('input[name="city"]').blur();
         }
     }
 

--- a/tests/playwright/src/helpers/page/webshop/WebshopOrdersView.ts
+++ b/tests/playwright/src/helpers/page/webshop/WebshopOrdersView.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test';
 import type { PaymentMethod, Product } from '@stamhoofd/structures';
+import type { TestAddress, TestBirthDay } from '../../../flows/WebshopOrderFlow.js';
 import { TableHelper } from '../TableHelper.js';
 import { EditOrderView } from './EditOrderView.js';
 
@@ -7,13 +8,13 @@ export class WebshopOrdersView {
     constructor(public readonly page: Page) {
     }
 
-    async addOrder({ firstName, lastName, email, phone, product, amount, paymentMethod }: { firstName: string; lastName: string; email: string; phone?: string; product: Product; amount?: number; paymentMethod?: PaymentMethod }) {
+    async addOrder({ firstName, lastName, email, phone, product, amount, paymentMethod, birthDay, gender, address }: { firstName: string; lastName: string; email: string; phone?: string; product: Product; amount?: number; paymentMethod?: PaymentMethod; birthDay?: TestBirthDay; gender?: 'Male' | 'Female' | 'Other'; address?: TestAddress }) {
         // table
         const table = new TableHelper(this.page);
         await table.clickAction('Bestelling toevoegen');
 
         const editOrderView = new EditOrderView(this.page);
-        await editOrderView.fillCustomerData({ firstName, lastName, email, phone });
+        await editOrderView.fillCustomerData({ firstName, lastName, email, phone, birthDay, gender, address });
         await editOrderView.addProduct({
             product,
             amount: amount ?? 1,

--- a/tests/playwright/src/helpers/test-data/TestWebshops.ts
+++ b/tests/playwright/src/helpers/test-data/TestWebshops.ts
@@ -1,6 +1,7 @@
 import type { Organization, Webshop } from '@stamhoofd/models';
 import { WebshopFactory } from '@stamhoofd/models';
-import { PaymentConfiguration, PaymentMethod, PrivatePaymentConfiguration, Product, ProductPrice, ProductType, SeatingPlan, SeatingPlanRow, SeatingPlanSeat, SeatingPlanSection, TransferSettings, WebshopMetaData, WebshopPrivateMetaData, WebshopTicketType, WebshopType } from '@stamhoofd/structures';
+import { PaymentConfiguration, PaymentMethod, PrivatePaymentConfiguration, Product, ProductPrice, ProductType, SeatingPlan, SeatingPlanRow, SeatingPlanSeat, SeatingPlanSection, TransferSettings, WebshopDeliveryMethod, WebshopMetaData, WebshopPrivateMetaData, WebshopTicketType, WebshopType } from '@stamhoofd/structures';
+import type { Country } from '@stamhoofd/types/Country';
 import { CaddyConfigHelper } from '../../setup/helpers/CaddyConfigHelper.js';
 import { WorkerData } from '../worker/WorkerData.js';
 
@@ -25,6 +26,14 @@ export interface CreateWebshopOptions {
     /** Optional uri suffix on the custom domain (tickets.domain.com/<domainUri>) */
     domainUri?: string;
     name?: string;
+    /** Ask for the customer's birth day during checkout */
+    birthDayEnabled?: boolean;
+    /** Ask for the customer's address during checkout */
+    addressEnabled?: boolean;
+    /** Ask for the customer's gender during checkout */
+    genderEnabled?: boolean;
+    /** Add a delivery checkout method covering the given countries (enables the delivery address step) */
+    deliveryCountries?: Country[];
 }
 
 export class TestWebshops {
@@ -45,6 +54,10 @@ export class TestWebshops {
             customDomainPrefix,
             domainUri,
             name = `Testwebshop ${WorkerData.id}`,
+            birthDayEnabled = false,
+            addressEnabled = false,
+            genderEnabled = false,
+            deliveryCountries,
         } = options;
 
         let meta = WebshopMetaData.patch({});
@@ -83,7 +96,17 @@ export class TestWebshops {
             cartEnabled,
             // Keep the customer step minimal so the order flow doesn't require a phone number
             phoneEnabled: false,
+            birthDayEnabled,
+            addressEnabled,
+            genderEnabled,
         });
+
+        if (deliveryCountries) {
+            meta.checkoutMethods.addPut(WebshopDeliveryMethod.create({
+                name: 'Levering',
+                countries: deliveryCountries,
+            }));
+        }
 
         const privateMeta = WebshopPrivateMetaData.patch({
             paymentConfiguration: PrivatePaymentConfiguration.patch({ stripeAccountId }),

--- a/tests/playwright/src/tests/webshop-customer-fields.spec.ts
+++ b/tests/playwright/src/tests/webshop-customer-fields.spec.ts
@@ -1,0 +1,246 @@
+// test should always be imported first
+import { setup, test } from '../test-fixtures/base.js';
+setup();
+
+// other imports
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { STPackageService } from '@stamhoofd/backend/tests/helpers';
+import type { User } from '@stamhoofd/models';
+import { Order, Organization, OrganizationFactory, Token, UserFactory } from '@stamhoofd/models';
+import {
+    Gender,
+    PaymentMethod,
+    PermissionLevel,
+    Permissions,
+    STPackageBundle,
+    Token as TokenStruct,
+    Version,
+} from '@stamhoofd/structures';
+import { Country } from '@stamhoofd/types/Country';
+import { TestUtils } from '@stamhoofd/test-utils';
+import type { TestAddress, TestBirthDay } from '../flows/WebshopOrderFlow.js';
+import { WebshopOrderFlow } from '../flows/WebshopOrderFlow.js';
+import { DashboardPage, DashboardTab, WorkerData } from '../helpers/index.js';
+import { WebshopOrdersView } from '../helpers/page/webshop/WebshopOrdersView.js';
+import { TestWebshops } from '../helpers/test-data/TestWebshops.js';
+
+const PointOfSaleLabel = 'plaatse';
+
+// A French address avoids the Belgian/Dutch postal-code database lookup during validation.
+const testAddress: TestAddress = { street: 'Rue de Test', number: '10', postalCode: '75001', city: 'Paris', country: Country.France };
+const testBirthDay: TestBirthDay = { day: 15, month: 6, year: 1990 };
+
+async function createWebshopOrganization(prefix: string): Promise<Organization> {
+    const organization = await new OrganizationFactory({
+        name: `${prefix}${WorkerData.id}`,
+        packages: [STPackageBundle.Webshops],
+    }).create();
+
+    await STPackageService.updateOrganizationPackages(organization.id);
+
+    const refreshed = await Organization.getByID(organization.id);
+    if (!refreshed) {
+        throw new Error('Organization not found after creation');
+    }
+    return refreshed;
+}
+
+async function createAdmin(organization: Organization): Promise<User> {
+    const email = `admin-${WorkerData.id}-${Date.now()}@test.be`;
+    const fullPermissions = Permissions.create({ level: PermissionLevel.Full });
+
+    if (STAMHOOFD.userMode === 'platform') {
+        return await new UserFactory({ email, globalPermissions: fullPermissions }).create();
+    }
+    return await new UserFactory({ email, organization, permissions: fullPermissions }).create();
+}
+
+async function loginAs({ page, user }: { page: Page; user: User }) {
+    const token = await Token.createToken(user);
+    const tokenString = JSON.stringify(new TokenStruct(token).encode({ version: Version }));
+
+    if (STAMHOOFD.userMode === 'platform') {
+        await page.addInitScript(({ tokenString }) => {
+            window.localStorage.setItem('token-platform', tokenString);
+        }, { tokenString });
+    } else {
+        const organizationId = user.organizationId;
+        await page.addInitScript(({ organizationId, tokenString }) => {
+            if (organizationId) {
+                window.localStorage.setItem('token-' + organizationId, tokenString);
+            } else {
+                window.localStorage.setItem('token-platform', tokenString);
+            }
+        }, { organizationId, tokenString });
+    }
+}
+
+/** Navigate the admin dashboard to a webshop's orders table (works even when there are no orders yet). */
+async function openWebshopOrders(adminPage: Page, organization: Organization, webshopName: string) {
+    const dashboard = new DashboardPage(adminPage);
+    await dashboard.openOrganizationDashboard({ organizationUri: organization.uri });
+    await dashboard.openTab(DashboardTab.Webshops);
+    await adminPage.getByTestId('webshop-menu-item').filter({ hasText: webshopName }).click();
+    await adminPage.getByTestId('open-orders-button').click();
+    await adminPage.getByTestId('table').waitFor();
+}
+
+test.describe('Webshop customer fields (organization mode) @webshop-customer-fields', () => {
+    test.beforeAll(() => {
+        TestUtils.setPermanentEnvironment('userMode', 'organization');
+    });
+
+    test('only asks for birth day, gender and address when enabled', async ({ page }) => {
+        const organization = await createWebshopOrganization('CustFields');
+
+        // A shop with all fields disabled does not show them in the customer step
+        const disabled = await TestWebshops.create({
+            organization,
+            name: `Fields off ${WorkerData.id}`,
+            productCount: 1,
+            cartEnabled: false,
+            paymentMethods: [PaymentMethod.PointOfSale],
+        });
+
+        const offFlow = new WebshopOrderFlow(page, { cartEnabled: false });
+        await offFlow.goto(WorkerData.urls.webshopUri(disabled.webshop.uri));
+        await offFlow.addProduct('Product 1');
+        await offFlow.goToCheckout();
+        await offFlow.expectCustomerFields({ birthDay: false, gender: false, address: false });
+
+        // A shop with all fields enabled shows them
+        const enabled = await TestWebshops.create({
+            organization,
+            name: `Fields on ${WorkerData.id}`,
+            productCount: 1,
+            cartEnabled: false,
+            paymentMethods: [PaymentMethod.PointOfSale],
+            birthDayEnabled: true,
+            addressEnabled: true,
+            genderEnabled: true,
+        });
+
+        const onFlow = new WebshopOrderFlow(page, { cartEnabled: false });
+        await onFlow.goto(WorkerData.urls.webshopUri(enabled.webshop.uri));
+        await onFlow.addProduct('Product 1');
+        await onFlow.goToCheckout();
+        await onFlow.expectCustomerFields({ birthDay: true, gender: true, address: true });
+    });
+
+    test('stores birth day, gender and address for a webshop order', async ({ page }) => {
+        const organization = await createWebshopOrganization('CustFieldsWebshop');
+        const { webshop } = await TestWebshops.create({
+            organization,
+            name: `Webshop fields ${WorkerData.id}`,
+            productCount: 1,
+            cartEnabled: false,
+            paymentMethods: [PaymentMethod.PointOfSale],
+            birthDayEnabled: true,
+            addressEnabled: true,
+            genderEnabled: true,
+        });
+
+        const flow = new WebshopOrderFlow(page, { cartEnabled: false });
+        await flow.goto(WorkerData.urls.webshopUri(webshop.uri));
+        await flow.addProduct('Product 1');
+        await flow.goToCheckout();
+        await flow.fillCustomer({ birthDay: testBirthDay, gender: 'Female', address: testAddress });
+        await flow.selectPaymentMethod(PointOfSaleLabel);
+        await flow.confirmPayment();
+        await flow.expectOrderConfirmed();
+
+        // The confirmation page lists the filled-in information
+        const orderView = page.getByTestId('order-view');
+        await expect(orderView).toContainText('Paris');
+        await expect(orderView).toContainText('1990');
+        await expect(orderView).toContainText($t('%XM')); // "Vrouw"
+
+        // The fields are stored on the order in the database
+        const orders = await Order.select().where('webshopId', webshop.id).fetch();
+        expect(orders).toHaveLength(1);
+        const customer = orders[0].data.customer;
+        expect(customer.gender).toBe(Gender.Female);
+        expect(customer.address?.city).toBe('Paris');
+        expect(customer.birthDay?.getFullYear()).toBe(1990);
+    });
+
+    test('stores birth day, gender and address for a dashboard order', async ({ browser }) => {
+        const organization = await createWebshopOrganization('CustFieldsDash');
+        const { webshop } = await TestWebshops.create({
+            organization,
+            name: `Dashboard fields ${WorkerData.id}`,
+            productCount: 1,
+            cartEnabled: false,
+            paymentMethods: [PaymentMethod.PointOfSale],
+            birthDayEnabled: true,
+            addressEnabled: true,
+            genderEnabled: true,
+        });
+
+        const admin = await createAdmin(organization);
+        const adminContext = await browser.newContext();
+        const adminPage = await adminContext.newPage();
+        await loginAs({ page: adminPage, user: admin });
+
+        await openWebshopOrders(adminPage, organization, webshop.meta.name);
+
+        await new WebshopOrdersView(adminPage).addOrder({
+            firstName: 'Jane',
+            lastName: 'Doe',
+            email: 'jane.doe@test.be',
+            product: webshop.products[0],
+            paymentMethod: PaymentMethod.PointOfSale,
+            birthDay: testBirthDay,
+            gender: 'Male',
+            address: testAddress,
+        });
+
+        const orders = await Order.select().where('webshopId', webshop.id).fetch();
+        expect(orders).toHaveLength(1);
+        const customer = orders[0].data.customer;
+        expect(customer.firstName).toBe('Jane');
+        expect(customer.gender).toBe(Gender.Male);
+        expect(customer.address?.city).toBe('Paris');
+        expect(customer.birthDay?.getFullYear()).toBe(1990);
+
+        await adminContext.close();
+    });
+
+    test('syncs the delivery address to the customer address', async ({ page }) => {
+        const organization = await createWebshopOrganization('CustFieldsDelivery');
+        const { webshop } = await TestWebshops.create({
+            organization,
+            name: `Delivery fields ${WorkerData.id}`,
+            productCount: 1,
+            cartEnabled: false,
+            paymentMethods: [PaymentMethod.PointOfSale],
+            addressEnabled: true,
+            deliveryCountries: [Country.France],
+        });
+
+        const flow = new WebshopOrderFlow(page, { cartEnabled: false });
+        await flow.goto(WorkerData.urls.webshopUri(webshop.uri));
+        await flow.addProduct('Product 1');
+
+        // The delivery address is asked in its own step, before the customer step
+        await flow.fillDeliveryAddressStep(testAddress);
+
+        // The customer step does not ask for the address again (delivery already collected it)
+        await flow.expectCustomerFields({ birthDay: false, gender: false, address: false });
+        await flow.fillCustomer();
+        // For a delivery order the "point of sale" method is labelled "bij levering"
+        await flow.selectPaymentMethod('levering');
+        await flow.confirmPayment();
+        await flow.expectOrderConfirmed();
+
+        // The delivery address is copied onto the customer
+        const orders = await Order.select().where('webshopId', webshop.id).fetch();
+        expect(orders).toHaveLength(1);
+        const data = orders[0].data;
+        expect(data.address).not.toBeNull();
+        expect(data.customer.address).not.toBeNull();
+        expect(data.customer.address?.city).toBe('Paris');
+        expect(data.customer.address?.toString()).toBe(data.address?.toString());
+    });
+});


### PR DESCRIPTION
## What

Adds optional **birth day**, **address** and **gender** fields to the webshop customer.

- The webshop `Customer` structure gains `birthDay`, `address` and `gender` (mirroring `MemberDetails`), added as versioned fields (`...NextVersion`).
- `WebshopMetaData` gains `birthDayEnabled`, `addressEnabled` and `genderEnabled`, all defaulting to `false`.
- The fields are only asked when enabled, both in:
  - the **public webshop checkout** (customer step), and
  - the **manual dashboard order** flow (`EditOrderView`).
- The filled-in values are listed:
  - when viewing an order in the **dashboard** (`OrderView`), and
  - on the **webshop order confirmation** page.
- New toggles to enable the fields live in the webshop record settings.

### Delivery address syncing

When a delivery method is chosen, the delivery address is reused as the customer address so it is not asked twice (the customer-step address input is hidden and prefilled). Any delivery address is always copied onto the customer — even when `addressEnabled` is `false`.

## Tests

- `shared/structures/src/webshops/Checkout.test.ts` — unit coverage for `validateCustomer` (required/cleared per flag, gender reset, admin bypass) and the delivery → customer address copy.
- `tests/playwright/src/tests/webshop-customer-fields.spec.ts` — E2E: fields shown only when enabled, stored in the DB via both the webshop and the dashboard, and delivery-address syncing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786283908&installation_id=138085646&pr_number=593&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F593&signature=abbbd6a13b830e08cc14ada5dd42384cafa72d947af5d01ba0ea18d583634318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->