### PR TITLE
✨ Reconnect Vite HMR instead of full-reloading when Caddy drops the socket

### DIFF
--- a/frontend/shared/vite-config/hmrReconnectPlugin.runtime.test.ts
+++ b/frontend/shared/vite-config/hmrReconnectPlugin.runtime.test.ts
@@ -1,0 +1,201 @@
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+import { createServer } from 'vite';
+import hmrReconnectPlugin from './hmrReconnectPlugin.js';
+
+/**
+ * Unlike hmrReconnectPlugin.test.ts (which only checks the string surgery), this
+ * actually *runs* the patched client. It boots a real Vite dev server with the
+ * plugin, grabs the served & transformed `/@vite/client`, and executes it in a
+ * sandbox with a fake WebSocket so we can drive a disconnect and observe what
+ * the client does: it must reconnect (open a fresh HMR socket) instead of
+ * reloading the page, and the new socket must be wired to the message handler.
+ */
+
+type Listener = (event: unknown) => void;
+
+class MockWebSocket {
+    static instances: MockWebSocket[] = [];
+
+    static reset(): void {
+        MockWebSocket.instances = [];
+    }
+
+    static ofProtocol(protocol: string): MockWebSocket[] {
+        return MockWebSocket.instances.filter(ws => ws.protocol === protocol);
+    }
+
+    static last(protocol: string): MockWebSocket | undefined {
+        return MockWebSocket.ofProtocol(protocol).at(-1);
+    }
+
+    // Mirror the WebSocket readyState constants the client reads via `socket.OPEN`.
+    readonly CONNECTING = 0;
+    readonly OPEN = 1;
+    readonly CLOSING = 2;
+    readonly CLOSED = 3;
+
+    readyState = 0;
+    private readonly listeners: Record<string, Listener[]> = {};
+
+    constructor(public readonly url: string, public readonly protocol?: string) {
+        MockWebSocket.instances.push(this);
+    }
+
+    addEventListener(type: string, cb: Listener): void {
+        (this.listeners[type] ??= []).push(cb);
+    }
+
+    removeEventListener(type: string, cb: Listener): void {
+        this.listeners[type] = (this.listeners[type] ?? []).filter(fn => fn !== cb);
+    }
+
+    send(): void {}
+
+    close(): void {
+        this.readyState = this.CLOSED;
+    }
+
+    private emit(type: string, event: unknown): void {
+        for (const cb of [...(this.listeners[type] ?? [])]) {
+            cb(event);
+        }
+    }
+
+    /** Test helper: server accepted the socket. */
+    simulateOpen(): void {
+        this.readyState = this.OPEN;
+        this.emit('open', {});
+    }
+
+    /** Test helper: connection dropped (e.g. Caddy reload). */
+    simulateDrop(): void {
+        this.readyState = this.CLOSED;
+        this.emit('close', { wasClean: false });
+    }
+
+    /** Test helper: a message pushed by the server. */
+    simulateMessage(data: unknown): void {
+        this.emit('message', { data: JSON.stringify(data) });
+    }
+}
+
+/** Let queued microtasks and any setTimeout(0) work drain. */
+async function flush(rounds = 6): Promise<void> {
+    for (let i = 0; i < rounds; i++) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+}
+
+async function loadPatchedClient(): Promise<string> {
+    const server = await createServer({
+        configFile: false,
+        root: import.meta.dirname,
+        logLevel: 'silent',
+        optimizeDeps: { noDiscovery: true },
+        server: { middlewareMode: true, hmr: false, ws: false },
+        plugins: [hmrReconnectPlugin()],
+    });
+    try {
+        const result = await server.transformRequest('/@vite/client');
+        if (!result) {
+            throw new Error('Vite did not return a /@vite/client module');
+        }
+        return result.code;
+    } finally {
+        await server.close();
+    }
+}
+
+function runClient(code: string, reload: () => void): void {
+    // The served client has three ESM-only bits that a classic vm.Script can't
+    // parse: a side-effect `import "…/env.mjs"`, `import.meta`, and the trailing
+    // `export { … }`. Strip/stub them so we can run the (otherwise fully
+    // define-replaced) client in a sandbox.
+    const script = 'const __viteImportMeta = { url: "http://localhost:5173/@vite/client", env: { DEV: true, PROD: false, MODE: "development", BASE_URL: "/" } };\n'
+        + code
+            .replace(/^\s*import\s+["'][^"']+["'];?\s*$/gm, '')
+            .replace(/import\.meta/g, '__viteImportMeta')
+            .replace(/^export\s*\{[^}]*\};?\s*$/m, '');
+
+    const sandbox: Record<string, unknown> = {
+        console: { debug() {}, log() {}, info() {}, warn() {}, error() {} },
+        URL,
+        Blob,
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        queueMicrotask,
+        Promise,
+        WebSocket: MockWebSocket,
+        fetch: vi.fn(),
+        addEventListener() {},
+        removeEventListener() {},
+        document: {
+            visibilityState: 'visible',
+            addEventListener() {},
+            removeEventListener() {},
+            querySelector: () => null,
+            querySelectorAll: () => [] as unknown[],
+            createElement: () => ({
+                setAttribute() {}, addEventListener() {}, appendChild() {},
+                remove() {}, insertAdjacentElement() {}, cloneNode() { return this; },
+                style: {},
+            }),
+            head: { appendChild() {} },
+            body: { appendChild() {} },
+        },
+        location: { href: 'http://localhost:5173/', reload },
+    };
+    // The client reads `window`/`self` and checks `"document" in globalThis`.
+    sandbox.window = sandbox;
+    sandbox.self = sandbox;
+
+    vm.createContext(sandbox);
+    new vm.Script(script, { filename: 'vite-client-patched.js' }).runInContext(sandbox as vm.Context);
+}
+
+describe('hmrReconnectPlugin (runtime)', () => {
+    it('reconnects the HMR socket instead of reloading the page', async () => {
+        const code = await loadPatchedClient();
+        expect(code).toContain('transport.connect(createHMRHandler(handleMessage))');
+
+        MockWebSocket.reset();
+        const reload = vi.fn();
+        runClient(code, reload);
+
+        // The client opens its HMR socket on load.
+        await flush();
+        const firstSocket = MockWebSocket.last('vite-hmr');
+        expect(firstSocket).toBeDefined();
+        firstSocket!.simulateOpen();
+        await flush();
+
+        const hmrSocketsBefore = MockWebSocket.ofProtocol('vite-hmr').length;
+
+        // Simulate Caddy tearing down the proxied WebSocket.
+        firstSocket!.simulateDrop();
+        await flush();
+
+        // It should be probing the server (vite-ping), NOT reloading.
+        const pingSocket = MockWebSocket.last('vite-ping');
+        expect(pingSocket).toBeDefined();
+        expect(reload).not.toHaveBeenCalled();
+
+        // Server is reachable again: the ping succeeds.
+        pingSocket!.simulateOpen();
+        await flush();
+
+        // A brand new HMR socket must have been opened, and still no reload.
+        expect(MockWebSocket.ofProtocol('vite-hmr').length).toBe(hmrSocketsBefore + 1);
+        expect(reload).not.toHaveBeenCalled();
+
+        // The reconnected socket is live: a server message is handled without error.
+        const secondSocket = MockWebSocket.last('vite-hmr');
+        expect(secondSocket).not.toBe(firstSocket);
+        expect(() => secondSocket!.simulateMessage({ type: 'connected' })).not.toThrow();
+        await flush();
+        expect(reload).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/shared/vite-config/hmrReconnectPlugin.test.ts
+++ b/frontend/shared/vite-config/hmrReconnectPlugin.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import hmrReconnectPlugin from './hmrReconnectPlugin.js';
+
+const require = createRequire(import.meta.url);
+
+// The actual dev client shipped by the installed Vite version. Running the
+// transform against this (rather than a hand-written fixture) is the whole
+// point: it fails loudly if a Vite upgrade renames the internals or moves the
+// reload branch, i.e. exactly the "plugin silently stopped working" case.
+const viteClientPath = path.join(path.dirname(require.resolve('vite/package.json')), 'dist/client/client.mjs');
+const realClient = readFileSync(viteClientPath, 'utf-8');
+
+type TransformFn = (this: { warn: (msg: string) => void }, code: string, id: string) => string | undefined | void;
+
+function getTransform(): TransformFn {
+    const transform = hmrReconnectPlugin().transform;
+    if (typeof transform !== 'function') {
+        throw new Error('Expected hmrReconnectPlugin().transform to be a function');
+    }
+    return transform as unknown as TransformFn;
+}
+
+function runTransform(code: string, id: string, ctx: { warn: (msg: string) => void } = { warn: () => {} }): string | undefined | void {
+    return getTransform().call(ctx, code, id);
+}
+
+const countReloads = (code: string) => code.match(/location\.reload\(\)/g)?.length ?? 0;
+const disconnectReloadPattern = /waitForSuccessfulPing\([^)]*\);\s*location\.reload\(\);/;
+
+describe('hmrReconnectPlugin', () => {
+    it('replaces the disconnect-branch reload in the real Vite client', () => {
+        // Sanity-check our assumptions about the client we are patching: the
+        // identifiers we inject must already exist at module scope, and the
+        // reload branch must be there to replace.
+        expect(realClient).toContain('transport.connect(createHMRHandler(handleMessage))');
+        expect(realClient).toMatch(disconnectReloadPattern);
+
+        const result = runTransform(realClient, viteClientPath);
+
+        expect(typeof result).toBe('string');
+        const patched = result as string;
+
+        // The disconnect branch now reconnects instead of reloading.
+        expect(patched).toContain('transport.connect(createHMRHandler(handleMessage))');
+        expect(patched).not.toMatch(disconnectReloadPattern);
+
+        // Only the disconnect reload is touched; the error-overlay and
+        // debounced full-reload branches keep their own location.reload().
+        expect(countReloads(patched)).toBe(countReloads(realClient) - 1);
+    });
+
+    it('leaves non-client modules untouched', () => {
+        const code = 'export const answer = 42; location.reload();';
+        expect(runTransform(code, '/src/some-app-module.ts')).toBeUndefined();
+    });
+
+    it('warns and makes no change when the reload branch is missing', () => {
+        const warn = vi.fn();
+        const result = runTransform('const notTheClient = true;', viteClientPath, { warn });
+
+        expect(result).toBeUndefined();
+        expect(warn).toHaveBeenCalledOnce();
+    });
+});

--- a/frontend/shared/vite-config/hmrReconnectPlugin.ts
+++ b/frontend/shared/vite-config/hmrReconnectPlugin.ts
@@ -1,0 +1,43 @@
+import type { Plugin } from 'vite';
+
+/**
+ * Vite's HMR client has no reconnect logic: when the HMR WebSocket drops
+ * (e.g. Caddy reloads its config and tears down the proxied connection), the
+ * client polls the server and then does a full `location.reload()`. That makes
+ * every open tab reload whenever Caddy restarts.
+ *
+ * This patches the dev client so that, on disconnect, it transparently
+ * re-opens the HMR socket instead of reloading the page. Everything it needs
+ * (`transport`, `createHMRHandler`, `handleMessage`) already lives at module
+ * scope in Vite's client, so the change is a single statement swap.
+ *
+ * If the reconnect itself fails, the fresh socket's close handler runs the same
+ * branch again, so it is self-healing.
+ */
+export default function hmrReconnectPlugin(): Plugin {
+    return {
+        name: 'stamhoofd:hmr-reconnect',
+        apply: 'serve',
+        transform(code, id) {
+            if (!id.includes('vite/dist/client/client.mjs')) {
+                return;
+            }
+
+            // Only the disconnect branch reloads right after a successful ping;
+            // the other `location.reload()` calls (error overlay, debounced
+            // full-reload) are intentionally left untouched.
+            const patched = code.replace(
+                /(await waitForSuccessfulPing\([^)]*\);\s*)location\.reload\(\);/,
+                '$1console.log("[vite] reconnecting HMR socket…");'
+                + 'transport.connect(createHMRHandler(handleMessage));',
+            );
+
+            if (patched === code) {
+                this.warn('hmr-reconnect: could not find the reload branch in Vite\'s client — internals may have changed. Leaving it unpatched.');
+                return;
+            }
+
+            return patched;
+        },
+    };
+}

--- a/frontend/shared/vite-config/package.json
+++ b/frontend/shared/vite-config/package.json
@@ -5,7 +5,11 @@
     "type": "module",
     "exports": {
         ".": "./vite.config.shared.ts",
-        "./svgNamespacePlugin": "./svgNamespacePlugin.ts"
+        "./svgNamespacePlugin": "./svgNamespacePlugin.ts",
+        "./hmrReconnectPlugin": "./hmrReconnectPlugin.ts"
+    },
+    "scripts": {
+        "test": "vitest run"
     },
     "dependencies": {
         "@stamhoofd/assets": "*",

--- a/frontend/shared/vite-config/vite.config.shared.ts
+++ b/frontend/shared/vite-config/vite.config.shared.ts
@@ -8,6 +8,7 @@ import postcssDiscardDulicates from 'postcss-discard-duplicates';
 import type { ViteUserConfig } from 'vitest/config';
 import iconConfig from '@stamhoofd/assets/images/icons/icons.font.js';
 import svgNamespacePlugin from '@stamhoofd/vite-config/svgNamespacePlugin';
+import hmrReconnectPlugin from '@stamhoofd/vite-config/hmrReconnectPlugin';
 
 // https://vitejs.dev/config/
 export async function buildConfig(options: { name: 'web-app' | 'webshop' | 'calculator'; port: number; clientFiles?: string[]; frontendDir: string }): Promise<ViteUserConfig> {
@@ -83,6 +84,9 @@ export async function buildConfig(options: { name: 'web-app' | 'webshop' | 'calc
             ],
         },
         plugins: [
+            // Keeps the page from full-reloading when the HMR socket drops
+            // (e.g. on a Caddy config reload). Dev-only via apply: 'serve'.
+            hmrReconnectPlugin(),
             viteSvgToWebfont({
                 ...iconConfig,
                 context: resolve(frontendDir, './shared/assets/images/icons/'),

--- a/frontend/shared/vite-config/vitest.config.ts
+++ b/frontend/shared/vite-config/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        watch: false,
+        globals: true,
+        environment: 'node',
+        root: import.meta.dirname,
+    },
+});

--- a/shared/cli/src/runtime/monorepo-runner.ts
+++ b/shared/cli/src/runtime/monorepo-runner.ts
@@ -65,6 +65,7 @@ export type UnitTestPackage = {
 export const unitTestPackages: UnitTestPackage[] = [
     { name: 'structures', path: 'shared/structures', needsDatabase: false },
     { name: 'object-differ', path: 'shared/object-differ', needsDatabase: false },
+    { name: 'vite-config', path: 'frontend/shared/vite-config', needsDatabase: false },
     { name: 'sgv', path: 'shared/sgv', needsDatabase: false },
     { name: 'eslint', path: 'shared/eslint', needsDatabase: false },
     { name: 'utility', path: 'shared/utility', needsDatabase: false },


### PR DESCRIPTION
## Problem

In local development, Caddy reverse-proxies the Vite dev servers. When Caddy reloads its config it drops the proxied HMR WebSocket, and the stock Vite client has no reconnect logic — its only recovery is a full `location.reload()`. So every Caddy reload reloads every open tab, losing app state.

## Change

`hmrReconnectPlugin` — a dev-only Vite plugin (`apply: 'serve'`) that patches the served `/@vite/client` via the `transform` hook. It string-replaces the `location.reload()` in the `vite:ws:disconnect` branch with `transport.connect(createHMRHandler(handleMessage))` (all three identifiers already exist at module scope in Vite's client), so on disconnect the client re-opens the HMR socket instead of reloading. `waitForSuccessfulPing` still gates the reconnect on the server being reachable again, so it naturally waits out the Caddy reload.

- Wired into the dev `plugins` array in `vite.config.shared.ts`.
- **Fails safe:** only the disconnect-branch reload is touched (the error-overlay and debounced full-reload calls are left intact). If a future Vite version moves/renames the matched code, the regex misses → the transform `warn`s and no-ops → stock reload behaviour.

## Tests

`frontend/shared/vite-config` is registered as a `stam test` unit package, runnable via `yarn stam test vite-config`:

- **`hmrReconnectPlugin.test.ts`** — runs the transform against the *real* installed `node_modules/vite/dist/client/client.mjs`, so a Vite upgrade that breaks the patch fails loudly instead of silently no-oping. Also covers the non-client and warn-and-no-op paths.
- **`hmrReconnectPlugin.runtime.test.ts`** — boots a real Vite server, extracts the served + transformed client, and executes it in a Node `vm` sandbox with a mock WebSocket to drive disconnect → ping → reconnect. Asserts no `location.reload()`, that a fresh HMR socket opens, and that the reconnected socket handles a message. Verified to fail on the unpatched client.

## Known limitations

- Assumes the Vite dev-server process keeps running (true for a Caddy reload). If Vite itself restarts, reconnecting instead of reloading can mean missed updates until a manual refresh.
- Minor, bounded, dev-only: each reconnect leaks one no-op `setInterval` (Vite only clears its ping interval on explicit `disconnect()`), harmless since it's guarded by `readyState === OPEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786293091&installation_id=138085646&pr_number=595&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F595&signature=0faa1d5ec4efad1bbcd20e3d6010a8a30739feae5e8ec4a584685d10831d1c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->