### PR TITLE
🐛 Fixed unreadable prices when payable balance items have VAT

### DIFF
--- a/frontend/shared/components/src/payments/BalanceItemRow.vue
+++ b/frontend/shared/components/src/payments/BalanceItemRow.vue
@@ -4,7 +4,7 @@
             <BalanceItemIcon :item="item" :is-payable="isPayable" />
         </template>
 
-        <BalanceItemTitleBox :item="item" :is-payable="isPayable" />
+        <BalanceItemTitleBox :item="item" :is-payable="isPayable" :exclude-vat="excludeVat" />
 
         <template v-if="item.status === BalanceItemStatus.Canceled || item.amount" #middleRight>
             <p v-if="item.status === BalanceItemStatus.Canceled" class="style-price-base negative">
@@ -17,14 +17,14 @@
         </template>
 
         <template #right>
-            <p v-if="!item.isDue" v-tooltip="item.dueAt ? ('Te betalen tegen ' + formatDate(item.dueAt)) : undefined" class="style-price-base disabled style-tooltip">
-                ({{ formatPrice(item.price) }})
+            <p v-if="!item.isDue" v-tooltip="item.dueAt ? $t('Te betalen tegen {date}', {date: formatDate(item.dueAt)}) : undefined" class="style-price-base disabled style-tooltip">
+                ({{ formatPrice(displayPrice) }})
             </p>
-            <p v-else class="style-price-base" :class="{negative: item.price < 0}">
-                {{ formatPrice(item.price) }}
+            <p v-else class="style-price-base" :class="{negative: displayPrice < 0}">
+                {{ formatPrice(displayPrice) }}
             </p>
 
-            <p v-if="item.pricePaid < 0 && item.price < 0" class="style-price-base negative small">
+            <p v-if="item.pricePaid < 0 && item.payablePriceWithVAT < 0" class="style-price-base negative small">
                 {{ $t('%1UY', {price: formatPrice(-item.pricePaid )}) }}
             </p>
 
@@ -71,14 +71,22 @@ const props = withDefaults(
         item: BalanceItem | GroupedBalanceItems;
         isPayable: boolean;
         hasWrite?: boolean;
+
+        /**
+         * Show the price excluding VAT (used together with a separate VAT overview).
+         */
+        excludeVat?: boolean;
     }>(),
     {
         hasWrite: true,
+        excludeVat: false,
     },
 );
 
 const context = useContext();
 const present = usePresent();
+
+const displayPrice = computed(() => props.excludeVat ? props.item.payablePriceWithoutVAT : props.item.payablePriceWithVAT);
 
 const canClick = computed(() => {
     return props.hasWrite && !props.isPayable && props.item instanceof BalanceItem;
@@ -154,7 +162,7 @@ function showContextMenu(event: MouseEvent) {
 async function editBalanceItem(balanceItem: BalanceItem) {
     const component = AsyncComponent(() => import('#payments/EditBalanceItemView.vue'), {
         balanceItem,
-        isNew: false
+        isNew: false,
     });
     await present({
         components: [

--- a/frontend/shared/components/src/payments/BalanceItemTitleBox.vue
+++ b/frontend/shared/components/src/payments/BalanceItemTitleBox.vue
@@ -4,11 +4,11 @@
             <span>{{ $t('%gg') }}</span>
             <span class="icon disabled tiny" />
         </p>
-        <p v-else-if="item.priceOpen < 0 && item.pricePaid > item.price && item.pricePaid > 0" class="style-title-prefix-list">
+        <p v-else-if="item.priceOpen < 0 && item.pricePaid > item.payablePriceWithVAT && item.pricePaid > 0" class="style-title-prefix-list">
             <span>{{ $t('%gh') }}</span>
             <span class="icon undo small" />
         </p>
-        <p v-else-if="item.price >= 0 && item.priceOpen < 0" class="style-title-prefix-list">
+        <p v-else-if="item.payablePriceWithVAT >= 0 && item.priceOpen < 0" class="style-title-prefix-list">
             <span v-if="isPayable">{{ $t('%10a') }}</span>
             <span v-else>{{ $t('%10b') }}</span>
             <span class="icon undo small" />
@@ -18,7 +18,7 @@
     <h3 class="style-title-list">
         {{ item.itemTitle }}
     </h3>
-    <p v-if="paymentStatus === null && item.dueAt && item.price >= 0" class="style-description-small" :class="{error: item.isOverDue}">
+    <p v-if="paymentStatus === null && item.dueAt && item.payablePriceWithVAT >= 0" class="style-description-small" :class="{error: item.isOverDue}">
         <span>{{ $t('%gf', {date: formatDate(item.dueAt)}) }}</span>
         <span v-if="item.isOverDue" class="icon error gray tiny" />
     </p>
@@ -30,10 +30,10 @@
                 {{ formatPrice(item.unitPrice) }} {{ item.unitPriceSuffix }} {{ $t('%1ZM') }}
             </p>
             <p v-else-if="item.unitPriceSuffix" class="style-description-small">
-                {{ formatPrice(item.unitPriceWithVAT) }} {{ item.unitPriceSuffix }}
+                {{ formatPrice(unitPriceDisplay) }} {{ item.unitPriceSuffix }}
             </p>
             <p v-else-if="item.amount !== 1" class="style-description-small">
-                {{ $t('%1J3', {price: formatPrice(item.unitPriceWithVAT)}) }}
+                {{ $t('%1J3', {price: formatPrice(unitPriceDisplay)}) }}
             </p>
         </template>
 
@@ -54,8 +54,9 @@
 <script lang="ts" setup>
 import type { GroupedBalanceItems, PaymentStatus } from '@stamhoofd/structures';
 import { BalanceItem, BalanceItemStatus } from '@stamhoofd/structures';
+import { computed } from 'vue';
 
-withDefaults(
+const props = withDefaults(
     defineProps<{
         item: BalanceItem | GroupedBalanceItems;
         isPayable: boolean;
@@ -64,12 +65,20 @@ withDefaults(
         price?: number | null;
         paymentStatus?: PaymentStatus | null;
         showPrices?: boolean;
+
+        /**
+         * Show the unit price excluding VAT (used together with a separate VAT overview).
+         */
+        excludeVat?: boolean;
     }>(),
     {
         price: null,
         paymentStatus: null,
         showPrices: true,
+        excludeVat: false,
     },
 );
+
+const unitPriceDisplay = computed(() => props.excludeVat ? props.item.unitPriceWithoutVAT : props.item.unitPriceWithVAT);
 
 </script>

--- a/frontend/shared/components/src/payments/BalancePriceBreakdown.vue
+++ b/frontend/shared/components/src/payments/BalancePriceBreakdown.vue
@@ -6,11 +6,11 @@
 import PriceBreakdownBox from '#views/PriceBreakdownBox.vue';
 import { ComponentWithProperties, NavigationController } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '#containers/AsyncComponent.ts';
-import type { DetailedReceivableBalance } from '@stamhoofd/structures';
-import { BalanceItem, DetailedPayableBalance } from '@stamhoofd/structures';
+import type { DetailedReceivableBalance, PriceBreakdown } from '@stamhoofd/structures';
+import { BalanceItem, DetailedPayableBalance, getVATExcemptInvoiceNote } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
 import { computed } from 'vue';
 import { usePositionableSheet } from '#tables/usePositionableSheet.ts';
-
 
 const props = defineProps<{
     item: DetailedPayableBalance | DetailedReceivableBalance;
@@ -18,12 +18,19 @@ const props = defineProps<{
 
 const isPayable = props.item instanceof DetailedPayableBalance;
 
-const priceBreakdown = computed(() => {
+/**
+ * Only payable balances with items that have an exclusive VAT rate show VAT rows: those items are
+ * listed excluding VAT, so the breakdown adds the VAT back with the same rows as on an invoice.
+ */
+const vatBreakdown = computed(() => props.item instanceof DetailedPayableBalance && props.item.hasExclusiveVAT ? props.item.VATBreakdown : []);
+const totalVAT = computed(() => vatBreakdown.value.reduce((sum, subtotal) => sum + subtotal.VAT, 0));
+
+const priceBreakdown = computed((): PriceBreakdown => {
     const now = BalanceItem.getDueOffset();
     const laterBalance = BalanceItem.getOutstandingBalance(props.item.filteredBalanceItems.filter(i => i.dueAt !== null && i.dueAt > now));
     const balance = BalanceItem.getOutstandingBalance(props.item.filteredBalanceItems.filter(i => i.dueAt === null || i.dueAt <= now));
-    
-    const discountBalance = isPayable ? BalanceItem.getOutstandingBalance(props.item.discountBalanceItems) : BalanceItem.getOutstandingBalance([])
+
+    const discountBalance = isPayable ? BalanceItem.getOutstandingBalance(props.item.discountBalanceItems) : BalanceItem.getOutstandingBalance([]);
 
     if (balance.priceOpen < 0) {
         if (laterBalance.priceOpen > 0) {
@@ -36,14 +43,14 @@ const priceBreakdown = computed(() => {
 
     const paid = balance.pricePaid + laterBalance.pricePaid - discountBalance.pricePaid;
 
-    const all = [
+    const all: PriceBreakdown = [
         {
             name: $t(`%1Xl`),
             price: discountBalance.priceOpen, // only relevant shown
             action: {
                 icon: 'info-circle',
-                handler: showDiscountSheet
-            }
+                handler: showDiscountSheet,
+            },
         },
         {
             name: paid >= 0 ? $t(`%ly`) : $t('%1Yy'),
@@ -55,10 +62,28 @@ const priceBreakdown = computed(() => {
         },
     ].filter(a => a.price !== 0);
 
+    const totalWithVAT = balance.payablePriceWithVAT + laterBalance.payablePriceWithVAT - discountBalance.payablePriceWithVAT;
+
     if (all.length > 0) {
         all.unshift({
-            name: $t(`%lz`),
-            price: balance.payablePriceWithVAT + laterBalance.payablePriceWithVAT - discountBalance.payablePriceWithVAT,
+            name: vatBreakdown.value.length > 0 ? $t(`%1KL`) : $t(`%lz`),
+            price: totalWithVAT,
+        });
+    }
+
+    // The items are listed excluding VAT: start with the total excluding VAT and the VAT that is
+    // added to it (like on an invoice), so every row follows from the rows above it
+    if (vatBreakdown.value.length > 0) {
+        const single = vatBreakdown.value.length === 1 ? vatBreakdown.value[0] : null;
+
+        all.unshift({
+            name: $t(`%1KK`),
+            price: totalWithVAT - totalVAT.value,
+        }, {
+            name: $t(`%1JE`) + (single ? ' (' + Formatter.percentage(single.VATPercentage * 100) + ')' : ''),
+            description: single?.VATExcempt ? getVATExcemptInvoiceNote(single.VATExcempt) : undefined,
+            price: totalVAT.value,
+            action: single ? undefined : { icon: 'info-circle', handler: showVATDetails },
         });
     }
 
@@ -78,20 +103,30 @@ const priceBreakdown = computed(() => {
     ];
 });
 
-
 const { presentPositionableSheet } = usePositionableSheet();
+
+async function showVATDetails(event: MouseEvent) {
+    await presentPositionableSheet(event, {
+        components: [
+            new ComponentWithProperties(NavigationController, {
+                root: AsyncComponent(() => import('./BalanceVATDetailsBox.vue'), {
+                    vatBreakdown: vatBreakdown.value,
+                }),
+            }),
+        ],
+    }, { minimumHeight: 185 });
+}
 
 async function showDiscountSheet(event: MouseEvent) {
     await presentPositionableSheet(event, {
         components: [
             new ComponentWithProperties(NavigationController, {
                 root: AsyncComponent(() => import('./components/DiscountsSheet.vue'), {
-                    items: props.item.discountBalanceItems
+                    items: props.item.discountBalanceItems,
                 }),
             }),
         ],
     }, { minimumHeight: 185, width: 500 });
 }
-
 
 </script>

--- a/frontend/shared/components/src/payments/BalanceVATDetailsBox.test.ts
+++ b/frontend/shared/components/src/payments/BalanceVATDetailsBox.test.ts
@@ -1,0 +1,54 @@
+import type { BalanceItemVATSubtotal } from '@stamhoofd/structures';
+import { getVATExcemptInvoiceNote, VATExcemptReason } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+import { expect, test } from 'vitest';
+import { render } from 'vitest-browser-vue';
+import BalanceVATDetailsBox from './BalanceVATDetailsBox.vue';
+
+function renderBox(vatBreakdown: BalanceItemVATSubtotal[]) {
+    return render(BalanceVATDetailsBox, {
+        props: { vatBreakdown },
+        global: {
+            provide: {
+                // Render as a popup so the navigation bar (with its own dependencies) is skipped
+                reactive_popup: {},
+            },
+            config: {
+                globalProperties: {
+                    $t: (globalThis as any).$t ?? ((value: string) => value),
+                    formatPrice: Formatter.price.bind(Formatter),
+                    formatPercentage: Formatter.percentage.bind(Formatter),
+                } as any,
+            },
+        },
+    });
+}
+
+test('lists the taxable amount and VAT per rate', () => {
+    renderBox([
+        { VATPercentage: 21, VATExcempt: null, taxablePrice: 4_13_00, VAT: 86_73 },
+        { VATPercentage: 6, VATExcempt: null, taxablePrice: 5_00_00, VAT: 30_00 },
+    ]);
+
+    // First grid item is the header row
+    const rows = Array.from(document.querySelectorAll('.st-grid-item')).slice(1);
+    expect(rows).toHaveLength(2);
+
+    expect(rows[0].textContent).toContain('21%');
+    expect(rows[0].textContent).toContain('4,13');
+    expect(rows[0].textContent).toContain('0,87');
+
+    expect(rows[1].textContent).toContain('6%');
+    expect(rows[1].textContent).toContain('\u20AC\u00A05');
+    expect(rows[1].textContent).toContain('0,30');
+});
+
+test('shows the exemption note for exempt groups', () => {
+    renderBox([
+        { VATPercentage: 0, VATExcempt: VATExcemptReason.IntraCommunityServices, taxablePrice: 5_00_00, VAT: 0 },
+    ]);
+
+    const row = Array.from(document.querySelectorAll('.st-grid-item'))[1];
+    expect(row.textContent).toContain(getVATExcemptInvoiceNote(VATExcemptReason.IntraCommunityServices));
+    expect(row.textContent).toContain('(0%)');
+});

--- a/frontend/shared/components/src/payments/BalanceVATDetailsBox.vue
+++ b/frontend/shared/components/src/payments/BalanceVATDetailsBox.vue
@@ -1,0 +1,57 @@
+<template>
+    <div class="st-view">
+        <STNavigationBar v-if="!popup" :title="$t('%1JE')" />
+
+        <main>
+            <STGrid>
+                <STGridItem class="header price-grid">
+                    {{ $t('%1KU') }}
+
+                    <template #middleRight>
+                        {{ $t('%1KV') }}
+                    </template>
+
+                    <template #right>
+                        {{ $t('%1JE') }}
+                    </template>
+                </STGridItem>
+
+                <STGridItem v-for="(subtotal, index) of vatBreakdown" :key="index" class="price-grid">
+                    <h3 v-if="!subtotal.VATExcempt" class="style-title-list">
+                        {{ formatPercentage(subtotal.VATPercentage * 100) }}
+                    </h3>
+                    <h3 v-else class="style-title-list">
+                        {{ getVATExcemptInvoiceNote(subtotal.VATExcempt) }} ({{ formatPercentage(subtotal.VATPercentage * 100) }})
+                    </h3>
+
+                    <template #middleRight>
+                        <p class="style-price-base" :class="{negative: subtotal.taxablePrice < 0}">
+                            {{ formatPrice(subtotal.taxablePrice) }}
+                        </p>
+                    </template>
+
+                    <template #right>
+                        <p class="style-price-base" :class="{negative: subtotal.VAT < 0}">
+                            {{ formatPrice(subtotal.VAT) }}
+                        </p>
+                    </template>
+                </STGridItem>
+            </STGrid>
+        </main>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { usePopup } from '@simonbackx/vue-app-navigation';
+import STGrid from '#layout/STGrid.vue';
+import STGridItem from '#layout/STGridItem.vue';
+import type { BalanceItemVATSubtotal } from '@stamhoofd/structures';
+import { getVATExcemptInvoiceNote } from '@stamhoofd/structures';
+import STNavigationBar from '#navigation/STNavigationBar.vue';
+
+defineProps<{
+    vatBreakdown: BalanceItemVATSubtotal[];
+}>();
+
+const popup = usePopup();
+</script>

--- a/frontend/shared/components/src/payments/GroupedBalanceList.vue
+++ b/frontend/shared/components/src/payments/GroupedBalanceList.vue
@@ -1,19 +1,29 @@
 <template>
     <STGrid>
-        <BalanceItemRow v-for="group in groupedItems" :key="group.id" :has-write="hasWrite" :item="group" :is-payable="isPayable" />
+        <BalanceItemRow v-for="group in groupedItems" :key="group.id" :has-write="hasWrite" :item="group" :is-payable="isPayable" :exclude-vat="excludeVat" />
     </STGrid>
 </template>
 
 <script setup lang="ts">
-import type { DetailedReceivableBalance} from '@stamhoofd/structures';
+import type { DetailedReceivableBalance } from '@stamhoofd/structures';
 import { DetailedPayableBalance, GroupedBalanceItems } from '@stamhoofd/structures';
 import { computed } from 'vue';
 import BalanceItemRow from './BalanceItemRow.vue';
 import STGrid from '../layout/STGrid.vue';
 
-const props = defineProps<{
-    item: DetailedPayableBalance | DetailedReceivableBalance;
-}>();
+const props = withDefaults(
+    defineProps<{
+        item: DetailedPayableBalance | DetailedReceivableBalance;
+
+        /**
+         * Show the prices excluding VAT (used together with a separate VAT overview).
+         */
+        excludeVat?: boolean;
+    }>(),
+    {
+        excludeVat: false,
+    },
+);
 const isPayable = props.item instanceof DetailedPayableBalance;
 
 const items = computed(() => isPayable ? props.item.payableBalanceItems : props.item.filteredBalanceItems);

--- a/frontend/shared/components/src/payments/PayableBalanceTable.test.ts
+++ b/frontend/shared/components/src/payments/PayableBalanceTable.test.ts
@@ -1,0 +1,158 @@
+import { BalanceItemType, BalanceItemWithPayments, BaseOrganization, DetailedPayableBalance } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-vue';
+import { userEvent } from 'vitest/browser';
+import PayableBalanceTable from './PayableBalanceTable.vue';
+
+function createItem(overrides: Partial<{ unitPrice: number; amount: number; VATPercentage: number | null; VATIncluded: boolean; description: string }> = {}) {
+    return BalanceItemWithPayments.create({
+        type: BalanceItemType.Other,
+        description: overrides.description ?? 'Test item',
+        amount: overrides.amount ?? 1,
+        unitPrice: overrides.unitPrice ?? 4_13_00,
+        VATPercentage: overrides.VATPercentage === undefined ? 21 : overrides.VATPercentage,
+        VATIncluded: overrides.VATIncluded ?? false,
+    });
+}
+
+function createBalance(balanceItems: BalanceItemWithPayments[]) {
+    return DetailedPayableBalance.create({
+        organization: BaseOrganization.create({ id: 'org' }),
+        balanceItems,
+    });
+}
+
+function renderTable(item: DetailedPayableBalance) {
+    const present = vi.fn().mockResolvedValue(undefined);
+    const result = render(PayableBalanceTable, {
+        props: { item },
+        global: {
+            provide: {
+                reactive_navigation_pop: vi.fn().mockResolvedValue(undefined),
+                reactive_navigation_dismiss: vi.fn().mockResolvedValue(undefined),
+                reactive_navigation_present: present,
+                reactive_navigation_push: vi.fn().mockResolvedValue(undefined),
+            },
+            config: {
+                globalProperties: {
+                    $t: (globalThis as any).$t ?? ((value: string) => value),
+                    $isMobile: false,
+                    $context: null,
+                    formatPrice: Formatter.price.bind(Formatter),
+                    formatFloat: Formatter.float.bind(Formatter),
+                    formatPercentage: Formatter.percentage.bind(Formatter),
+                    formatPriceChange: Formatter.priceChange.bind(Formatter),
+                    formatDate: Formatter.date.bind(Formatter),
+                    formatDateRange: Formatter.dateRange.bind(Formatter),
+                    formatStartDate: Formatter.startDate.bind(Formatter),
+                } as any,
+            },
+            directives: {
+                tooltip: {},
+                copyable: {},
+                autofocus: {},
+            },
+        },
+    });
+    return { result, present };
+}
+
+/**
+ * The prices shown in the price breakdown box, trimmed.
+ * Note: formatPrice renders '€' followed by a non-breaking space (\u00A0).
+ */
+function breakdownPrices(): (string | undefined)[] {
+    return Array.from(document.querySelectorAll('.pricing-box .right')).map(el => el.textContent?.trim());
+}
+
+test('shows the empty state when there are no payable items', () => {
+    renderTable(createBalance([]));
+    expect(document.querySelector('.info-box')).not.toBeNull();
+});
+
+test('lists items excluding VAT and adds invoice-style VAT rows to the price breakdown', () => {
+    // 4,13 excl. VAT + 21% -> 0,87 VAT -> 5,00 incl. VAT
+    renderTable(createBalance([createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21, VATIncluded: false })]));
+
+    // The item list shows the price excluding VAT, without the VAT mixed in
+    const itemList = document.querySelector('.st-grid');
+    expect(itemList).not.toBeNull();
+    expect(itemList!.textContent).toContain('4,13');
+    expect(itemList!.textContent).not.toContain('0,87');
+
+    // The price breakdown shows: total excl. VAT / VAT (21%) / to pay — same as an invoice
+    expect(document.querySelectorAll('.pricing-box .left')).toHaveLength(3);
+    const box = document.querySelector('.pricing-box')!;
+    expect(box.textContent).toContain('(21%)');
+    expect(breakdownPrices()).toEqual(['€\u00A04,13', '€\u00A00,87', '€\u00A05']);
+
+    // A single VAT rate needs no details action
+    expect(box.querySelector('button.info-circle')).toBeNull();
+});
+
+test('the breakdown stays additive when partially paid', () => {
+    // 5,00 excl. VAT + 21% -> 6,05 incl. VAT, of which 1,21 was already paid
+    const item = createItem({ unitPrice: 5_00_00, amount: 1, VATPercentage: 21, VATIncluded: false });
+    item.pricePaid = 1_21_00;
+    renderTable(createBalance([item]));
+
+    // Every row follows from the rows above it:
+    // total excl. VAT (5,00) + VAT (1,05) = total incl. VAT (6,05), minus paid (1,21) = to pay (4,84)
+    expect(breakdownPrices()).toEqual(['\u20AC\u00A05', '\u20AC\u00A01,05', '\u20AC\u00A06,05', '\u20AC\u00A01,21', '\u20AC\u00A04,84']);
+});
+
+test('VAT-inclusive items in the same basket also show unit prices excluding VAT', () => {
+    // The excl. VAT item switches the list to prices excluding VAT; the VAT-inclusive item
+    // (2 x 12,10 incl. 21% VAT) must then show its unit price excluding VAT (10,00) too
+    renderTable(createBalance([
+        createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21, VATIncluded: false }),
+        createItem({ unitPrice: 12_10_00, amount: 2, VATPercentage: 21, VATIncluded: true, description: 'Inclusive item' }),
+    ]));
+
+    const itemList = document.querySelector('.st-grid')!;
+    expect(itemList.textContent).toContain('\u20AC\u00A010');
+    expect(itemList.textContent).not.toContain('12,10');
+});
+
+test('shows an info action with the VAT details when there are multiple VAT rates', async () => {
+    const { present } = renderTable(createBalance([
+        createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21 }),
+        createItem({ unitPrice: 5_00_00, amount: 1, VATPercentage: 6 }),
+    ]));
+
+    const box = document.querySelector('.pricing-box')!;
+
+    // No single percentage in the VAT row name
+    expect(box.textContent).not.toContain('(21%)');
+    expect(box.textContent).not.toContain('(6%)');
+
+    // The info action opens the per-rate VAT details sheet
+    const button = box.querySelector<HTMLButtonElement>('button.info-circle');
+    expect(button).not.toBeNull();
+    await userEvent.click(button!);
+    expect(present).toHaveBeenCalled();
+});
+
+test('does not add VAT rows when there are no VAT rates', () => {
+    renderTable(createBalance([createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: null })]));
+
+    // Only the 'to pay' row remains
+    expect(document.querySelectorAll('.pricing-box .left')).toHaveLength(1);
+    expect(breakdownPrices()).toEqual(['€\u00A04,13']);
+});
+
+test('does not add VAT rows when VAT is included in the price', () => {
+    renderTable(createBalance([createItem({ unitPrice: 5_00_00, amount: 1, VATPercentage: 21, VATIncluded: true })]));
+
+    expect(document.querySelectorAll('.pricing-box .left')).toHaveLength(1);
+    expect(breakdownPrices()).toEqual(['€\u00A05']);
+});
+
+test('emits checkout when the pay button is clicked', async () => {
+    const { result } = renderTable(createBalance([createItem()]));
+
+    await userEvent.click(document.querySelector('.style-button-bar button')!);
+
+    expect(result.emitted()).toHaveProperty('checkout');
+});

--- a/frontend/shared/components/src/payments/PayableBalanceTable.vue
+++ b/frontend/shared/components/src/payments/PayableBalanceTable.vue
@@ -3,7 +3,7 @@
         {{ $t('%h9') }}
     </p>
     <template v-if="items.length">
-        <GroupedBalanceList :item="item" />
+        <GroupedBalanceList :item="item" :exclude-vat="hasExclusiveVAT" />
         <BalancePriceBreakdown :item="item" />
         <p v-if="payableBalanceItems.length" class="style-button-bar right-align">
             <button class="button primary" type="button" @click="$emit('checkout')">
@@ -24,8 +24,9 @@ const props = defineProps<{
     item: DetailedPayableBalance;
 }>();
 
-defineEmits(['checkout'])
+defineEmits(['checkout']);
 const items = computed(() => props.item.filteredBalanceItems);
 const payableBalanceItems = computed(() => props.item.payableBalanceItems);
+const hasExclusiveVAT = computed(() => props.item.hasExclusiveVAT);
 
 </script>

--- a/shared/structures/src/BalanceItem.test.ts
+++ b/shared/structures/src/BalanceItem.test.ts
@@ -1,7 +1,24 @@
 import { TestUtils } from '@stamhoofd/test-utils';
-import { BalanceItemRelationType, BalanceItemType, getApplicableBalanceItemRelationTypes, getApplicableBalanceItemTypes } from './BalanceItem.js';
-import { Organization } from './Organization.js';
+import { BalanceItem, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, BalanceItemWithPayments, getApplicableBalanceItemRelationTypes, getApplicableBalanceItemTypes, GroupedBalanceItems, VATExcemptReason } from './BalanceItem.js';
+import { DetailedPayableBalance } from './endpoints/PayableBalanceCollection.js';
+import { BaseOrganization, Organization } from './Organization.js';
 import { Platform } from './Platform.js';
+
+/**
+ * Helper to create a payable (Due) balance item with an exclusive VAT rate.
+ * unitPrice is in the internal integer format (1 euro = 10000).
+ */
+function createItem(overrides: Partial<{ unitPrice: number; amount: number; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; type: BalanceItemType; description: string }> = {}) {
+    return BalanceItemWithPayments.create({
+        type: overrides.type ?? BalanceItemType.Other,
+        description: overrides.description ?? 'Test item',
+        amount: overrides.amount ?? 1,
+        unitPrice: overrides.unitPrice ?? 4_13_00,
+        VATPercentage: overrides.VATPercentage === undefined ? 21 : overrides.VATPercentage,
+        VATIncluded: overrides.VATIncluded ?? false,
+        VATExcempt: overrides.VATExcempt ?? null,
+    });
+}
 
 describe('getApplicableBalanceItemTypes / getApplicableBalanceItemRelationTypes', () => {
     const membershipOrganization = Organization.create({ id: 'membership-org' });
@@ -119,5 +136,128 @@ describe('getApplicableBalanceItemTypes / getApplicableBalanceItemRelationTypes'
             expect(relations).toContain(BalanceItemRelationType.MembershipType);
             expect(relations).not.toContain(BalanceItemRelationType.STPackage);
         });
+    });
+});
+
+describe('BalanceItem.getPayableVATBreakdown', () => {
+    test('groups the VAT per rate and sums the taxable price and VAT', () => {
+        const items = [
+            createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21 }), // taxable 41300, VAT 8673
+            createItem({ unitPrice: 10_00_00, amount: 2, VATPercentage: 21 }), // taxable 200000, VAT 42000
+            createItem({ unitPrice: 5_00_00, amount: 1, VATPercentage: 6 }), // taxable 50000, VAT 3000
+        ];
+
+        const breakdown = BalanceItem.getPayableVATBreakdown(items);
+
+        // Sorted descending by percentage
+        expect(breakdown).toEqual([
+            { VATPercentage: 21, VATExcempt: null, taxablePrice: 41300 + 200000, VAT: 8673 + 42000 },
+            { VATPercentage: 6, VATExcempt: null, taxablePrice: 50000, VAT: 3000 },
+        ]);
+    });
+
+    test('ignores items without a VAT rate or exemption', () => {
+        const items = [
+            createItem({ unitPrice: 3_00_00, VATPercentage: null }),
+        ];
+
+        expect(BalanceItem.getPayableVATBreakdown(items)).toEqual([]);
+    });
+
+    test('groups exempt items per exemption reason with a 0% rate, like on invoices', () => {
+        // Two exempt items with different underlying rates end up in one 0% group
+        const items = [
+            createItem({ unitPrice: 5_00_00, amount: 1, VATPercentage: 21, VATExcempt: VATExcemptReason.IntraCommunityServices }),
+            createItem({ unitPrice: 3_00_00, amount: 1, VATPercentage: 6, VATExcempt: VATExcemptReason.IntraCommunityServices }),
+        ];
+
+        expect(BalanceItem.getPayableVATBreakdown(items)).toEqual([
+            { VATPercentage: 0, VATExcempt: VATExcemptReason.IntraCommunityServices, taxablePrice: 80000, VAT: 0 },
+        ]);
+    });
+
+    test('is based on the full payable price, so payments do not change it', () => {
+        // 5,00 excl. VAT + 21% -> 6,05 incl. VAT, partially paid
+        const item = createItem({ unitPrice: 5_00_00, amount: 1, VATPercentage: 21 });
+        item.pricePaid = 1_21_00;
+
+        expect(BalanceItem.getPayableVATBreakdown([item])).toEqual([
+            // Payments are shown as separate breakdown rows; the VAT reconciles with the total incl. VAT
+            { VATPercentage: 21, VATExcempt: null, taxablePrice: 50000, VAT: 10500 },
+        ]);
+    });
+
+    test('hidden and canceled items add nothing', () => {
+        const item = createItem({ unitPrice: 5_00_00, amount: 1, VATPercentage: 21 });
+        item.status = BalanceItemStatus.Canceled;
+
+        expect(BalanceItem.getPayableVATBreakdown([item])).toEqual([]);
+    });
+});
+
+describe('GroupedBalanceItems.payablePriceWithoutVAT', () => {
+    test('sums the prices excluding VAT of all items in the group', () => {
+        const groups = GroupedBalanceItems.group([
+            createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21 }),
+            createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21 }),
+        ]);
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0].payablePriceWithoutVAT).toBe(2 * 41300);
+        // The full price (including VAT) is still available and larger
+        expect(groups[0].payablePriceWithVAT).toBe(2 * 49973);
+    });
+
+    test('unitPriceWithoutVAT strips the VAT from the unit price of VAT-inclusive items', () => {
+        // 12,10 incl. 21% VAT per piece -> 10,00 excl. VAT per piece
+        const item = createItem({ unitPrice: 12_10_00, amount: 2, VATPercentage: 21, VATIncluded: true });
+        expect(item.unitPriceWithoutVAT).toBe(10_00_00);
+        expect(item.unitPriceWithVAT).toBe(12_10_00);
+
+        const groups = GroupedBalanceItems.group([item]);
+        expect(groups[0].unitPriceWithoutVAT).toBe(10_00_00);
+    });
+
+    test('does not count hidden or canceled items, mirroring payablePriceWithVAT', () => {
+        const group = new GroupedBalanceItems();
+        group.add(createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21 })); // Due
+        group.add(BalanceItemWithPayments.create({
+            type: BalanceItemType.Other,
+            amount: 1,
+            unitPrice: 4_13_00,
+            VATPercentage: 21,
+            VATIncluded: false,
+            status: BalanceItemStatus.Canceled,
+        }));
+
+        // Only the Due item contributes to both payable prices
+        expect(group.payablePriceWithoutVAT).toBe(41300);
+        expect(group.payablePriceWithVAT).toBe(49973);
+    });
+});
+
+describe('DetailedPayableBalance VAT helpers', () => {
+    function createBalance(balanceItems: BalanceItemWithPayments[]) {
+        return DetailedPayableBalance.create({
+            organization: BaseOrganization.create({ id: 'org' }),
+            balanceItems,
+        });
+    }
+
+    test('detects exclusive VAT items', () => {
+        const balance = createBalance([createItem({ VATPercentage: 21, VATIncluded: false })]);
+        expect(balance.hasExclusiveVAT).toBe(true);
+        expect(balance.VATBreakdown).toHaveLength(1);
+    });
+
+    test('does not treat VAT-inclusive items as exclusive VAT', () => {
+        const balance = createBalance([createItem({ VATPercentage: 21, VATIncluded: true })]);
+        expect(balance.hasExclusiveVAT).toBe(false);
+    });
+
+    test('has no exclusive VAT and no breakdown when there are no VAT rates', () => {
+        const balance = createBalance([createItem({ VATPercentage: null })]);
+        expect(balance.hasExclusiveVAT).toBe(false);
+        expect(balance.VATBreakdown).toEqual([]);
     });
 });

--- a/shared/structures/src/BalanceItem.ts
+++ b/shared/structures/src/BalanceItem.ts
@@ -332,6 +332,19 @@ export function doBalanceItemRelationsMatch(a: Map<BalanceItemRelationType, Bala
     return true;
 }
 
+/**
+ * The VAT for a group of balance items sharing the same VAT rate (and exemption).
+ */
+export type BalanceItemVATSubtotal = {
+    VATPercentage: number;
+    VATExcempt: VATExcemptReason | null;
+    /**
+     * Value on which the VAT is calculated (taxable amount, excluding VAT)
+     */
+    taxablePrice: number;
+    VAT: number;
+};
+
 export class BalanceItem extends AutoEncoder {
     @field({ decoder: StringDecoder, defaultValue: () => uuidv4() })
     id: string;
@@ -421,6 +434,18 @@ export class BalanceItem extends AutoEncoder {
     }
 
     /**
+     * Total price excluding VAT that needs to be paid.
+     *
+     * The difference with priceWithoutVAT is that it takes into account canceled and hidden balance items
+     */
+    get payablePriceWithoutVAT() {
+        if (this.status === BalanceItemStatus.Hidden || this.status === BalanceItemStatus.Canceled) {
+            return 0;
+        }
+        return this.priceWithoutVAT;
+    }
+
+    /**
      * Difference here is that when the VAT is excempt, this is still set, while VAT will be zero.
      */
     get calculatedVAT() {
@@ -476,6 +501,13 @@ export class BalanceItem extends AutoEncoder {
             return 0;
         }
         return STMath.round(this.priceWithVAT / this.amount);
+    }
+
+    get unitPriceWithoutVAT() {
+        if (this.amount === 0) {
+            return 0;
+        }
+        return STMath.round(this.priceWithoutVAT / this.amount);
     }
 
     /**
@@ -624,6 +656,42 @@ export class BalanceItem extends AutoEncoder {
             priceOpen: totalOpen,
             pricePaid: totalPaid,
         };
+    }
+
+    /**
+     * Groups the VAT of the given balance items per VAT rate (and exemption).
+     * Sums the payable prices: taxablePrice + VAT = the payable price including VAT of each group.
+     * Items without VAT and empty groups are left out.
+     */
+    static getPayableVATBreakdown(items: BalanceItem[]): BalanceItemVATSubtotal[] {
+        const map = new Map<string, BalanceItemVATSubtotal>();
+
+        for (const item of items) {
+            if (!item.VATPercentage && !item.VATExcempt) {
+                continue;
+            }
+
+            // Exempt items are grouped per exemption reason with a 0% rate, like on invoices
+            const VATPercentage = item.VATExcempt ? 0 : (item.VATPercentage ?? 0);
+            const key = VATPercentage + '-' + (item.VATExcempt ?? '');
+            let subtotal = map.get(key);
+            if (!subtotal) {
+                subtotal = {
+                    VATPercentage,
+                    VATExcempt: item.VATExcempt,
+                    taxablePrice: 0,
+                    VAT: 0,
+                };
+                map.set(key, subtotal);
+            }
+
+            subtotal.taxablePrice += item.payablePriceWithoutVAT;
+            subtotal.VAT += item.payablePriceWithVAT - item.payablePriceWithoutVAT;
+        }
+
+        return Array.from(map.values())
+            .filter(subtotal => subtotal.taxablePrice !== 0 || subtotal.VAT !== 0)
+            .sort((a, b) => Sorter.byNumberValue(a.VATPercentage, b.VATPercentage));
     }
 
     static filterBalanceItems(items: BalanceItem[]) {
@@ -987,7 +1055,7 @@ export class BalanceItem extends AutoEncoder {
             } else if (item.status === BalanceItemStatus.Canceled) {
                 prefix = $t(`%gg`);
                 prefixClass = 'error';
-            } else if (item.priceOpen < 0 && item.pricePaid > item.price && item.pricePaid > 0) {
+            } else if (item.priceOpen < 0 && item.pricePaid > item.payablePriceWithVAT && item.pricePaid > 0) {
                 prefix = $t(`%gh`);
             } else if (item.priceOpen < 0) {
                 prefix = $t(`%10a`);
@@ -999,7 +1067,7 @@ export class BalanceItem extends AutoEncoder {
                 price = Formatter.price(item.priceOpen);
             }
 
-            if (item.price === item.amount * item.unitPrice) {
+            if (item.payablePriceWithVAT === item.amount * item.unitPrice) {
                 if (description) {
                     description += `\n`;
                 }
@@ -1008,7 +1076,7 @@ export class BalanceItem extends AutoEncoder {
                 if (description) {
                     description += `\n`;
                 }
-                description += `<span class="email-style-discount-old-price">${Formatter.escapeHtml(Formatter.float(item.amount))} x ${Formatter.escapeHtml(Formatter.price(item.unitPrice))}</span><span class="email-style-discount-price">${Formatter.escapeHtml(Formatter.price(item.price))}</span>`;
+                description += `<span class="email-style-discount-old-price">${Formatter.escapeHtml(Formatter.float(item.amount))} x ${Formatter.escapeHtml(Formatter.price(item.unitPrice))}</span><span class="email-style-discount-price">${Formatter.escapeHtml(Formatter.price(item.payablePriceWithVAT))}</span>`;
             }
 
             if (item.pricePaid !== 0 && item.pricePaid !== (item.amount * item.unitPrice)) {
@@ -1109,15 +1177,19 @@ export class GroupedBalanceItems {
         return this.items.reduce((acc, item) => acc + item.priceOpen, 0);
     }
 
-    get price() {
+    get payablePriceWithVAT() {
         return this.items.reduce((acc, item) => acc + item.payablePriceWithVAT, 0);
+    }
+
+    get payablePriceWithoutVAT() {
+        return this.items.reduce((acc, item) => acc + item.payablePriceWithoutVAT, 0);
     }
 
     get unitPriceWithVAT() {
         if (this.amount === 0) {
             return 0;
         }
-        return Math.round(this.price / this.amount);
+        return Math.round(this.payablePriceWithVAT / this.amount);
     }
 
     get pricePending() {
@@ -1164,8 +1236,11 @@ export class GroupedBalanceItems {
         return this.items[0].unitPrice;
     }
 
-    get unitPriceWithAT() {
-        return this.items[0].unitPriceWithVAT;
+    get unitPriceWithoutVAT() {
+        if (this.amount === 0) {
+            return 0;
+        }
+        return Math.round(this.payablePriceWithoutVAT / this.amount);
     }
 
     get dueAt() {

--- a/shared/structures/src/endpoints/PayableBalanceCollection.ts
+++ b/shared/structures/src/endpoints/PayableBalanceCollection.ts
@@ -54,6 +54,23 @@ export class DetailedPayableBalance extends AutoEncoder {
     get discountBalanceItems() {
         return BalanceItem.filterDiscountBalanceItems(this.balanceItems);
     }
+
+    /**
+     * Whether the payable items contain items with a VAT rate that is added on top of the price (excluding VAT).
+     * When this is the case, the item prices become hard to read (they include rounded VAT), so we show the
+     * prices excluding VAT together with a separate VAT overview instead.
+     */
+    get hasExclusiveVAT() {
+        return this.payableBalanceItems.some(item => !item.VATIncluded && !!item.VATPercentage);
+    }
+
+    /**
+     * VAT of the payable items, grouped per VAT percentage.
+     * Based on the full payable prices, so it reconciles with the listed item prices and the total.
+     */
+    get VATBreakdown() {
+        return BalanceItem.getPayableVATBreakdown(this.payableBalanceItems);
+    }
 }
 
 export class DetailedPayableBalanceCollection extends AutoEncoder {

--- a/shared/utility/src/Formatter.test.ts
+++ b/shared/utility/src/Formatter.test.ts
@@ -1,0 +1,37 @@
+import { Formatter } from './Formatter.js';
+
+describe('Formatter.price', () => {
+    // Prices are stored as integers up to 4 digits after the decimal point (1 euro = 10000),
+    // but should never be displayed with more than 2 digits after the comma. See STA-1320.
+
+    test('never shows more than 2 digits after the comma', () => {
+        for (const value of [4_99_73, 4_13_40, 4_13_50, 1_23_55, 1, 9_99_99, -4_99_73]) {
+            expect(Formatter.price(value)).not.toMatch(/[.,]\d{3,}/);
+        }
+    });
+
+    test('rounds the hidden extra digits to the nearest cent', () => {
+        // 4,1340 -> 4,13 (rounds down)
+        expect(Formatter.price(4_13_40)).toContain('4,13');
+        // 4,1350 -> 4,14 (rounds half up)
+        expect(Formatter.price(4_13_50)).toContain('4,14');
+        // 1,2355 -> 1,24 (rounds half up)
+        expect(Formatter.price(1_23_55)).toContain('1,24');
+    });
+
+    test('a value that rounds to a whole euro matches the whole euro', () => {
+        // 4,9973 rounds to 5,00
+        expect(Formatter.price(4_99_73)).toBe(Formatter.price(5_00_00));
+    });
+
+    test('removes zero decimals by default but keeps them when asked', () => {
+        expect(Formatter.price(5_00_00)).not.toContain(',00');
+        expect(Formatter.price(5_00_00, false)).toContain('5,00');
+        // A rounded whole euro also drops the decimals
+        expect(Formatter.price(4_99_73)).not.toContain(',');
+    });
+
+    test('keeps the negative sign', () => {
+        expect(Formatter.price(-4_13_40).startsWith('-')).toBe(true);
+    });
+});

--- a/shared/utility/src/Formatter.ts
+++ b/shared/utility/src/Formatter.ts
@@ -463,10 +463,13 @@ export class Formatter {
     }
 
     static price(value: number, removeZeroDecimals = true): string {
+        // We store prices with up to 4 digits after the decimal point for correct VAT calculations,
+        // but we never display more than 2 digits: users confuse 5,012 euro with 5.012 euro.
+        // The extra digits are rounded away here.
         const formatted = new Intl.NumberFormat('nl-BE', {
             style: 'currency',
             currency: 'EUR',
-            maximumFractionDigits: 4,
+            maximumFractionDigits: 2,
             minimumFractionDigits: 2,
         }).format(Math.abs(value) / 100_00);
 


### PR DESCRIPTION
Fixes STA-1320

## Problem

When payable balance items have an exclusive VAT rate, the listed prices include rounded VAT with up to 4 decimals (e.g. € 4,9973), which is unreadable — users confuse 5,012 euro with 5.012 euro.

## Changes

**Formatter**
- `Formatter.price` never displays more than 2 decimals: the extra precision is rounded to the nearest cent.

**Payable balance display (like invoices)**
- When payable items carry an exclusive VAT rate, `PayableBalanceTable` lists all items **excluding VAT** and the price breakdown shows invoice-style rows that read as an additive ledger: `Totaal excl. BTW / BTW (21%) / Totaal incl. BTW / Reeds betaald / Te betalen`.
- With a single VAT rate the percentage is shown inline (with the exemption note if applicable); with multiple rates an info action opens a per-rate VAT details sheet (`BalanceVATDetailsBox`, mirroring `InvoiceVATDetailsBox`).
- Exempt items are grouped per exemption reason with a 0% rate, like on invoices.
- Receivable balance views are unaffected (`excludeVat` defaults to false; VAT rows are gated on `DetailedPayableBalance`).

**Structures naming cleanup**
- `GroupedBalanceItems.price` → `payablePriceWithVAT`; new `BalanceItem.payablePriceWithoutVAT` and `unitPriceWithoutVAT`; `BalanceItem.getPayableVATBreakdown()` groups the VAT per rate. The `payable*` prefix consistently means the balance item status is taken into account.
- Removed the dead `unitPriceWithAT` typo getter.

## Tests

- `Formatter.price` unit tests (rounding, max 2 decimals, zero-decimal stripping)
- Structures tests for `getPayableVATBreakdown`, `payablePriceWithoutVAT` and `unitPriceWithoutVAT`
- Component tests (vitest-browser) for `PayableBalanceTable` (8) and `BalanceVATDetailsBox` (2): excl-VAT listing, additive ledger with partial payments, multi-rate info action, mixed VAT-inclusive baskets, no-VAT cases, checkout emit

All verified: `yarn stam test structures BalanceItem` (26), `yarn stam test utility Formatter` (5), component tests (10), models Email tests (22, covers `getDetailsHTMLTable`), eslint clean, repo-wide typecheck (15 projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786546484&installation_id=138085646&pr_number=604&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F604&signature=ef9c71e866d77406accdbd47e8418875b3f6e776d107fcc008936da0714ec531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->