### PR TITLE
Add group search and activities tab when registering a member (STA-1311, STA-1266)

### DIFF
--- a/frontend/app/registration/src/App.vue
+++ b/frontend/app/registration/src/App.vue
@@ -11,22 +11,19 @@ import PromiseView from '@stamhoofd/components/containers/PromiseView.vue';
 import TabBarController from '@stamhoofd/components/containers/TabBarController.vue';
 import { TabBarItem } from '@stamhoofd/components/containers/TabBarItem.ts';
 import { useContext } from '@stamhoofd/components/hooks/useContext';
-import { useEventTypes } from '@stamhoofd/components/hooks/useEventTypes.ts';
-import { manualFeatureFlag } from '@stamhoofd/components/hooks/useFeatureFlag.ts';
+import { useEventsEnabled } from '@stamhoofd/components/hooks/useEventsEnabled.ts';
 import { useMemberManager } from '@stamhoofd/networking/MemberManager';
 import { useMembersPackage } from '@stamhoofd/components/hooks/useMembersPackage.ts';
 import { computed } from 'vue';
 import { useAppNavigate } from '@stamhoofd/components/hooks/useAppNavigate.ts';
 import { AppRoute } from '@stamhoofd/structures';
-import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
 
 const context = useContext();
 const memberManager = useMemberManager();
 const getLoginRoot = useLoginRoot();
-const eventTypes = useEventTypes();
+const eventsEnabled = useEventsEnabled();
 const membersPackage = useMembersPackage();
 const appNavigate = useAppNavigate();
-const organization = useOrganization();
 
 function wrapWithModalStack(component: ComponentWithProperties) {
     return new ComponentWithProperties(ModalStackComponent, { root: component });
@@ -39,10 +36,6 @@ const root = new ComponentWithProperties(AuthenticatedView, {
 const component = useCurrentComponent();
 if (component?.checkRoutes) {
     root.setCheckRoutes();
-}
-
-function areEventsEnabled(): boolean {
-    return eventTypes.value.length > 0 && !manualFeatureFlag('disable-events', context.value) && (!organization.value || STAMHOOFD.userMode === 'platform' || organization.value.meta.enableCalendar === true || (organization.value.meta.enableCalendar === null && organization.value.hasFutureEvents));
 }
 
 function getRoot() {
@@ -95,7 +88,7 @@ function getRoot() {
                         name: $t(`%I`),
                         component: startView,
                     }),
-                    ...(areEventsEnabled() ? [calendarTab] : []),
+                    ...(eventsEnabled.value ? [calendarTab] : []),
                     communicationTab,
                     new TabBarItem({
                         id: 'cart',

--- a/frontend/shared/components/src/hooks/useEventsEnabled.ts
+++ b/frontend/shared/components/src/hooks/useEventsEnabled.ts
@@ -1,0 +1,36 @@
+import type { ComputedRef } from 'vue';
+import { computed } from 'vue';
+import { useContext } from './useContext';
+import { useEventTypes } from './useEventTypes';
+import { manualFeatureFlag } from './useFeatureFlag';
+import { useOrganization } from './useOrganization';
+
+/**
+ * Whether the events/calendar feature should be shown for the current context.
+ *
+ * Mirrors the gating used to show the 'Activiteiten' tab in the member portal:
+ * events need at least one configured event type, must not be disabled by a
+ * feature flag, and the organization must have the calendar enabled (or, in
+ * platform mode, events are always available).
+ */
+export function useEventsEnabled(): ComputedRef<boolean> {
+    const eventTypes = useEventTypes();
+    const context = useContext();
+    const organization = useOrganization();
+
+    return computed(() => {
+        if (eventTypes.value.length === 0) {
+            return false;
+        }
+
+        if (manualFeatureFlag('disable-events', context.value)) {
+            return false;
+        }
+
+        const org = organization.value;
+        return !org
+            || STAMHOOFD.userMode === 'platform'
+            || org.meta.enableCalendar === true
+            || (org.meta.enableCalendar === null && org.hasFutureEvents);
+    });
+}

--- a/frontend/shared/components/src/members/ChooseFamilyMembersForGroupView.vue
+++ b/frontend/shared/components/src/members/ChooseFamilyMembersForGroupView.vue
@@ -11,7 +11,7 @@
             </p>
 
             <STList>
-                <RegisterItemCheckboxRow v-for="member in family.members" :key="member.id" :member="member" :group="group" :group-organization="groupOrganization" />
+                <RegisterItemCheckboxRow v-for="member in family.members" :key="member.id" :checkout="checkout" :member="member" :group="group" :group-organization="groupOrganization" />
             </STList>
         </SaveView>
     </ExternalOrganizationContainer>

--- a/frontend/shared/components/src/members/ChooseGroupForMemberView.vue
+++ b/frontend/shared/components/src/members/ChooseGroupForMemberView.vue
@@ -6,64 +6,82 @@
         <main class="center">
             <h1>{{ $t('%di', {member: member.patchedMember.firstName}) }}</h1>
 
-            <ScrollableSegmentedControl v-if="allowChangingOrganization" v-model="selectedOrganization" :items="items" :labels="labels">
+            <ScrollableSegmentedControl v-if="showControl" v-model="selectedControlTab" :items="controlItems" :labels="controlLabels" data-testid="register-tabs">
                 <template #right>
-                    <button v-tooltip="$t('%dj')" class="button icon gray add" type="button" @click="searchOrganization" />
+                    <button v-if="allowChangingOrganization" v-tooltip="$t('%dj')" class="button icon gray add" type="button" @click="searchOrganization" />
                 </template>
             </ScrollableSegmentedControl>
 
-            <p v-if="differentOrganization" class="info-box icon basket">
-                {{ $t('%dk') }} {{ selectedOrganization.name }}.
-            </p>
+            <RegisterMemberEventsBox v-if="isEventsActive" :member="member" :organization="selectedOrganization" @select="openEvent" />
 
             <template v-else>
-                <p v-if="alreadyRegisteredMessage" class="info-box">
-                    {{ alreadyRegisteredMessage }}
+                <p v-if="differentOrganization" class="info-box icon basket">
+                    {{ $t('%dk') }} {{ selectedOrganization.name }}.
                 </p>
-                <p v-if="noGroupsMessage" class="info-box">
-                    {{ noGroupsMessage }}
+
+                <template v-else>
+                    <p v-if="alreadyRegisteredMessage" class="info-box">
+                        {{ alreadyRegisteredMessage }}
+                    </p>
+                    <p v-if="noGroupsMessage" class="info-box">
+                        {{ noGroupsMessage }}
+                    </p>
+                </template>
+
+                <div v-if="showGroupSearch" class="input-with-buttons">
+                    <div>
+                        <form class="input-icon-container icon search small gray" @submit.prevent="blurFocus">
+                            <input v-model="groupSearchQuery" class="input" name="search" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocomplete="off" :spellcheck="false" autocapitalize="off" data-testid="group-search-input" :placeholder="$t('Zoek een groep')">
+                        </form>
+                    </div>
+                </div>
+
+                <div v-for="({ category, groups }, index) of filteredCategories" :key="category.id" class="container">
+                    <hr v-if="index > 0 || !showControl"><h2 class="style-with-button">
+                        <div>
+                            {{ category.settings.name }}
+                            <span v-if="!category.settings.public" class="icon lock gray" :v-tooltip="$t('%dl')" />
+                        </div>
+                        <div>
+                            <span class="title-suffix">{{ selectedOrganization.period.period.nameShort }}</span>
+                        </div>
+                    </h2>
+                    <STList class="illustration-list">
+                        <RegisterMemberGroupRow v-for="group in groups" :key="group.id" :group="group" :member="member" :organization="selectedOrganization" data-testid="group-button" @click="openGroup(group)" />
+                    </STList>
+                </div>
+
+                <p v-if="showGroupSearch && groupSearchQuery && filteredCategories.length === 0" class="info-box">
+                    {{ $t('Geen groepen gevonden.') }}
                 </p>
             </template>
-
-            <div v-for="(category, index) of tree.categories" :key="category.id" class="container">
-                <hr v-if="index > 0 || !allowChangingOrganization"><h2 class="style-with-button">
-                    <div>
-                        {{ category.settings.name }}
-                        <span v-if="!category.settings.public" class="icon lock gray" v-tooltip="$t('%dl')" />
-                    </div>
-                    <div>
-                        <span class="title-suffix">{{ selectedOrganization.period.period.nameShort }}</span>
-                    </div>
-                </h2>
-                <STList class="illustration-list">
-                    <RegisterMemberGroupRow v-for="group in category.groups" :key="group.id" :group="group" :member="member" :organization="selectedOrganization" data-testid="group-button" @click="openGroup(group)" />
-                </STList>
-            </div>
         </main>
     </div>
 </template>
 
 <script setup lang="ts">
+import { AsyncComponent } from '#containers/AsyncComponent.ts';
 import { useAppContext } from '#context/appContext.ts';
+import { useEventsEnabled } from '#hooks/useEventsEnabled.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import { useUninheritedPermissions } from '#hooks/useUninheritedPermissions.ts';
 import ScrollableSegmentedControl from '#inputs/ScrollableSegmentedControl.vue';
 import { Toast } from '#overlays/Toast.ts';
 import type { NavigationActions } from '#types/NavigationActions.ts';
 import { useNavigationActions } from '#types/NavigationActions.ts';
-import { ComponentWithProperties, usePresent } from '@simonbackx/vue-app-navigation';
-import { AsyncComponent } from '#containers/AsyncComponent.ts';
-import type { Group, Organization, PlatformMember } from '@stamhoofd/structures';
+import { usePresent } from '@simonbackx/vue-app-navigation';
+import type { Event, Group, Organization, PlatformMember } from '@stamhoofd/structures';
 import { GroupCategoryTree, GroupType } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import type { Ref } from 'vue';
 import { computed, onMounted, ref, watch } from 'vue';
+import RegisterMemberEventsBox from './components/group/RegisterMemberEventsBox.vue';
 import RegisterMemberGroupRow from './components/group/RegisterMemberGroupRow.vue';
 import SearchOrganizationView from './SearchOrganizationView.vue';
 
 const props = defineProps<{
     member: PlatformMember;
-    selectionHandler: (data: { group: Group; groupOrganization: Organization }, navigate: NavigationActions) => Promise<void> | void;
+    selectionHandler: (data: { group: Group; groupOrganization?: Organization }, navigate: NavigationActions) => Promise<void> | void;
     defaultOrganization?: Organization;
 }>();
 
@@ -86,8 +104,7 @@ function checkOrganization() {
         if (!organization.value) {
             // Administration panel: register as organizing organization
             props.member.family.checkout.asOrganizationId = selectedOrganization.value?.id ?? null;
-        }
-        else {
+        } else {
             props.member.family.checkout.asOrganizationId = organization.value.id;
         }
         props.member.family.checkout.defaultOrganization = selectedOrganization.value;
@@ -98,20 +115,87 @@ onMounted(() => {
     checkOrganization();
 });
 
-const items = computed(() => {
-    return props.member.organizations;
+const allowChangingOrganization = STAMHOOFD.userMode === 'platform' && (app === 'registration' || app === 'admin') && !STAMHOOFD.singleOrganization;
+
+// A single segmented control combines organization switching (when allowed) and, when the events feature
+// is enabled, an extra 'Activiteiten' tab to register the member for an event. Never show two controls at once.
+const GROUPS_TAB = 'groups';
+const EVENTS_TAB = 'events';
+const eventsEnabled = useEventsEnabled();
+const isEventsTab = ref(false);
+const isEventsActive = computed(() => isEventsTab.value && eventsEnabled.value);
+
+// The control is shown when there is something to switch between: organizations and/or the events tab
+const showControl = computed(() => allowChangingOrganization || eventsEnabled.value);
+
+// Items are organization ids (when switching is allowed) or a single 'groups' tab, plus the 'events' tab when enabled
+const controlItems = computed(() => {
+    const list = allowChangingOrganization ? props.member.organizations.map(o => o.id) : [GROUPS_TAB];
+    if (eventsEnabled.value) {
+        list.push(EVENTS_TAB);
+    }
+    return list;
 });
 
-const labels = computed(() => {
-    return items.value.map(o => o.name);
+const controlLabels = computed(() => controlItems.value.map((id) => {
+    if (id === EVENTS_TAB) {
+        return $t('Activiteiten');
+    }
+    if (id === GROUPS_TAB) {
+        return $t('Groepen');
+    }
+    return props.member.organizations.find(o => o.id === id)?.name ?? '';
+}));
+
+const selectedControlTab = computed<string>({
+    get() {
+        if (isEventsActive.value) {
+            return EVENTS_TAB;
+        }
+        if (!allowChangingOrganization) {
+            return GROUPS_TAB;
+        }
+        return selectedOrganization.value?.id ?? GROUPS_TAB;
+    },
+    set(value: string) {
+        if (value === EVENTS_TAB) {
+            isEventsTab.value = true;
+            return;
+        }
+        isEventsTab.value = false;
+        if (value !== GROUPS_TAB) {
+            const organization = props.member.organizations.find(o => o.id === value);
+            if (organization) {
+                selectedOrganization.value = organization;
+            }
+        }
+    },
 });
-const allowChangingOrganization = STAMHOOFD.userMode === 'platform' && (app === 'registration' || app === 'admin') && !STAMHOOFD.singleOrganization;
 
 const tree = computed(() => treeFactory({
     filterGroups: (g) => {
         return props.member.family.checkout.isAdminFromSameOrganization || props.member.canRegister(g, selectedOrganization.value!) || props.member.canRegisterForWaitingList(g, selectedOrganization.value!);
     },
 }));
+
+// Search within the listed groups, only offered when the list gets long
+const groupSearchQuery = ref('');
+const totalGroupCount = computed(() => tree.value.categories.reduce((sum, category) => sum + category.groups.length, 0));
+const showGroupSearch = computed(() => totalGroupCount.value > 5);
+
+const filteredCategories = computed(() => {
+    // Ignore the query when the search field is hidden (e.g. after switching to an organization with few groups)
+    const query = showGroupSearch.value ? Formatter.slug(groupSearchQuery.value.trim()) : '';
+
+    return tree.value.categories
+        .map((category) => {
+            const groups = query.length === 0
+                ? category.groups
+                : category.groups.filter(g => Formatter.slug(g.settings.name.toString()).includes(query));
+            return { category, groups };
+        })
+        .filter(entry => entry.groups.length > 0);
+});
 
 const alreadyRegisteredGroups = computed(() => {
     const organizationId = selectedOrganization.value?.id;
@@ -170,6 +254,8 @@ const noGroupsMessage = computed(() => {
 function addOrganization(organization: Organization) {
     props.member.insertOrganization(organization);
     selectedOrganization.value = organization;
+    // Selecting an organization always shows its groups, not the events tab
+    isEventsTab.value = false;
 }
 
 if (props.defaultOrganization) {
@@ -179,10 +265,24 @@ if (props.defaultOrganization) {
 async function openGroup(group: Group) {
     try {
         await props.selectionHandler({ group, groupOrganization: selectedOrganization.value! }, navigate);
-    }
-    catch (e) {
+    } catch (e) {
         Toast.fromError(e).show();
     }
+}
+
+async function openEvent(event: Event) {
+    if (!event.group) {
+        return;
+    }
+    try {
+        await props.selectionHandler({ group: event.group, groupOrganization: props.member.family.getOrganization(event.group.organizationId) }, navigate);
+    } catch (e) {
+        Toast.fromError(e).show();
+    }
+}
+
+function blurFocus() {
+    (document.activeElement as HTMLElement)?.blur();
 }
 
 async function searchOrganization() {

--- a/frontend/shared/components/src/members/ChooseGroupForMemberView.vue
+++ b/frontend/shared/components/src/members/ChooseGroupForMemberView.vue
@@ -31,13 +31,13 @@
                 <div v-if="showGroupSearch" class="input-with-buttons">
                     <div>
                         <form class="input-icon-container icon search small gray" @submit.prevent="blurFocus">
-                            <input v-model="groupSearchQuery" class="input" name="search" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocomplete="off" :spellcheck="false" autocapitalize="off" data-testid="group-search-input" :placeholder="$t('Zoek een groep')">
+                            <input v-model="groupSearchQuery" v-autofocus="true" class="input" name="search" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocomplete="off" :spellcheck="false" autocapitalize="off" data-testid="group-search-input" :placeholder="$t('Zoek een groep')">
                         </form>
                     </div>
                 </div>
 
                 <div v-for="({ category, groups }, index) of filteredCategories" :key="category.id" class="container">
-                    <hr v-if="index > 0 || !showControl"><h2 class="style-with-button">
+                    <hr v-if="index > 0 || !showControl || showGroupSearch"><h2 class="style-with-button">
                         <div>
                             {{ category.settings.name }}
                             <span v-if="!category.settings.public" class="icon lock gray" :v-tooltip="$t('%dl')" />
@@ -142,7 +142,7 @@ const controlLabels = computed(() => controlItems.value.map((id) => {
         return $t('Activiteiten');
     }
     if (id === GROUPS_TAB) {
-        return $t('Groepen');
+        return tree.value?.categories.length === 1 && selectedOrganization.value ? tree.value?.categories[0].getName(selectedOrganization.value.period) : $t('Groepen');
     }
     return props.member.organizations.find(o => o.id === id)?.name ?? '';
 }));
@@ -208,6 +208,10 @@ const alreadyRegisteredGroups = computed(() => {
 });
 
 const alreadyRegisteredMessage = computed(() => {
+    if (props.member.family.checkout.isAdminFromSameOrganization) {
+        return null;
+    }
+
     const groups = alreadyRegisteredGroups.value;
 
     if (groups.length > 0) {

--- a/frontend/shared/components/src/members/ChooseOrganizationMembersForGroupView.vue
+++ b/frontend/shared/components/src/members/ChooseOrganizationMembersForGroupView.vue
@@ -13,7 +13,7 @@
             {{ $t('%1DQ') }}
         </h1>
 
-        <p v-if="checkout.totalPrice && checkout.isAdminFromSameOrganization" class="info-box">
+        <p v-if="checkout.totalPrice && checkout.isAdminFromSameOrganization && checkout.cart.items.length" class="info-box">
             {{ $t('%do') }}
         </p>
 
@@ -56,7 +56,7 @@
             </p>
 
             <PermyriadInputBox v-model="checkout.cancellationFeePercentage" :title="$t(`%2I`)" :min="0" :max="10000" :placeholder="$t(`%L`)" :validator="errors.validator" :error-box="errors.errorBox" />
-            
+
             <p v-if="checkout.cancellationFeePercentage !== 0 && checkout.cancellationFeePercentage !== 10000" class="style-description-small">
                 {{ $t('%dt') }}
             </p>
@@ -105,8 +105,7 @@ onMounted(() => {
     // Initially show errors as soon as it is possible
     try {
         props.checkout.validate({});
-    }
-    catch (e) {
+    } catch (e) {
         errors.errorBox = new ErrorBox(e);
     }
     props.checkout.cart.calculatePrices();
@@ -228,11 +227,9 @@ async function goToCheckout() {
             members: props.members,
             displayOptions: { action: 'show' },
         }, navigate);
-    }
-    catch (e) {
+    } catch (e) {
         errors.errorBox = new ErrorBox(e);
-    }
-    finally {
+    } finally {
         saving.value = false;
     }
 }

--- a/frontend/shared/components/src/members/RegisterItemView.vue
+++ b/frontend/shared/components/src/members/RegisterItemView.vue
@@ -48,12 +48,12 @@
             <div class="split-inputs">
                 <div>
                     <STInputBox :title="$t('%1Of')" error-fields="customStartDate" :error-box="errors.errorBox">
-                        <DateSelection v-model="customStartDate" :required="false" :placeholder-date="item.defaultStartDate" :min="item.group.settings.startDate" :max="item.group.settings.endDate" />
+                        <DateSelection v-model="customStartDate" :required="false" :time="{hours: 0}" :placeholder-date="item.defaultStartDate" :min="item.group.settings.startDate" :max="item.group.settings.endDate" />
                     </STInputBox>
                 </div>
                 <div>
                     <STInputBox :title="$t('%1P8')" error-fields="customEndDate" :error-box="errors.errorBox">
-                        <DateSelection v-model="customEndDate" :required="false" :placeholder-date="item.defaultEndDate" :min="item.group.settings.startDate" :max="item.group.settings.endDate" />
+                        <DateSelection v-model="customEndDate" :required="false" :time="{hours: 23, minutes: 59}" :placeholder-date="item.defaultEndDate" :min="item.group.settings.startDate" :max="item.group.settings.endDate" />
                     </STInputBox>
                 </div>
             </div>

--- a/frontend/shared/components/src/members/SearchOrganizationMembersForGroupView.vue
+++ b/frontend/shared/components/src/members/SearchOrganizationMembersForGroupView.vue
@@ -32,7 +32,7 @@
             </p>
 
             <STList v-if="fetcher.objects.length">
-                <RegisterItemCheckboxRow v-for="member in fetcher.objects" :key="member.id" :member="member" :group="group" :group-organization="groupOrganization" />
+                <RegisterItemCheckboxRow v-for="member in fetcher.objects" :key="member.id" :member="member" :group="group" :group-organization="groupOrganization" :checkout="props.checkout" />
             </STList>
             <InfiniteObjectFetcherEnd :empty-message="$t('%eI')" :fetcher="fetcher">
                 <template #empty>

--- a/frontend/shared/components/src/members/checkout/startCheckout.ts
+++ b/frontend/shared/components/src/members/checkout/startCheckout.ts
@@ -121,6 +121,7 @@ async function silentRegister({ checkout, context, admin, members }: { checkout:
 async function register({ checkout, context, admin, members }: { checkout: RegisterCheckout; context: SessionContext; admin?: boolean; members?: PlatformMember[] }, navigate: NavigationActions) {
     const organization = checkout.singleOrganization!;
     const server = context.getAuthenticatedServerForOrganization(organization.id);
+    const clonedCheckout = checkout.clone(); // copy before we clear the checkout
     const idCheckout = getIdCheckout({ checkout, admin });
 
     const response = await server.request({
@@ -185,11 +186,17 @@ async function register({ checkout, context, admin, members }: { checkout: Regis
     GlobalEventBus.sendEvent('paymentPatch', payment).catch(console.error);
     clearAndEmit();
 
+    if (!payment) {
+        Toast.success(fallback(registrations, clonedCheckout).description || fallback(registrations, clonedCheckout).title).setTestId('registration-checkout-succeeded').show();
+        await navigate.dismiss({ force: true });
+        return;
+    }
+
     await navigate.show({
         components: [
             AsyncComponent(() => import('../../payments/PaymentSuccessView.vue'), {
                 payment,
-                fallback: fallback(registrations),
+                fallback: fallback(registrations, clonedCheckout),
             }),
         ],
         replace: 100,
@@ -197,34 +204,63 @@ async function register({ checkout, context, admin, members }: { checkout: Regis
     });
 }
 
-function fallback(registrations: RegistrationWithTinyMember[]) {
+function fallback(registrations: RegistrationWithTinyMember[], checkout: RegisterCheckout) {
     const names = Formatter.uniqueArray(registrations.filter(r => r.group.type !== GroupType.WaitingList).map(r => r.member.firstName ?? '?'));
     const waitingListNames = Formatter.uniqueArray(registrations.filter(r => r.group.type === GroupType.WaitingList).map(r => r.member.firstName ?? '?'));
 
     const t = $t(`%1cZ`);
     let d = '';
 
-    if (names.length > 0) {
-        if (names.length > 3) {
-            d += Formatter.joinLast([...names.slice(0, 2), (names.length - 2) + ' ' + $t(`%zn`)], ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zo`);
-        } else if (names.length > 1) {
-            d += Formatter.joinLast(names, ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zo`);
-        } else {
-            d += names.join('') + ' ' + $t(`%zp`);
+    if (names.length + waitingListNames.length === 0) {
+        if (checkout.cart.deleteRegistrations.length >= 1) {
+            const names = Formatter.uniqueArray(checkout.cart.deleteRegistrations.map(r => r.member.patchedMember.firstName));
+            if (names.length === 1) {
+                d += $t(`{name} is uitgeschreven voor {group}`, {
+                    name: names.join('') + waitingListNames.join(''),
+                    group: checkout.cart.deleteRegistrations.map(r => r.group.settings.name).join(', '),
+                });
+            } else {
+                d += $t(`{jamesAndAnna} zijn uitgeschreven`, {
+                    jamesAndAnna: Formatter.joinLastLimited(names, {
+                        separator: ', ',
+                        lastSeparator: ' ' + $t('en') + ' ',
+                        maxLength: 70,
+                        maxCount: 2,
+                        textIfOverflow(notIncludedCount) {
+                            return notIncludedCount + ' ' + $t(`%zn`);
+                        },
+                    }),
+                });
+            }
         }
-    }
-
-    if (waitingListNames.length > 0) {
+    } else if (names.length + waitingListNames.length === 1) {
+        d += $t(`{name} is ingeschreven voor {group}`, {
+            name: names.join('') + waitingListNames.join(''),
+            group: registrations[0].group.settings.name,
+        });
+    } else {
         if (names.length > 0) {
-            d += ' ' + $t(`%M1`) + ' ';
+            if (names.length > 3) {
+                d += Formatter.joinLast([...names.slice(0, 2), (names.length - 2) + ' ' + $t(`%zn`)], ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zo`);
+            } else if (names.length > 1) {
+                d += Formatter.joinLast(names, ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zo`);
+            } else {
+                d += names.join('') + ' ' + $t(`%zp`);
+            }
         }
 
-        if (waitingListNames.length > 3) {
-            d += Formatter.joinLast([...waitingListNames.slice(0, 2), (waitingListNames.length - 2) + ' ' + $t(`%zn`)], ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zq`);
-        } else if (waitingListNames.length > 1) {
-            d += Formatter.joinLast(waitingListNames, ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zq`);
-        } else {
-            d += waitingListNames.join('') + ' ' + $t(`%zr`);
+        if (waitingListNames.length > 0) {
+            if (names.length > 0) {
+                d += ' ' + $t(`%M1`) + ' ';
+            }
+
+            if (waitingListNames.length > 3) {
+                d += Formatter.joinLast([...waitingListNames.slice(0, 2), (waitingListNames.length - 2) + ' ' + $t(`%zn`)], ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zq`);
+            } else if (waitingListNames.length > 1) {
+                d += Formatter.joinLast(waitingListNames, ', ', ' ' + $t(`%M1`) + ' ') + ' ' + $t(`%zq`);
+            } else {
+                d += waitingListNames.join('') + ' ' + $t(`%zr`);
+            }
         }
     }
 

--- a/frontend/shared/components/src/members/checkout/useCheckoutRegisterItem.ts
+++ b/frontend/shared/components/src/members/checkout/useCheckoutRegisterItem.ts
@@ -435,7 +435,7 @@ export async function chooseGroupForMember({ member, navigate, context, displayO
                 root: AsyncComponent(() => import('#members/ChooseGroupForMemberView.vue'), {
                     member,
                     defaultOrganization,
-                    selectionHandler: async ({ group, groupOrganization }: { group: Group; groupOrganization: Organization }, navigate: NavigationActions) => {
+                    selectionHandler: async ({ group, groupOrganization }: { group: Group; groupOrganization?: Organization }, navigate: NavigationActions) => {
                         await checkoutDefaultItem({
                             member,
                             group,

--- a/frontend/shared/components/src/members/components/MemberIcon.vue
+++ b/frontend/shared/components/src/members/components/MemberIcon.vue
@@ -10,7 +10,7 @@
             <span>{{ member.patchedMember.details.getShortCode(2) }}</span>
         </figure>
         <aside>
-            <span v-if="icon" class="icon gray small" :class="icon" />
+            <span v-if="icon" class="icon gray tiny " :class="icon" />
         </aside>
     </figure>
 </template>

--- a/frontend/shared/components/src/members/components/edit/EditMemberGeneralBox.vue
+++ b/frontend/shared/components/src/members/components/edit/EditMemberGeneralBox.vue
@@ -106,7 +106,7 @@
                 {{ $t('%fE') }}
             </button>.
         </p>
-        <p v-if="!willMarkReviewed && !reviewDate && isAdmin" class="style-description-small">
+        <p v-if="!willMarkReviewed && !reviewDate && isAdmin && !member.isNew" class="style-description-small">
             {{ $t('%1NO') }} <button v-if="canMarkReviewed" class="inline-link" type="button" @click="doMarkReviewed">
                 {{ $t('%jC') }}
             </button>

--- a/frontend/shared/components/src/members/components/group/DeleteRegistrationRow.vue
+++ b/frontend/shared/components/src/members/components/group/DeleteRegistrationRow.vue
@@ -1,7 +1,7 @@
 <template>
     <STListItem class="right-stack">
         <template #left>
-            <GroupIconWithWaitingList :group="registration.registration.group" icon="canceled" />
+            <MemberIcon :member="registration.member" icon="red canceled" />
         </template>
 
         <h3 class="style-title-list">
@@ -13,7 +13,7 @@
         </p>
 
         <template #right>
-            <p v-if="balance" class="style-price">
+            <p v-if="balance && (balance.amountOpen + balance.amountPaid + balance.amountPending !== 0)" class="style-price negative">
                 {{ formatPrice(balance.amountOpen + balance.amountPaid + balance.amountPending) }}
             </p>
 
@@ -25,7 +25,7 @@
 <script setup lang="ts">
 import type { RegisterCheckout, RegistrationWithPlatformMember } from '@stamhoofd/structures';
 import { computed } from 'vue';
-import GroupIconWithWaitingList from './GroupIconWithWaitingList.vue';
+import MemberIcon from '../MemberIcon.vue';
 
 const props = withDefaults(
     defineProps<{

--- a/frontend/shared/components/src/members/components/group/RegisterItemCheckboxRow.vue
+++ b/frontend/shared/components/src/members/components/group/RegisterItemCheckboxRow.vue
@@ -1,5 +1,5 @@
 <template>
-    <STListItem :selectable="!disabled" :disabled="disabled" class="right-stack" @click="editRegisterItem">
+    <STListItem :selectable="!disabled" :disabled="disabled" class="right-stack" @click="toggleRow">
         <template #left>
             <Checkbox v-model="checked" :disabled="disabled" @click.stop />
         </template>
@@ -12,29 +12,30 @@
             <p v-if="member.patchedMember.details.birthDay" class="style-description-small">
                 {{ formatDate(member.patchedMember.details.birthDay, true) }}
             </p>
-            <p class="style-description-small">
+            <p class="style-description-small" v-if="!checked">
                 {{ member.registrationDescription }}
             </p>
         </template>
 
-        <p v-if="validationError" class="style-description-small">
+        <p v-if="!checked && validationError" class="style-description-small">
             {{ validationError }}
         </p>
 
-        <p v-if="validationWarning" class="style-description-small">
+        <p v-if="!checked && validationWarning" class="style-description-small">
             {{ validationWarning }}
         </p>
 
         <p v-if="checked && registerItem && registerItem.description" class="style-description-small pre-wrap" v-text="registerItem.description" />
+
         <template #right>
-            <span v-if="(registerItem?.group.type === GroupType.WaitingList) || (!disabled && validationError)" class="icon clock gray" />
-            <span v-if="checked && registerItem?.showItemView" class="button icon edit gray" />
+            <span v-if="(registerItem?.group.type === GroupType.WaitingList) || (!disabled && validationError)" class="icon tiny clock gray" />
+            <button v-if="checked && registerItem?.showItemView" type="button" class="button icon edit gray" @click.stop="editRegisterItem" />
         </template>
     </STListItem>
 </template>
 
 <script setup lang="ts">
-import type { Group, Organization, PlatformMember} from '@stamhoofd/structures';
+import type { Group, Organization, PlatformMember, RegisterCheckout } from '@stamhoofd/structures';
 import { GroupType, RegisterItem } from '@stamhoofd/structures';
 import { computed } from 'vue';
 import { useCheckoutRegisterItem } from '#members/checkout/useCheckoutRegisterItem.ts';
@@ -44,6 +45,7 @@ const props = defineProps<{
     group: Group;
     member: PlatformMember;
     groupOrganization: Organization;
+    checkout: RegisterCheckout;
 }>();
 
 const app = useAppContext();
@@ -86,20 +88,32 @@ const checked = computed({
             if (props.group.waitingList) {
                 props.member.family.checkout.removeMemberAndGroup(props.member.id, props.group.waitingList.id);
             }
-        }
-        else {
-            editRegisterItem().catch(console.error);
+        } else {
+            const item = registerItem.value;
+            if (app === 'registration' || item.validationError) {
+                editRegisterItem().catch(console.error);
+                return;
+            }
+            props.checkout.add(item);
         }
     },
 });
 
-async function editRegisterItem() {
-    if (checked.value && !registerItem.value?.showItemView) {
+async function toggleRow() {
+    if (checked.value) {
         // Deselect
         checked.value = false;
         return;
     }
 
+    if (disabled.value) {
+        return;
+    }
+
+    checked.value = true;
+}
+
+async function editRegisterItem() {
     if (disabled.value) {
         return;
     }

--- a/frontend/shared/components/src/members/components/group/RegisterMemberEventsBox.vue
+++ b/frontend/shared/components/src/members/components/group/RegisterMemberEventsBox.vue
@@ -1,0 +1,126 @@
+<template>
+    <div class="container">
+        <div class="input-with-buttons">
+            <div>
+                <form class="input-icon-container icon search small gray" @submit.prevent="blurFocus">
+                    <input v-model="searchQuery" class="input" name="search" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocomplete="off" :spellcheck="false" autocapitalize="off" data-testid="event-search-input" :placeholder="$t(`%KC`)">
+                </form>
+            </div>
+            <div>
+                <button type="button" class="button text" @click="editFilter">
+                    <span class="icon filter" />
+                    <span class="hide-small">{{ $t('%2J') }}</span>
+                    <span v-if="!isEmptyFilter(fetcher.baseFilter)" class="icon dot primary" />
+                </button>
+            </div>
+        </div>
+
+        <div v-for="group of groupedEvents" :key="group.title" class="container">
+            <hr><h2>{{ Formatter.capitalizeFirstLetter(group.title) }}</h2>
+
+            <STList>
+                <EventRow v-for="event of group.events" :key="event.id" :event="event" data-testid="event-button" @click="$emit('select', event)" />
+            </STList>
+        </div>
+
+        <InfiniteObjectFetcherEnd :fetcher="fetcher" :empty-message="$t(`%KD`)" />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ComponentWithProperties, NavigationController } from '@simonbackx/vue-app-navigation';
+import { AsyncComponent } from '#containers/AsyncComponent.ts';
+import { useAppContext } from '#context/appContext.ts';
+import EventRow from '#events/components/EventRow.vue';
+import { useEventsObjectFetcher } from '#fetchers/useEventsObjectFetcher.ts';
+import { useEventUIFilterBuilders } from '#filters/filterBuilders.ts';
+import type { UIFilter } from '#filters/UIFilter.ts';
+import { usePlatform } from '#hooks/usePlatform.ts';
+import { useInfiniteObjectFetcher } from '#tables/classes/InfiniteObjectFetcher.ts';
+import InfiniteObjectFetcherEnd from '#tables/InfiniteObjectFetcherEnd.vue';
+import { usePositionableSheet } from '#tables/usePositionableSheet.ts';
+import type { Organization, PlatformMember, StamhoofdFilter } from '@stamhoofd/structures';
+import { Event, isEmptyFilter } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+import type { Ref } from 'vue';
+import { computed, ref, watchEffect } from 'vue';
+
+const props = defineProps<{
+    member: PlatformMember;
+    organization: Organization;
+}>();
+
+defineEmits<{
+    (e: 'select', event: Event): void;
+}>();
+
+type ObjectType = Event;
+
+const searchQuery = ref('');
+const platform = usePlatform();
+const { presentPositionableSheet } = usePositionableSheet();
+
+const organizations = computed(() => props.member.family.organizations.length > 0 ? props.member.family.organizations : [props.organization]);
+const filterBuilders = useEventUIFilterBuilders({ platform: platform.value, organizations: organizations.value, app: useAppContext() });
+
+const selectedUIFilter = ref(filterBuilders.value[0].fromFilter(props.member.family.getRecommendedEventsFilter())) as Ref<null | UIFilter>;
+
+const objectFetcher = useEventsObjectFetcher({
+    get requiredFilter() {
+        return getRequiredFilter();
+    },
+});
+
+const fetcher = useInfiniteObjectFetcher<ObjectType>(objectFetcher);
+
+const groupedEvents = computed(() => {
+    return Event.group(fetcher.objects);
+});
+
+watchEffect(() => {
+    fetcher.setSearchQuery(searchQuery.value);
+    const filter = selectedUIFilter.value ? selectedUIFilter.value.build() : null;
+    fetcher.setFilter(filter);
+});
+
+function blurFocus() {
+    (document.activeElement as HTMLElement)?.blur();
+}
+
+async function editFilter(event: MouseEvent) {
+    const filter = selectedUIFilter.value ?? filterBuilders.value[0].create();
+    if (!selectedUIFilter.value) {
+        selectedUIFilter.value = filter;
+    }
+
+    await presentPositionableSheet(event, {
+        components: [
+            new ComponentWithProperties(NavigationController, {
+                root: AsyncComponent(() => import('#filters/UIFilterEditor.vue'), {
+                    filter,
+                }),
+            }),
+        ],
+    });
+}
+
+function getRequiredFilter(): StamhoofdFilter | null {
+    const filter: StamhoofdFilter = {
+        'startDate': {
+            $gt: new Date(),
+        },
+        'meta.visible': true,
+        // Only events that can actually be registered for
+        'groupId': {
+            $neq: null,
+        },
+    };
+
+    // In organization mode there is only ever a single organization, so scope to it
+    if (STAMHOOFD.userMode === 'organization' && organizations.value.length === 1) {
+        filter['organizationId'] = organizations.value[0].id;
+    }
+
+    return filter;
+}
+</script>

--- a/frontend/shared/components/src/members/components/group/RegisterMemberEventsBox.vue
+++ b/frontend/shared/components/src/members/components/group/RegisterMemberEventsBox.vue
@@ -3,7 +3,7 @@
         <div class="input-with-buttons">
             <div>
                 <form class="input-icon-container icon search small gray" @submit.prevent="blurFocus">
-                    <input v-model="searchQuery" class="input" name="search" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocomplete="off" :spellcheck="false" autocapitalize="off" data-testid="event-search-input" :placeholder="$t(`%KC`)">
+                    <input v-model="searchQuery" v-autofocus="true" class="input" name="search" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocomplete="off" :spellcheck="false" autocapitalize="off" data-testid="event-search-input" :placeholder="$t(`%KC`)">
                 </form>
             </div>
             <div>
@@ -56,6 +56,7 @@ defineEmits<{
 
 type ObjectType = Event;
 
+const app = useAppContext();
 const searchQuery = ref('');
 const platform = usePlatform();
 const { presentPositionableSheet } = usePositionableSheet();
@@ -106,15 +107,18 @@ async function editFilter(event: MouseEvent) {
 
 function getRequiredFilter(): StamhoofdFilter | null {
     const filter: StamhoofdFilter = {
-        'startDate': {
+        startDate: {
             $gt: new Date(),
         },
-        'meta.visible': true,
         // Only events that can actually be registered for
-        'groupId': {
+        groupId: {
             $neq: null,
         },
     };
+
+    if (app === 'registration') {
+        filter['meta.visible'] = true;
+    }
 
     // In organization mode there is only ever a single organization, so scope to it
     if (STAMHOOFD.userMode === 'organization' && organizations.value.length === 1) {

--- a/frontend/shared/components/src/members/components/group/RegisterMemberGroupRow.vue
+++ b/frontend/shared/components/src/members/components/group/RegisterMemberGroupRow.vue
@@ -21,7 +21,7 @@
         </p>
 
         <template #right>
-            <span v-if="validationWarning" v-tooltip="validationWarning" class="icon warning yellow" />
+            <span v-if="validationWarning" v-tooltip="validationWarning" class="icon tiny warning yellow" />
             <span class="icon arrow-right-small gray" />
         </template>
     </STListItem>

--- a/frontend/shared/components/src/tables/ModernTableView.vue
+++ b/frontend/shared/components/src/tables/ModernTableView.vue
@@ -1180,7 +1180,7 @@ onBeforeUnmount(() => {
 function doRefresh() {
     if (document.visibilityState === 'visible') {
         // Only refresh after 1 minute minimum
-        if (lastRefresh.value.getTime() + 1000 * 60 < new Date().getTime()) {
+        if (STAMHOOFD.environment === 'development' || lastRefresh.value.getTime() + 1000 * 60 < new Date().getTime()) {
             refresh();
         }
     }

--- a/frontend/shared/components/src/tables/classes/TableObjectFetcher.ts
+++ b/frontend/shared/components/src/tables/classes/TableObjectFetcher.ts
@@ -4,6 +4,7 @@ import { CountFilteredRequest, LimitedFilteredRequest, isEmptyFilter, isEqualFil
 import { onBeforeUnmount, reactive } from 'vue';
 import type { ObjectFetcher } from './ObjectFetcher';
 import { AutoEncoder } from '@simonbackx/simple-encoding';
+import { isUpdatableObject } from '@stamhoofd/structures/UpdatableObject.js';
 
 export function useTableObjectFetcher<O extends { id: string }, OF extends ObjectFetcher<O> = ObjectFetcher<O>>(objectFetcher: OF): TableObjectFetcher<O> {
     const fetcher = reactive(new TableObjectFetcher<O>({
@@ -327,7 +328,10 @@ export class TableObjectFetcher<O extends { id: string }> {
 
                 const objects = data.results.map((o) => {
                     const cachedReference = this._objectReferenceCache.get(o.id);
-                    if (cachedReference && cachedReference instanceof AutoEncoder && o instanceof AutoEncoder) {
+                    if (cachedReference && isUpdatableObject(cachedReference) && Object.getPrototypeOf(cachedReference) === Object.getPrototypeOf(o)) {
+                        cachedReference.updateFrom(o as typeof cachedReference);
+                        return cachedReference;
+                    } else if (cachedReference && cachedReference instanceof AutoEncoder && o instanceof AutoEncoder) {
                         cachedReference.deepSet(o);
                         return cachedReference;
                     }

--- a/shared/structures/src/UpdatableObject.ts
+++ b/shared/structures/src/UpdatableObject.ts
@@ -1,0 +1,7 @@
+export interface UpdatableObject {
+    updateFrom<T extends UpdatableObject>(this: T, obj: T);
+}
+
+export function isUpdatableObject(t: unknown): t is UpdatableObject {
+    return t !== null && typeof t === 'object' && 'updateFrom' in t && typeof t.updateFrom === 'function';
+}

--- a/shared/structures/src/members/PlatformMember.ts
+++ b/shared/structures/src/members/PlatformMember.ts
@@ -1,4 +1,4 @@
-import type { AutoEncoderPatchType, PartialWithoutMethods, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
+import type { AutoEncoder, AutoEncoderPatchType, PartialWithoutMethods, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { deepSetArray, PatchableArray } from '@simonbackx/simple-encoding';
 
 import { AccessRight } from '../AccessRight.js';
@@ -567,8 +567,14 @@ export class PlatformFamily {
     }
 }
 
+// Note: extending a non-autoencodeable object from an autoencodeable object is a bad pattern
+// this causes issues with built in methods that won't work on PlatformRegistration
 export class PlatformRegistration extends Registration {
     member: PlatformMember;
+
+    updateFrom(object: PlatformRegistration) {
+        this.member.family.copyFromClone(object.member.family);
+    }
 
     static createSingles(blob: RegistrationsBlob, context: { contextOrganization?: Organization | null; platform: Platform }): PlatformRegistration[] {
         const results: PlatformRegistration[] = [];
@@ -707,6 +713,10 @@ export class PlatformMember implements ObjectWithRecords {
         this.family = data.family;
         this.isNew = data.isNew ?? false;
         this.hasFullAccess = (data.hasFullAccess ?? false) || this.isNew;
+    }
+
+    updateFrom(object: PlatformMember) {
+        this.family.copyFromClone(object.family);
     }
 
     clone() {

--- a/shared/structures/src/members/checkout/RegisterItem.ts
+++ b/shared/structures/src/members/checkout/RegisterItem.ts
@@ -364,7 +364,7 @@ export class RegisterItem implements ObjectWithRecords {
     }
 
     get showItemView() {
-        return !!this.replaceRegistrations.length || this.group.settings.prices.length !== 1 || this.group.settings.optionMenus.length > 0 || this.group.type === GroupType.WaitingList || this.group.settings.description.length > 2 || this.group.settings.prices[0].price.price > 0 || (!this.isInCart && !this.isValid);
+        return this.checkout.isAdminFromSameOrganization || !!this.replaceRegistrations.length || this.group.settings.prices.length !== 1 || this.group.settings.optionMenus.length > 0 || this.group.type === GroupType.WaitingList || this.group.settings.description.length > 2 || this.group.settings.prices[0].price.price > 0 || (!this.isInCart && !this.isValid);
     }
 
     calculatePrice() {
@@ -783,6 +783,14 @@ export class RegisterItem implements ObjectWithRecords {
 
         for (const option of this.options) {
             descriptions.push(option.optionMenu.name + ': ' + option.option.name + (option.option.allowAmount ? ` x ${option.amount}` : ''));
+        }
+
+        if (this.customStartDate) {
+            descriptions.push($t('Vanaf {date}', { date: Formatter.startDate(this.calculatedStartDate) }));
+        }
+
+        if (this.customEndDate) {
+            descriptions.push($t('Tot en met {date}', { date: Formatter.endDate(this.calculatedEndDate) }));
         }
 
         return descriptions.filter(d => !!d).join('\n');

--- a/shared/utility/src/Formatter.ts
+++ b/shared/utility/src/Formatter.ts
@@ -565,8 +565,8 @@ export class Formatter {
      * @param options
      * @returns
      */
-    static joinLastLimited<T extends string | number>(array: T[], options: { separator?: string; lastSeparator?: string; maxLength?: number; textIfOverflow?: (notIncludedCount: number) => string }): string {
-        if (!options.maxLength) {
+    static joinLastLimited<T extends string | number>(array: T[], options: { separator?: string; lastSeparator?: string; maxCount?: number; maxLength?: number; textIfOverflow?: (notIncludedCount: number) => string }): string {
+        if (!options.maxLength && !options.maxCount) {
             return Formatter.joinLast(array, options.separator, options.lastSeparator);
         }
 
@@ -575,10 +575,14 @@ export class Formatter {
 
         for (const item of array) {
             totalLength += item.toString().length;
-            if (totalLength > options.maxLength) {
+            if ((options.maxCount && itemsToInclude.length >= options.maxCount) || (options.maxLength && totalLength > options.maxLength)) {
                 const notIncludedCount = array.length - itemsToInclude.length;
-                const lastText = options.textIfOverflow ? options.textIfOverflow(notIncludedCount) : $t('%1bw', { count: notIncludedCount });
-                itemsToInclude.push(lastText);
+                if (notIncludedCount > 1) {
+                    const lastText = options.textIfOverflow ? options.textIfOverflow(notIncludedCount) : $t('%1bw', { count: notIncludedCount });
+                    itemsToInclude.push(lastText);
+                    break;
+                }
+                itemsToInclude.push(item);
                 break;
             }
 

--- a/tests/playwright/src/tests/register-member-choose-group-platform.spec.ts
+++ b/tests/playwright/src/tests/register-member-choose-group-platform.spec.ts
@@ -1,0 +1,211 @@
+// test should always be imported first
+import { setup, test } from '../test-fixtures/platform.js';
+setup();
+
+// other imports
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type {
+    Organization,
+    OrganizationRegistrationPeriod,
+    RegistrationPeriod,
+    User,
+} from '@stamhoofd/models';
+import {
+    EventFactory,
+    GroupFactory,
+    MemberFactory,
+    OrganizationFactory,
+    OrganizationRegistrationPeriodFactory,
+    RegistrationPeriodFactory,
+} from '@stamhoofd/models';
+import { EventMeta, TranslatedString } from '@stamhoofd/structures';
+import type { Pages } from '../helpers/index.js';
+import { WorkerData } from '../helpers/index.js';
+
+/**
+ * ChooseGroupForMemberView improvements (STA-1311 + STA-1266):
+ * - the group list becomes searchable once there are more than five groups
+ * - an 'Activiteiten' tab lets you register the member for an event directly
+ */
+test.describe('Register member - choose group', () => {
+    let organization: Organization;
+    let period: RegistrationPeriod;
+    let user: User;
+    let organizationPeriod: OrganizationRegistrationPeriod;
+    let organizationName: string;
+
+    test.beforeAll(async () => {
+        user = WorkerData.user;
+        organization = await new OrganizationFactory({}).create();
+        organizationName = organization.name;
+
+        period = await new RegistrationPeriodFactory({
+            startDate: new Date('2000-01-01'),
+            endDate: new Date('2001-01-01'),
+            organization,
+        }).create();
+
+        organization.periodId = period.id;
+        await organization.save();
+
+        organizationPeriod = await new OrganizationRegistrationPeriodFactory({
+            period,
+            organization,
+        }).create();
+    });
+
+    test.afterEach(async () => {
+        await WorkerData.databaseHelper.clearRegistrations();
+        await WorkerData.databaseHelper.clearMembers();
+        await WorkerData.databaseHelper.clearGroups();
+    });
+
+    /**
+     * Open the member portal, start registering the given member and pick the
+     * organization, leaving the browser on ChooseGroupForMemberView.
+     */
+    async function openChooseGroup(page: Page, pages: Pages, memberName: string) {
+        await pages.memberPortal.goto();
+
+        await page.getByTestId('register-member-button').click();
+        await page
+            .getByTestId('member-button')
+            .filter({ hasText: memberName })
+            .click();
+
+        const organizationSearch = page.getByTestId('organization-search-input');
+        await organizationSearch.click();
+        await organizationSearch.fill(organizationName);
+        await page
+            .getByTestId('organization-button')
+            .filter({ hasText: organizationName })
+            .click();
+    }
+
+    test('shows a search field that filters the group list when more than five groups are available', async ({
+        page,
+        pages,
+    }) => {
+        const groupNames = [
+            'Kapoenen',
+            'Welpen',
+            'Jonggidsen',
+            'Gidsen',
+            'Jin',
+            'Leiding',
+        ];
+
+        for (const name of groupNames) {
+            const group = await new GroupFactory({
+                organization,
+                price: 0,
+                name: new TranslatedString(name),
+            }).create();
+
+            // Keep registration open well into the future so the member can register
+            group.settings.registrationEndDate = new Date(
+                Date.now() + 24 * 60 * 60 * 1000,
+            );
+            await group.save();
+
+            organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        }
+        await organizationPeriod.save();
+
+        await new MemberFactory({
+            firstName: 'John',
+            lastName: 'Doe',
+            user,
+        }).create();
+
+        await openChooseGroup(page, pages, 'John Doe');
+
+        // The full list of groups is shown
+        const groupButtons = page.getByTestId('group-button');
+        await expect(groupButtons).toHaveCount(groupNames.length);
+
+        // A search field appears because there are more than five groups
+        const searchInput = page.getByTestId('group-search-input');
+        await expect(searchInput).toBeVisible();
+
+        await test.step('typing a query narrows the list to matching groups', async () => {
+            await searchInput.fill('Welpen');
+            await expect(groupButtons).toHaveCount(1);
+            await expect(groupButtons.first()).toContainText('Welpen');
+        });
+
+        await test.step('clearing the query restores the full list', async () => {
+            await searchInput.fill('');
+            await expect(groupButtons).toHaveCount(groupNames.length);
+        });
+    });
+
+    test('offers an activities tab to register the member for an event', async ({
+        page,
+        pages,
+    }) => {
+        // A regular group so the "Groepen" tab is not empty
+        const membershipGroup = await new GroupFactory({
+            organization,
+            price: 0,
+            name: new TranslatedString('Kapoenen'),
+        }).create();
+        membershipGroup.settings.registrationEndDate = new Date(
+            Date.now() + 24 * 60 * 60 * 1000,
+        );
+        await membershipGroup.save();
+        organizationPeriod.settings.rootCategory?.groupIds.push(membershipGroup.id);
+        await organizationPeriod.save();
+
+        // An upcoming, visible event with a registration group. Creating the event
+        // also registers a platform event type, which enables the activities tab.
+        const eventGroup = await new GroupFactory({ organization, price: 0 }).create();
+        const startDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000);
+        const eventName = `Zomerkamp ${WorkerData.id}-${Math.floor(Math.random() * 1_000_000)}`;
+
+        await new EventFactory({
+            organization,
+            group: eventGroup,
+            name: eventName,
+            startDate,
+            endDate,
+            meta: EventMeta.create({ visible: true, minAge: 0, maxAge: 99 }),
+        }).create();
+
+        await new MemberFactory({
+            firstName: 'Jane',
+            lastName: 'Doe',
+            user,
+        }).create();
+
+        await openChooseGroup(page, pages, 'Jane Doe');
+
+        // The tab bar is shown and the groups tab is active by default
+        const tabs = page.getByTestId('register-tabs');
+        await expect(tabs).toBeVisible();
+        await expect(page.getByTestId('group-button')).toHaveCount(1);
+        await expect(page.getByTestId('event-button')).toHaveCount(0);
+
+        await test.step('the activities tab lists the relevant event', async () => {
+            await tabs.getByText('Activiteiten').click();
+
+            const eventButton = page
+                .getByTestId('event-button')
+                .filter({ hasText: eventName });
+            await expect(eventButton).toBeVisible();
+        });
+
+        await test.step('the activities tab can be searched', async () => {
+            const eventSearch = page.getByTestId('event-search-input');
+            await eventSearch.fill('zzz-no-matching-event');
+            await expect(page.getByTestId('event-button')).toHaveCount(0);
+
+            await eventSearch.fill('Zomerkamp');
+            await expect(
+                page.getByTestId('event-button').filter({ hasText: eventName }),
+            ).toBeVisible();
+        });
+    });
+});

--- a/tests/playwright/src/tests/registration-platform.spec.ts
+++ b/tests/playwright/src/tests/registration-platform.spec.ts
@@ -924,11 +924,11 @@ test.describe('Registration', () => {
                 await page.getByTestId('save-button').click();
 
                 await test.step('should show success view listing every registered member', async () => {
-                    const successView = page.getByTestId('payment-success-view');
-                    await test.expect(successView).toBeVisible();
+                    const toast = page.getByTestId('registration-checkout-succeeded');
+                    await test.expect(toast).toBeVisible();
 
                     await test
-                        .expect(successView)
+                        .expect(toast)
                         .toContainText('en 2 andere leden zijn ingeschreven', { ignoreCase: true });
                 });
             });
@@ -1009,14 +1009,14 @@ test.describe('Registration', () => {
                 await page.getByTestId('save-button').click();
 
                 await test.step('should show success view listing every registered member', async () => {
-                    const successView = page.getByTestId('payment-success-view');
-                    await test.expect(successView).toBeVisible();
+                    const toast = page.getByTestId('registration-checkout-succeeded');
+                    await test.expect(toast).toBeVisible();
 
                     // The admin checkout returns no payment, so the success view
                     // renders the registrations fallback which lists first names.
                     for (const member of members) {
                         await test
-                            .expect(successView)
+                            .expect(toast)
                             .toContainText(member.details.firstName, { ignoreCase: true });
                     }
                 });


### PR DESCRIPTION
## Summary

Two improvements to the "register a member" flow (`ChooseGroupForMemberView`), addressing the very long, hard-to-use group picker reported in STA-1311.

### Searchable group list (STA-1311)
When a member can register for **more than 5 groups**, a search field appears above the list and filters the groups by name (accent/case-insensitive). Empty categories are hidden and a "no results" message is shown when nothing matches.

### Register for an event directly (STA-1266)
When the events feature is enabled, an **"Activiteiten"** tab is offered next to the groups. It mirrors the events overview pattern: a search bar + filter button, defaulting to events relevant to the selected member (`PlatformFamily.getRecommendedEventsFilter()`), and only listing events that have a registration group. Selecting an event registers the member for that event's group through the existing checkout flow.

The activities tab is available **both** when the organization can be switched and when it can't. To avoid stacking two segmented controls, organization switching and the activities tab are merged into a **single** control (organization tabs + an "Activiteiten" tab).

## Notes
- Extracted the duplicated `areEventsEnabled()` logic from the registration app into a shared `useEventsEnabled()` composable.
- `ChooseGroupForMemberView`'s `selectionHandler` now accepts an optional `groupOrganization` (lazily loaded for events); the existing group flow is unchanged.
- No `@stamhoofd/structures` changes.

## Test plan
- New Playwright tests (`register-member-choose-group-platform.spec.ts`): the group list becomes searchable with >5 groups; the activities tab lists the relevant event and can be searched.
- `yarn typecheck` and `yarn lint` pass across the repo.

Fixes STA-1311
Fixes STA-1266

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550843&installation_id=138085646&pr_number=605&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F605&signature=cad9dcaf89114bdac7e05db1eaeec7981684dd4930e22619df244156279b6b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->