### PR TITLE
✨ Add configurable default language for webshops

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopDefaultLanguage.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopDefaultLanguage.test.ts
@@ -1,0 +1,62 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import { OrganizationFactory, Token, UserFactory, Webshop, WebshopFactory } from '@stamhoofd/models';
+import { PermissionLevel, Permissions, PrivateWebshop, WebshopMetaData } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
+import { TestUtils } from '@stamhoofd/test-utils';
+
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { GetWebshopEndpoint } from '../../webshops/GetWebshopEndpoint.js';
+import { PatchWebshopEndpoint } from './PatchWebshopEndpoint.js';
+
+describe('Endpoint.PatchWebshop defaultLanguage', () => {
+    const patchEndpoint = new PatchWebshopEndpoint();
+    const getEndpoint = new GetWebshopEndpoint();
+
+    beforeEach(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    async function createAdminContext() {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({
+                level: PermissionLevel.Full,
+            }),
+        }).create();
+        const token = await Token.createToken(user);
+
+        return { organization, token };
+    }
+
+    test('a webshop returns Dutch as its default language', async () => {
+        const { organization, token } = await createAdminContext();
+        const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+        const request = Request.buildJson('GET', '/webshop/' + webshop.id, organization.getApiHost());
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+
+        const response = await testServer.test(getEndpoint, request);
+        expect(response.body.meta.defaultLanguage).toBe(Language.Dutch);
+    });
+
+    test('defaultLanguage can be updated', async () => {
+        const { organization, token } = await createAdminContext();
+        const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+        const patch = PrivateWebshop.patch({
+            meta: WebshopMetaData.patch({
+                defaultLanguage: Language.French,
+            }),
+        });
+        const request = Request.buildJson('PATCH', '/webshop/' + webshop.id, organization.getApiHost(), patch);
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+
+        const response = await testServer.test(patchEndpoint, request);
+        expect(response.body.meta.defaultLanguage).toBe(Language.French);
+
+        // Persisted in the database
+        const reloaded = await Webshop.getByID(webshop.id);
+        expect(reloaded?.meta.defaultLanguage).toBe(Language.French);
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopEndpoint.test.ts
@@ -5,12 +5,10 @@ import { Language } from '@stamhoofd/types/Language';
 import { TestUtils } from '@stamhoofd/test-utils';
 
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
-import { GetWebshopEndpoint } from '../../webshops/GetWebshopEndpoint.js';
 import { PatchWebshopEndpoint } from './PatchWebshopEndpoint.js';
 
-describe('Endpoint.PatchWebshop defaultLanguage', () => {
-    const patchEndpoint = new PatchWebshopEndpoint();
-    const getEndpoint = new GetWebshopEndpoint();
+describe('Endpoint.PatchWebshop', () => {
+    const endpoint = new PatchWebshopEndpoint();
 
     beforeEach(async () => {
         TestUtils.setEnvironment('userMode', 'platform');
@@ -29,17 +27,6 @@ describe('Endpoint.PatchWebshop defaultLanguage', () => {
         return { organization, token };
     }
 
-    test('a webshop returns Dutch as its default language', async () => {
-        const { organization, token } = await createAdminContext();
-        const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
-
-        const request = Request.buildJson('GET', '/webshop/' + webshop.id, organization.getApiHost());
-        request.headers.authorization = 'Bearer ' + token.accessToken;
-
-        const response = await testServer.test(getEndpoint, request);
-        expect(response.body.meta.defaultLanguage).toBe(Language.Dutch);
-    });
-
     test('defaultLanguage can be updated', async () => {
         const { organization, token } = await createAdminContext();
         const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
@@ -52,7 +39,7 @@ describe('Endpoint.PatchWebshop defaultLanguage', () => {
         const request = Request.buildJson('PATCH', '/webshop/' + webshop.id, organization.getApiHost(), patch);
         request.headers.authorization = 'Bearer ' + token.accessToken;
 
-        const response = await testServer.test(patchEndpoint, request);
+        const response = await testServer.test(endpoint, request);
         expect(response.body.meta.defaultLanguage).toBe(Language.French);
 
         // Persisted in the database

--- a/backend/app/api/src/endpoints/organization/webshops/GetWebshopEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/GetWebshopEndpoint.test.ts
@@ -1,6 +1,7 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import { OrganizationFactory, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
 import { PermissionLevel, Permissions, WebshopAuthType, WebshopMetaData } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
 
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
@@ -28,6 +29,16 @@ describe('Endpoint.GetWebshop', () => {
 
         expect(response.body.id).toEqual(webshop.id);
         expect((response.body as any).privateMeta).toBeUndefined();
+    });
+
+    test('Webshop defaults to Dutch as its default language', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+        const r = Request.buildJson('GET', '/webshop/' + webshop.id, organization.getApiHost());
+
+        const response = await testServer.test(endpoint, r);
+        expect(response.body.meta.defaultLanguage).toBe(Language.Dutch);
     });
 
     test('Allow access without organization scope', async () => {

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
@@ -10,6 +10,14 @@
             <WYSIWYGTextInput v-model="description" :color="color || defaultColor" :placeholder="$t(`%Rc`)" />
         </STInputBox>
 
+        <STInputBox error-fields="meta.defaultLanguage" :error-box="errors.errorBox" :title="$t(`Taal`)">
+            <Dropdown v-model="defaultLanguage">
+                <option v-for="language in languages" :key="language" :value="language">
+                    {{ LanguageHelper.getNativeName(language) }}
+                </option>
+            </Dropdown>
+        </STInputBox>
+
         <hr><h2>{{ $t('%2A') }}</h2>
 
         <STList>
@@ -153,6 +161,7 @@ import { useFeatureFlag } from '@stamhoofd/components/hooks/useFeatureFlag.ts';
 import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
 import Checkbox from '@stamhoofd/components/inputs/Checkbox.vue';
 import ColorInput from '@stamhoofd/components/inputs/ColorInput.vue';
+import Dropdown from '@stamhoofd/components/inputs/Dropdown.vue';
 import Radio from '@stamhoofd/components/inputs/Radio.vue';
 import RadioGroup from '@stamhoofd/components/inputs/RadioGroup.vue';
 import STInputBox from '@stamhoofd/components/inputs/STInputBox.vue';
@@ -165,7 +174,8 @@ import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 
 import LogoEditor from '@stamhoofd/components/views/LogoEditor.vue';
 import type { DarkMode, Image, RichText, SponsorConfig} from '@stamhoofd/structures';
-import { Cart, CartItem, CartReservedSeat, Policy, PrivateWebshop, ProductType, ResolutionRequest, TicketPublic, WebshopLayout, WebshopMetaData } from '@stamhoofd/structures';
+import { Cart, CartItem, CartReservedSeat, LanguageHelper, Policy, PrivateWebshop, ProductType, ResolutionRequest, TicketPublic, WebshopLayout, WebshopMetaData } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
 
 import { computed } from 'vue';
 import EditSponsorsBox from '../../sponsors/EditSponsorsBox.vue';
@@ -242,6 +252,16 @@ const layout = computed({
     get: () => webshop.value.meta.layout,
     set: (layout: WebshopLayout) => {
         const patch = WebshopMetaData.patch({ layout });
+        addPatch(PrivateWebshop.patch({ meta: patch }));
+    },
+});
+
+const languages = Object.values(Language);
+
+const defaultLanguage = computed({
+    get: () => webshop.value.meta.defaultLanguage,
+    set: (defaultLanguage: Language) => {
+        const patch = WebshopMetaData.patch({ defaultLanguage });
         addPatch(PrivateWebshop.patch({ meta: patch }));
     },
 });

--- a/frontend/app/webshop/src/App.vue
+++ b/frontend/app/webshop/src/App.vue
@@ -90,7 +90,9 @@ const root = new ComponentWithProperties(PromiseView, {
                 }
             }
 
-            I18nController.skipUrlPrefixForLocale = 'nl-' + response.data.organization.address.country;
+            const webshopLanguage = response.data.webshop?.meta.defaultLanguage ?? Language.Dutch;
+
+            I18nController.skipUrlPrefixForLocale = webshopLanguage + '-' + response.data.organization.address.country;
 
             // Set session
             const session = new SessionContext(response.data.organization);
@@ -99,12 +101,12 @@ const root = new ComponentWithProperties(PromiseView, {
             await I18nController.loadDefault({
                 $context: session,
                 defaultCountry: response.data.organization.address.country,
-                defaultLanguage: Language.Dutch,
+                defaultLanguage: webshopLanguage,
                 country: response.data.organization.address.country,
                 locales: {
-                    // For now always force the default locale
+                    // For now always force the webshop's default language
                     // if we add translations to webshops, we should add all the setup languages here
-                    [response.data.organization.address.country]: [Language.Dutch],
+                    [response.data.organization.address.country]: [webshopLanguage],
                 },
             });
 

--- a/shared/structures/src/webshops/WebshopMetaData.ts
+++ b/shared/structures/src/webshops/WebshopMetaData.ts
@@ -5,6 +5,7 @@ import { Colors, Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { Country } from '@stamhoofd/types/Country';
+import { Language } from '@stamhoofd/types/Language';
 import { Address } from '../addresses/Address.js';
 import { City } from '../addresses/City.js';
 import { CountryDecoder } from '../addresses/CountryDecoder.js';
@@ -615,6 +616,12 @@ export class WebshopMetaData extends AutoEncoder {
 
     @field({ decoder: StringDecoder, nullable: true, version: 374 })
     customCode: string | null = null;
+
+    /**
+     * The default language used when loading the webshop (instead of the hardcoded Dutch default).
+     */
+    @field({ decoder: new EnumDecoder(Language), ...NextVersion })
+    defaultLanguage: Language = Language.Dutch;
 
     /**
      * Returns whether the webshop is event/ticketing based - regardless whether scanners are used or not


### PR DESCRIPTION
## Summary

Adds a configurable **default language** to webshops so a shop can open in French or English instead of always defaulting to Dutch.

- **`shared/structures`** — new versioned `defaultLanguage` field on `WebshopMetaData` (additive via `...NextVersion`, defaults to `Language.Dutch`, so existing webshops keep their current Dutch behaviour).
- **Dashboard** — a "Taal" dropdown in the webshop's page settings (_Omslagfoto, beschrijving, kleur, en externe links_) lets admins pick the language.
- **Webshop app** — when a webshop loads, it uses `webshop.meta.defaultLanguage` instead of the hardcoded Dutch, both for the loaded locale and for the URL locale-prefix skip logic (so non-Dutch webshops don't suddenly gain a `/xx-yy/` URL prefix).

## Tests

- Backend integration test (`PatchWebshopDefaultLanguage.test.ts`): a webshop returns Dutch by default, and `defaultLanguage` can be patched and is persisted.
- `yarn lint`, `yarn typecheck`, and the new tests pass.

Fixes STA-1329

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786532276&installation_id=138085646&pr_number=600&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F600&signature=9a096a40647309c33a9d5126d1e7755b6aca32bc5bc7b7c486d101af5791e200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->