### PR TITLE
🐛 Fix stale filter keys surviving platform cache merge

### DIFF
--- a/backend/app/api/package.json
+++ b/backend/app/api/package.json
@@ -53,7 +53,7 @@
         "@bwip-js/node": "4.11.1",
         "@mollie/api-client": "4.5.0",
         "@simonbackx/simple-database": "1.37.1",
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-endpoints": "1.21.1",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-logging": "1.0.1",

--- a/backend/app/backup/package.json
+++ b/backend/app/backup/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "3.1068.0",
         "@simonbackx/simple-database": "1.37.1",
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-endpoints": "1.21.1",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-logging": "1.0.1",

--- a/backend/app/renderer/package.json
+++ b/backend/app/renderer/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@simonbackx/simple-database": "1.37.1",
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-endpoints": "1.21.1",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-logging": "1.0.1",

--- a/backend/shared/models/package.json
+++ b/backend/shared/models/package.json
@@ -32,7 +32,7 @@
         "@aws-sdk/client-sesv2": "3.1068.0",
         "@bwip-js/node": "4.11.1",
         "@mollie/api-client": "4.5.0",
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-endpoints": "1.21.1",
         "@simonbackx/simple-errors": "1.5.0",
         "argon2": "0.44.0",

--- a/backend/shared/sql/package.json
+++ b/backend/shared/sql/package.json
@@ -15,7 +15,7 @@
         "test:coverage": "vitest --coverage"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-logging": "1.0.1",
         "lru-cache": "11.5.1"

--- a/frontend/app/admin/package.json
+++ b/frontend/app/admin/package.json
@@ -12,7 +12,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-networking": "1.23.0",
         "@simonbackx/vue-app-navigation": "2.23.0",

--- a/frontend/app/auto/package.json
+++ b/frontend/app/auto/package.json
@@ -12,7 +12,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-networking": "1.23.0",
         "@simonbackx/vue-app-navigation": "2.23.0",

--- a/frontend/app/dashboard/package.json
+++ b/frontend/app/dashboard/package.json
@@ -16,7 +16,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-networking": "1.23.0",
         "@simonbackx/vue-app-navigation": "2.23.0",

--- a/frontend/app/mobile/package.json
+++ b/frontend/app/mobile/package.json
@@ -29,7 +29,7 @@
     "@capacitor/share": "^8.0.0",
     "@capacitor/status-bar": "^8.0.0",
     "@capgo/capacitor-updater": "8.49.4",
-    "@simonbackx/simple-encoding": "2.26.10",
+    "@simonbackx/simple-encoding": "2.26.11",
     "@simonbackx/simple-networking": "1.23.0",
     "@simonbackx/vue-app-navigation": "2.23.0",
     "@stamhoofd/assets": "*",

--- a/frontend/app/webshop/package.json
+++ b/frontend/app/webshop/package.json
@@ -16,7 +16,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/vue-app-navigation": "2.23.0",
         "@stamhoofd/assets": "*",

--- a/frontend/shared/components/package.json
+++ b/frontend/shared/components/package.json
@@ -19,7 +19,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-networking": "1.23.0",
         "@simonbackx/vue-app-navigation": "2.23.0",

--- a/frontend/shared/excel-export/package.json
+++ b/frontend/shared/excel-export/package.json
@@ -19,7 +19,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/vue-app-navigation": "2.23.0",
         "@stamhoofd/components": "*",
         "@stamhoofd/networking": "*",

--- a/frontend/shared/networking/package.json
+++ b/frontend/shared/networking/package.json
@@ -19,7 +19,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-networking": "1.23.0",
         "@simonbackx/vue-app-navigation": "2.23.0",

--- a/frontend/shared/sgv/package.json
+++ b/frontend/shared/sgv/package.json
@@ -20,7 +20,7 @@
         "typecheck": "vue-tsc --noEmit"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@simonbackx/simple-networking": "1.23.0",
         "@simonbackx/vue-app-navigation": "2.23.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typecheck": "lerna run typecheck --"
   },
   "dependencies": {
-    "@simonbackx/simple-encoding": "2.26.10",
+    "@simonbackx/simple-encoding": "2.26.11",
     "@simonbackx/simple-errors": "1.5.0",
     "@simonbackx/simple-networking": "1.23.0",
     "@simonbackx/vue-app-navigation": "2.23.0",

--- a/shared/object-differ/package.json
+++ b/shared/object-differ/package.json
@@ -24,7 +24,7 @@
         "test:coverage": "vitest --coverage"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10"
+        "@simonbackx/simple-encoding": "2.26.11"
     },
     "devDependencies": {
         "@stamhoofd/test-utils": "2.133.0",

--- a/shared/sgv/package.json
+++ b/shared/sgv/package.json
@@ -28,7 +28,7 @@
         "test": "vitest"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10",
+        "@simonbackx/simple-encoding": "2.26.11",
         "@simonbackx/simple-errors": "1.5.0",
         "@stamhoofd/structures": "2.133.0",
         "@stamhoofd/types": "2.133.0",

--- a/shared/structures/package.json
+++ b/shared/structures/package.json
@@ -28,7 +28,7 @@
         "test:coverage": "vitest --coverage"
     },
     "dependencies": {
-        "@simonbackx/simple-encoding": "2.26.10"
+        "@simonbackx/simple-encoding": "2.26.11"
     },
     "devDependencies": {
         "@simonbackx/simple-errors": "1.5.0",

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -19,6 +19,7 @@
         "@stamhoofd/structures": "*",
         "@stamhoofd/types": "*",
         "@stamhoofd/utility": "*",
+        "@simonbackx/simple-encoding": "*",
         "pino": "10.1.1"
     },
     "devDependencies": {

--- a/tests/playwright/src/tests/platform-cache-filter-merge.spec.ts
+++ b/tests/playwright/src/tests/platform-cache-filter-merge.spec.ts
@@ -1,0 +1,138 @@
+// test should always be imported first
+import { setup, test } from '../test-fixtures/platform.js';
+setup();
+
+// other imports
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { ObjectData, VersionBox, VersionBoxDecoder } from '@simonbackx/simple-encoding';
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { Platform } from '@stamhoofd/models';
+import type { StamhoofdFilter } from '@stamhoofd/structures';
+import { Platform as PlatformStruct, PropertyFilter, RecordCategory, Version } from '@stamhoofd/structures';
+import { WorkerData } from '../helpers/index.js';
+
+/**
+ * Regression coverage for the platform cache merge.
+ *
+ * When a Platform is already cached in localStorage and the app boots, it loads that cached
+ * Platform and then merges the fresh Platform received from the backend on top of it using
+ * `deepSet` (see PlatformManager.forceUpdate -> `this.$platform.deepSet(...)`), saving the
+ * merged result back to localStorage.
+ *
+ * A StamhoofdFilter is a plain-object dictionary (e.g. `{ $and: [...] }`) whose key set is data.
+ * `deepSet` used to copy over the keys of the *new* value only, never removing keys that existed on
+ * the cached filter but not the new one. So when the record-category filter was simplified from a
+ * two-condition `$and` to a single bare condition (the `$and` wrapper being dropped), the stale
+ * `$and` key survived the merge and the filter ended up as a mix of the old and the new state.
+ *
+ * This was fixed in `@simonbackx/simple-encoding` (deepSet now syncs the key set of plain-object
+ * dictionaries); these tests guard against a regression.
+ */
+test.describe('[Regression] Platform cache filter merge @platform-filter-merge', () => {
+    const CATEGORY_ID = 'deepset-filter-merge-category';
+
+    // Two independent record-category filter conditions.
+    const conditionA: StamhoofdFilter = { age: { $gt: 18 } };
+    const conditionB: StamhoofdFilter = { gender: { $eq: 'male' } };
+
+    test.afterEach(async () => {
+        await WorkerData.resetDatabase();
+    });
+
+    /**
+     * - Configure the backend platform so `/platform` serves `backendFilter`.
+     * - Seed localStorage with a cached platform that is identical to the backend one, except that
+     *   its record-category filter is `cachedFilter` (the stale state).
+     * - Boot the dashboard so PlatformManager loads the cached platform, fetches the fresh one and
+     *   merges it with `deepSet`, then persists the merged platform back to localStorage.
+     * - Return the merged record-category `enabledWhen` filter that ended up in localStorage.
+     */
+    async function mergeCachedPlatform(options: {
+        page: Page;
+        cachedFilter: StamhoofdFilter;
+        backendFilter: StamhoofdFilter;
+    }): Promise<StamhoofdFilter | null | undefined> {
+        // 1. Make the backend serve the fresh (new) filter.
+        const platform = await Platform.getForEditing();
+        platform.config.recordsConfiguration.recordCategories = [
+            RecordCategory.create({
+                id: CATEGORY_ID,
+                filter: new PropertyFilter(options.backendFilter, null),
+            }),
+        ];
+        await platform.save();
+
+        // 2. Build the cached platform: identical to the backend one, but with the stale filter.
+        const cachedStruct = (await Platform.getSharedPrivateStruct()).clone();
+        const cachedCategory = cachedStruct.config.recordsConfiguration.recordCategories.find(c => c.id === CATEGORY_ID);
+        if (!cachedCategory) {
+            throw new Error('Record category not found in cached platform struct');
+        }
+        cachedCategory.filter = new PropertyFilter(options.cachedFilter, null);
+        const cachedBlob = JSON.stringify(new VersionBox(cachedStruct).encode({ version: Version }));
+
+        // 3. Seed the cached platform in localStorage before the app boots.
+        await options.page.addInitScript((blob) => {
+            window.localStorage.setItem('platform', blob);
+        }, cachedBlob);
+
+        // 4. Boot the dashboard. This triggers the background platform fetch + deepSet merge.
+        await options.page.goto(WorkerData.urls.dashboard);
+
+        // 5. The fresh platform is fetched in the background and merged onto the cached one with
+        // deepSet, after which the merged platform is persisted back to localStorage. Wait until
+        // that write lands (the stored blob changes), then read and decode it.
+        const deadline = Date.now() + 30_000;
+        let mergedBlob: string | null = null;
+        while (Date.now() < deadline) {
+            const raw = await options.page.evaluate(() => window.localStorage.getItem('platform'));
+            if (raw && raw !== cachedBlob) {
+                mergedBlob = raw;
+                break;
+            }
+            await options.page.waitForTimeout(200);
+        }
+
+        if (!mergedBlob) {
+            throw new Error('Merged platform was not written back to localStorage in time');
+        }
+
+        const decoded = new VersionBoxDecoder(PlatformStruct as Decoder<PlatformStruct>)
+            .decode(new ObjectData(JSON.parse(mergedBlob), { version: 0 }));
+        const mergedCategory = decoded.data.config.recordsConfiguration.recordCategories.find(c => c.id === CATEGORY_ID);
+        return mergedCategory?.filter?.enabledWhen;
+    }
+
+    /**
+     * The regression: the cached filter is a two-condition `$and`, the fresh filter is a single bare
+     * condition (the `$and` wrapper dropped). After the merge the filter must equal the fresh one -
+     * before the fix the stale `$and` key survived, leaving the merged filter as a mix of both.
+     */
+    test('replaces a two-condition $and filter with a single bare condition', async ({ page }) => {
+        const merged = await mergeCachedPlatform({
+            page,
+            cachedFilter: { $and: [conditionA, conditionB] },
+            backendFilter: conditionA,
+        });
+
+        expect(merged).toEqual(conditionA);
+    });
+
+    /**
+     * Control: the cached filter is a two-condition `$and`, the fresh filter is a single-condition
+     * `$and`. Here the top-level `$and` key still exists on the new filter, so deepSet replaces the
+     * array in place and the merge is correct. This proves the harness reports a real pass when the
+     * merge behaves correctly (and isn't just failing for infrastructure reasons).
+     */
+    test('replaces a two-condition $and filter with a single-condition $and filter', async ({ page }) => {
+        const backendFilter: StamhoofdFilter = { $and: [conditionA] };
+        const merged = await mergeCachedPlatform({
+            page,
+            cachedFilter: { $and: [conditionA, conditionB] },
+            backendFilter,
+        });
+
+        expect(merged).toEqual(backendFilter);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,10 +2283,10 @@
     "@simonbackx/simple-logging" "^1.0.0"
     mysql2 "3.14.1"
 
-"@simonbackx/simple-encoding@2.26.10":
-  version "2.26.10"
-  resolved "https://registry.yarnpkg.com/@simonbackx/simple-encoding/-/simple-encoding-2.26.10.tgz#e09795c58428bd960bc78845a5c1f57a883446a3"
-  integrity sha512-vneA1iv1Lz3sQDBwRykxg79Z3UBpEMpOrQcwwBoXhESbpcoOFRJHE0Uc1GT/PLBbMVK67LV0aa2dg51ngBc6LQ==
+"@simonbackx/simple-encoding@*", "@simonbackx/simple-encoding@2.26.11":
+  version "2.26.11"
+  resolved "https://registry.yarnpkg.com/@simonbackx/simple-encoding/-/simple-encoding-2.26.11.tgz#9f134079ff859a92c5370a29f2a98877ae999884"
+  integrity sha512-elAmHQMs6J0cmqOG3X7II9DbPg05wK7CP0n52hR5/hYVCIypCHkpM8aKsOdLQNfM17vSnNH9+O7vhDhpniOuJQ==
 
 "@simonbackx/simple-endpoints@1.21.1":
   version "1.21.1"


### PR DESCRIPTION
## Problem

When a Platform is already cached in `localStorage` and the app boots, it loads that cached Platform and then merges the fresh Platform from the backend on top of it with `deepSet` (`PlatformManager.forceUpdate` → `this.$platform.deepSet(...)`), saving the merged result back to `localStorage`.

Record-category filters are plain-object `StamhoofdFilter`s whose key set is data. `deepSet` only copied over the keys of the *new* value and never removed keys that existed on the cached filter but not the new one. So when a filter was simplified from a two-condition `{ $and: [a, b] }` to a single bare `{ age: {...} }` condition (the `$and` wrapper dropped), the stale `$and` key survived the merge and the record category ended up with a filter that was a **mix of the old and new state**.

## Fix

Root cause was in `@simonbackx/simple-encoding`'s `deepSet`. Fixed upstream in **2.26.11**: for two plain-object dictionaries, `deepSet` now syncs the key set — it still reuses the `base` reference and merges nested values, but also removes base-only data keys (getters/setters/methods are left untouched). Class instances (AutoEncoders) and cross-prototype merges are unchanged.

This PR bumps `@simonbackx/simple-encoding` `2.26.10` → `2.26.11` across the workspace.

## Tests

Adds a Playwright regression test (`platform-cache-filter-merge.spec.ts`, `@platform-filter-merge`) that seeds an older Platform into `localStorage`, boots the dashboard so the real `deepSet` merge + `savePlatform` runs, and reads the merged filter back:

- **regression**: `{ $and: [A, B] }` → bare `{ age: {...} }` now yields exactly `{ age: {...} }` (before the bump it kept the stale `$and`)
- **control**: `{ $and: [A, B] }` → `{ $and: [A] }` still merges correctly

Both pass on `2.26.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786293606&installation_id=138085646&pr_number=596&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F596&signature=d99963f07d80a2353bdc633814471ecadc8a2aea3553794a1783b17e0d8b0837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->