### PR TITLE
✨ Allow importing members without registering them for a group

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/settings/modules/members/ImportMembersQuestionsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/modules/members/ImportMembersQuestionsView.vue
@@ -78,11 +78,35 @@
                 <hr>
                 <h2>{{ $t('%1IL') }}</h2>
 
-                <p class="warning-box">
+                <p v-if="!skipUnmatchedGroups" class="warning-box">
                     {{ membersNeedingAssignment.length }} {{ $t('%18z') }}
                 </p>
 
-                <STInputBox error-fields="group" :error-box="errors.errorBox" class="max" :title="$t(`%19E`)">
+                <!-- Not available in platform mode: members without registrations don't surface anywhere and admins wouldn't have access to them -->
+                <STList v-if="STAMHOOFD.userMode !== 'platform'">
+                    <STListItem :selectable="true" element-name="label">
+                        <template #left>
+                            <Checkbox v-model="skipUnmatchedGroups" />
+                        </template>
+                        <h3 class="style-title-list">
+                            {{ $t('Deze leden niet inschrijven voor een groep') }}
+                        </h3>
+                        <p class="style-description-small">
+                            {{ $t('Leden zonder een kolom die de inschrijvingsgroep bepaalt, worden aangemaakt of bijgewerkt, maar niet ingeschreven voor een groep.') }}
+                        </p>
+                    </STListItem>
+                </STList>
+
+                <p v-if="skipUnmatchedGroups && newMembersNeedingAssignment.length > 0" class="warning-box">
+                    <template v-if="newMembersNeedingAssignment.length === 1">
+                        {{ $t('Er wordt 1 nieuw lid aangemaakt, maar niet ingeschreven voor een groep. Zonder inschrijving is dit lid moeilijk terug te vinden in het systeem.') }}
+                    </template>
+                    <template v-else>
+                        {{ $t('{count} nieuwe leden worden aangemaakt, maar niet ingeschreven voor een groep. Zonder inschrijving zijn deze leden moeilijk terug te vinden in het systeem.', {count: newMembersNeedingAssignment.length}) }}
+                    </template>
+                </p>
+
+                <STInputBox v-if="!skipUnmatchedGroups" error-fields="group" :error-box="errors.errorBox" class="max" :title="$t(`%19E`)">
                     <RadioGroup>
                         <Radio v-model="autoAssign" :value="true">
                             {{ $t('%190') }}
@@ -100,7 +124,7 @@
                     </template>
                 </STInputBox>
 
-                <template v-if="autoAssign">
+                <template v-if="autoAssign && !skipUnmatchedGroups">
                     <STInputBox v-if="membersWithMultipleGroups.length > 0" error-fields="group" :error-box="errors.errorBox" class="max" :title="$t(`%19F`)">
                         <p class="info-box">
                             {{ $t('%19p', {
@@ -150,7 +174,7 @@
                         </template>
                     </STInputBox>
                 </template>
-                <template v-else>
+                <template v-else-if="!skipUnmatchedGroups">
                     <STInputBox error-fields="group" :error-box="errors.errorBox" class="max" :title="$t(`%19H`)">
                         <Dropdown v-model="defaultGroup">
                             <option v-for="group in groups" :key="group.id" :value="group">
@@ -181,6 +205,7 @@
 <script lang="ts" setup>
 import { ComponentWithProperties, usePop, usePresent, useShow } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '@stamhoofd/components/containers/AsyncComponent.ts';
+import Checkbox from '@stamhoofd/components/inputs/Checkbox.vue';
 import Dropdown from '@stamhoofd/components/inputs/Dropdown.vue';
 import Radio from '@stamhoofd/components/inputs/Radio.vue';
 import RadioGroup from '@stamhoofd/components/inputs/RadioGroup.vue';
@@ -221,6 +246,7 @@ const saving = ref(false);
 const paid = ref<boolean | null>(null);
 const isWaitingList = ref(false);
 const autoAssign = ref(true);
+const skipUnmatchedGroups = ref(false);
 const groups = props.period.groups;
 const defaultGroup = ref(groups[0]) as unknown as Ref<Group>;
 const multipleGroups = ref(calculateMultipleGroups(groups)) as unknown as Ref<Group[]>;
@@ -238,7 +264,7 @@ const memberImporter = new MemberImporter({
     requestOwner: owner,
 });
 
-watch([autoAssign, defaultGroup], () => {
+watch([autoAssign, defaultGroup, skipUnmatchedGroups], () => {
     autoAssignMembers(props.importMemberResults);
 });
 
@@ -259,6 +285,13 @@ const membersNeedingAssignment = computed(() => {
         return shouldAssignRegistrationToMember(m);
     });
 });
+
+/**
+ * New members (not yet in the system) that need a group assignment.
+ * When skipUnmatchedGroups is enabled these are created without any registration,
+ * which makes them hard to find in the system.
+ */
+const newMembersNeedingAssignment = computed(() => membersNeedingAssignment.value.filter(m => !m.isExisting));
 
 const waitingListWarning = computed(() => {
     if (!isWaitingList.value) {
@@ -363,6 +396,12 @@ function calculateMultipleGroups(groups: Group[]) {
 function autoAssignMembers(members: ImportMemberResult[]) {
     for (const member of members) {
         if (!shouldAssignRegistrationToMember(member)) {
+            member.importRegistrationResult.autoAssignedGroup = null;
+            continue;
+        }
+
+        if (skipUnmatchedGroups.value) {
+            // Do not register members that have no group defined in a column
             member.importRegistrationResult.autoAssignedGroup = null;
             continue;
         }
@@ -668,6 +707,7 @@ async function goNext() {
         const reports = await memberImporter.importResults(props.importMemberResults, {
             isWaitingList: isWaitingList.value,
             paid: paid.value,
+            allowMembersWithoutRegistration: skipUnmatchedGroups.value,
         }, progress => toast.setProgress(progress));
 
         toast.hide();

--- a/frontend/app/dashboard/src/views/dashboard/settings/modules/members/MemberImporter.ts
+++ b/frontend/app/dashboard/src/views/dashboard/settings/modules/members/MemberImporter.ts
@@ -20,6 +20,10 @@ interface RegistrationData {
 interface MemberImporterContext {
     readonly isWaitingList: boolean;
     readonly paid: boolean | null;
+    /**
+     * Allow new members to be imported without registering them for any group.
+     */
+    readonly allowMembersWithoutRegistration?: boolean;
 }
 
 export class MemberImporter {
@@ -54,7 +58,16 @@ export class MemberImporter {
     }
 
     async importResults(importMemberResults: ImportMemberResult[], importContext: MemberImporterContext, onProgress?: (progress: number) => void) {
-        if (importMemberResults.find(m => !m.isExisting && (m.importRegistrationResult.group === null && m.importRegistrationResult.autoAssignedGroup === null))) {
+        // A new member reaches this point without a group only when no group column was matched:
+        // an unmatched or empty group column value throws while parsing (ColumnMatcher.setValue) and
+        // routes to the error view, so it never gets here. Creating such members without a
+        // registration is therefore only allowed when the admin explicitly opted in — and never in
+        // platform mode, where members without a registration don't surface anywhere and admins
+        // wouldn't have access to them. The UI already hides the option in platform mode; this keeps
+        // the guarantee even if that ever changes.
+        const allowMembersWithoutRegistration = importContext.allowMembersWithoutRegistration && STAMHOOFD.userMode !== 'platform';
+
+        if (!allowMembersWithoutRegistration && importMemberResults.find(m => !m.isExisting && (m.importRegistrationResult.group === null && m.importRegistrationResult.autoAssignedGroup === null))) {
             throw new SimpleError({
                 code: 'no_group',
                 message: $t(`%1AE`),

--- a/tests/playwright/src/tests/import-members-organization.spec.ts
+++ b/tests/playwright/src/tests/import-members-organization.spec.ts
@@ -163,6 +163,43 @@ test.describe('Import members with an ID column (organization mode) @import-memb
         expect(newMember.details.lastName).toBe('Lid');
     });
 
+    test('new members can be imported without registering them for a group', async ({ page }) => {
+        test.setTimeout(90_000);
+        const scenario = await seedScenario('skip-group');
+        const { organization } = scenario;
+
+        // Two new members without an id and without a group column: they need a group assignment
+        const csv = [
+            'ID,Voornaam,Achternaam',
+            ',Nieuw,Lid1',
+            ',Nieuw,Lid2',
+        ].join('\n');
+
+        await openImportViewAndUpload({ page, scenario, csv });
+
+        await expect(page.getByRole('heading', { name: 'Importeer instellingen' })).toBeVisible();
+
+        // Choose not to register these members for a group
+        await page.getByText('Deze leden niet inschrijven voor een groep').click();
+
+        // A warning explains the new members will be created but not registered
+        await expect(page.getByText('moeilijk terug te vinden in het systeem')).toBeVisible();
+
+        await page.getByRole('button', { name: 'Importeer 2 leden' }).click();
+
+        await expect(page.getByText('Importeren voltooid')).toBeVisible({ timeout: 30_000 });
+
+        // Both members were created
+        const members = await Member.select().where('organizationId', organization.id).fetch();
+        expect(members).toHaveLength(2);
+
+        // ...but no registrations were created for them
+        for (const member of members) {
+            const registrations = await Registration.select().where('memberId', member.id).fetch();
+            expect(registrations).toHaveLength(0);
+        }
+    });
+
     test('an unknown id is a hard error and blocks the import', async ({ page }) => {
         const scenario = await seedScenario('unknown-id');
         const { organization, group } = scenario;


### PR DESCRIPTION
## What

Adds an option to the member-import flow: when importing members that have **no group defined by a spreadsheet column**, admins can now tick a checkbox to create those members **without registering them for any group** — instead of being forced to auto-assign or pick a single fallback group.

## Why

Some organizations want to import member data (contact details, etc.) without immediately registering everyone into a group. Today the import always requires a group for every new member.

## Changes

- **Checkbox** ("Deze leden niet inschrijven voor een groep") added directly above the "Automatisch groep bepalen" radio in `ImportMembersQuestionsView.vue`. When ticked, members that need group assignment keep an empty group (`autoAssignedGroup = null`), so `buildRegistration` returns `null` and they are created but never registered. The now-irrelevant auto-assign / single-group controls are hidden.
- **Warning** shown when new (non-existing) members would be created this way: they are created but not registered, which makes them hard to find in the system. Singular/plural variants included.
- **Platform mode**: the option is hidden entirely, because members without any registration don't surface anywhere and admins wouldn't have access to them. `MemberImporter` additionally refuses this state in platform mode as a logic-layer safety net, so the guarantee holds even if the UI ever changes.
- The pre-existing `no_group` guard is only bypassed when the admin explicitly opted in (and never in platform mode).

## Notes on the guard

A new member reaches the `no_group` guard without a group only when no group column was matched at all: an unmatched/empty group-column value throws during parsing (`ColumnMatcher.setValue`) and routes to the error view before this screen. So `group === null` here reliably means "no group column", and the bypass masks nothing.

## Tests

- Playwright (`import-members-organization.spec.ts`): new test imports two new members with the checkbox enabled, asserts the warning appears, and verifies both members are created with **zero** registrations. Existing import tests still pass (3/3).
- `yarn typecheck` and `yarn lint` clean.

## Not included

No dedicated platform-mode E2E: reaching this view in platform mode requires disproportionate seeding for a single `v-if`, so the platform guarantee is instead enforced (and documented) at both the UI and importer layers. Happy to add the E2E if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786527680&installation_id=138085646&pr_number=598&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F598&signature=188331b7c4be2a56fcba325035bda03834455d9eef87958eb5a8b35859b8cddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->