### PR TITLE
🐛 Fixed getOptionRequirement if choose one and option not listed

### DIFF
--- a/shared/structures/src/webshops/Discount.test.ts
+++ b/shared/structures/src/webshops/Discount.test.ts
@@ -18,10 +18,10 @@ function createProduct() {
     });
 }
 
-function createProductWithOptions() {
+function createProductWithOptions(multipleChoice = true) {
     const optionMenu = OptionMenu.create({
         name: "Kies je extra's",
-        multipleChoice: true,
+        multipleChoice,
         options: [
             Option.create({ name: 'Opdruk' }),
             Option.create({ name: 'Naam' }),
@@ -159,6 +159,54 @@ describe('ProductSelector.doesMatch', () => {
 
         expect(selector.doesMatch(withRequiredOption)).toBe(true);
         expect(selector.doesMatch(withoutRequiredOption)).toBe(false);
+    });
+});
+
+describe('ProductSelector.getOptionRequirement', () => {
+    it('defaults to optional for options that are not listed in a multiple choice menu', () => {
+        const { product, optionMenu, optionA, optionB } = createProductWithOptions();
+        const selector = ProductSelector.create({
+            productId: product.id,
+            optionIds: new Map([[optionA.id, OptionSelectionRequirement.Excluded]]),
+        });
+
+        expect(selector.getOptionRequirement(optionMenu, optionB)).toBe(OptionSelectionRequirement.Optional);
+    });
+
+    it('defaults to optional in a choose one menu when all listed options are optional', () => {
+        const { product, optionMenu, optionA, optionB } = createProductWithOptions(false);
+        const selector = ProductSelector.create({
+            productId: product.id,
+            optionIds: new Map([[optionA.id, OptionSelectionRequirement.Optional]]),
+        });
+
+        expect(selector.getOptionRequirement(optionMenu, optionB)).toBe(OptionSelectionRequirement.Optional);
+    });
+
+    it('defaults to excluded in a choose one menu when another option is required', () => {
+        const { product, optionMenu, optionA, optionB } = createProductWithOptions(false);
+        const selector = ProductSelector.create({
+            productId: product.id,
+            optionIds: new Map([[optionA.id, OptionSelectionRequirement.Required]]),
+        });
+
+        expect(selector.getOptionRequirement(optionMenu, optionB)).toBe(OptionSelectionRequirement.Excluded);
+    });
+
+    it('matches a cart item with an unlisted option in a choose one menu of optional options', () => {
+        const { product, optionMenu, optionA, optionB } = createProductWithOptions(false);
+        const selector = ProductSelector.create({
+            productId: product.id,
+            optionIds: new Map([[optionA.id, OptionSelectionRequirement.Optional]]),
+        });
+
+        const cartItem = CartItem.create({
+            product,
+            productPrice: product.prices[0],
+            options: [CartItemOption.create({ optionMenu, option: optionB })],
+        });
+
+        expect(selector.doesMatch(cartItem)).toBe(true);
     });
 });
 

--- a/shared/structures/src/webshops/Discount.ts
+++ b/shared/structures/src/webshops/Discount.ts
@@ -55,7 +55,7 @@ export class ProductSelector extends AutoEncoder {
                 return OptionSelectionRequirement.Optional;
             } else {
                 for (const o of optionMenu.options) {
-                    if (this.optionIds.get(o.id) ?? OptionSelectionRequirement.Optional !== OptionSelectionRequirement.Optional) {
+                    if ((this.optionIds.get(o.id) ?? OptionSelectionRequirement.Optional) !== OptionSelectionRequirement.Optional) {
                         return OptionSelectionRequirement.Excluded;
                     }
                 }


### PR DESCRIPTION
There's a second bug of the same family sitting three lines above the one I fixed, in the helper my fixed code calls. At Discount.ts:58:

if (this.optionIds.get(o.id) ?? OptionSelectionRequirement.Optional !== OptionSelectionRequirement.Optional) { Operator precedence makes this parse as get(o.id) ?? (Optional !== Optional) — that is, get(o.id) ?? false. So the condition is truthy for any stored value, including 'Optional' itself. The documented rule is "excluded unless all options are optional", but in practice: in a choose-one option menu, as soon as one option has an explicit entry (and the editor writes an explicit Optional on re-check, per ProductSelectorBox.vue:191), every option without an entry silently becomes Excluded — and the discount stops matching those cart items. The fix is one pair of parentheses around the ??.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786546121&installation_id=138085646&pr_number=603&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F603&signature=c65d6979f92aaa70345b10696728ee81e78c1fc40faa9d0621f4d427cc3ee2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->