### PR TITLE
✨ Prevent adding incompatible platform membership types

### DIFF
--- a/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.test.ts
@@ -3,10 +3,10 @@ import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray, PatchMap } from '@simonbackx/simple-encoding';
 import type { Endpoint } from '@simonbackx/simple-endpoints';
 import { Request } from '@simonbackx/simple-endpoints';
-import { GroupFactory, Member, MemberFactory, OrganizationFactory, OrganizationTagFactory, Platform, RegistrationFactory, Token, UserFactory } from '@stamhoofd/models';
+import { GroupFactory, Member, MemberFactory, MemberPlatformMembership, OrganizationFactory, OrganizationTagFactory, Platform, RegistrationFactory, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
 import { SQL } from '@stamhoofd/sql';
 import type { PatchAnswers } from '@stamhoofd/structures';
-import { Address, EmergencyContact, MemberDetails, MemberWithRegistrationsBlob, OrganizationMetaData, OrganizationRecordsConfiguration, Parent, PermissionLevel, Permissions, PermissionsResourceType, RecordCategory, RecordSettings, RecordTextAnswer, ResourcePermissions, ReviewTime, ReviewTimes, TranslatedString, UitpasNumberDetails, UitpasSocialTariff, UitpasSocialTariffStatus, Version } from '@stamhoofd/structures';
+import { Address, EmergencyContact, MemberDetails, MemberPlatformMembership as MemberPlatformMembershipStruct, MemberWithRegistrationsBlob, OrganizationMetaData, OrganizationRecordsConfiguration, Parent, PermissionLevel, Permissions, PermissionsResourceType, PlatformMembershipType, PlatformMembershipTypeConfig, RecordCategory, RecordSettings, RecordTextAnswer, ResourcePermissions, ReviewTime, ReviewTimes, TranslatedString, UitpasNumberDetails, UitpasSocialTariff, UitpasSocialTariffStatus, Version } from '@stamhoofd/structures';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { Country } from '@stamhoofd/types/Country';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
@@ -4032,6 +4032,136 @@ describe('Endpoint.PatchOrganizationMembersEndpoint', () => {
                     expect(result.body.members[0].details.uitpasNumberDetails?.socialTariff?.status).toEqual(UitpasSocialTariffStatus.Active);
                 });
             });
+        });
+    });
+
+    describe('Incompatible platform membership types', () => {
+        async function setup({ incompatibleWithB, existingRange, putRange }: {
+            incompatibleWithB: boolean;
+            existingRange?: { startDate: Date; endDate: Date };
+            putRange?: { startDate: Date; endDate: Date };
+        }) {
+            const period = await new RegistrationPeriodFactory({
+                startDate: new Date(2024, 0, 1, 0, 0, 0, 0),
+                endDate: new Date(2024, 11, 31, 23, 59, 59, 0),
+            }).create();
+
+            const organization = await new OrganizationFactory({ period }).create();
+
+            const typeB = PlatformMembershipType.create({
+                name: 'Type B',
+                periods: new Map([
+                    [period.id, PlatformMembershipTypeConfig.create({
+                        startDate: period.startDate,
+                        endDate: period.endDate,
+                    })],
+                ]),
+            });
+
+            const typeA = PlatformMembershipType.create({
+                name: 'Type A',
+                incompatibleMembershipTypeIds: incompatibleWithB ? [typeB.id] : [],
+                periods: new Map([
+                    [period.id, PlatformMembershipTypeConfig.create({
+                        startDate: period.startDate,
+                        endDate: period.endDate,
+                    })],
+                ]),
+            });
+
+            const platform = await Platform.getForEditing();
+            platform.periodId = period.id;
+            platform.config.membershipTypes = [typeA, typeB];
+            await platform.save();
+
+            const user = await new UserFactory({
+                permissions: Permissions.create({ level: PermissionLevel.Full }),
+                organization,
+            }).create();
+            const token = await Token.createToken(user);
+
+            const member = await new MemberFactory({ organization }).create();
+            const group = await new GroupFactory({ organization, period }).create();
+            await new RegistrationFactory({ member, group }).create();
+
+            // The member already has a membership of type B in this period
+            const existing = new MemberPlatformMembership();
+            existing.memberId = member.id;
+            existing.membershipTypeId = typeB.id;
+            existing.organizationId = organization.id;
+            existing.periodId = period.id;
+            existing.startDate = existingRange?.startDate ?? period.startDate;
+            existing.endDate = existingRange?.endDate ?? period.endDate;
+            await existing.save();
+
+            const arr: Body = new PatchableArray();
+            const memberPatch = MemberWithRegistrationsBlob.patch({ id: member.id });
+            memberPatch.platformMemberships.addPut(MemberPlatformMembershipStruct.create({
+                memberId: member.id,
+                membershipTypeId: typeA.id,
+                organizationId: organization.id,
+                periodId: period.id,
+                startDate: putRange?.startDate ?? period.startDate,
+                endDate: putRange?.endDate ?? period.endDate,
+            }));
+            arr.addPatch(memberPatch);
+
+            const request = Request.buildJson('PATCH', baseUrl, organization.getApiHost(), arr);
+            request.headers.authorization = 'Bearer ' + token.accessToken;
+
+            return { period, organization, typeA, typeB, member, request };
+        }
+
+        test('Blocks adding a membership type the member already has an incompatible type for in the same period', async () => {
+            const { typeA, member, request } = await setup({ incompatibleWithB: true });
+
+            await expect(testServer.test(endpoint, request)).rejects.toThrow(STExpect.simpleError({
+                code: 'invalid_field',
+                field: 'membershipTypeId',
+                message: 'Incompatible membership type',
+            }));
+
+            // The incompatible membership was not created
+            const memberships = await MemberPlatformMembership.select()
+                .where('memberId', member.id)
+                .where('membershipTypeId', typeA.id)
+                .where('deletedAt', null)
+                .fetch();
+            expect(memberships.length).toBe(0);
+        });
+
+        test('Allows adding a membership type that is not marked incompatible with a type the member already has', async () => {
+            const { typeA, member, request } = await setup({ incompatibleWithB: false });
+
+            const result = await testServer.test(endpoint, request);
+            expect(result.status).toBe(200);
+
+            const memberships = await MemberPlatformMembership.select()
+                .where('memberId', member.id)
+                .where('membershipTypeId', typeA.id)
+                .where('deletedAt', null)
+                .fetch();
+            expect(memberships.length).toBe(1);
+        });
+
+        test('Allows adding an incompatible membership type when the dates do not overlap', async () => {
+            const { typeA, member, request } = await setup({
+                incompatibleWithB: true,
+                // Existing membership covers the first half of the period
+                existingRange: { startDate: new Date(2024, 0, 1, 0, 0, 0, 0), endDate: new Date(2024, 5, 30, 23, 59, 59, 0) },
+                // New membership covers the second half, so there is no overlap
+                putRange: { startDate: new Date(2024, 6, 1, 0, 0, 0, 0), endDate: new Date(2024, 11, 31, 23, 59, 59, 0) },
+            });
+
+            const result = await testServer.test(endpoint, request);
+            expect(result.status).toBe(200);
+
+            const memberships = await MemberPlatformMembership.select()
+                .where('memberId', member.id)
+                .where('membershipTypeId', typeA.id)
+                .where('deletedAt', null)
+                .fetch();
+            expect(memberships.length).toBe(1);
         });
     });
 });

--- a/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.ts
@@ -603,7 +603,7 @@ export class PatchOrganizationMembersEndpoint extends Endpoint<Params, Query, Bo
                             code: 'invalid_field',
                             field: 'membershipTypeId',
                             message: 'Incompatible membership type',
-                            human: $t('Dit lid heeft in deze periode al een aansluiting die niet gecombineerd kan worden met deze aansluiting.'),
+                            human: $t('Dit lid heeft al een aansluiting die niet gecombineerd kan worden met deze aansluiting.'),
                         });
                     }
                 }

--- a/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/PatchOrganizationMembersEndpoint.ts
@@ -67,6 +67,25 @@ export const duplicateCheckLimiter = new RateLimiter({
 });
 
 /**
+ * A where clause that matches memberships whose [startDate, endDate] range overlaps
+ * with the given [startDate, endDate] range.
+ */
+function membershipDateRangeOverlaps(startDate: Date, endDate: Date) {
+    return SQL.where(
+        SQL.where('startDate', SQLWhereSign.LessEqual, startDate)
+            .and('endDate', SQLWhereSign.GreaterEqual, startDate),
+    )
+        .or(
+            SQL.where('startDate', SQLWhereSign.LessEqual, endDate)
+                .and('endDate', SQLWhereSign.GreaterEqual, endDate),
+        )
+        .or(
+            SQL.where('startDate', SQLWhereSign.GreaterEqual, startDate)
+                .and('endDate', SQLWhereSign.LessEqual, endDate),
+        );
+}
+
+/**
  * One endpoint to create, patch and delete members and their registrations and payments
  */
 
@@ -568,26 +587,34 @@ export class PatchOrganizationMembersEndpoint extends Endpoint<Params, Query, Bo
                 // Correct price and dates
                 await membership.calculatePrice(member);
 
+                // Block if the member already has an incompatible membership type overlapping these dates.
+                // Uses the requested dates (like the duplicate check below) so the two checks stay consistent.
+                if (membershipType.incompatibleMembershipTypeIds.length > 0) {
+                    const incompatible = await MemberPlatformMembership.select()
+                        .where('memberId', member.id)
+                        .where('membershipTypeId', membershipType.incompatibleMembershipTypeIds)
+                        .where('periodId', put.periodId)
+                        .where('deletedAt', null)
+                        .where(membershipDateRangeOverlaps(put.startDate, put.endDate))
+                        .first(false);
+
+                    if (incompatible) {
+                        throw new SimpleError({
+                            code: 'invalid_field',
+                            field: 'membershipTypeId',
+                            message: 'Incompatible membership type',
+                            human: $t('Dit lid heeft in deze periode al een aansluiting die niet gecombineerd kan worden met deze aansluiting.'),
+                        });
+                    }
+                }
+
                 // Check duplicate memberships after correcting the dates
                 const existing = await MemberPlatformMembership.select()
                     .where('memberId', member.id)
                     .where('membershipTypeId', put.membershipTypeId)
                     .where('periodId', put.periodId)
                     .where('deletedAt', null)
-                    .where(
-                        SQL.where(
-                            SQL.where('startDate', SQLWhereSign.LessEqual, put.startDate)
-                                .and('endDate', SQLWhereSign.GreaterEqual, put.startDate),
-                        )
-                            .or(
-                                SQL.where('startDate', SQLWhereSign.LessEqual, put.endDate)
-                                    .and('endDate', SQLWhereSign.GreaterEqual, put.endDate),
-                            )
-                            .or(
-                                SQL.where('startDate', SQLWhereSign.GreaterEqual, put.startDate)
-                                    .and('endDate', SQLWhereSign.LessEqual, put.endDate),
-                            ),
-                    )
+                    .where(membershipDateRangeOverlaps(put.startDate, put.endDate))
                     .first(false);
 
                 if (existing && (membershipType.behaviour === PlatformMembershipTypeBehaviour.Days || !existing.generated || existing.locked || existing.price < membership.price)) {

--- a/frontend/app/admin/src/views/settings/membership-types/EditMembershipTypeView.vue
+++ b/frontend/app/admin/src/views/settings/membership-types/EditMembershipTypeView.vue
@@ -44,7 +44,7 @@
         </p>
 
         <hr><h2>{{ $t('Niet-combineerbare aansluitingen') }}</h2>
-        <p>{{ $t('Selecteer aansluitingstypes die niet samen met dit type in dezelfde periode toegevoegd kunnen worden. Bij het handmatig toevoegen van dit type wordt gecontroleerd of het lid nog geen van deze types heeft in dezelfde periode.') }}</p>
+        <p>{{ $t('Bij het handmatig toevoegen van dit type wordt gecontroleerd of het lid nog geen van deze types heeft in dezelfde periode.') }}</p>
 
         <p v-if="otherMembershipTypes.length === 0" class="info-box">
             {{ $t('Er zijn geen andere aansluitingstypes om uit te kiezen.') }}

--- a/frontend/app/admin/src/views/settings/membership-types/EditMembershipTypeView.vue
+++ b/frontend/app/admin/src/views/settings/membership-types/EditMembershipTypeView.vue
@@ -43,6 +43,18 @@
             </button>
         </p>
 
+        <hr><h2>{{ $t('Niet-combineerbare aansluitingen') }}</h2>
+        <p>{{ $t('Selecteer aansluitingstypes die niet samen met dit type in dezelfde periode toegevoegd kunnen worden. Bij het handmatig toevoegen van dit type wordt gecontroleerd of het lid nog geen van deze types heeft in dezelfde periode.') }}</p>
+
+        <p v-if="otherMembershipTypes.length === 0" class="info-box">
+            {{ $t('Er zijn geen andere aansluitingstypes om uit te kiezen.') }}
+        </p>
+        <MultipleChoiceInput
+            v-else
+            v-model="incompatibleMembershipTypeIds"
+            :items="otherMembershipTypes.map(t => ({ name: t.name, value: t.id }))"
+        />
+
         <hr><h2>{{ $t("%1CP") }}</h2>
 
         <Checkbox v-model="requiredTagIdsEnabled">
@@ -91,11 +103,13 @@ import DefaultAgeGroupIdsInput from '@stamhoofd/components/inputs/DefaultAgeGrou
 import Dropdown from '@stamhoofd/components/inputs/Dropdown.vue';
 import { ErrorBox } from '@stamhoofd/components/errors/ErrorBox.ts';
 import JumpToContainer from '@stamhoofd/components/containers/JumpToContainer.vue';
+import MultipleChoiceInput from '@stamhoofd/components/inputs/MultipleChoiceInput.vue';
 import SaveView from '@stamhoofd/components/navigation/SaveView.vue';
 import TagIdsInput from '@stamhoofd/components/inputs/TagIdsInput.vue';
 import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 import { useErrors } from '@stamhoofd/components/errors/useErrors.ts';
 import { usePatch } from '@stamhoofd/components/hooks/usePatch.ts';
+import { usePlatform } from '@stamhoofd/components/hooks/usePlatform.ts';
 import { usePlatformManager } from '@stamhoofd/networking/PlatformManager';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import type { PlatformMembershipType, RegistrationPeriod } from '@stamhoofd/structures';
@@ -111,6 +125,7 @@ const saving = ref(false);
 const deleting = ref(false);
 
 const platformManager = usePlatformManager();
+const platform = usePlatform();
 const owner = useRequestOwner();
 const loading = ref(false);
 const originalPeriods = ref([]) as Ref<RegistrationPeriod[]>;
@@ -213,6 +228,13 @@ const description = computed({
 const behaviour = computed({
     get: () => patched.value.behaviour,
     set: behaviour => addPatch({ behaviour }),
+});
+
+const otherMembershipTypes = computed(() => platform.value.config.membershipTypes.filter(t => t.id !== props.type.id));
+
+const incompatibleMembershipTypeIds = computed({
+    get: () => patched.value.incompatibleMembershipTypeIds,
+    set: incompatibleMembershipTypeIds => addPatch({ incompatibleMembershipTypeIds: incompatibleMembershipTypeIds as any }),
 });
 
 const requiredTagIdsEnabled = computed({

--- a/shared/structures/src/Platform.ts
+++ b/shared/structures/src/Platform.ts
@@ -285,6 +285,14 @@ export class PlatformMembershipType extends AutoEncoder {
     @field({ decoder: new ArrayDecoder(StringDecoder), nullable: true })
     requiredDefaultAgeGroupIds: string[] | null = null;
 
+    /**
+     * Membership types that cannot be combined with this type in the same period.
+     * When manually adding a membership of this type, the member may not already
+     * have a membership of one of these types in the same period.
+     */
+    @field({ decoder: new ArrayDecoder(StringDecoder), ...NextVersion })
+    incompatibleMembershipTypeIds: string[] = [];
+
     getPrice(periodId: string, date: Date, tagIds: string[], isReduced: boolean) {
         const period = this.periods.get(periodId);
         if (!period) {


### PR DESCRIPTION
## What

Implements the core of [STA-808](https://linear.app/stamhoofd/issue/STA-808/bepaalde-aansluitingcombinaties-niet-toelaten): prevent members from getting **incompatible** platform membership combinations (e.g. a full-year membership + a camp insurance covering an overlapping period).

## Changes

- **`shared/structures` — `PlatformMembershipType`**: new `incompatibleMembershipTypeIds: string[]` field (added additively via `...NextVersion`) listing the membership types this type cannot be combined with in the same period.
- **`PatchOrganizationMembersEndpoint`**: when manually adding a platform membership, block it if the member already has a non-deleted membership of one of the added type's incompatible types **in the same period with overlapping dates**. Previously only a duplicate of the *exact same* type was blocked. The date-overlap clause is extracted into a shared `membershipDateRangeOverlaps` helper reused by both the incompatible check and the existing duplicate check.
- **Admin UI (`EditMembershipTypeView.vue`)**: a multiple-choice input to configure which other membership types are incompatible.

## Tests

Added integration tests on the endpoint:
- blocks adding a type the member already has an overlapping incompatible type for;
- allows adding when the types are not marked incompatible;
- allows adding an incompatible type when the dates do **not** overlap.

Full `yarn typecheck` + `yarn lint` pass; the endpoint test file (57 tests) passes.

## Notes / not in scope

- The incompatibility check is **uni-directional**: it reads the incompatible list of the type being added. To make two types mutually exclusive, both should list each other. Happy to make it bidirectional if preferred.
- The issue also mentions a UX request (a visual indicator in the members tab showing which age/work group is linked to an automatic membership). That part is **not** included here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786461060&installation_id=138085646&pr_number=597&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F597&signature=97c5d21ea5c934818ac341ac12032a6ed15402785891679ca89255fe396e1a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->