### PR TITLE
✨ Mark zero-price created/pending payments as succeeded

### DIFF
--- a/backend/app/api/src/seeds/1783939632-mark-zero-price-payments-succeeded.ts
+++ b/backend/app/api/src/seeds/1783939632-mark-zero-price-payments-succeeded.ts
@@ -30,21 +30,43 @@ export default new Migration(async () => {
             );
             const organizations = organizationIds.length ? await Organization.getByIDs(...organizationIds) : [];
 
-            for (const payment of payments) {
-                if (!payment.organizationId) {
-                    console.warn('Payment without organizationId, skipping', payment.id);
-                    continue;
-                }
+            // Load the attached balance item payments of this batch in bulk, to decide which
+            // payments actually move money and therefore need the PaymentService side effects.
+            const { balanceItemPayments } = await Payment.loadBalanceItems(payments);
 
-                const organization = organizations.find(o => o.id === payment.organizationId);
-                if (!organization) {
-                    console.warn('Organization not found for payment, skipping', payment.id, payment.organizationId);
-                    continue;
-                }
+            for (const payment of payments) {
+                // Only route through the PaymentService (which marks balance items as paid, flushes
+                // caches, ...) when the payment moves money on at least one balance item. When all
+                // attached balance item payments are zero (or there are none), update the status
+                // directly to avoid those side effects.
+                const hasNonZeroBalanceItemPayment = balanceItemPayments.some(
+                    bip => bip.paymentId === payment.id && bip.price !== 0,
+                );
 
                 try {
-                    // Attribute the payment to its original date instead of the migration run date.
-                    await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded, payment.createdAt);
+                    if (hasNonZeroBalanceItemPayment) {
+                        if (!payment.organizationId) {
+                            console.warn('Payment without organizationId, skipping', payment.id);
+                            continue;
+                        }
+
+                        const organization = organizations.find(o => o.id === payment.organizationId);
+                        if (!organization) {
+                            console.warn('Organization not found for payment, skipping', payment.id, payment.organizationId);
+                            continue;
+                        }
+
+                        // Attribute the payment to its original date instead of the migration run date.
+                        await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded, payment.createdAt);
+                    } else {
+                        // No side effects needed: update the status directly.
+                        payment.status = PaymentStatus.Succeeded;
+                        payment.paidAt = payment.createdAt;
+                        await payment.save({
+                            skipMarkSaved: true,
+                            skipSendEvents: true,
+                        });
+                    }
                     succeeded++;
                 } catch (e) {
                     // Isolate failures per payment: one bad row should not abort (and wedge) the whole migration.

--- a/backend/app/api/src/seeds/1783939632-mark-zero-price-payments-succeeded.ts
+++ b/backend/app/api/src/seeds/1783939632-mark-zero-price-payments-succeeded.ts
@@ -30,18 +30,20 @@ export default new Migration(async () => {
             );
             const organizations = organizationIds.length ? await Organization.getByIDs(...organizationIds) : [];
 
-            // Load the attached balance item payments of this batch in bulk, to decide which
-            // payments actually move money and therefore need the PaymentService side effects.
+            // Load the attached balance item payments of this batch in bulk, and collect the ids of
+            // the payments that move money on at least one balance item. Those need the PaymentService
+            // side effects (marking balance items as paid, flushing caches, ...); the rest can be
+            // updated directly.
             const { balanceItemPayments } = await Payment.loadBalanceItems(payments);
+            const paymentIdsWithNonZeroBalanceItemPayment = new Set(
+                balanceItemPayments.filter(bip => bip.price !== 0).map(bip => bip.paymentId),
+            );
 
             for (const payment of payments) {
-                // Only route through the PaymentService (which marks balance items as paid, flushes
-                // caches, ...) when the payment moves money on at least one balance item. When all
-                // attached balance item payments are zero (or there are none), update the status
-                // directly to avoid those side effects.
-                const hasNonZeroBalanceItemPayment = balanceItemPayments.some(
-                    bip => bip.paymentId === payment.id && bip.price !== 0,
-                );
+                // Only route through the PaymentService when the payment moves money on at least one
+                // balance item. When all attached balance item payments are zero (or there are none),
+                // update the status directly to avoid those side effects.
+                const hasNonZeroBalanceItemPayment = paymentIdsWithNonZeroBalanceItemPayment.has(payment.id);
 
                 try {
                     if (hasNonZeroBalanceItemPayment) {

--- a/backend/app/api/src/seeds/1783939632-mark-zero-price-payments-succeeded.ts
+++ b/backend/app/api/src/seeds/1783939632-mark-zero-price-payments-succeeded.ts
@@ -1,0 +1,66 @@
+import { Migration } from '@simonbackx/simple-database';
+import { Organization, Payment } from '@stamhoofd/models';
+import { QueryableModel } from '@stamhoofd/sql';
+import { PaymentStatus } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+import { SeedTools } from '../helpers/SeedTools.js';
+import { PaymentService } from '../services/PaymentService.js';
+
+export default new Migration(async () => {
+    if (STAMHOOFD.environment === 'test') {
+        console.log('skipped in tests');
+        return;
+    }
+
+    console.log('Start marking zero-price payments as succeeded.');
+
+    let succeeded = 0;
+
+    const result = await SeedTools.loopBatched({
+        // Keyset pagination on id: marking a payment as succeeded drops it from this filter,
+        // but rows are never skipped because each next batch is fetched by id > lastId.
+        query: Payment.select()
+            .where('price', 0)
+            .where('status', [PaymentStatus.Created, PaymentStatus.Pending]),
+        batchSize: 100,
+        batchAction: async (payments: Payment[]) => {
+            // Load the organizations of this batch in bulk
+            const organizationIds = Formatter.uniqueArray(
+                payments.map(p => p.organizationId).filter((id): id is string => id !== null),
+            );
+            const organizations = organizationIds.length ? await Organization.getByIDs(...organizationIds) : [];
+
+            for (const payment of payments) {
+                if (!payment.organizationId) {
+                    console.warn('Payment without organizationId, skipping', payment.id);
+                    continue;
+                }
+
+                const organization = organizations.find(o => o.id === payment.organizationId);
+                if (!organization) {
+                    console.warn('Organization not found for payment, skipping', payment.id, payment.organizationId);
+                    continue;
+                }
+
+                try {
+                    // Attribute the payment to its original date instead of the migration run date.
+                    await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded, payment.createdAt);
+                    succeeded++;
+                } catch (e) {
+                    // Isolate failures per payment: one bad row should not abort (and wedge) the whole migration.
+                    console.error('Failed to mark payment as succeeded, skipping', payment.id, e);
+                }
+
+                if (QueryableModel.shutdownMigrations) {
+                    break;
+                }
+            }
+
+            if (QueryableModel.shutdownMigrations) {
+                throw new Error('Stopping migration gracefully');
+            }
+        },
+    });
+
+    console.log(`Finished marking zero-price payments as succeeded: ${succeeded} of ${result.total} payments.`);
+});


### PR DESCRIPTION
## Summary

Adds a one-off seed migration (`backend/app/api/src/seeds/1783939632-mark-zero-price-payments-succeeded.ts`) that loops all payments with a price of `0` that are still in the `Created` or `Pending` status, and marks each of them as succeeded.

fixes STA-1331

## Details

- Uses `SeedTools.loopBatched` with the query `price = 0 AND status IN (Created, Pending)`. `allBatched` paginates by keyset (`id > lastId`), so marking rows succeeded — which drops them from the filter — never skips or double-processes rows.
- Each batch bulk-loads the attached balance item payments (`Payment.loadBalanceItems`) to decide, per payment, whether it actually moves money:
  - **Has at least one non-zero balance item payment** → routed through `PaymentService.handlePaymentStatusUpdate` (marks balance items paid, flushes caches, etc.), keyed to the payment's own organization.
  - **All attached balance item payments are zero (or there are none)** → status updated directly (`skipMarkSaved` / `skipSendEvents`), avoiding those side effects.
- `paidAt` is set to the payment's original `createdAt` rather than the migration run date, so these payments keep their real date in any date-based reporting.
- Failures are isolated per payment (logged and skipped) so one bad row cannot abort and wedge the rest of the migration; the `shutdownMigrations` graceful-stop check is preserved.
- Skips in the `test` environment, matching the convention of the other seeds.

## Testing

- `tsc --noEmit` (api package): passes
- `eslint` on the new file: passes

Follows repo convention: seeds in `backend/app/api/src/seeds/` have no colocated tests and skip in the `test` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)