### PR TITLE
✨ Translatable email templates and emails

### DIFF
--- a/backend/app/api/src/email-recipient-loaders/orders.ts
+++ b/backend/app/api/src/email-recipient-loaders/orders.ts
@@ -1,4 +1,4 @@
-import { Email, Webshop } from '@stamhoofd/models';
+import { Email, runWithRecipientLocale, Webshop } from '@stamhoofd/models';
 import type { EmailRecipient, LimitedFilteredRequest, WebshopPreview } from '@stamhoofd/structures';
 import { mergeFilters, PaginatedResponse } from '@stamhoofd/structures';
 import { GetWebshopOrdersEndpoint } from '../endpoints/organization/dashboard/webshops/GetWebshopOrdersEndpoint.js';
@@ -8,13 +8,11 @@ import { EmailRecipientFilterType } from '@stamhoofd/structures/email/EmailRecip
 
 Email.recipientLoaders.set(EmailRecipientFilterType.Orders, {
     fetch: async (query: LimitedFilteredRequest) => {
-        // #region get organization struct
         const organization = Context.organization;
         if (organization === undefined) {
             throw new Error('Organization is undefined');
         }
         const organizationStruct = organization.getBaseStructure();
-        // #endregion
 
         const result = await GetWebshopOrdersEndpoint.buildData(query);
 
@@ -32,17 +30,15 @@ Email.recipientLoaders.set(EmailRecipientFilterType.Orders, {
 
             webshopPreviewMap.set(webshopId, AuthenticatedStructures.webshopPreview(webshop));
         }
-        // #endregion
 
-        // #region get recipients
         const recipients: EmailRecipient[] = [];
 
         for (const order of result.results) {
-            // todo: filter double emails? => should probably happen in query?
             const webshopPreview = webshopPreviewMap.get(order.webshopId)!;
-            recipients.push(order.getEmailRecipient(organizationStruct, webshopPreview));
+            runWithRecipientLocale({ language: order.consumerLanguage }, organization, () => {
+                recipients.push(order.getEmailRecipient(organizationStruct, webshopPreview));
+            });
         }
-        // #endregion
 
         return new PaginatedResponse({
             results: recipients,

--- a/backend/app/api/src/endpoints/global/email/CreateEmailEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/email/CreateEmailEndpoint.ts
@@ -83,6 +83,7 @@ export class CreateEmailEndpoint extends Endpoint<Params, Query, Body, ResponseB
         model.html = request.body.html;
         model.text = request.body.text;
         model.json = request.body.json;
+        model.translations = request.body.translations;
         model.status = request.body.status;
         model.attachments = request.body.attachments;
         model.sendAsEmail = request.body.sendAsEmail ?? true;

--- a/backend/app/api/src/endpoints/global/email/PatchEmailEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/email/PatchEmailEndpoint.test.ts
@@ -1,8 +1,10 @@
 import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
+import { PatchMap } from '@simonbackx/simple-encoding';
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, RegistrationPeriod, User } from '@stamhoofd/models';
 import { Email, EmailRecipient, GroupFactory, MemberFactory, OrganizationFactory, RegistrationFactory, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
-import { AccessRight, EmailRecipientFilter, EmailRecipientSubfilter, EmailStatus, Email as EmailStruct, OrganizationEmail, Parent, PermissionLevel, Permissions, PermissionsResourceType, ResourcePermissions, UserPermissions, Version } from '@stamhoofd/structures';
+import { AccessRight, EmailContent, EmailRecipientFilter, EmailRecipientSubfilter, EmailStatus, Email as EmailStruct, OrganizationEmail, Parent, PermissionLevel, Permissions, PermissionsResourceType, ResourcePermissions, UserPermissions, Version } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
 import { PatchEmailEndpoint } from './PatchEmailEndpoint.js';
@@ -1198,5 +1200,121 @@ describe('Endpoint.PatchEmailEndpoint', () => {
         for (const sentEmail of sentEmails) {
             expect(sentEmail.html).toContain('Identical Email');
         }
+    });
+
+    describe('Translations', () => {
+        const createDraftEmail = async () => {
+            const email = new Email();
+            email.subject = 'Default subject';
+            email.status = EmailStatus.Draft;
+            email.text = 'Default text';
+            email.html = '<p>Default html</p>';
+            email.json = {};
+            email.userId = user.id;
+            email.organizationId = organization.id;
+            email.senderId = sender.id;
+            await email.save();
+            return email;
+        };
+
+        test('a translation can be added to a draft email', async () => {
+            const email = await createDraftEmail();
+
+            const body = EmailStruct.patch({
+                id: email.id,
+                translations: new PatchMap([[Language.French, EmailContent.create({ subject: 'Sujet français', html: '<p>Français</p>', text: 'Français' })]]),
+            });
+
+            const response = await patchEmail(body, token, organization);
+            expect(response.body.translations.get(Language.French)!.subject).toBe('Sujet français');
+
+            const saved = await Email.getByID(email.id);
+            expect(saved!.translations.get(Language.French)!.subject).toBe('Sujet français');
+            expect(saved!.subject).toBe('Default subject');
+        });
+
+        test('a translation can be removed from a draft email', async () => {
+            const email = await createDraftEmail();
+            email.translations = new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet français' })],
+                [Language.English, EmailContent.create({ subject: 'English subject' })],
+            ]);
+            await email.save();
+
+            const body = EmailStruct.patch({
+                id: email.id,
+                translations: new PatchMap([[Language.French, null]]),
+            });
+
+            await patchEmail(body, token, organization);
+
+            const saved = await Email.getByID(email.id);
+            expect(saved!.translations.size).toBe(1);
+            expect(saved!.translations.get(Language.English)!.subject).toBe('English subject');
+        });
+
+        test('patching the subject keeps the translations', async () => {
+            const email = await createDraftEmail();
+            email.translations = new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet français' })],
+            ]);
+            await email.save();
+
+            const body = EmailStruct.patch({
+                id: email.id,
+                subject: 'New default subject',
+            });
+
+            await patchEmail(body, token, organization);
+
+            const saved = await Email.getByID(email.id);
+            expect(saved!.subject).toBe('New default subject');
+            expect(saved!.translations.get(Language.French)!.subject).toBe('Sujet français');
+        });
+
+        const createSendableEmail = async () => {
+            const email = new Email();
+            email.subject = 'Default subject';
+            email.status = EmailStatus.Draft;
+            email.text = 'Default text {{unsubscribeUrl}}';
+            email.html = '<!DOCTYPE html><html><body><p>Default html</p>{{unsubscribeUrl}}</body></html>';
+            email.json = {};
+            email.userId = user.id;
+            email.organizationId = organization.id;
+            email.senderId = sender.id;
+            return email;
+        };
+
+        test('cannot send an email with an incomplete translation', async () => {
+            const email = await createSendableEmail();
+            email.translations = new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet français', text: '', html: '' })],
+            ]);
+            await email.save();
+
+            const body = EmailStruct.patch({ id: email.id, status: EmailStatus.Sending });
+
+            await expect(patchEmail(body, token, organization))
+                .rejects
+                .toThrow(STExpect.errorWithCode('invalid_field'));
+        });
+
+        test('cannot send an email when a translation misses the unsubscribe button', async () => {
+            const email = await createSendableEmail();
+            email.translations = new Map([
+                [Language.French, EmailContent.create({
+                    subject: 'Sujet français',
+                    text: 'Texte français',
+                    html: '<!DOCTYPE html><html><body><p>Français</p></body></html>',
+                })],
+            ]);
+            await email.save();
+
+            const body = EmailStruct.patch({ id: email.id, status: EmailStatus.Sending });
+
+            await expect(patchEmail(body, token, organization))
+                .rejects
+                .toThrow(STExpect.errorWithCode('missing_unsubscribe_button'));
+        });
     });
 });

--- a/backend/app/api/src/endpoints/global/email/PatchEmailEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/email/PatchEmailEndpoint.ts
@@ -114,6 +114,10 @@ export class PatchEmailEndpoint extends Endpoint<Params, Query, Body, ResponseBo
             model.json = request.body.json;
         }
 
+        if (request.body.translations !== undefined) {
+            model.translations = patchObject(model.translations, request.body.translations);
+        }
+
         if (request.body.recipientFilter) {
             if (model.status !== EmailStatus.Draft) {
                 throw new SimpleError({

--- a/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.test.ts
@@ -1,10 +1,12 @@
 import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
-import { PatchableArray } from '@simonbackx/simple-encoding';
+import { PatchableArray, PatchMap } from '@simonbackx/simple-encoding';
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, RegistrationPeriod } from '@stamhoofd/models';
 import { EmailTemplate, GroupFactory, OrganizationFactory, Platform, RegistrationPeriodFactory, Token, UserFactory } from '@stamhoofd/models';
-import { EmailTemplate as EmailTemplateStruct, EmailTemplateType, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions, Version } from '@stamhoofd/structures';
+import { EmailContent, EmailTemplate as EmailTemplateStruct, EmailTemplateType, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions, Version } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
 import { TestUtils } from '@stamhoofd/test-utils';
+import { v4 as uuidv4 } from 'uuid';
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
 import { PatchEmailTemplatesEndpoint } from './PatchEmailTemplatesEndpoint.js';
 
@@ -85,6 +87,120 @@ describe('Endpoint.PatchEmailTemplatesEndpoint', () => {
 
             const response = await patchEmailTemplates(body, token);
             expect(response.body).toBeDefined();
+        });
+    });
+
+    describe('Translations', () => {
+        const createOrganizationWithAdmin = async () => {
+            const organization = await new OrganizationFactory({ period }).create();
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            }).create();
+            const token = await Token.createToken(user);
+            return { organization, token };
+        };
+
+        const createTemplate = async (organization: Organization, translations?: Map<Language, EmailContent>) => {
+            const template = new EmailTemplate();
+            template.subject = 'Default subject';
+            template.type = EmailTemplateType.SavedMembersEmail;
+            template.json = {};
+            template.html = '<p>Default</p>';
+            template.text = 'Default';
+            template.organizationId = organization.id;
+            if (translations) {
+                template.translations = translations;
+            }
+            await template.save();
+            return template;
+        };
+
+        test('a template can be created with translations', async () => {
+            const { organization, token } = await createOrganizationWithAdmin();
+
+            const body: PatchableArrayAutoEncoder<EmailTemplateStruct> = new PatchableArray();
+            body.addPut(EmailTemplateStruct.create({
+                id: uuidv4(),
+                subject: 'Default subject',
+                html: '<p>Default</p>',
+                text: 'Default',
+                type: EmailTemplateType.SavedMembersEmail,
+                translations: new Map([
+                    [Language.French, EmailContent.create({ subject: 'Sujet français', html: '<p>Français</p>', text: 'Français' })],
+                ]),
+            }));
+
+            const response = await patchEmailTemplates(body, token, organization);
+            expect(response.body).toHaveLength(1);
+            expect(response.body[0].translations.get(Language.French)!.subject).toBe('Sujet français');
+
+            const saved = await EmailTemplate.getByID(response.body[0].id);
+            expect(saved!.translations.get(Language.French)!.subject).toBe('Sujet français');
+        });
+
+        test('a translation can be added to an existing template without changing other content', async () => {
+            const { organization, token } = await createOrganizationWithAdmin();
+            const template = await createTemplate(organization, new Map([
+                [Language.English, EmailContent.create({ subject: 'English subject' })],
+            ]));
+
+            const body: PatchableArrayAutoEncoder<EmailTemplateStruct> = new PatchableArray();
+            body.addPatch(EmailTemplateStruct.patch({
+                id: template.id,
+                translations: new PatchMap([[Language.French, EmailContent.create({ subject: 'Sujet français' })]]),
+            }));
+
+            const response = await patchEmailTemplates(body, token, organization);
+            expect(response.body).toHaveLength(1);
+
+            const saved = await EmailTemplate.getByID(template.id);
+            expect(saved!.subject).toBe('Default subject');
+            expect(saved!.translations.size).toBe(2);
+            expect(saved!.translations.get(Language.English)!.subject).toBe('English subject');
+            expect(saved!.translations.get(Language.French)!.subject).toBe('Sujet français');
+        });
+
+        test('a translation can be deleted', async () => {
+            const { organization, token } = await createOrganizationWithAdmin();
+            const template = await createTemplate(organization, new Map([
+                [Language.English, EmailContent.create({ subject: 'English subject' })],
+                [Language.French, EmailContent.create({ subject: 'Sujet français' })],
+            ]));
+
+            const body: PatchableArrayAutoEncoder<EmailTemplateStruct> = new PatchableArray();
+            body.addPatch(EmailTemplateStruct.patch({
+                id: template.id,
+                translations: new PatchMap([[Language.French, null]]),
+            }));
+
+            await patchEmailTemplates(body, token, organization);
+
+            const saved = await EmailTemplate.getByID(template.id);
+            expect(saved!.translations.size).toBe(1);
+            expect(saved!.translations.get(Language.French)).toBeUndefined();
+            expect(saved!.translations.get(Language.English)!.subject).toBe('English subject');
+        });
+
+        test('patching only the subject keeps the translations', async () => {
+            const { organization, token } = await createOrganizationWithAdmin();
+            const template = await createTemplate(organization, new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet français' })],
+            ]));
+
+            const body: PatchableArrayAutoEncoder<EmailTemplateStruct> = new PatchableArray();
+            body.addPatch(EmailTemplateStruct.patch({
+                id: template.id,
+                subject: 'New default subject',
+            }));
+
+            await patchEmailTemplates(body, token, organization);
+
+            const saved = await EmailTemplate.getByID(template.id);
+            expect(saved!.subject).toBe('New default subject');
+            expect(saved!.translations.get(Language.French)!.subject).toBe('Sujet français');
         });
     });
 });

--- a/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/email-templates/PatchEmailTemplatesEndpoint.ts
@@ -1,5 +1,5 @@
 import type { AutoEncoderPatchType, Decoder, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
-import { PatchableArrayDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { PatchableArrayDecoder, patchObject, StringDecoder } from '@simonbackx/simple-encoding';
 import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
 import { EmailTemplate, Group, Platform, Webshop } from '@stamhoofd/models';
@@ -51,6 +51,7 @@ export class PatchEmailTemplatesEndpoint extends Endpoint<Params, Query, Body, R
             template.subject = patch.subject ?? template.subject;
             template.text = patch.text ?? template.text;
             template.json = patch.json ?? template.json;
+            template.translations = patchObject(template.translations, patch.translations);
 
             await template.save();
 
@@ -94,6 +95,7 @@ export class PatchEmailTemplatesEndpoint extends Endpoint<Params, Query, Body, R
             template.subject = struct.subject;
             template.text = struct.text;
             template.json = struct.json;
+            template.translations = struct.translations;
 
             template.type = struct.type;
 

--- a/backend/app/api/src/endpoints/organization/webshops/OrderConfirmationEmailLanguage.test.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/OrderConfirmationEmailLanguage.test.ts
@@ -1,7 +1,7 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import { EmailMocker } from '@stamhoofd/email';
 import { EmailTemplateFactory, OrganizationFactory, WebshopFactory } from '@stamhoofd/models';
-import { Cart, CartItem, Customer, EmailTemplateType, OrderData, PaymentMethod, Product, ProductPrice } from '@stamhoofd/structures';
+import { Cart, CartItem, Customer, EmailContent, EmailTemplateType, OrderData, PaymentMethod, Product, ProductPrice } from '@stamhoofd/structures';
 import { TestUtils } from '@stamhoofd/test-utils';
 import { Country } from '@stamhoofd/types/Country';
 import { Language } from '@stamhoofd/types/Language';
@@ -66,5 +66,90 @@ describe('Order confirmation email language', () => {
         const dutchEmail = await placeFreeOrderInLanguage('nl');
         expect(dutchEmail.html).toContain(dutchStatusName);
         expect(dutchEmail.html).not.toContain(frenchStatusName);
+    });
+
+    test('selects the translated template that matches the language the customer ordered in', async () => {
+        TestUtils.setEnvironment('locales', { [Country.Belgium]: [Language.Dutch, Language.French] });
+
+        const organization = await new OrganizationFactory({}).create();
+        const freeProductPrice = ProductPrice.create({ name: 'Free', price: 0, stock: 100 });
+        const product = Product.create({ name: 'Product', stock: 100, prices: [freeProductPrice] });
+        const webshop = await new WebshopFactory({
+            organizationId: organization.id,
+            products: [product],
+        }).create();
+
+        // The template has default (Dutch) content and a French translation. The French translation
+        // must be selected for a French order, the default content for a Dutch order.
+        // Both order-table replacements are included: their headers/titles are localized per
+        // recipient (consumer) language, independently of the selected template translation.
+        const tables = '{{orderTable}} {{orderDetailsTable}}';
+        await new EmailTemplateFactory({
+            organization,
+            webshopId: webshop.id,
+            type: EmailTemplateType.OrderConfirmationOnline,
+            subject: 'Standaard onderwerp',
+            html: `<p>Standaard inhoud ${tables}</p>`,
+            text: 'Standaard inhoud',
+            translations: new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet français', html: `<p>Contenu français ${tables}</p>`, text: 'Contenu français' })],
+            ]),
+        }).create();
+
+        // Table headers/titles rendered via $t inside the order tables. Hardcoded on purpose so we
+        // don't verify $t with the same $t machinery we're testing.
+        // orderTable column headers (%Sc / %M4) and an orderDetailsTable row title (%xA).
+        const dutch = { orderColumn: 'Artikel', amountColumn: 'Aantal', orderNumberTitle: 'Bestelnummer' };
+        const french = { orderColumn: 'Article', amountColumn: 'Nombre', orderNumberTitle: 'Numéro de commande' };
+
+        const placeFreeOrderInLanguage = async (language: string) => {
+            EmailMocker.transactional.reset();
+
+            const orderData = OrderData.create({
+                paymentMethod: PaymentMethod.Unknown,
+                cart: Cart.create({
+                    items: [CartItem.create({ product, productPrice: freeProductPrice, amount: 1 })],
+                }),
+                customer: Customer.create({ firstName: 'John', lastName: 'Doe', email: 'john@example.com', phone: '+32412345678' }),
+            });
+
+            const r = Request.buildJson('POST', `/webshop/${webshop.id}/order`, organization.getApiHost(), orderData);
+            r.headers['accept-language'] = language;
+            await testServer.test(endpoint, r);
+
+            const emails = await EmailMocker.transactional.getSucceededEmails();
+            expect(emails).toHaveLength(1);
+            return emails[0];
+        };
+
+        // French order → the French translation of the template is used
+        const frenchEmail = await placeFreeOrderInLanguage('fr');
+        expect(frenchEmail.subject).toBe('Sujet français');
+        expect(frenchEmail.html).toContain('Contenu français');
+        expect(frenchEmail.html).not.toContain('Standaard inhoud');
+
+        // Both order tables are rendered in the recipient's (consumer) language, French
+        expect(frenchEmail.html).toContain(french.orderColumn);
+        expect(frenchEmail.html).toContain(french.amountColumn);
+        expect(frenchEmail.html).toContain(french.orderNumberTitle);
+        // No Dutch table headers/titles leak into the French email
+        expect(frenchEmail.html).not.toContain(dutch.orderColumn);
+        expect(frenchEmail.html).not.toContain(dutch.amountColumn);
+        expect(frenchEmail.html).not.toContain(dutch.orderNumberTitle);
+
+        // Dutch order → no Dutch translation exists, so the default content is used
+        const dutchEmail = await placeFreeOrderInLanguage('nl');
+        expect(dutchEmail.subject).toBe('Standaard onderwerp');
+        expect(dutchEmail.html).toContain('Standaard inhoud');
+        expect(dutchEmail.html).not.toContain('Contenu français');
+
+        // Both order tables are rendered in Dutch
+        expect(dutchEmail.html).toContain(dutch.orderColumn);
+        expect(dutchEmail.html).toContain(dutch.amountColumn);
+        expect(dutchEmail.html).toContain(dutch.orderNumberTitle);
+        // No French table headers/titles leak into the Dutch email
+        expect(dutchEmail.html).not.toContain(french.orderColumn);
+        expect(dutchEmail.html).not.toContain(french.amountColumn);
+        expect(dutchEmail.html).not.toContain(french.orderNumberTitle);
     });
 });

--- a/backend/shared/i18n/src/I18n.ts
+++ b/backend/shared/i18n/src/I18n.ts
@@ -33,8 +33,8 @@ export class I18n {
      * Run a handler with a temporary i18n override. All global $t calls made during the
      * handler will use the given i18n instead of the current request/context one.
      */
-    static async runWithLocale<T>(i18n: I18n, handler: () => Promise<T>): Promise<T> {
-        return await this.overrideStorage.run(i18n, handler);
+    static runWithLocale<T>(i18n: I18n, handler: () => T): T {
+        return this.overrideStorage.run(i18n, handler);
     }
 
     static async load() {
@@ -72,8 +72,7 @@ export class I18n {
             if (typeof (element) !== 'string') {
                 const map2 = this.loadRecursive(element, (prefix ? prefix + '.' : '') + key);
                 map2.forEach((val, key) => map.set(key, val));
-            }
-            else {
+            } else {
                 map.set((prefix ? prefix + '.' : '') + key, element);
             }
         }

--- a/backend/shared/models/src/factories/EmailTemplateFactory.ts
+++ b/backend/shared/models/src/factories/EmailTemplateFactory.ts
@@ -2,8 +2,9 @@ import { Factory } from '@simonbackx/simple-database';
 
 import { EmailTemplate } from '../models/index.js';
 import type { Organization } from '../models/Organization.js';
-import type { EmailTemplateType} from '@stamhoofd/structures';
+import type { EmailContent, EmailTemplateType } from '@stamhoofd/structures';
 import { EmailTemplate as EmailTemplateStruct } from '@stamhoofd/structures';
+import type { Language } from '@stamhoofd/types/Language';
 
 class Options {
     organization?: Organization;
@@ -14,6 +15,7 @@ class Options {
     subject?: string;
     html?: string;
     text?: string;
+    translations?: Map<Language, EmailContent>;
 }
 
 export class EmailTemplateFactory extends Factory<Options, EmailTemplate> {
@@ -40,6 +42,10 @@ export class EmailTemplateFactory extends Factory<Options, EmailTemplate> {
                 template.html += `<p>${replacement.token}: {{${replacement.token}}}</p>`;
                 template.text += `${replacement.token}: {{${replacement.token}}}\n`;
             }
+        }
+
+        if (this.options.translations) {
+            template.translations = this.options.translations;
         }
 
         await template.save();

--- a/backend/shared/models/src/helpers/EmailBuilder.test.ts
+++ b/backend/shared/models/src/helpers/EmailBuilder.test.ts
@@ -1,6 +1,8 @@
 import { EmailMocker } from '@stamhoofd/email';
 import { EmailContent, EmailTemplateType, Recipient } from '@stamhoofd/structures';
+import { Country } from '@stamhoofd/types/Country';
 import { Language } from '@stamhoofd/types/Language';
+import { TestUtils } from '@stamhoofd/test-utils';
 import { EmailTemplateFactory } from '../factories/EmailTemplateFactory.js';
 import { OrganizationFactory } from '../factories/OrganizationFactory.js';
 import { RegistrationPeriodFactory } from '../factories/RegistrationPeriodFactory.js';
@@ -62,6 +64,41 @@ describe('sendEmailTemplate with translations', () => {
 
         const unknown = emails.find(e => e.to.includes('unknown@example.com'))!;
         expect(unknown.subject).toBe('Default subject');
+    });
+
+    test('generates recipient replacements in the recipient language', async () => {
+        // French must be a valid locale, otherwise it gets corrected to the default language
+        TestUtils.setEnvironment('locales', { [Country.Belgium]: [Language.Dutch, Language.French] });
+
+        // The unsubscribe URL is localized per recipient (it is not part of the translatable content)
+        await new EmailTemplateFactory({
+            organization,
+            type,
+            subject: 'Subject',
+            html: '<p>{{greeting}} {{unsubscribeUrl}}</p>',
+            text: '{{greeting}} {{unsubscribeUrl}}',
+        }).create();
+
+        await sendEmailTemplate(organization, {
+            recipients: [
+                Recipient.create({ email: 'french@example.com', language: Language.French }),
+                Recipient.create({ email: 'dutch@example.com', language: Language.Dutch }),
+                Recipient.create({ email: 'unknown@example.com' }),
+            ],
+            template: { type },
+            type: 'transactional',
+        });
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        const french = emails.find(e => e.to.includes('french@example.com'))!;
+        const dutch = emails.find(e => e.to.includes('dutch@example.com'))!;
+        const unknown = emails.find(e => e.to.includes('unknown@example.com'))!;
+
+        // The unsubscribe page URL points to the recipient's localized page
+        expect(french.html).toContain('/fr-BE/unsubscribe');
+        expect(dutch.html).toContain('/nl-BE/unsubscribe');
+        // No language set: falls back to the ambient (default) locale
+        expect(unknown.html).toContain('/nl-BE/unsubscribe');
     });
 
     test('a missing language never falls back to the translation of a different template', async () => {

--- a/backend/shared/models/src/helpers/EmailBuilder.test.ts
+++ b/backend/shared/models/src/helpers/EmailBuilder.test.ts
@@ -1,0 +1,125 @@
+import { EmailMocker } from '@stamhoofd/email';
+import { EmailContent, EmailTemplateType, Recipient } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
+import { EmailTemplateFactory } from '../factories/EmailTemplateFactory.js';
+import { OrganizationFactory } from '../factories/OrganizationFactory.js';
+import { RegistrationPeriodFactory } from '../factories/RegistrationPeriodFactory.js';
+import { Email } from '../models/Email.js';
+import type { Organization } from '../models/Organization.js';
+import type { RegistrationPeriod } from '../models/RegistrationPeriod.js';
+import { sendEmailTemplate } from './EmailBuilder.js';
+
+describe('sendEmailTemplate with translations', () => {
+    let period: RegistrationPeriod;
+    let organization: Organization;
+
+    beforeAll(async () => {
+        period = await new RegistrationPeriodFactory({
+            startDate: new Date(2023, 0, 1),
+            endDate: new Date(2023, 11, 31),
+        }).create();
+    });
+
+    beforeEach(async () => {
+        organization = await new OrganizationFactory({ period }).create();
+    });
+
+    const type = EmailTemplateType.ForgotPassword;
+
+    test('each recipient receives the content in its own language, with the default as fallback', async () => {
+        await new EmailTemplateFactory({
+            organization,
+            type,
+            subject: 'Default subject',
+            html: '<p>Default html</p>',
+            text: 'Default text',
+            translations: new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet français', html: '<p>Français</p>', text: 'Français' })],
+            ]),
+        }).create();
+
+        await sendEmailTemplate(organization, {
+            recipients: [
+                Recipient.create({ email: 'french@example.com', language: Language.French }),
+                Recipient.create({ email: 'english@example.com', language: Language.English }),
+                Recipient.create({ email: 'unknown@example.com' }),
+            ],
+            template: { type },
+            type: 'transactional',
+        });
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        expect(emails).toHaveLength(3);
+
+        const french = emails.find(e => e.to.includes('french@example.com'))!;
+        expect(french.subject).toBe('Sujet français');
+        expect(french.html).toContain('Français');
+
+        // English has no translation: falls back to the default content
+        const english = emails.find(e => e.to.includes('english@example.com'))!;
+        expect(english.subject).toBe('Default subject');
+        expect(english.html).toContain('Default html');
+
+        const unknown = emails.find(e => e.to.includes('unknown@example.com'))!;
+        expect(unknown.subject).toBe('Default subject');
+    });
+
+    test('a missing language never falls back to the translation of a different template', async () => {
+        // Platform level template with a French translation
+        await new EmailTemplateFactory({
+            type,
+            subject: 'Platform subject',
+            html: '<p>Platform html</p>',
+            text: 'Platform text',
+            translations: new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet plateforme', html: '<p>Plateforme</p>', text: 'Plateforme' })],
+            ]),
+        }).create();
+
+        // Organization level template without any translations
+        await new EmailTemplateFactory({
+            organization,
+            type,
+            subject: 'Organization subject',
+            html: '<p>Organization html</p>',
+            text: 'Organization text',
+        }).create();
+
+        await sendEmailTemplate(organization, {
+            recipients: [
+                Recipient.create({ email: 'french@example.com', language: Language.French }),
+            ],
+            template: { type },
+            type: 'transactional',
+        });
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        expect(emails).toHaveLength(1);
+
+        // The organization template wins, and its default content is used for French:
+        // never the French translation of the platform template
+        expect(emails[0].subject).toBe('Organization subject');
+        expect(emails[0].html).toContain('Organization html');
+    });
+
+    test('setFromTemplate copies the translations of the template onto the email', async () => {
+        await new EmailTemplateFactory({
+            organization,
+            type: EmailTemplateType.SavedMembersEmail,
+            subject: 'Default subject',
+            html: '<p>Default html</p>',
+            text: 'Default text',
+            translations: new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet français', html: '<p>Français</p>', text: 'Français' })],
+            ]),
+        }).create();
+
+        const email = new Email();
+        email.organizationId = organization.id;
+        expect(await email.setFromTemplate(EmailTemplateType.SavedMembersEmail)).toBe(true);
+
+        expect(email.subject).toBe('Default subject');
+        expect(email.translations.size).toBe(1);
+        expect(email.translations.get(Language.French)!.subject).toBe('Sujet français');
+    });
+});

--- a/backend/shared/models/src/helpers/EmailBuilder.test.ts
+++ b/backend/shared/models/src/helpers/EmailBuilder.test.ts
@@ -1,5 +1,5 @@
 import { EmailMocker } from '@stamhoofd/email';
-import { EmailContent, EmailTemplateType, Recipient } from '@stamhoofd/structures';
+import { EmailContent, EmailTemplateType, Recipient, Replacement } from '@stamhoofd/structures';
 import { Country } from '@stamhoofd/types/Country';
 import { Language } from '@stamhoofd/types/Language';
 import { TestUtils } from '@stamhoofd/test-utils';
@@ -9,7 +9,7 @@ import { RegistrationPeriodFactory } from '../factories/RegistrationPeriodFactor
 import { Email } from '../models/Email.js';
 import type { Organization } from '../models/Organization.js';
 import type { RegistrationPeriod } from '../models/RegistrationPeriod.js';
-import { sendEmailTemplate } from './EmailBuilder.js';
+import { removeUnusedReplacements, sendEmailTemplate } from './EmailBuilder.js';
 
 describe('sendEmailTemplate with translations', () => {
     let period: RegistrationPeriod;
@@ -158,5 +158,78 @@ describe('sendEmailTemplate with translations', () => {
         expect(email.subject).toBe('Default subject');
         expect(email.translations.size).toBe(1);
         expect(email.translations.get(Language.French)!.subject).toBe('Sujet français');
+    });
+
+    test('replaceAll is applied to the html of every language, not only the default', async () => {
+        await new EmailTemplateFactory({
+            organization,
+            type,
+            subject: 'Subject',
+            // The same placeholder appears in both the default and the translated html
+            html: '<p>Default __PLACEHOLDER__</p>',
+            text: 'Default __PLACEHOLDER__',
+            translations: new Map([
+                [Language.French, EmailContent.create({ subject: 'Sujet', html: '<p>Français __PLACEHOLDER__</p>', text: 'Français __PLACEHOLDER__' })],
+            ]),
+        }).create();
+
+        await sendEmailTemplate(organization, {
+            recipients: [
+                Recipient.create({ email: 'french@example.com', language: Language.French }),
+                Recipient.create({ email: 'default@example.com' }),
+            ],
+            template: { type },
+            type: 'transactional',
+            replaceAll: [{ from: '__PLACEHOLDER__', to: 'REPLACED' }],
+        });
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        const french = emails.find(e => e.to.includes('french@example.com'))!;
+        const fallback = emails.find(e => e.to.includes('default@example.com'))!;
+
+        // The replaceAll must reach the translated html too, otherwise the placeholder leaks
+        expect(french.html).toContain('Français REPLACED');
+        expect(french.html).not.toContain('__PLACEHOLDER__');
+        expect(fallback.html).toContain('Default REPLACED');
+        expect(fallback.html).not.toContain('__PLACEHOLDER__');
+    });
+});
+
+describe('Email.getCombinedHtml', () => {
+    test('combines the default html with the html of every translation', () => {
+        const email = new Email();
+        email.html = '<p>Default {{signInUrl}}</p>';
+        email.translations = new Map([
+            [Language.French, EmailContent.create({ html: '<p>Français {{balanceTable}}</p>' })],
+        ]);
+
+        const combined = email.getCombinedHtml();
+        expect(combined).toContain('{{signInUrl}}');
+        expect(combined).toContain('{{balanceTable}}');
+    });
+
+    test('keeps a replacement that is only used inside a translation', () => {
+        const email = new Email();
+        // The default html uses signInUrl, only the French translation uses balanceTable
+        email.html = '<p>Default {{signInUrl}}</p>';
+        email.translations = new Map([
+            [Language.French, EmailContent.create({ html: '<p>Français {{balanceTable}}</p>' })],
+        ]);
+
+        const replacements = [
+            Replacement.create({ token: 'signInUrl', value: 'https://example.com' }),
+            Replacement.create({ token: 'balanceTable', value: '', html: '<table></table>' }),
+            Replacement.create({ token: 'outstandingBalance', value: '€ 10' }),
+        ];
+
+        // Using only the default html would wrongly strip balanceTable (used only by the translation)
+        const usingDefaultHtml = removeUnusedReplacements(email.html ?? '', replacements).map(r => r.token);
+        expect(usingDefaultHtml).not.toContain('balanceTable');
+
+        // Using the combined html keeps every replacement that any language needs, and still drops the truly unused one
+        const usingCombinedHtml = removeUnusedReplacements(email.getCombinedHtml(), replacements).map(r => r.token);
+        expect(usingCombinedHtml).toContain('signInUrl');
+        expect(usingCombinedHtml).toContain('balanceTable');
+        expect(usingCombinedHtml).not.toContain('outstandingBalance');
     });
 });

--- a/backend/shared/models/src/helpers/EmailBuilder.ts
+++ b/backend/shared/models/src/helpers/EmailBuilder.ts
@@ -309,7 +309,9 @@ export async function getEmailBuilder(organization: Organization | null, email: 
                 continue;
             }
 
-            const unsubscribeUrl = 'https://' + STAMHOOFD.domains.dashboard + '/' + (organization ? (organization.i18n.locale + '/') : '') + 'unsubscribe?id=' + encodeURIComponent(unsubscribe.id) + '&token=' + encodeURIComponent(unsubscribe.token) + '&type=' + encodeURIComponent(email.unsubscribeType ?? 'all');
+            // Localize the unsubscribe page to the recipient's language (Organization.i18n is always Dutch)
+            const unsubscribeLocale = organization ? getRecipientI18n(recipient, organization).locale : null;
+            const unsubscribeUrl = 'https://' + STAMHOOFD.domains.dashboard + '/' + (unsubscribeLocale ? (unsubscribeLocale + '/') : '') + 'unsubscribe?id=' + encodeURIComponent(unsubscribe.id) + '&token=' + encodeURIComponent(unsubscribe.token) + '&type=' + encodeURIComponent(email.unsubscribeType ?? 'all');
             recipient.replacements.push(Replacement.create({
                 token: 'unsubscribeUrl',
                 value: unsubscribeUrl,
@@ -581,6 +583,30 @@ export function stripRecipientReplacementsForWebDisplay(recipient: Recipient | E
 }
 
 /**
+ * Build the I18n an email should be rendered in for a specific recipient.
+ *
+ * Falls back to the current (ambient) locale when the recipient has no language set — so flows
+ * that already established a locale (order emails wrapped in I18n.runWithLocale, or the request
+ * locale) keep working unchanged.
+ */
+export function getRecipientI18n(recipient: { language?: Language | null }, organization: Organization | null): I18n {
+    return new I18n(recipient.language ?? $getLanguage(), organization?.address.country ?? $getCountry());
+}
+
+/**
+ * Render everything inside `handler` in the recipient's language: all $t / $getLanguage /
+ * $getCountry calls (and therefore every generated replacement) use the recipient's locale.
+ *
+ * This is the single place that binds "a recipient" to "its language" when generating email
+ * content. Generate recipient replacements inside this wrapper so new replacements are localized
+ * automatically, and pass the provided i18n to helpers that take an explicit locale (e.g. getAppHost).
+ */
+export async function runWithRecipientLocale<T>(recipient: { language?: Language | null }, organization: Organization | null, handler: (i18n: I18n) => Promise<T>): Promise<T> {
+    const i18n = getRecipientI18n(recipient, organization);
+    return await I18n.runWithLocale(i18n, () => handler(i18n));
+}
+
+/**
  * @param options.forPreview if true, it will hide sensitive information in the preview that could leak information to admin users
  */
 export async function fillRecipientReplacements(recipient: Recipient | EmailRecipientStruct | EmailRecipient, options: {
@@ -595,181 +621,187 @@ export async function fillRecipientReplacements(recipient: Recipient | EmailReci
         options.platform = await Platform.getSharedPrivateStruct();
     }
     const { organization, platform, from, replyTo } = options;
-    let recipientUser: User | null | undefined = null;
-    recipient.replacements = recipient.replacements.slice();
-    if (options.forPreview) {
-        stripSensitiveRecipientReplacements(recipient, options);
-    }
 
-    if (!recipient.email && !recipient.userId) {
-        const signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false) : STAMHOOFD.domains.dashboard) + '/login';
-        recipient.replacements.push(Replacement.create({
-            token: 'signInUrl',
-            value: signInUrl,
-        }));
+    // Render every recipient replacement (greeting, loginDetails, balance table, URLs...) in the
+    // recipient's own language, so translated emails are consistent end-to-end. Any replacement
+    // added below is localized automatically; helpers with an explicit locale get the same i18n.
+    await runWithRecipientLocale(recipient, organization, async (i18n) => {
+        let recipientUser: User | null | undefined = null;
+        recipient.replacements = recipient.replacements.slice();
+        if (options.forPreview) {
+            stripSensitiveRecipientReplacements(recipient, options);
+        }
 
-        if (!recipient.replacements.find(r => r.token === 'loginDetails')) {
+        if (!recipient.email && !recipient.userId) {
+            const signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false, i18n) : STAMHOOFD.domains.dashboard) + '/login';
             recipient.replacements.push(Replacement.create({
-                token: 'loginDetails',
-                value: '',
+                token: 'signInUrl',
+                value: signInUrl,
             }));
-        }
-    } else {
-        // Default signInUrl
-        recipientUser = recipient.userId ? await User.select().where('id', recipient.userId).first(false) : await User.getForAuthentication(organization?.id ?? null, recipient.email!, { allowWithoutAccount: true });
-        if (STAMHOOFD.userMode !== 'platform' && recipientUser && recipientUser.organizationId && recipientUser.organizationId !== (organization?.id ?? null)) {
-            console.warn('User organization does not match current organization, ignoring userId', recipient.userId, recipientUser.organizationId, organization?.id ?? null);
-            recipientUser = null;
-        }
 
-        let signInUrl: string;
-        if (!recipientUser || !recipientUser.hasAccount()) {
-            // We can create a special token
-            if (recipientUser) {
-                signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false) : STAMHOOFD.domains.dashboard) + '/account-aanmaken?email=' + encodeURIComponent(recipientUser?.email);
-            } else {
-                signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false) : STAMHOOFD.domains.dashboard) + '/account-aanmaken';
+            if (!recipient.replacements.find(r => r.token === 'loginDetails')) {
+                recipient.replacements.push(Replacement.create({
+                    token: 'loginDetails',
+                    value: '',
+                }));
             }
         } else {
-            signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false) : STAMHOOFD.domains.dashboard) + '/login?email=' + encodeURIComponent(recipientUser.email);
+        // Default signInUrl
+            recipientUser = recipient.userId ? await User.select().where('id', recipient.userId).first(false) : await User.getForAuthentication(organization?.id ?? null, recipient.email!, { allowWithoutAccount: true });
+            if (STAMHOOFD.userMode !== 'platform' && recipientUser && recipientUser.organizationId && recipientUser.organizationId !== (organization?.id ?? null)) {
+                console.warn('User organization does not match current organization, ignoring userId', recipient.userId, recipientUser.organizationId, organization?.id ?? null);
+                recipientUser = null;
+            }
+
+            let signInUrl: string;
+            if (!recipientUser || !recipientUser.hasAccount()) {
+            // We can create a special token
+                if (recipientUser) {
+                    signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false, i18n) : STAMHOOFD.domains.dashboard) + '/account-aanmaken?email=' + encodeURIComponent(recipientUser?.email);
+                } else {
+                    signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false, i18n) : STAMHOOFD.domains.dashboard) + '/account-aanmaken';
+                }
+            } else {
+                signInUrl = 'https://' + (organization && STAMHOOFD.userMode === 'organization' ? getAppHost('registration', organization, false, i18n) : STAMHOOFD.domains.dashboard) + '/login?email=' + encodeURIComponent(recipientUser.email);
+            }
+
+            recipient.replacements.push(Replacement.create({
+                token: 'signInUrl',
+                value: signInUrl,
+            }));
         }
 
-        recipient.replacements.push(Replacement.create({
-            token: 'signInUrl',
-            value: signInUrl,
-        }));
-    }
-
-    if (options.forceRefresh) {
+        if (options.forceRefresh) {
         // Remove loginDetails to force refresh
-        recipient.replacements = recipient.replacements.filter(r => r.token !== 'loginDetails');
-    }
+            recipient.replacements = recipient.replacements.filter(r => r.token !== 'loginDetails');
+        }
 
-    if (!recipient.replacements.find(r => r.token === 'loginDetails')) {
-        if (recipientUser) {
-            const emailEscaped = `<strong>${Formatter.escapeHtml(recipientUser.email)}</strong>`;
-            const suffixes: string[] = [];
-            const { Member } = await import('../models/Member.js');
-            const memberIds = await Member.getMemberIdsForUser(recipientUser);
-            const members = await Member.getByIDs(...memberIds);
-            if (members.length > 0) {
-                for (const member of members) {
-                    suffixes.push(
-                        $t('%1EC', {
-                            firstName: Formatter.escapeHtml(member.firstName),
-                            securityCode: `<span class="style-inline-code">${Formatter.escapeHtml(options.forPreview ? '••••' : Formatter.spaceString(member.details.securityCode ?? '', 4, '-'))}</span>`,
+        if (!recipient.replacements.find(r => r.token === 'loginDetails')) {
+            if (recipientUser) {
+                const emailEscaped = `<strong>${Formatter.escapeHtml(recipientUser.email)}</strong>`;
+                const suffixes: string[] = [];
+                const { Member } = await import('../models/Member.js');
+                const memberIds = await Member.getMemberIdsForUser(recipientUser);
+                const members = await Member.getByIDs(...memberIds);
+                if (members.length > 0) {
+                    for (const member of members) {
+                        suffixes.push(
+                            $t('%1EC', {
+                                firstName: Formatter.escapeHtml(member.firstName),
+                                securityCode: `<span class="style-inline-code">${Formatter.escapeHtml(options.forPreview ? '••••' : Formatter.spaceString(member.details.securityCode ?? '', 4, '-'))}</span>`,
+                            }),
+                        );
+                    }
+                } else {
+                    console.log('No member found for user', recipientUser.id);
+                }
+                const suffix = suffixes.length > 0 ? (' ' + suffixes.join(' ')) : '';
+                recipient.replacements.push(
+                    Replacement.create({
+                        token: 'loginDetails',
+                        value: '',
+                        html: recipientUser.hasAccount()
+                            ? `<p class="description"><em>${$t('%1EA', { email: emailEscaped })}${suffix}</em></p>`
+                            : `<p class="description"><em>${$t('%1EB', { email: emailEscaped })}${suffix}</em></p>`,
+                    }),
+                );
+            } else {
+                if (recipient.email) {
+                    const emailEscaped = `<strong>${Formatter.escapeHtml(recipient.email)}</strong>`;
+                    console.log('No user found for email', recipient.email);
+                    recipient.replacements.push(
+                        Replacement.create({
+                            token: 'loginDetails',
+                            value: '',
+                            html: `<p class="description"><em>${$t('%1EB', { email: emailEscaped })}</em></p>`,
+                        }),
+                    );
+                } else {
+                    recipient.replacements.push(
+                        Replacement.create({
+                            token: 'loginDetails',
+                            value: '',
+                            html: '',
                         }),
                     );
                 }
-            } else {
-                console.log('No member found for user', recipientUser.id);
-            }
-            const suffix = suffixes.length > 0 ? (' ' + suffixes.join(' ')) : '';
-            recipient.replacements.push(
-                Replacement.create({
-                    token: 'loginDetails',
-                    value: '',
-                    html: recipientUser.hasAccount()
-                        ? `<p class="description"><em>${$t('%1EA', { email: emailEscaped })}${suffix}</em></p>`
-                        : `<p class="description"><em>${$t('%1EB', { email: emailEscaped })}${suffix}</em></p>`,
-                }),
-            );
-        } else {
-            if (recipient.email) {
-                const emailEscaped = `<strong>${Formatter.escapeHtml(recipient.email)}</strong>`;
-                console.log('No user found for email', recipient.email);
-                recipient.replacements.push(
-                    Replacement.create({
-                        token: 'loginDetails',
-                        value: '',
-                        html: `<p class="description"><em>${$t('%1EB', { email: emailEscaped })}</em></p>`,
-                    }),
-                );
-            } else {
-                recipient.replacements.push(
-                    Replacement.create({
-                        token: 'loginDetails',
-                        value: '',
-                        html: '',
-                    }),
-                );
             }
         }
-    }
 
-    if (options.forceRefresh) {
+        if (options.forceRefresh) {
         // Remove loginDetails to force refresh
-        recipient.replacements = recipient.replacements.filter(r => r.token !== 'balanceTable' && r.token !== 'outstandingBalance');
-    }
+            recipient.replacements = recipient.replacements.filter(r => r.token !== 'balanceTable' && r.token !== 'outstandingBalance');
+        }
 
-    // Load balance of this user
-    // todo: only if detected it is used
-    if (!recipient.replacements.find(r => r.token === 'balanceTable')) {
-        if (organization && recipientUser) {
-            const balanceItemModels = await CachedBalance.balanceForObjects(organization.id, [recipientUser.id], ReceivableBalanceType.user);
-            const balanceItems = balanceItemModels.map(i => i.getStructure());
+        // Load balance of this user
+        // todo: only if detected it is used
+        if (!recipient.replacements.find(r => r.token === 'balanceTable')) {
+            if (organization && recipientUser) {
+                const balanceItemModels = await CachedBalance.balanceForObjects(organization.id, [recipientUser.id], ReceivableBalanceType.user);
+                const balanceItems = balanceItemModels.map(i => i.getStructure());
 
-            // Get members
-            recipient.replacements.push(
-                Replacement.create({
-                    token: 'outstandingBalance',
-                    value: Formatter.price(balanceItems.reduce((sum, i) => sum + i.priceOpen, 0)),
-                }),
-                Replacement.create({
-                    token: 'balanceTable',
-                    value: '',
-                    html: BalanceItemStruct.getDetailsHTMLTable(balanceItems),
-                }),
-            );
+                // Get members
+                recipient.replacements.push(
+                    Replacement.create({
+                        token: 'outstandingBalance',
+                        value: Formatter.price(balanceItems.reduce((sum, i) => sum + i.priceOpen, 0)),
+                    }),
+                    Replacement.create({
+                        token: 'balanceTable',
+                        value: '',
+                        html: BalanceItemStruct.getDetailsHTMLTable(balanceItems),
+                    }),
+                );
+            } else {
+                recipient.replacements.push(
+                    Replacement.create({
+                        token: 'outstandingBalance',
+                        value: Formatter.price(0),
+                    }),
+                    Replacement.create({
+                        token: 'balanceTable',
+                        value: '',
+                        html: BalanceItemStruct.getDetailsHTMLTable([]),
+                    }),
+                );
+            }
+        }
+
+        if (from || replyTo) {
+            const fromAddress = replyTo?.email ?? from!.email;
+
+            if (fromAddress) {
+                recipient.replacements.push(Replacement.create({
+                    token: 'fromAddress',
+                    value: fromAddress,
+                }));
+            }
+
+            const name = replyTo?.name ?? from?.name;
+            if (name) {
+                recipient.replacements.push(Replacement.create({
+                    token: 'fromName',
+                    value: name,
+                }));
+            }
+        }
+
+        if (recipient instanceof EmailRecipient) {
+            recipient.replacements.push(...recipient.getRecipient().getDefaultReplacements());
         } else {
-            recipient.replacements.push(
-                Replacement.create({
-                    token: 'outstandingBalance',
-                    value: Formatter.price(0),
-                }),
-                Replacement.create({
-                    token: 'balanceTable',
-                    value: '',
-                    html: BalanceItemStruct.getDetailsHTMLTable([]),
-                }),
-            );
-        }
-    }
-
-    if (from || replyTo) {
-        const fromAddress = replyTo?.email ?? from!.email;
-
-        if (fromAddress) {
-            recipient.replacements.push(Replacement.create({
-                token: 'fromAddress',
-                value: fromAddress,
-            }));
+            recipient.replacements.push(...recipient.getDefaultReplacements());
         }
 
-        const name = replyTo?.name ?? from?.name;
-        if (name) {
-            recipient.replacements.push(Replacement.create({
-                token: 'fromName',
-                value: name,
-            }));
+        if (organization) {
+            const extra = organization.meta.getEmailReplacements(organization);
+            recipient.replacements.push(...extra);
         }
-    }
 
-    if (recipient instanceof EmailRecipient) {
-        recipient.replacements.push(...recipient.getRecipient().getDefaultReplacements());
-    } else {
-        recipient.replacements.push(...recipient.getDefaultReplacements());
-    }
-
-    if (organization) {
-        const extra = organization.meta.getEmailReplacements(organization);
+        // Defaults
+        const extra = platform.config.getEmailReplacements(platform);
         recipient.replacements.push(...extra);
-    }
 
-    // Defaults
-    const extra = platform.config.getEmailReplacements(platform);
-    recipient.replacements.push(...extra);
-
-    // Remove duplicates
-    cleanReplacements(recipient.replacements);
+        // Remove duplicates
+        cleanReplacements(recipient.replacements);
+    });
 }

--- a/backend/shared/models/src/helpers/EmailBuilder.ts
+++ b/backend/shared/models/src/helpers/EmailBuilder.ts
@@ -1,7 +1,8 @@
 import type { EmailBuilder, EmailInterfaceRecipient } from '@stamhoofd/email';
 import { Email, EmailAddress } from '@stamhoofd/email';
-import type { EmailRecipient as EmailRecipientStruct, EmailTemplateType, OrganizationEmail, Platform as PlatformStruct, Recipient } from '@stamhoofd/structures';
+import type { EmailContent, EmailRecipient as EmailRecipientStruct, EmailTemplateType, OrganizationEmail, Platform as PlatformStruct, Recipient } from '@stamhoofd/structures';
 import { BalanceItem as BalanceItemStruct, getAppHost, ReceivableBalanceType, replaceEmailHtml, replaceEmailText, Replacement } from '@stamhoofd/structures';
+import type { Language } from '@stamhoofd/types/Language';
 import { Formatter } from '@stamhoofd/utility';
 
 import { SimpleError } from '@simonbackx/simple-errors';
@@ -228,6 +229,7 @@ async function getEmailBuilderForTemplate(organization: Organization | null, opt
         ...options,
         subject: template.subject,
         html: template.html,
+        translations: template.translations,
     });
 }
 
@@ -238,6 +240,12 @@ export type EmailBuilderOptions = {
     replyTo?: EmailInterfaceRecipient | null;
     subject: string;
     html: string;
+
+    /**
+     * Full content overrides per language. Recipients with a language that has an override
+     * receive that content, all others receive the default subject/html.
+     */
+    translations?: Map<Language, EmailContent>;
     attachments?: { filename: string; path?: string; href?: string; content?: string | Buffer; contentType?: string; encoding?: string }[];
     type?: 'transactional' | 'broadcast';
     unsubscribeType?: 'all' | 'marketing';
@@ -340,9 +348,28 @@ export async function getEmailBuilder(organization: Organization | null, email: 
 
     let emailIndex = 0;
 
-    for (const s of email.replaceAll ?? []) {
-        email.html = email.html.replaceAll(s.from, s.to);
-    }
+    // The subject and html can differ per recipient language
+    const contentCache = new Map<Language | null, { subject: string; html: string }>();
+    const resolveContent = (language: Language | null) => {
+        const cached = contentCache.get(language);
+        if (cached) {
+            return cached;
+        }
+
+        // Strict selection: only use a translation of this email, never fall back to
+        // a different template for a missing language (content correctness above language)
+        const translation = language !== null ? email.translations?.get(language) : undefined;
+        const subject = translation ? translation.subject : email.subject;
+        let html = translation ? translation.html : email.html;
+
+        for (const s of email.replaceAll ?? []) {
+            html = html.replaceAll(s.from, s.to);
+        }
+
+        const result = { subject, html };
+        contentCache.set(language, result);
+        return result;
+    };
 
     if (queue.length === 0) {
         if (email.callback) {
@@ -360,8 +387,9 @@ export async function getEmailBuilder(organization: Organization | null, email: 
             return undefined;
         }
 
-        const replacedHtml = replaceEmailHtml(email.html, recipient.replacements);
-        const replacedSubject = replaceEmailText(email.subject, recipient.replacements);
+        const content = resolveContent(recipient.language ?? null);
+        const replacedHtml = replaceEmailHtml(content.html, recipient.replacements);
+        const replacedSubject = replaceEmailText(content.subject, recipient.replacements);
 
         emailIndex += 1;
 

--- a/backend/shared/models/src/helpers/EmailBuilder.ts
+++ b/backend/shared/models/src/helpers/EmailBuilder.ts
@@ -601,9 +601,9 @@ export function getRecipientI18n(recipient: { language?: Language | null }, orga
  * content. Generate recipient replacements inside this wrapper so new replacements are localized
  * automatically, and pass the provided i18n to helpers that take an explicit locale (e.g. getAppHost).
  */
-export async function runWithRecipientLocale<T>(recipient: { language?: Language | null }, organization: Organization | null, handler: (i18n: I18n) => Promise<T>): Promise<T> {
+export function runWithRecipientLocale<T>(recipient: { language?: Language | null }, organization: Organization | null, handler: (i18n: I18n) => T): T {
     const i18n = getRecipientI18n(recipient, organization);
-    return await I18n.runWithLocale(i18n, () => handler(i18n));
+    return I18n.runWithLocale(i18n, () => handler(i18n));
 }
 
 /**

--- a/backend/shared/models/src/migrations/1783987708-email-templates-translations.sql
+++ b/backend/shared/models/src/migrations/1783987708-email-templates-translations.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `email_templates`
+ADD COLUMN `translations` json NOT NULL DEFAULT ('{"value": {}, "version": 0}');

--- a/backend/shared/models/src/migrations/1783987708-email-translations.sql
+++ b/backend/shared/models/src/migrations/1783987708-email-translations.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `email_templates`
+ADD COLUMN `translations` json NOT NULL DEFAULT ('{"value": {}, "version": 0}');
+
+ALTER TABLE `emails`
+ADD COLUMN `translations` json NOT NULL DEFAULT ('{"value": {}, "version": 0}');
+
+ALTER TABLE `email_recipients`
+ADD COLUMN `language` varchar(2) NULL DEFAULT NULL;

--- a/backend/shared/models/src/migrations/1783987708-email-translations.sql
+++ b/backend/shared/models/src/migrations/1783987708-email-translations.sql
@@ -1,8 +1,0 @@
-ALTER TABLE `email_templates`
-ADD COLUMN `translations` json NOT NULL DEFAULT ('{"value": {}, "version": 0}');
-
-ALTER TABLE `emails`
-ADD COLUMN `translations` json NOT NULL DEFAULT ('{"value": {}, "version": 0}');
-
-ALTER TABLE `email_recipients`
-ADD COLUMN `language` varchar(2) NULL DEFAULT NULL;

--- a/backend/shared/models/src/migrations/1783987709-emails-translations.sql
+++ b/backend/shared/models/src/migrations/1783987709-emails-translations.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `emails`
+ADD COLUMN `translations` json NOT NULL DEFAULT ('{"value": {}, "version": 0}');

--- a/backend/shared/models/src/migrations/1783987710-email-recipients-language.sql
+++ b/backend/shared/models/src/migrations/1783987710-email-recipients-language.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `email_recipients`
+ADD COLUMN `language` varchar(2) NULL DEFAULT NULL;

--- a/backend/shared/models/src/models/Email.ts
+++ b/backend/shared/models/src/models/Email.ts
@@ -1,9 +1,11 @@
 import { column } from '@simonbackx/simple-database';
 import type { BaseOrganization, EmailRecipient as EmailRecipientStruct, EmailTemplateType, PaginatedResponse, StamhoofdFilter, User as UserStruct } from '@stamhoofd/structures';
-import { EmailAttachment, EmailPreview, EmailRecipientFilter, EmailRecipientsStatus, EmailStatus, Email as EmailStruct, EmailWithRecipients, getExampleRecipient, isSoftEmailRecipientError, LimitedFilteredRequest, SortItemDirection } from '@stamhoofd/structures';
+import { EmailAttachment, EmailContent, EmailPreview, EmailRecipientFilter, EmailRecipientsStatus, EmailStatus, Email as EmailStruct, EmailWithRecipients, getExampleRecipient, isSoftEmailRecipientError, LanguageHelper, LimitedFilteredRequest, SortItemDirection } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
 import { v4 as uuidv4 } from 'uuid';
 import type { EmailRecipientFilterType } from '@stamhoofd/structures/email/EmailRecipientFilterType.js';
-import { AnyDecoder, ArrayDecoder } from '@simonbackx/simple-encoding';
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { AnyDecoder, ArrayDecoder, EnumDecoder, MapDecoder } from '@simonbackx/simple-encoding';
 import { isSimpleError, isSimpleErrors, SimpleError, SimpleErrors } from '@simonbackx/simple-errors';
 import { I18n } from '@stamhoofd/backend-i18n/I18n';
 import type { EmailInterfaceRecipient } from '@stamhoofd/email';
@@ -104,6 +106,10 @@ export class Email extends QueryableModel {
 
     @column({ type: 'string', nullable: true })
     text: string | null = null;
+
+    /** Full content overrides per language. The default content (subject/html/text/json) is used for all recipients without a matching override */
+    @column({ type: 'json', decoder: new MapDecoder(new EnumDecoder(Language), EmailContent as Decoder<EmailContent>) })
+    translations: Map<Language, EmailContent> = new Map();
 
     @column({ type: 'string', nullable: true })
     fromAddress: string | null = null;
@@ -257,6 +263,16 @@ export class Email extends QueryableModel {
             });
         }
 
+        for (const [language, content] of this.translations) {
+            if (content.subject.length === 0 || content.text.length === 0 || content.html.length === 0) {
+                throw new SimpleError({
+                    code: 'invalid_field',
+                    message: 'Missing subject, text or html in translation ' + language,
+                    human: $t('De vertaling in het {language} is onvolledig. Vul het onderwerp en de inhoud aan of verwijder de vertaling.', { language: LanguageHelper.getName(language) }),
+                });
+            }
+        }
+
         if (this.fromAddress == null || this.fromAddress.length == 0) {
             throw new SimpleError({
                 code: 'invalid_field',
@@ -304,6 +320,17 @@ export class Email extends QueryableModel {
                     message: 'Missing unsubscribe button',
                     human: $t(`%DS`),
                     field: 'html',
+                });
+            }
+        }
+
+        for (const [language, content] of this.translations) {
+            if ((content.html && !content.html.includes(replacement)) || (content.text && !content.text.includes(replacement))) {
+                throw new SimpleError({
+                    code: 'missing_unsubscribe_button',
+                    message: 'Missing unsubscribe button in translation ' + language,
+                    human: $t(`%DS`),
+                    field: 'translations',
                 });
             }
         }
@@ -436,8 +463,16 @@ export class Email extends QueryableModel {
         this.text = defaultTemplate.text;
         this.subject = defaultTemplate.subject;
         this.json = defaultTemplate.json;
+        this.translations = new Map([...defaultTemplate.translations.entries()].map(([language, content]) => [language, content.clone()]));
 
         return true;
+    }
+
+    /**
+     * The html of all languages combined - only used to check which replacements are in use.
+     */
+    getCombinedHtml(): string {
+        return [this.html ?? '', ...[...this.translations.values()].map(content => content.html)].join(' ');
     }
 
     async lock<T>(callback: (upToDate: Email, options: QueueHandlerOptions) => Promise<T> | T): Promise<T> {
@@ -729,6 +764,7 @@ export class Email extends QueryableModel {
             replyTo: data.replyTo,
             subject: this.subject!,
             html: this.html!,
+            translations: this.translations,
             type: this.emailType ? 'transactional' : 'broadcast',
             attachments: data.attachments,
             callback(error: Error | null) {
@@ -1159,6 +1195,7 @@ export class Email extends QueryableModel {
 
             const membersSet = new Set<string>();
             const emailsSet = new Set<string>();
+            const combinedHtml = upToDate.getCombinedHtml();
 
             let count = 0;
             let countWithoutEmail = 0;
@@ -1207,6 +1244,7 @@ export class Email extends QueryableModel {
                             recipient.email = item.email;
                             recipient.firstName = item.firstName;
                             recipient.lastName = item.lastName;
+                            recipient.language = item.language ?? null;
                             recipient.replacements = item.replacements;
                             recipient.memberId = item.memberId ?? null;
                             recipient.userId = item.userId ?? null;
@@ -1219,7 +1257,7 @@ export class Email extends QueryableModel {
                                 replyTo: null,
                                 forPreview: false,
                             });
-                            recipient.replacements = removeUnusedReplacements(upToDate.html ?? '', recipient.replacements);
+                            recipient.replacements = removeUnusedReplacements(combinedHtml, recipient.replacements);
 
                             let duplicateOfRecipientId: string | null = null;
                             if (item.email && emailsSet.has(item.email)) {
@@ -1345,6 +1383,7 @@ export class Email extends QueryableModel {
                             recipient.email = item.email;
                             recipient.firstName = item.firstName;
                             recipient.lastName = item.lastName;
+                            recipient.language = item.language ?? null;
                             recipient.replacements = item.replacements;
                             recipient.memberId = item.memberId ?? null;
                             recipient.userId = item.userId ?? null;
@@ -1477,7 +1516,7 @@ export class Email extends QueryableModel {
                 organization,
             });
             if (this.html) {
-                struct.replacements = removeUnusedReplacements(this.html, struct.replacements);
+                struct.replacements = removeUnusedReplacements(this.getCombinedHtml(), struct.replacements);
             }
         }
 

--- a/backend/shared/models/src/models/EmailRecipient.ts
+++ b/backend/shared/models/src/models/EmailRecipient.ts
@@ -1,5 +1,6 @@
 import { column } from '@simonbackx/simple-database';
 import { EmailRecipient as EmailRecipientStruct, Recipient, Replacement, TinyMember } from '@stamhoofd/structures';
+import type { Language } from '@stamhoofd/types/Language';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ArrayDecoder } from '@simonbackx/simple-encoding';
@@ -43,6 +44,12 @@ export class EmailRecipient extends QueryableModel {
 
     @column({ type: 'string', nullable: true })
     email: string | null = null;
+
+    /**
+     * Preferred language of this recipient, used to select the email content translation.
+     */
+    @column({ type: 'string', nullable: true })
+    language: Language | null = null;
 
     @column({ type: 'json', decoder: new ArrayDecoder(Replacement) })
     replacements: Replacement[] = [];

--- a/backend/shared/models/src/models/EmailTemplate.ts
+++ b/backend/shared/models/src/models/EmailTemplate.ts
@@ -1,8 +1,10 @@
 import { column } from '@simonbackx/simple-database';
-import { AnyDecoder } from '@simonbackx/simple-encoding';
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { AnyDecoder, EnumDecoder, MapDecoder } from '@simonbackx/simple-encoding';
 import { QueryableModel } from '@stamhoofd/sql';
 import type { EmailTemplateType } from '@stamhoofd/structures';
-import { EmailTemplate as EmailTemplateStruct } from '@stamhoofd/structures';
+import { EmailContent, EmailTemplate as EmailTemplateStruct } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
 import { v4 as uuidv4 } from 'uuid';
 
 /**
@@ -43,6 +45,10 @@ export class EmailTemplate extends QueryableModel {
 
     @column({ type: 'string' })
     text: string;
+
+    /** Full content overrides per language. The default content (subject/html/text/json) is used for all languages without an override */
+    @column({ type: 'json', decoder: new MapDecoder(new EnumDecoder(Language), EmailContent as Decoder<EmailContent>) })
+    translations: Map<Language, EmailContent> = new Map();
 
     @column({
         type: 'datetime', beforeSave() {

--- a/backend/shared/models/src/models/Order.ts
+++ b/backend/shared/models/src/models/Order.ts
@@ -924,6 +924,7 @@ export class Order extends QueryableModel {
                 // Clear first and last name
                 recipient.firstName = null;
                 recipient.lastName = null;
+                recipient.language = this.webshop.meta.defaultLanguage;
                 recipient.replacements = recipient.replacements.filter(r => !['firstName', 'lastName'].includes(r.token));
                 data.to.merge(recipient);
                 recipient = data.to;

--- a/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
@@ -95,6 +95,19 @@
                     {{ $t('%ZZt') }}
                 </p>
             </STListItem>
+
+            <STListItem :selectable="true" element-name="label">
+                <template #left>
+                    <Checkbox :model-value="getFeatureFlag('email-translations')" @update:model-value="setFeatureFlag('email-translations', !!$event)" />
+                </template>
+                <h3 class="style-title-list">
+                    {{ $t('Vertalingen voor e-mails') }}
+                </h3>
+
+                <p class="style-description-small">
+                    {{ $t('Wanneer ingeschakeld kan je vertalingen toevoegen aan e-mails en e-mailsjablonen. Bestaande vertalingen blijven altijd bewerkbaar.') }}
+                </p>
+            </STListItem>
         </STList>
 
         <STList>

--- a/frontend/shared/components/src/email/EditEmailTemplateView.vue
+++ b/frontend/shared/components/src/email/EditEmailTemplateView.vue
@@ -1,5 +1,5 @@
 <template>
-    <EditorView ref="editorView" class="mail-view" :email-block="emailBlock" :save-text="$t('%1Op')" :replacements="replacements" :title="$t(`%aP`)" @save="save">
+    <EditorView ref="editorView" class="mail-view" :email-block="emailBlock" :save-text="$t('%1Op')" :loading="contentLanguage.switching.value" :replacements="replacements" :title="$t(`%aP`)" @save="save">
         <p v-if="prefix" class="style-title-prefix" v-text="prefix" />
         <h1 v-if="isNew" class="style-navigation-title">
             {{ $t('%aM') }}
@@ -17,11 +17,14 @@
                     <span class="list-input">{{ EmailTemplate.getTypeTitle(emailTemplate.type) }}</span>
                 </div>
             </STListItem>
-            <STListItem class="no-padding" element-name="label">
+            <STListItem class="no-padding right-stack" element-name="label">
                 <div class="list-input-box">
                     <span>{{ $t('%aO') }}:</span>
                     <input id="mail-subject" v-model="subject" class="list-input" type="text" :placeholder="$t(`%aQ`)">
                 </div>
+                <template #right>
+                    <EmailLanguageButton :model-value="contentLanguage.currentLanguage.value" :languages="contentLanguage.languages.value" :disabled="contentLanguage.switching.value" @update:model-value="contentLanguage.switchTo($event).catch(console.error)" @add="contentLanguage.addLanguage($event).catch(console.error)" @remove="contentLanguage.removeLanguage($event).catch(console.error)" />
+                </template>
             </STListItem>
         </template>
     </EditorView>
@@ -32,16 +35,17 @@ import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { usePop } from '@simonbackx/vue-app-navigation';
 import type { Replacement } from '@stamhoofd/structures';
 import { EmailTemplate, EmailTemplateType } from '@stamhoofd/structures';
-import type { Ref} from 'vue';
+import type { Ref } from 'vue';
 import { computed, nextTick, onMounted, ref } from 'vue';
 import EditorView from '../editor/EditorView.vue';
-import { EmailStyler } from '../editor/EmailStyler';
 import { ErrorBox } from '../errors/ErrorBox';
 import { useErrors } from '../errors/useErrors';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import { usePatch } from '#hooks/usePatch.ts';
 import { usePlatform } from '#hooks/usePlatform.ts';
 import { CenteredMessage } from '../overlays/CenteredMessage';
+import EmailLanguageButton from './EmailLanguageButton.vue';
+import { confirmStaleEmailContentLanguages, useEmailContentLanguage } from './hooks/useEmailContentLanguage';
 
 const props = withDefaults(
     defineProps<{
@@ -63,15 +67,17 @@ const pop = usePop();
 const organization = useOrganization();
 const platform = usePlatform();
 
+const contentLanguage = useEmailContentLanguage({
+    editor: () => editor.value,
+    patched: () => patched.value,
+    addPatch,
+});
+const subject = contentLanguage.subject;
+
 onMounted(() => {
     if (props.emailTemplate.json && (props.emailTemplate.json as any).type) {
         editor.value?.commands.setContent(props.emailTemplate.json);
     }
-});
-
-const subject = computed({
-    get: () => patched.value.subject,
-    set: subject => addPatch({ subject }),
 });
 
 const replacements = computed(() => {
@@ -95,30 +101,29 @@ const emailBlock = computed(() => {
     return EmailTemplate.canAddEmailOnlyContent(patched.value.type);
 });
 
-async function getHTML() {
-    const e = editor.value;
-    if (!e) {
-        // When editor is not yet loaded: slow internet -> need to know html on dismiss confirmation
-        return {
-            text: '',
-            html: '',
-            json: {},
-        };
+async function confirmStaleTranslations(): Promise<boolean> {
+    if (props.isNew) {
+        // On creation it doesn't matter that only one language received content
+        return true;
     }
-
-    const base: string = e.getHTML();
-    return {
-        ...await EmailStyler.format(base, subject.value),
-        json: e.getJSON(),
-    };
+    return await confirmStaleEmailContentLanguages(props.emailTemplate, patched.value, {
+        ignoreText: $t('Toch opslaan'),
+        switchTo: language => contentLanguage.switchTo(language),
+    });
 }
 
 async function save() {
+    if (contentLanguage.switching.value) {
+        return;
+    }
     try {
-        addPatch({
-            ...(await getHTML()),
-        });
+        await contentLanguage.flush();
         await nextTick();
+
+        if (!await confirmStaleTranslations()) {
+            return;
+        }
+
         await props.saveHandler(patch.value);
         await pop({ force: true });
     }
@@ -128,7 +133,8 @@ async function save() {
 }
 
 const shouldNavigateAway = async () => {
-    if (!hasChanges.value && (await getHTML()).text === patched.value.text) {
+    const derived = await contentLanguage.getDerivedContent();
+    if (!hasChanges.value && (!derived || derived.text === contentLanguage.contentFor(derived.language).text)) {
         return true;
     }
     return await CenteredMessage.confirm($t('%A0'), $t('%4X'));

--- a/frontend/shared/components/src/email/EditEmailTemplateView.vue
+++ b/frontend/shared/components/src/email/EditEmailTemplateView.vue
@@ -36,7 +36,7 @@ import { usePop } from '@simonbackx/vue-app-navigation';
 import type { Replacement } from '@stamhoofd/structures';
 import { EmailTemplate, EmailTemplateType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
-import { computed, nextTick, onMounted, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import EditorView from '../editor/EditorView.vue';
 import { ErrorBox } from '../errors/ErrorBox';
 import { useErrors } from '../errors/useErrors';
@@ -74,11 +74,7 @@ const contentLanguage = useEmailContentLanguage({
 });
 const subject = contentLanguage.subject;
 
-onMounted(() => {
-    if (props.emailTemplate.json && (props.emailTemplate.json as any).type) {
-        editor.value?.commands.setContent(props.emailTemplate.json);
-    }
-});
+// The editor content is loaded by useEmailContentLanguage once the editor is available
 
 const replacements = computed(() => {
     const base: Replacement[] = [...EmailTemplate.getSupportedReplacementsForType(patched.value.type)];
@@ -126,8 +122,7 @@ async function save() {
 
         await props.saveHandler(patch.value);
         await pop({ force: true });
-    }
-    catch (e) {
+    } catch (e) {
         errors.errorBox = new ErrorBox(e);
     }
 }

--- a/frontend/shared/components/src/email/EditEmailTemplatesView.vue
+++ b/frontend/shared/components/src/email/EditEmailTemplatesView.vue
@@ -215,16 +215,14 @@ const editableList = computed(() => {
                     defaultTemplate = patched.value.find(template => template.type === type && template.groupId === null && template.webshopId === null && template.organizationId === orgId) ?? defaultTemplate ?? null;
                 }
 
-                base.push(
-                    EmailTemplate.create({
-                        ...defaultTemplate,
-                        id: '', // clear
-                        organizationId: organization.value?.id ?? null,
-                        groupId: group?.id ?? null,
-                        webshopId: props.webshopId,
-                        type,
-                    }),
-                );
+                // Clone to avoid sharing object references (e.g. the translations map) with the default template
+                const seeded = defaultTemplate?.clone() ?? EmailTemplate.create({});
+                seeded.id = ''; // clear
+                seeded.organizationId = organization.value?.id ?? null;
+                seeded.groupId = group?.id ?? null;
+                seeded.webshopId = props.webshopId;
+                seeded.type = type;
+                base.push(seeded);
             }
         }
     }

--- a/frontend/shared/components/src/email/EditEmailTemplatesView.vue
+++ b/frontend/shared/components/src/email/EditEmailTemplatesView.vue
@@ -104,6 +104,7 @@ import type { AutoEncoderPatchType, Decoder } from '@simonbackx/simple-encoding'
 import { ArrayDecoder, PatchableArray } from '@simonbackx/simple-encoding';
 import { ComponentWithProperties, usePop, usePresent } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '#containers/AsyncComponent.ts';
+import { I18nController } from '@stamhoofd/frontend-i18n/I18nController';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import type { Group } from '@stamhoofd/structures';
 import { EmailTemplate, EmailTemplateType } from '@stamhoofd/structures';
@@ -112,7 +113,6 @@ import { v4 as uuidv4 } from 'uuid';
 import type { Ref } from 'vue';
 import { computed, ref } from 'vue';
 import { usePlatform } from '#hooks/usePlatform.ts';
-
 
 const props = withDefaults(
     defineProps<{
@@ -215,8 +215,18 @@ const editableList = computed(() => {
                     defaultTemplate = patched.value.find(template => template.type === type && template.groupId === null && template.webshopId === null && template.organizationId === orgId) ?? defaultTemplate ?? null;
                 }
 
-                // Clone to avoid sharing object references (e.g. the translations map) with the default template
-                const seeded = defaultTemplate?.clone() ?? EmailTemplate.create({});
+                // Seed the new override with the default template's content in the current language
+                // only, and deliberately without its translations map: most users won't keep extra
+                // translations up to date, and a stale translation is riskier than none. They can add
+                // translations explicitly in the editor.
+                const seeded = EmailTemplate.create({});
+                if (defaultTemplate) {
+                    const content = defaultTemplate.getContentForLanguage(I18nController.shared.language);
+                    seeded.subject = content.subject;
+                    seeded.html = content.html;
+                    seeded.text = content.text;
+                    seeded.json = content.json;
+                }
                 seeded.id = ''; // clear
                 seeded.organizationId = organization.value?.id ?? null;
                 seeded.groupId = group?.id ?? null;
@@ -275,8 +285,7 @@ async function editEmail(emailTemplate: EmailTemplate) {
                         patch.id = emailTemplate.id;
                         patch.updatedAt = new Date();
                         addPatch(patch);
-                    }
-                    else {
+                    } else {
                         // Create
                         const toCreate = emailTemplate.patch(patch);
                         toCreate.id = uuidv4();
@@ -337,8 +346,7 @@ async function loadTemplates() {
         });
         templates.value = response.data;
         loading.value = false;
-    }
-    catch (e) {
+    } catch (e) {
         errors.errorBox = new ErrorBox(e);
     }
 }
@@ -350,8 +358,7 @@ async function doSelectItem(item: EmailTemplate) {
                 await pop({ force: true });
             }
         }
-    }
-    else {
+    } else {
         await editEmail(item);
     }
 }
@@ -380,8 +387,7 @@ async function saveWithoutDismiss() {
         saving.value = false;
 
         return true;
-    }
-    catch (e) {
+    } catch (e) {
         errors.errorBox = new ErrorBox(e);
     }
     saving.value = false;

--- a/frontend/shared/components/src/email/EmailLanguageButton.vue
+++ b/frontend/shared/components/src/email/EmailLanguageButton.vue
@@ -1,6 +1,7 @@
 <template>
-    <!-- Also visible when translations exist while the platform has a single language: they should remain manageable -->
-    <template v-if="hasLanguages || languages.length > 0">
+    <!-- Hidden by default; shown when translations are enabled (feature flag / admin app) or when
+         translations already exist, so existing translations remain manageable -->
+    <template v-if="languages.length > 0 || (hasLanguages && translationsEnabled)">
         <button class="button text small gray" type="button" :disabled="disabled" data-testid="email-language-button" @click="showMenu">
             <span class="icon language small" />
             <span v-if="modelValue" class="style-tag">{{ modelValue.toUpperCase() }}</span>
@@ -14,6 +15,7 @@ import { LanguageHelper } from '@stamhoofd/structures';
 import type { Language } from '@stamhoofd/types/Language';
 import { ContextMenu, ContextMenuItem } from '../overlays/ContextMenu';
 import { useSwitchLanguage } from '../views/hooks/useSwitchLanguage';
+import { useEmailTranslationsEnabled } from './hooks/useEmailTranslationsEnabled';
 
 const props = withDefaults(defineProps<{
     /**
@@ -35,6 +37,7 @@ const emit = defineEmits<{
  */
 const modelValue = defineModel<Language | null>({ required: true });
 const { hasLanguages } = useSwitchLanguage();
+const translationsEnabled = useEmailTranslationsEnabled();
 
 async function showMenu(event: MouseEvent) {
     const menu = new ContextMenu([

--- a/frontend/shared/components/src/email/EmailLanguageButton.vue
+++ b/frontend/shared/components/src/email/EmailLanguageButton.vue
@@ -1,0 +1,78 @@
+<template>
+    <!-- Also visible when translations exist while the platform has a single language: they should remain manageable -->
+    <template v-if="hasLanguages || languages.length > 0">
+        <button class="button text small gray" type="button" :disabled="disabled" data-testid="email-language-button" @click="showMenu">
+            <span class="icon language small" />
+            <span v-if="modelValue" class="style-tag">{{ modelValue.toUpperCase() }}</span>
+        </button>
+    </template>
+</template>
+
+<script setup lang="ts">
+import { I18nController } from '@stamhoofd/frontend-i18n/I18nController';
+import { LanguageHelper } from '@stamhoofd/structures';
+import type { Language } from '@stamhoofd/types/Language';
+import { ContextMenu, ContextMenuItem } from '../overlays/ContextMenu';
+import { useSwitchLanguage } from '../views/hooks/useSwitchLanguage';
+
+const props = withDefaults(defineProps<{
+    /**
+     * Languages for which a translation exists
+     */
+    languages: Language[];
+    disabled?: boolean;
+}>(), {
+    disabled: false,
+});
+
+const emit = defineEmits<{
+    add: [language: Language];
+    remove: [language: Language];
+}>();
+
+/**
+ * The language that is currently being edited (null = the default content)
+ */
+const modelValue = defineModel<Language | null>({ required: true });
+const { hasLanguages } = useSwitchLanguage();
+
+async function showMenu(event: MouseEvent) {
+    const menu = new ContextMenu([
+        [
+            new ContextMenuItem({
+                name: $t('Standaardtekst'),
+                description: $t('Gebruikt voor alle talen zonder vertaling'),
+                selected: modelValue.value === null,
+                action: () => {
+                    modelValue.value = null;
+                },
+            }),
+        ],
+        [...new Set([...I18nController.shared.availableLanguages, ...props.languages])].map((language) => {
+            const exists = props.languages.includes(language);
+            const isCurrent = modelValue.value === language;
+
+            return new ContextMenuItem({
+                name: LanguageHelper.getName(language),
+                selected: isCurrent,
+                icon: exists && !isCurrent ? 'success' : null,
+                description: !exists ? $t('Vertaling toevoegen') : (isCurrent ? $t('Klik om deze vertaling te verwijderen') : null) ?? undefined,
+                action: () => {
+                    if (!exists) {
+                        emit('add', language);
+                        return;
+                    }
+                    if (!isCurrent) {
+                        modelValue.value = language;
+                        return;
+                    }
+                    emit('remove', language);
+                },
+            });
+        }),
+    ]);
+    await menu.show({
+        button: event.currentTarget as HTMLButtonElement,
+    });
+}
+</script>

--- a/frontend/shared/components/src/email/EmailView.vue
+++ b/frontend/shared/components/src/email/EmailView.vue
@@ -45,11 +45,14 @@
                         <span v-else class="style-placeholder-skeleton" />
                     </template>
                 </STListItem>
-                <STListItem class="no-padding" element-name="label">
+                <STListItem class="no-padding right-stack" element-name="label">
                     <div class="list-input-box">
                         <span>{{ $t('%aO') }}:</span>
                         <input id="mail-subject" v-model="subject" class="list-input" type="text" :placeholder="$t(`%aQ`)">
                     </div>
+                    <template #right>
+                        <EmailLanguageButton :model-value="contentLanguage.currentLanguage.value" :languages="contentLanguage.languages.value" :disabled="contentLanguage.switching.value" @update:model-value="contentLanguage.switchTo($event).catch(console.error)" @add="contentLanguage.addLanguage($event).catch(console.error)" @remove="contentLanguage.removeLanguage($event).catch(console.error)" />
+                    </template>
                 </STListItem>
 
                 <STListItem v-if="senders.length > 0" class="no-padding" element-name="label">
@@ -113,13 +116,14 @@
 
 <script setup lang="ts">
 import type { AutoEncoderPatchType, Decoder, PartialWithoutMethods, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
-import { encodeObject, PatchableArray } from '@simonbackx/simple-encoding';
+import { encodeObject, PatchableArray, PatchMap } from '@simonbackx/simple-encoding';
 import { ComponentWithProperties, usePop, usePresent, useShow } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '#containers/AsyncComponent.ts';
 import { AppManager } from '@stamhoofd/networking/AppManager';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
-import type { EmailRecipientSubfilter, File } from '@stamhoofd/structures';
+import type { EmailContent, EmailRecipientSubfilter, File } from '@stamhoofd/structures';
 import { AccessRight, Email, EmailAttachment, EmailPreview, EmailRecipientFilter, EmailStatus, EmailTemplate, PermissionsResourceType } from '@stamhoofd/structures';
+import type { Language } from '@stamhoofd/types/Language';
 import { Formatter, sleep, throttle } from '@stamhoofd/utility';
 import type { Ref } from 'vue';
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
@@ -127,7 +131,6 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { usePatchEmail } from '../communication/hooks/usePatchEmail';
 import LoadingViewTransition from '#containers/LoadingViewTransition.vue';
 import EditorView from '../editor/EditorView.vue';
-import { EmailStyler } from '../editor/EmailStyler';
 import { ErrorBox } from '../errors/ErrorBox';
 import { useErrors } from '../errors/useErrors';
 import { GlobalEventBus } from '../EventBus';
@@ -144,6 +147,8 @@ import { ContextMenu, ContextMenuItem } from '../overlays/ContextMenu';
 import { Toast } from '../overlays/Toast';
 
 import ProgressRing from '../icons/ProgressRing.vue';
+import EmailLanguageButton from './EmailLanguageButton.vue';
+import { confirmStaleEmailContentLanguages, useEmailContentLanguage } from './hooks/useEmailContentLanguage';
 
 const props = withDefaults(defineProps<{
     defaultSubject?: string;
@@ -243,6 +248,12 @@ const patchedEmail = computed(() => {
 function addPatch(newPatch: PartialWithoutMethods<AutoEncoderPatchType<Email>>) {
     patch.value = patch.value ? patch.value.patch(Email.patch(newPatch)) : Email.patch(newPatch);
 }
+
+const contentLanguage = useEmailContentLanguage({
+    editor: () => editor.value,
+    patched: () => patchedEmail.value ?? Email.create({}),
+    addPatch,
+});
 
 const recipientFilter = computed(() => {
     const filter = EmailRecipientFilter.create({});
@@ -355,12 +366,7 @@ async function doDelete() {
     }
 }
 
-const subject = computed({
-    get: () => patchedEmail.value?.subject || '',
-    set: (subject) => {
-        addPatch({ subject });
-    },
-});
+const subject = contentLanguage.subject;
 
 const senderId = computed({
     get: () => email.value?.senderId ?? null,
@@ -403,8 +409,8 @@ watch(editor, (e) => {
         return;
     }
     const handler = () => {
-        // save json
-        addPatch({ json: e.getJSON() });
+        // save json of the language that is currently being edited
+        contentLanguage.onEditorUpdate();
     };
     e.on('update', handler);
 
@@ -500,11 +506,11 @@ async function patchEmail(async = false) {
     let _savingPatch = patch.value;
 
     try {
-        const { text, html } = await getHTML();
-        _savingPatch = _savingPatch.patch({
-            text,
-            html,
-        });
+        const derived = await contentLanguage.getDerivedContent();
+        if (derived) {
+            // Merge the derived html/text into the language that is currently in the editor
+            _savingPatch = contentLanguage.patchDerivedContent(_savingPatch, derived);
+        }
     } catch (e) {
         console.error('failed to set text and html', e);
     }
@@ -580,27 +586,19 @@ async function manageEmails() {
     });
 }
 
-async function getHTML() {
-    const e = editor.value;
-    if (!e) {
-        // When editor is not yet loaded: slow internet -> need to know html on dismiss confirmation
-        return {
-            text: '',
-            html: '',
-            JSON: {},
-        };
-    }
-
-    const base: string = e.getHTML();
-    return {
-        ...await EmailStyler.format(base, subject.value),
-        json: e.getJSON(),
-    };
-}
-
 const hasMoreSettings = computed(() => {
     return willSend.value && !!patchedEmail.value?.recipientFilter.canShowInMemberPortal;
 });
+
+async function confirmStaleTranslations(): Promise<boolean> {
+    if (!initialEmail || !patchedEmail.value) {
+        return true;
+    }
+    return await confirmStaleEmailContentLanguages(initialEmail, patchedEmail.value, {
+        ignoreText: $t('Toch verzenden'),
+        switchTo: language => contentLanguage.switchTo(language),
+    });
+}
 
 async function send() {
     if (sending.value) {
@@ -628,8 +626,14 @@ async function send() {
         return;
     }
 
-    if (subject.value.trim().length === 0) {
+    if ((patchedEmail.value?.subject ?? '').trim().length === 0) {
+        // The default (untranslated) subject is required, translations are optional
         Toast.error($t(`%1Ft`)).show();
+        return;
+    }
+
+    // Check before the (possible) hand-off to EmailSendSettingsView, which sends without this check
+    if (!await confirmStaleTranslations()) {
         return;
     }
 
@@ -680,17 +684,19 @@ async function send() {
     sending.value = true;
 
     try {
-        const { text, html } = await getHTML();
+        let body = Email.patch({
+            ...patch.value,
+            status: EmailStatus.Sending,
+        });
+        const derived = await contentLanguage.getDerivedContent();
+        if (derived) {
+            // Merge the derived html/text/json into the language that is currently in the editor
+            body = contentLanguage.patchDerivedContent(body, derived);
+        }
         const response = await context.value.authenticatedServer.request({
             method: 'PATCH',
             path: '/email/' + email.value.id,
-            body: Email.patch({
-                ...patch.value,
-                status: EmailStatus.Sending,
-                text,
-                html,
-                json: editor.value?.getJSON(),
-            }),
+            body,
             decoder: EmailPreview as Decoder<EmailPreview>,
             owner,
             shouldRetry: false,
@@ -832,8 +838,10 @@ async function openTemplates() {
         return;
     }
 
-    const current = await getHTML();
-    const hasExistingContent = (current).text.length > 2 || subject.value.length > 0;
+    // Make sure the editor content is stored in the patch, so we can read the content of all languages
+    await contentLanguage.flush();
+    const defaultContent = contentLanguage.contentFor(null);
+    const hasExistingContent = defaultContent.text.length > 2 || defaultContent.subject.length > 0 || contentLanguage.languages.value.length > 0;
 
     await present({
         components: [
@@ -849,18 +857,36 @@ async function openTemplates() {
                             return false;
                         }
                     }
-                    // todo
-                    // set json and subject
+
+                    // Load the template in all languages: replace the existing translations with the ones of the template
+                    const translations: PatchMap<Language, EmailContent | null> = new PatchMap();
+                    for (const language of patchedEmail.value?.translations.keys() ?? []) {
+                        translations.set(language, null);
+                    }
+                    for (const [language, content] of template.translations) {
+                        translations.set(language, content.clone());
+                    }
+                    addPatch({ translations });
+
+                    // Set json and subject of the default content
+                    contentLanguage.currentLanguage.value = null;
                     editor.value?.commands.setContent(template.json);
                     subject.value = template.subject;
+
+                    // The loaded template is the new baseline to detect (partially) changed translations
+                    await nextTick();
+                    initialEmail = patchedEmail.value?.clone() ?? initialEmail;
 
                     return true;
                 },
                 createOption: hasExistingContent
                     ? EmailTemplate.create({
                             id: '',
-                            ...current,
-                            subject: subject.value,
+                            subject: defaultContent.subject,
+                            html: defaultContent.html,
+                            text: defaultContent.text,
+                            json: defaultContent.json,
+                            translations: new Map([...(patchedEmail.value?.translations ?? new Map<Language, EmailContent>())].map(([language, content]) => [language, content.clone()])),
                             type,
                         })
                     : null,
@@ -889,12 +915,15 @@ const shouldNavigateAway = async () => {
         if (!initialEmail) {
             return true;
         }
+        // Compare against the content of the language that is currently in the editor
+        const initialContent = initialEmail.getContentForLanguage(contentLanguage.currentLanguage.value);
+
         // encode object is added for reliable sorting the keys to compare
         const json = JSON.stringify(encodeObject(editor.value?.getJSON() ?? {}, { version: 0 }));
-        if (initialEmail.subject === subject.value && JSON.stringify(encodeObject(initialEmail.json, { version: 0 })) === json && initialEmail.attachments.length === patchedEmail.value?.attachments.length) {
+        if (initialContent.subject === subject.value && JSON.stringify(encodeObject(initialContent.json, { version: 0 })) === json && initialEmail.attachments.length === patchedEmail.value?.attachments.length) {
             return true;
         }
-        console.log('has changes because of json/subject', json, initialEmail.json);
+        console.log('has changes because of json/subject', json, initialContent.json);
     }
 
     if (autoSaveEnabled.value) {

--- a/frontend/shared/components/src/email/EmailView.vue
+++ b/frontend/shared/components/src/email/EmailView.vue
@@ -404,21 +404,6 @@ watch(patch, (newValue, oldValue) => {
     doThrottledPatch();
 }, {});
 
-watch(editor, (e) => {
-    if (!e) {
-        return;
-    }
-    const handler = () => {
-        // save json of the language that is currently being edited
-        contentLanguage.onEditorUpdate();
-    };
-    e.on('update', handler);
-
-    return () => {
-        e.off('update', handler);
-    };
-}, { deep: false });
-
 onMounted(() => {
     // Create the email
     createEmail().catch((e) => {
@@ -441,11 +426,7 @@ async function createEmail() {
         email.value = props.editEmail;
         creatingEmail.value = false;
 
-        await nextTick();
-
-        if (props.editEmail.json) {
-            editor.value?.commands.setContent(props.editEmail.json);
-        }
+        // The editor content is loaded by useEmailContentLanguage once the editor is available
         return;
     }
 
@@ -469,11 +450,7 @@ async function createEmail() {
         email.value = response.data;
         creatingEmail.value = false;
 
-        await nextTick();
-
-        if (response.data.json) {
-            editor.value?.commands.setContent(response.data.json);
-        }
+        // The editor content is loaded by useEmailContentLanguage once the editor is available
     } catch (e) {
         errors.errorBox = new ErrorBox(e);
         return;

--- a/frontend/shared/components/src/email/hooks/useEmailContentLanguage.test.ts
+++ b/frontend/shared/components/src/email/hooks/useEmailContentLanguage.test.ts
@@ -1,0 +1,92 @@
+import { EmailContent } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
+import { describe, expect, test } from 'vitest';
+import type { EmailContentHolder } from './useEmailContentLanguage';
+import { getChangedEmailContentLanguages, getStaleEmailContentLanguages } from './useEmailContentLanguage';
+
+function buildHolder(options: { subject?: string; json?: any; translations?: [Language, { subject?: string; json?: any }][] } = {}): EmailContentHolder {
+    return {
+        subject: options.subject ?? 'Default subject',
+        html: '<p>html</p>',
+        text: 'text',
+        json: options.json ?? { type: 'doc' },
+        translations: new Map((options.translations ?? []).map(([language, content]) => [language, EmailContent.create({
+            subject: content.subject ?? 'Translated subject',
+            html: '<p>html</p>',
+            text: 'text',
+            json: content.json ?? { type: 'doc' },
+        })])),
+    };
+}
+
+describe('getChangedEmailContentLanguages', () => {
+    test('returns nothing when nothing changed', () => {
+        const original = buildHolder({ translations: [[Language.French, {}]] });
+        const patched = buildHolder({ translations: [[Language.French, {}]] });
+        expect(getChangedEmailContentLanguages(original, patched)).toEqual([]);
+    });
+
+    test('detects a changed default subject as null', () => {
+        const original = buildHolder();
+        const patched = buildHolder({ subject: 'Other subject' });
+        expect(getChangedEmailContentLanguages(original, patched)).toEqual([null]);
+    });
+
+    test('detects changed, added and removed translations', () => {
+        const original = buildHolder({ translations: [[Language.French, {}], [Language.English, {}]] });
+        const patched = buildHolder({ translations: [[Language.French, { subject: 'Nouveau sujet' }], [Language.Dutch, {}]] });
+        expect(getChangedEmailContentLanguages(original, patched).sort()).toEqual([Language.Dutch, Language.English, Language.French].sort());
+    });
+
+    test('ignores html and text differences: only subject and json are compared', () => {
+        const original = buildHolder();
+        const patched = buildHolder();
+        patched.html = '<p>different derived html</p>';
+        patched.text = 'different derived text';
+        expect(getChangedEmailContentLanguages(original, patched)).toEqual([]);
+    });
+});
+
+describe('getStaleEmailContentLanguages', () => {
+    test('empty when nothing changed', () => {
+        const original = buildHolder({ translations: [[Language.French, {}]] });
+        const patched = buildHolder({ translations: [[Language.French, {}]] });
+        expect(getStaleEmailContentLanguages(original, patched)).toEqual([]);
+    });
+
+    test('reports untouched translations when only the default content changed', () => {
+        const original = buildHolder({ translations: [[Language.French, {}]] });
+        const patched = buildHolder({ subject: 'Updated default', translations: [[Language.French, {}]] });
+        expect(getStaleEmailContentLanguages(original, patched)).toEqual([Language.French]);
+    });
+
+    test('reports the default content when only a translation changed', () => {
+        const original = buildHolder({ translations: [[Language.French, {}]] });
+        const patched = buildHolder({ translations: [[Language.French, { subject: 'Nouveau sujet' }]] });
+        expect(getStaleEmailContentLanguages(original, patched)).toEqual([null]);
+    });
+
+    test('empty when every existing language was updated', () => {
+        const original = buildHolder({ translations: [[Language.French, {}]] });
+        const patched = buildHolder({ subject: 'Updated default', translations: [[Language.French, { subject: 'Nouveau sujet' }]] });
+        expect(getStaleEmailContentLanguages(original, patched)).toEqual([]);
+    });
+
+    test('adding a new translation does not make other languages stale', () => {
+        const original = buildHolder({ translations: [[Language.French, {}]] });
+        const patched = buildHolder({ translations: [[Language.French, {}], [Language.English, {}]] });
+        expect(getStaleEmailContentLanguages(original, patched)).toEqual([]);
+    });
+
+    test('removing a translation does not make other languages stale', () => {
+        const original = buildHolder({ translations: [[Language.French, {}], [Language.English, {}]] });
+        const patched = buildHolder({ translations: [[Language.French, {}]] });
+        expect(getStaleEmailContentLanguages(original, patched)).toEqual([]);
+    });
+
+    test('changing the default and adding a translation still reports untouched translations', () => {
+        const original = buildHolder({ translations: [[Language.French, {}]] });
+        const patched = buildHolder({ subject: 'Updated default', translations: [[Language.French, {}], [Language.English, {}]] });
+        expect(getStaleEmailContentLanguages(original, patched)).toEqual([Language.French]);
+    });
+});

--- a/frontend/shared/components/src/email/hooks/useEmailContentLanguage.ts
+++ b/frontend/shared/components/src/email/hooks/useEmailContentLanguage.ts
@@ -1,0 +1,318 @@
+import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
+import { encodeObject, PatchMap } from '@simonbackx/simple-encoding';
+import { EmailContent } from '@stamhoofd/structures';
+import type { Language } from '@stamhoofd/types/Language';
+import type { Editor, JSONContent } from '@tiptap/core';
+import type { Ref } from 'vue';
+import { computed, ref } from 'vue';
+import { EmailStyler } from '../../editor/EmailStyler';
+import { CenteredMessage } from '../../overlays/CenteredMessage';
+
+/**
+ * The fields shared by the Email and EmailTemplate structures that make up the translatable content.
+ * The root subject/html/text/json is the default (untranslated) content, translations contains
+ * full content overrides per language.
+ */
+export type EmailContentHolder = {
+    subject: string | null;
+    html: string | null;
+    text: string | null;
+    json: any;
+    translations: Map<Language, EmailContent>;
+};
+
+export type EmailContentPatch = {
+    subject?: string;
+    html?: string;
+    text?: string;
+    json?: any;
+    translations?: PatchMap<Language, EmailContent | AutoEncoderPatchType<EmailContent> | null>;
+};
+
+/**
+ * Manages which language of an email (template) is being edited: keeps the subject input and the
+ * TipTap editor in sync with either the default content (root fields) or a translation, and writes
+ * all edits back into the patch of the view.
+ */
+export function useEmailContentLanguage(options: {
+    editor: () => Editor | null | undefined;
+    patched: () => EmailContentHolder;
+    addPatch: (patch: EmailContentPatch) => void;
+}) {
+    /**
+     * null = editing the default (untranslated) content
+     */
+    const currentLanguage: Ref<Language | null> = ref(null);
+
+    /**
+     * Guards against interleaving language switches: deriving html/text from the editor is async
+     */
+    const switching = ref(false);
+
+    const languages = computed(() => [...options.patched().translations.keys()]);
+
+    function contentFor(language: Language | null): EmailContent {
+        const patched = options.patched();
+        if (language !== null) {
+            return patched.translations.get(language) ?? EmailContent.create({});
+        }
+        return EmailContent.create({
+            subject: patched.subject ?? '',
+            html: patched.html ?? '',
+            text: patched.text ?? '',
+            json: patched.json ?? {},
+        });
+    }
+
+    function mergeContent(base: EmailContent, content: Partial<{ subject: string; html: string; text: string; json: any }>): EmailContent {
+        return EmailContent.create({
+            subject: content.subject ?? base.subject,
+            html: content.html ?? base.html,
+            text: content.text ?? base.text,
+            json: content.json ?? base.json,
+        });
+    }
+
+    function applyContentPatch(language: Language | null, content: Partial<{ subject: string; html: string; text: string; json: any }>) {
+        if (language === null) {
+            options.addPatch(content);
+            return;
+        }
+        // Always store the full content of a translation, so it stays a consistent set
+        options.addPatch({ translations: new PatchMap([[language, mergeContent(contentFor(language), content)]]) });
+    }
+
+    const subject = computed({
+        get: () => contentFor(currentLanguage.value).subject,
+        set: (subject: string) => applyContentPatch(currentLanguage.value, { subject }),
+    });
+
+    /**
+     * Read the current editor content and derive the html/text from it. The language is captured
+     * before the (async) derivation: the user could switch to a different language in the meantime.
+     */
+    async function getDerivedContent(): Promise<{ language: Language | null; html: string; text: string; json: any } | null> {
+        const editor = options.editor();
+        if (!editor) {
+            return null;
+        }
+        const language = currentLanguage.value;
+        const json = editor.getJSON();
+        return {
+            language,
+            ...await EmailStyler.format(editor.getHTML(), contentFor(language).subject),
+            json,
+        };
+    }
+
+    /**
+     * Store the current editor content (json + derived html/text) in the patch,
+     * for the language that is currently being edited.
+     */
+    async function flush() {
+        const derived = await getDerivedContent();
+        if (!derived) {
+            return;
+        }
+        const { language, ...content } = derived;
+        applyContentPatch(language, content);
+    }
+
+    function loadEditor(language: Language | null) {
+        const editor = options.editor();
+        if (!editor) {
+            return;
+        }
+        const content = contentFor(language);
+        if (content.json && (content.json as { type?: string }).type) {
+            editor.commands.setContent(content.json as JSONContent);
+        }
+        else {
+            editor.commands.clearContent();
+        }
+    }
+
+    async function switchTo(language: Language | null) {
+        if (switching.value || language === currentLanguage.value) {
+            return;
+        }
+        switching.value = true;
+        try {
+            await flush();
+            currentLanguage.value = language;
+            loadEditor(language);
+        }
+        finally {
+            switching.value = false;
+        }
+    }
+
+    async function addLanguage(language: Language) {
+        if (switching.value || languages.value.includes(language)) {
+            return;
+        }
+        switching.value = true;
+        try {
+            await flush();
+
+            // Seed the new translation with the content that is currently displayed
+            options.addPatch({ translations: new PatchMap([[language, contentFor(currentLanguage.value).clone()]]) });
+            currentLanguage.value = language;
+        }
+        finally {
+            switching.value = false;
+        }
+    }
+
+    async function removeLanguage(language: Language) {
+        if (switching.value) {
+            return;
+        }
+        if (!await CenteredMessage.confirm($t('Ben je zeker dat je deze vertaling wilt verwijderen?'), $t('Verwijderen'), $t('De inhoud van deze taal gaat verloren. Ontvangers in deze taal ontvangen daarna de standaardtekst.'))) {
+            return;
+        }
+        // The switching guard stops onEditorUpdate from writing a patch while the editor content is replaced
+        switching.value = true;
+        try {
+            options.addPatch({ translations: new PatchMap([[language, null]]) });
+            if (currentLanguage.value === language) {
+                currentLanguage.value = null;
+                loadEditor(null);
+            }
+        }
+        finally {
+            switching.value = false;
+        }
+    }
+
+    /**
+     * Call on TipTap 'update' events to keep the json in the patch up to date (used for auto-saving).
+     * The html/text are not derived here because that is async and expensive: use flush() or
+     * patchDerivedContent() before actually using them.
+     */
+    function onEditorUpdate() {
+        const editor = options.editor();
+        if (!editor || switching.value) {
+            return;
+        }
+        applyContentPatch(currentLanguage.value, { json: editor.getJSON() });
+    }
+
+    /**
+     * Merge derived html/text (+ json) into a detached patch (one that is about to be sent to the server),
+     * targeting the language the content was derived from.
+     */
+    function patchDerivedContent<P extends { patch: (p: any) => P }>(base: P, derived: { language: Language | null; html: string; text: string; json?: any }): P {
+        const { language, ...content } = derived;
+        if (language === null) {
+            return base.patch(content);
+        }
+        const patch: EmailContentPatch = { translations: new PatchMap([[language, mergeContent(contentFor(language), content)]]) };
+        return base.patch(patch);
+    }
+
+    return {
+        currentLanguage,
+        switching,
+        languages,
+        subject,
+        contentFor,
+        getDerivedContent,
+        flush,
+        loadEditor,
+        switchTo,
+        addLanguage,
+        removeLanguage,
+        onEditorUpdate,
+        patchDerivedContent,
+    };
+}
+
+/**
+ * Ask the user to review translations that might have become stale (see getStaleEmailContentLanguages).
+ * Returns true when saving/sending can continue; on 'review' the editor is switched to the first
+ * stale language and false is returned.
+ */
+export async function confirmStaleEmailContentLanguages(original: EmailContentHolder, patched: EmailContentHolder, options: { ignoreText: string; switchTo: (language: Language | null) => Promise<void> }): Promise<boolean> {
+    const staleLanguages = getStaleEmailContentLanguages(original, patched);
+    if (staleLanguages.length === 0) {
+        return true;
+    }
+
+    const option = await CenteredMessage.show({
+        title: $t('Andere talen nakijken?'),
+        description: $t('Je hebt niet alle talen van deze e-mail aangepast. Kijk de andere vertalingen na zodat de inhoud in elke taal hetzelfde blijft.'),
+        buttons: [
+            {
+                text: $t('Vertalingen nakijken'),
+                type: 'primary',
+                value: 'review',
+            },
+            {
+                text: options.ignoreText,
+                type: 'secundary',
+                value: 'ignore',
+            },
+        ],
+    });
+
+    if (option === 'review') {
+        // Jump to the first language that was not updated
+        await options.switchTo(staleLanguages[0]);
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Languages that might have become stale: the user changed some languages that already existed,
+ * but did not touch these. Newly added or removed translations never make other languages stale.
+ * Returns an empty array when nothing was changed, or when every existing language was updated.
+ */
+export function getStaleEmailContentLanguages(original: EmailContentHolder, patched: EmailContentHolder): (Language | null)[] {
+    const changed = getChangedEmailContentLanguages(original, patched);
+    const preexisting: (Language | null)[] = [null, ...[...original.translations.keys()].filter(language => patched.translations.has(language))];
+    const changedPreexisting = preexisting.filter(language => changed.includes(language));
+
+    if (changedPreexisting.length === 0 || changedPreexisting.length === preexisting.length) {
+        return [];
+    }
+    return preexisting.filter(language => !changed.includes(language));
+}
+
+/**
+ * Which languages (null = the default content) differ between the original and the patched version?
+ */
+export function getChangedEmailContentLanguages(original: EmailContentHolder, patched: EmailContentHolder): (Language | null)[] {
+    const changed: (Language | null)[] = [];
+
+    if (!emailContentIsEqual(
+        { subject: original.subject ?? '', html: original.html ?? '', text: original.text ?? '', json: original.json ?? {} },
+        { subject: patched.subject ?? '', html: patched.html ?? '', text: patched.text ?? '', json: patched.json ?? {} },
+    )) {
+        changed.push(null);
+    }
+
+    const allLanguages = new Set([...original.translations.keys(), ...patched.translations.keys()]);
+    for (const language of allLanguages) {
+        const originalContent = original.translations.get(language);
+        const patchedContent = patched.translations.get(language);
+        if (!originalContent || !patchedContent) {
+            // Added or removed
+            changed.push(language);
+            continue;
+        }
+        if (!emailContentIsEqual(originalContent, patchedContent)) {
+            changed.push(language);
+        }
+    }
+
+    return changed;
+}
+
+function emailContentIsEqual(a: { subject: string; html: string; text: string; json: any }, b: { subject: string; html: string; text: string; json: any }) {
+    // Note: html is derived from json (styling can differ between builds), and text is derived from html
+    // so it is enough (and more stable) to compare subject + json.
+    // encodeObject is added for reliable sorting of the keys before comparing
+    return a.subject === b.subject && JSON.stringify(encodeObject(a.json ?? {}, { version: 0 })) === JSON.stringify(encodeObject(b.json ?? {}, { version: 0 }));
+}

--- a/frontend/shared/components/src/email/hooks/useEmailContentLanguage.ts
+++ b/frontend/shared/components/src/email/hooks/useEmailContentLanguage.ts
@@ -4,7 +4,7 @@ import { EmailContent } from '@stamhoofd/structures';
 import type { Language } from '@stamhoofd/types/Language';
 import type { Editor, JSONContent } from '@tiptap/core';
 import type { Ref } from 'vue';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { EmailStyler } from '../../editor/EmailStyler';
 import { CenteredMessage } from '../../overlays/CenteredMessage';
 
@@ -48,6 +48,12 @@ export function useEmailContentLanguage(options: {
      * Guards against interleaving language switches: deriving html/text from the editor is async
      */
     const switching = ref(false);
+
+    /**
+     * True while we programmatically replace the editor content, so the resulting 'update' event
+     * (TipTap emits one on setContent) is not written back to the patch.
+     */
+    let suppressUpdate = false;
 
     const languages = computed(() => [...options.patched().translations.keys()]);
 
@@ -124,11 +130,15 @@ export function useEmailContentLanguage(options: {
             return;
         }
         const content = contentFor(language);
-        if (content.json && (content.json as { type?: string }).type) {
-            editor.commands.setContent(content.json as JSONContent);
-        }
-        else {
-            editor.commands.clearContent();
+        suppressUpdate = true;
+        try {
+            if (content.json && (content.json as { type?: string }).type) {
+                editor.commands.setContent(content.json as JSONContent);
+            } else {
+                editor.commands.clearContent();
+            }
+        } finally {
+            suppressUpdate = false;
         }
     }
 
@@ -141,8 +151,7 @@ export function useEmailContentLanguage(options: {
             await flush();
             currentLanguage.value = language;
             loadEditor(language);
-        }
-        finally {
+        } finally {
             switching.value = false;
         }
     }
@@ -158,8 +167,7 @@ export function useEmailContentLanguage(options: {
             // Seed the new translation with the content that is currently displayed
             options.addPatch({ translations: new PatchMap([[language, contentFor(currentLanguage.value).clone()]]) });
             currentLanguage.value = language;
-        }
-        finally {
+        } finally {
             switching.value = false;
         }
     }
@@ -179,24 +187,36 @@ export function useEmailContentLanguage(options: {
                 currentLanguage.value = null;
                 loadEditor(null);
             }
-        }
-        finally {
+        } finally {
             switching.value = false;
         }
     }
 
     /**
-     * Call on TipTap 'update' events to keep the json in the patch up to date (used for auto-saving).
-     * The html/text are not derived here because that is async and expensive: use flush() or
-     * patchDerivedContent() before actually using them.
+     * Keep the json of the currently edited language in the patch on every editor change (used for
+     * auto-saving). The html/text are not derived here because that is async and expensive: use
+     * flush() or patchDerivedContent() before actually using them.
      */
     function onEditorUpdate() {
         const editor = options.editor();
-        if (!editor || switching.value) {
+        if (!editor || switching.value || suppressUpdate) {
             return;
         }
         applyContentPatch(currentLanguage.value, { json: editor.getJSON() });
     }
+
+    // This composable owns the editor <-> patch synchronisation: when the editor becomes available it
+    // loads the current language's content and then stores every change back into the patch, so views
+    // don't have to wire this up (and can't forget to).
+    watch(options.editor, (editor, _oldEditor, onCleanup) => {
+        if (!editor) {
+            return;
+        }
+        loadEditor(currentLanguage.value);
+        const handler = () => onEditorUpdate();
+        editor.on('update', handler);
+        onCleanup(() => editor.off('update', handler));
+    }, { immediate: true });
 
     /**
      * Merge derived html/text (+ json) into a detached patch (one that is about to be sent to the server),
@@ -223,7 +243,6 @@ export function useEmailContentLanguage(options: {
         switchTo,
         addLanguage,
         removeLanguage,
-        onEditorUpdate,
         patchDerivedContent,
     };
 }

--- a/frontend/shared/components/src/email/hooks/useEmailTranslationsEnabled.ts
+++ b/frontend/shared/components/src/email/hooks/useEmailTranslationsEnabled.ts
@@ -1,0 +1,23 @@
+import { useAppContext } from '#context/appContext.ts';
+import { useFeatureFlag } from '#hooks/useFeatureFlag.ts';
+import type { ComputedRef } from 'vue';
+import { computed } from 'vue';
+
+/**
+ * Whether the UI for *adding* translations to emails and email templates should be shown.
+ *
+ * Hidden by default, and enabled per organization through the 'email-translations' feature flag.
+ * The admin app always enables it. Content that already has translations must stay manageable, so
+ * callers keep showing the translation UI whenever translations already exist, regardless of this.
+ */
+export function useEmailTranslationsEnabled(): ComputedRef<boolean> {
+    const app = useAppContext();
+    const getFeatureFlag = useFeatureFlag();
+
+    return computed(() => {
+        if (app === 'admin') {
+            return true;
+        }
+        return getFeatureFlag('email-translations');
+    });
+}

--- a/shared/structures/src/AuditLogReplacement.test.ts
+++ b/shared/structures/src/AuditLogReplacement.test.ts
@@ -23,6 +23,7 @@ describe('AuditLogReplacement', () => {
             'EventNotificationStatus',
             'Gender',
             'GroupStatus',
+            'Language',
             'OrderStatus',
             'OrganizationType',
             'ParentType',
@@ -35,7 +36,8 @@ describe('AuditLogReplacement', () => {
 
         expect(getAuditLogPatchKeyName(PaymentStatus.Pending)).toBe('%mu');
         expect(AuditLogReplacement.create({ value: PaymentStatus.Pending, type: AuditLogReplacementType.Key }).toString()).toBe('%mu');
-        expect(AuditLogReplacementDependencies.enumHelpers).toHaveLength(getRegisteredAuditLogEnums().length - 1);
+        // EventNotificationStatus and Language are not registered as legacy enums
+        expect(AuditLogReplacementDependencies.enumHelpers).toHaveLength(getRegisteredAuditLogEnums().length - 2);
         expect(AuditLogReplacement.enum('EventNotificationStatus', EventNotificationStatus.Accepted)?.toString()).toBe('%B1');
     });
 

--- a/shared/structures/src/circular-dependencies/AuditLogReplacementDependencies.ts
+++ b/shared/structures/src/circular-dependencies/AuditLogReplacementDependencies.ts
@@ -1,7 +1,9 @@
 import { Country } from '@stamhoofd/types/Country';
+import { Language } from '@stamhoofd/types/Language';
 import { AccessRight, AccessRightHelper } from '../AccessRight.js';
 import { CountryHelper } from '../addresses/CountryDecoder.js';
 import { AuditLogReplacementDependencies, registerAuditLogEnum } from '../AuditLogReplacement.js';
+import { LanguageHelper } from '../Language.js';
 import { STPackageType, STPackageTypeHelper } from '../billing/STPackage.js';
 import { DocumentStatus, DocumentStatusHelper } from '../Document.js';
 import { EmailTemplate, EmailTemplateType } from '../email/EmailTemplate.js';
@@ -34,5 +36,6 @@ registerAuditLogEnum('Gender', Gender, getGenderName, { legacy: true });
 registerAuditLogEnum('SetupStepType', SetupStepType, getSetupStepName, { legacy: true });
 registerAuditLogEnum('EmailTemplateType', EmailTemplateType, EmailTemplate.getTypeTitle, { legacy: true });
 registerAuditLogEnum('EventNotificationStatus', EventNotificationStatus, EventNotificationStatusHelper.getName);
+registerAuditLogEnum('Language', Language, LanguageHelper.getName);
 
 AuditLogReplacementDependencies.uuidToName = uuidToName;

--- a/shared/structures/src/email/Email.ts
+++ b/shared/structures/src/email/Email.ts
@@ -1,7 +1,9 @@
-import { AnyDecoder, ArrayDecoder, AutoEncoder, BooleanDecoder, DateDecoder, EnumDecoder, field, IntegerDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { AnyDecoder, ArrayDecoder, AutoEncoder, BooleanDecoder, DateDecoder, EnumDecoder, field, IntegerDecoder, MapDecoder, StringDecoder } from '@simonbackx/simple-encoding';
 import { SimpleErrors } from '@simonbackx/simple-errors';
+import { Language } from '@stamhoofd/types/Language';
 import { v4 as uuidv4 } from 'uuid';
 import { EmailAttachment, Recipient, replaceEmailText, Replacement } from '../endpoints/EmailRequest.js';
+import { EmailContent, getEmailContentForLanguage } from './EmailContent.js';
 import { StamhoofdFilterDecoder } from '../filters/FilteredRequest.js';
 import type { StamhoofdFilter } from '../filters/StamhoofdFilter.js';
 import { TinyMember } from '../members/Member.js';
@@ -130,6 +132,13 @@ export class Email extends AutoEncoder {
     @field({ decoder: StringDecoder, nullable: true })
     html: string | null = null;
 
+    /**
+     * Full content overrides per language. The default content (subject/html/text/json)
+     * is 'untranslated' and is used for all recipients without a matching override.
+     */
+    @field({ decoder: new MapDecoder(new EnumDecoder(Language), EmailContent), ...NextVersion })
+    translations: Map<Language, EmailContent> = new Map();
+
     @field({ decoder: StringDecoder, nullable: true })
     fromAddress: string | null = null;
 
@@ -195,17 +204,32 @@ export class Email extends AutoEncoder {
         return null;
     }
 
+    get defaultContent(): EmailContent {
+        return EmailContent.create({
+            subject: this.subject ?? '',
+            html: this.html ?? '',
+            text: this.text ?? '',
+            json: this.json,
+        });
+    }
+
+    getContentForLanguage(language: Language | null): EmailContent {
+        return getEmailContentForLanguage(this.defaultContent, this.translations, language);
+    }
+
     getSubjectFor(recipient: EmailRecipient | null) {
-        return replaceEmailText(this.subject || '', recipient?.replacements || []);
+        const content = this.getContentForLanguage(recipient?.language ?? null);
+        return replaceEmailText(content.subject, recipient?.replacements || []);
     }
 
     getSnippetFor(recipient: EmailRecipient | null) {
-        if (!this.text) {
+        const content = this.getContentForLanguage(recipient?.language ?? null);
+        if (!content.text) {
             return '';
         }
 
-        // Trim starting/ending whitespaces and newline from this.text
-        let stripped = this.text.trim();
+        // Trim starting/ending whitespaces and newline from the text
+        let stripped = content.text.trim();
 
         // Remove duplicate newlines
         stripped = stripped.replace(/\n+/g, '\n');
@@ -217,8 +241,8 @@ export class Email extends AutoEncoder {
 
         const stripStrings = ['{{greeting}}', 'Dag {{firstName}},', 'Beste,', 'Beste {{firstName}},', 'Geachte,', 'Hallo,'];
 
-        if (this.subject) {
-            stripStrings.push(this.subject);
+        if (content.subject) {
+            stripStrings.push(content.subject);
         }
 
         for (const str of stripStrings) {
@@ -290,6 +314,12 @@ export class EmailRecipient extends AutoEncoder {
 
     @field({ decoder: StringDecoder, nullable: true, version: 380 })
     userId: string | null = null;
+
+    /**
+     * Preferred language of this recipient, used to select the email content translation.
+     */
+    @field({ decoder: new EnumDecoder(Language), nullable: true, ...NextVersion })
+    language: Language | null = null;
 
     @field({ decoder: new ArrayDecoder(Replacement) })
     replacements: Replacement[] = [];

--- a/shared/structures/src/email/EmailContent.test.ts
+++ b/shared/structures/src/email/EmailContent.test.ts
@@ -1,0 +1,125 @@
+import type { AutoEncoderPatchType, Decoder, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
+import { ObjectData, PatchableArray, PatchableArrayDecoder, PatchMap, StringDecoder } from '@simonbackx/simple-encoding';
+import { Language } from '@stamhoofd/types/Language';
+import { Version } from '../Version.js';
+import { Email, EmailRecipient } from './Email.js';
+import { EmailContent, getEmailContentForLanguage } from './EmailContent.js';
+import { EmailTemplate } from './EmailTemplate.js';
+
+describe('EmailContent', () => {
+    describe('getEmailContentForLanguage', () => {
+        const defaultContent = EmailContent.create({ subject: 'Default', html: '<p>Default</p>', text: 'Default' });
+        const french = EmailContent.create({ subject: 'Français', html: '<p>Français</p>', text: 'Français' });
+        const translations = new Map([[Language.French, french]]);
+
+        it('returns the translation if it exists', () => {
+            expect(getEmailContentForLanguage(defaultContent, translations, Language.French)).toBe(french);
+        });
+
+        it('returns the default content for a missing language', () => {
+            expect(getEmailContentForLanguage(defaultContent, translations, Language.English)).toBe(defaultContent);
+        });
+
+        it('returns the default content when no language is set', () => {
+            expect(getEmailContentForLanguage(defaultContent, translations, null)).toBe(defaultContent);
+        });
+    });
+
+    describe('EmailTemplate.translations encoding', () => {
+        it('encodes and decodes translations at the latest version', () => {
+            const template = EmailTemplate.create({
+                subject: 'Default',
+                html: '<p>Default</p>',
+                text: 'Default',
+                translations: new Map([[Language.French, EmailContent.create({ subject: 'Français', html: '<p>Français</p>', text: 'Français' })]]),
+            });
+
+            const encoded = JSON.parse(JSON.stringify(template.encode({ version: Version })));
+            const decoded = new ObjectData(encoded, { version: Version }).decode(EmailTemplate as Decoder<EmailTemplate>);
+
+            expect(decoded.translations.size).toBe(1);
+            expect(decoded.translations.get(Language.French)!.subject).toBe('Français');
+            expect(decoded.getContentForLanguage(Language.French).subject).toBe('Français');
+            expect(decoded.getContentForLanguage(Language.English).subject).toBe('Default');
+            expect(decoded.getContentForLanguage(null).subject).toBe('Default');
+        });
+
+        it('strips translations for old clients', () => {
+            const template = EmailTemplate.create({
+                subject: 'Default',
+                translations: new Map([[Language.French, EmailContent.create({ subject: 'Français' })]]),
+            });
+
+            // The translations field is added at the (unreleased) NextVersion = current Version, so
+            // every older version should not receive it
+            const encoded = JSON.parse(JSON.stringify(template.encode({ version: Version - 1 }))) as Record<string, unknown>;
+            expect(encoded.translations).toBeUndefined();
+
+            const decoded = new ObjectData(encoded, { version: Version - 1 }).decode(EmailTemplate as Decoder<EmailTemplate>);
+            expect(decoded.translations.size).toBe(0);
+        });
+
+        it('supports a translations PatchMap inside a PatchableArray', () => {
+            const decoder = new PatchableArrayDecoder(EmailTemplate as Decoder<EmailTemplate>, EmailTemplate.patchType() as Decoder<AutoEncoderPatchType<EmailTemplate>>, StringDecoder);
+
+            const patchableArray: PatchableArrayAutoEncoder<EmailTemplate> = new PatchableArray();
+            patchableArray.addPatch(EmailTemplate.patch({
+                id: 'template-id',
+                translations: new PatchMap([[Language.French, EmailContent.create({ subject: 'Français' })]]),
+            }));
+
+            // Encode and decode the patchable array (as it would be sent to the backend)
+            const encoded = JSON.parse(JSON.stringify(patchableArray.encode({ version: Version })));
+            const decoded = new ObjectData(encoded, { version: Version }).decode(decoder);
+
+            const template = EmailTemplate.create({
+                id: 'template-id',
+                subject: 'Default',
+                translations: new Map([[Language.English, EmailContent.create({ subject: 'English' })]]),
+            });
+
+            const patched = decoded.applyTo([template]);
+            expect(patched[0].translations.size).toBe(2);
+            expect(patched[0].translations.get(Language.French)!.subject).toBe('Français');
+            expect(patched[0].translations.get(Language.English)!.subject).toBe('English');
+
+            // Deleting a language
+            const deleteArray: PatchableArrayAutoEncoder<EmailTemplate> = new PatchableArray();
+            deleteArray.addPatch(EmailTemplate.patch({
+                id: 'template-id',
+                translations: new PatchMap([[Language.English, null]]),
+            }));
+            const encodedDelete = JSON.parse(JSON.stringify(deleteArray.encode({ version: Version })));
+            const decodedDelete = new ObjectData(encodedDelete, { version: Version }).decode(decoder);
+
+            const afterDelete = decodedDelete.applyTo(patched);
+            expect(afterDelete[0].translations.size).toBe(1);
+            expect(afterDelete[0].translations.get(Language.English)).toBeUndefined();
+        });
+    });
+
+    describe('Email per recipient language', () => {
+        const email = Email.create({
+            subject: 'Default {{firstName}}',
+            text: 'This is the default text of this email with enough length to show a snippet',
+            html: '<p>Default</p>',
+            translations: new Map([[Language.French, EmailContent.create({
+                subject: 'Français {{firstName}}',
+                text: 'Ceci est le texte français de cet e-mail avec une longueur suffisante pour un extrait',
+                html: '<p>Français</p>',
+            })]]),
+        });
+
+        it('uses the translation for the subject and snippet of a recipient with a translated language', () => {
+            const recipient = EmailRecipient.create({ email: 'test@example.com', language: Language.French });
+            expect(email.getSubjectFor(recipient)).toBe('Français {{firstName}}');
+            expect(email.getSnippetFor(recipient)).toContain('français');
+        });
+
+        it('uses the default content for a recipient without language or with a missing language', () => {
+            expect(email.getSubjectFor(null)).toBe('Default {{firstName}}');
+            expect(email.getSubjectFor(EmailRecipient.create({ email: 'test@example.com', language: Language.English }))).toBe('Default {{firstName}}');
+            expect(email.getSnippetFor(EmailRecipient.create({ email: 'test@example.com' }))).toContain('default text');
+        });
+    });
+});

--- a/shared/structures/src/email/EmailContent.ts
+++ b/shared/structures/src/email/EmailContent.ts
@@ -1,0 +1,42 @@
+import { AnyDecoder, AutoEncoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import { Language } from '@stamhoofd/types/Language';
+
+/**
+ * The full content of an email or email template in a single language.
+ * html and text are derived from the editor json, so they always belong together as a set.
+ */
+export class EmailContent extends AutoEncoder {
+    @field({ decoder: StringDecoder })
+    subject = '';
+
+    /**
+     * Template converted to HTML, with the {{replacements}} still in place
+     */
+    @field({ decoder: StringDecoder })
+    html = '';
+
+    @field({ decoder: StringDecoder })
+    text = '';
+
+    /**
+     * Raw editor json used to edit the content
+     */
+    @field({ decoder: AnyDecoder })
+    json: any = {};
+}
+
+/**
+ * Strict language selection: only searches the provided translations map and falls back to
+ * the default content. It never falls back to a different template (level), so the content
+ * always stays correct — better correct content in the wrong language than wrong content
+ * in the right language.
+ */
+export function getEmailContentForLanguage(defaultContent: EmailContent, translations: Map<Language, EmailContent>, language: Language | null): EmailContent {
+    if (language !== null) {
+        const translated = translations.get(language);
+        if (translated) {
+            return translated;
+        }
+    }
+    return defaultContent;
+}

--- a/shared/structures/src/email/EmailTemplate.ts
+++ b/shared/structures/src/email/EmailTemplate.ts
@@ -1,6 +1,8 @@
-import { AnyDecoder, AutoEncoder, DateDecoder, EnumDecoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import { AnyDecoder, AutoEncoder, DateDecoder, EnumDecoder, field, MapDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { Language } from '@stamhoofd/types/Language';
 import { v4 as uuidv4 } from 'uuid';
 import type { Replacement } from '../endpoints/EmailRequest.js';
+import { EmailContent, getEmailContentForLanguage } from './EmailContent.js';
 import { EmailRecipientFilterType } from './EmailRecipientFilterType.js';
 import { ExampleReplacements } from './exampleReplacements.js';
 import type { OrganizationPrivateMetaData } from '../OrganizationPrivateMetaData.js';
@@ -178,6 +180,13 @@ export class EmailTemplate extends AutoEncoder {
     @field({ decoder: AnyDecoder })
     json = {};
 
+    /**
+     * Full content overrides per language. The default content (subject/html/text/json)
+     * is 'untranslated' and is used for all languages without an override.
+     */
+    @field({ decoder: new MapDecoder(new EnumDecoder(Language), EmailContent), ...NextVersion })
+    translations: Map<Language, EmailContent> = new Map();
+
     @field({ decoder: StringDecoder, nullable: true })
     groupId: string | null = null;
 
@@ -189,6 +198,19 @@ export class EmailTemplate extends AutoEncoder {
 
     @field({ decoder: DateDecoder, optional: true })
     updatedAt: Date = new Date();
+
+    get defaultContent(): EmailContent {
+        return EmailContent.create({
+            subject: this.subject,
+            html: this.html,
+            text: this.text,
+            json: this.json,
+        });
+    }
+
+    getContentForLanguage(language: Language | null): EmailContent {
+        return getEmailContentForLanguage(this.defaultContent, this.translations, language);
+    }
 
     static getDefaultForRecipient(type: EmailRecipientFilterType): EmailTemplateType | null {
         if (type === EmailRecipientFilterType.Members || type === EmailRecipientFilterType.MemberParents || type === EmailRecipientFilterType.RegistrationMembers || type === EmailRecipientFilterType.RegistrationParents) {

--- a/shared/structures/src/endpoints/EmailRequest.test.ts
+++ b/shared/structures/src/endpoints/EmailRequest.test.ts
@@ -1,0 +1,24 @@
+import { Language } from '@stamhoofd/types/Language';
+import { Recipient } from './EmailRequest.js';
+
+describe('Recipient.merge', () => {
+    describe('language', () => {
+        it('keeps its own language and ignores the incoming one when set', () => {
+            const recipient = Recipient.create({ email: 'test@example.com', language: Language.French });
+            recipient.merge(Recipient.create({ email: 'test@example.com', language: Language.Dutch }));
+            expect(recipient.language).toBe(Language.French);
+        });
+
+        it('takes the incoming language when its own is not set', () => {
+            const recipient = Recipient.create({ email: 'test@example.com', language: null });
+            recipient.merge(Recipient.create({ email: 'test@example.com', language: Language.Dutch }));
+            expect(recipient.language).toBe(Language.Dutch);
+        });
+
+        it('stays null when neither has a language', () => {
+            const recipient = Recipient.create({ email: 'test@example.com', language: null });
+            recipient.merge(Recipient.create({ email: 'test@example.com', language: null }));
+            expect(recipient.language).toBeNull();
+        });
+    });
+});

--- a/shared/structures/src/endpoints/EmailRequest.ts
+++ b/shared/structures/src/endpoints/EmailRequest.ts
@@ -1,4 +1,5 @@
-import { ArrayDecoder, AutoEncoder, BooleanDecoder, EmailDecoder, field, RecordDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { ArrayDecoder, AutoEncoder, BooleanDecoder, EmailDecoder, EnumDecoder, field, RecordDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { Language } from '@stamhoofd/types/Language';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 import { File } from '../files/File.js';
@@ -108,6 +109,12 @@ export class Recipient extends AutoEncoder {
     @field({ decoder: StringDecoder, nullable: true, version: 80 })
     userId: string | null = null;
 
+    /**
+     * Preferred language of this recipient, used to select the email content translation.
+     */
+    @field({ decoder: new EnumDecoder(Language), nullable: true, ...NextVersion })
+    language: Language | null = null;
+
     /// For reference and filtering
     /**
      * @deprecated
@@ -155,6 +162,7 @@ export class Recipient extends AutoEncoder {
             }
         }
         this.userId = this.userId ?? recipient.userId;
+        this.language = this.language ?? recipient.language;
         this.types = Formatter.uniqueArray(this.types.concat(recipient.types));
     }
 

--- a/shared/structures/src/index.ts
+++ b/shared/structures/src/index.ts
@@ -144,6 +144,7 @@ export * from './endpoints/UitpasNumbersGetDetailsRequest.js';
 export * from './email/EditorSmartButton.js';
 export * from './email/EditorSmartVariable.js';
 export * from './email/Email.js';
+export * from './email/EmailContent.js';
 
 // Grouping
 export * from './grouping/PaginatedResponse.js';

--- a/shared/structures/src/webshops/Order.ts
+++ b/shared/structures/src/webshops/Order.ts
@@ -225,7 +225,7 @@ export class Order extends AutoEncoder {
         const allFree = this.data.cart.items.every(i => i.getPriceWithoutDiscounts() === 0);
 
         if (allFree) {
-            let str = `<table width="100%" cellspacing="0" cellpadding="0" class="email-data-table"><thead><tr><th>Artikel</th><th>Aantal</th></tr></thead><tbody>`;
+            let str = `<table width="100%" cellspacing="0" cellpadding="0" class="email-data-table"><thead><tr><th>${$t('%Sc')}</th><th>${$t('%M4')}</th></tr></thead><tbody>`;
 
             for (const item of this.data.cart.items) {
                 str += `<tr><td><h4>${Formatter.escapeHtml(item.product.name)}</h4>${item.description.length > 0 ? '<p style="white-space: pre-wrap;">' + Formatter.escapeHtml(item.description) + '</p>' : ''}</td><td>${Formatter.escapeHtml(item.formattedAmount ?? '1')}</td></tr>`;
@@ -233,7 +233,7 @@ export class Order extends AutoEncoder {
             return str + '</tbody></table>';
         }
 
-        let str = `<table width="100%" cellspacing="0" cellpadding="0" class="email-data-table"><thead><tr><th>Artikel</th><th>Aantal</th></tr></thead><tbody>`;
+        let str = `<table width="100%" cellspacing="0" cellpadding="0" class="email-data-table"><thead><tr><th>${$t('%Sc')}</th><th>${$t('%M4')}</th></tr></thead><tbody>`;
 
         for (const item of this.data.cart.items) {
             str += `<tr><td><h4>${Formatter.escapeHtml(item.product.name)}</h4>${item.description.length > 0 ? '<p style="white-space: pre-wrap;">' + Formatter.escapeHtml(item.description) + '</p>' : ''}${'<p style="white-space: pre-wrap;">' + Formatter.escapeHtml(item.getFormattedPriceWithDiscount() || item.getFormattedPriceWithoutDiscount()) + '</p>'}</td><td>${Formatter.escapeHtml(item.formattedAmount ?? '1')}</td></tr>`;
@@ -351,6 +351,7 @@ export class Order extends AutoEncoder {
             lastName: customer.lastName,
             email,
             replacements: this.getRecipientReplacements(organization, webshop),
+            language: this.consumerLanguage ?? webshop.meta.defaultLanguage,
         });
     }
 
@@ -363,6 +364,7 @@ export class Order extends AutoEncoder {
             lastName: order.data.customer.lastName,
             email,
             replacements: this.getRecipientReplacements(organization, webshop, payment ? [payment] : order.payments),
+            language: this.consumerLanguage ?? webshop.meta.defaultLanguage,
         });
     }
 

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -15,6 +15,7 @@
         "@stamhoofd/backend": "*",
         "@stamhoofd/backend-i18n": "*",
         "@stamhoofd/cli": "*",
+        "@stamhoofd/email": "*",
         "@stamhoofd/models": "*",
         "@stamhoofd/structures": "*",
         "@stamhoofd/types": "*",

--- a/tests/playwright/src/tests/email-translations-orders.spec.ts
+++ b/tests/playwright/src/tests/email-translations-orders.spec.ts
@@ -1,0 +1,202 @@
+// test should always be imported first
+import { setup, test } from '../test-fixtures/base.js';
+setup();
+
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { STPackageService } from '@stamhoofd/backend/tests/helpers';
+import { EmailMocker } from '@stamhoofd/email';
+import type { Organization, User, Webshop } from '@stamhoofd/models';
+import { OrderFactory, Organization as OrganizationModel, OrganizationFactory, Token, UserFactory } from '@stamhoofd/models';
+import { OrganizationEmail, PermissionLevel, Permissions, STPackageBundle, Token as TokenStruct, Version, WebshopTicketType } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { DashboardPage, DashboardTab, TableHelper, WorkerData } from '../helpers/index.js';
+import { TestWebshops } from '../helpers/test-data/TestWebshops.js';
+
+// Route emails through the in-process mailer mock so we can read back what each recipient received.
+EmailMocker.infect();
+
+test.describe('Translated emails to webshop orders @translated-order-email', () => {
+    let organization: Organization;
+    let admin: User;
+    let webshop: Webshop;
+
+    const orders = [
+        { language: Language.Dutch, firstName: 'Niels', email: `nl-order-${WorkerData.id}@example.com` },
+        { language: Language.French, firstName: 'Fabien', email: `fr-order-${WorkerData.id}@example.com` },
+        { language: Language.English, firstName: 'Emily', email: `en-order-${WorkerData.id}@example.com` },
+    ] as const;
+
+    test.beforeAll(async () => {
+        TestUtils.setPermanentEnvironment('userMode', 'organization');
+        // Three languages are needed for a default + two translations
+        TestUtils.setPermanentEnvironment('locales', { BE: [Language.Dutch, Language.French, Language.English] });
+
+        organization = await new OrganizationFactory({
+            name: `Vertaalde e-mails ${WorkerData.id}`,
+            packages: [STPackageBundle.Webshops],
+        }).create();
+        await STPackageService.updateOrganizationPackages(organization.id);
+
+        const refreshed = await OrganizationModel.getByID(organization.id);
+        if (!refreshed) {
+            throw new Error('Organization not found after creation');
+        }
+        organization = refreshed;
+
+        // A sender the admin is allowed to send from (needed for the send flow)
+        organization.privateMeta.emails.push(OrganizationEmail.create({
+            email: `shop-${WorkerData.id}@example.com`,
+            name: 'Webshop',
+        }));
+        // The translation UI is hidden behind a feature flag by default
+        organization.privateMeta.featureFlags = ['email-translations'];
+        await organization.save();
+
+        admin = await new UserFactory({
+            email: `mail-admin-${WorkerData.id}@example.com`,
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+
+        const created = await TestWebshops.create({
+            organization,
+            name: `Vertaalshop ${WorkerData.id}`,
+            ticketType: WebshopTicketType.None,
+            productCount: 1,
+            cartEnabled: false,
+        });
+        webshop = created.webshop;
+
+        // One order per consumer language
+        for (const order of orders) {
+            const model = await new OrderFactory({
+                webshop,
+                firstName: order.firstName,
+                lastName: 'Klant',
+                email: order.email,
+            }).create();
+            model.consumerLanguage = order.language;
+            await model.save();
+        }
+    });
+
+    async function setEditorContent(page: Page, text: string) {
+        const editor = page.locator('.ProseMirror').first();
+        await editor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.press('Backspace');
+        await editor.pressSequentially(text);
+        // The body before the {{...}} placeholder is language specific: assert that part landed
+        await expect(editor).toContainText(text.split('{{')[0].trim());
+    }
+
+    /**
+     * Add + switch to a translation via the language button, then wait until the switch actually
+     * completed. Switching is async (it flushes the editor first), so without this wait a following
+     * subject/body edit could still land on the previous language and corrupt it.
+     */
+    async function switchToLanguage(page: Page, menuName: string, tag: string) {
+        await page.getByTestId('email-language-button').click();
+        const menu = page.locator('.context-menu-container:visible').last();
+        await expect(menu.locator('.context-menu-item').first()).toBeVisible();
+        await menu.locator('.context-menu-item', { hasText: menuName }).first().click();
+        // The language button shows the active language as a tag once the switch is done
+        await expect(page.getByTestId('email-language-button')).toContainText(tag);
+    }
+
+    test('each order receives the email in its own language, with the default as fallback', async ({ browser }) => {
+        // Keep the dashboard in Dutch even though English is an available language (the browser
+        // default of Playwright is English, which would otherwise switch the dashboard to English)
+        const context = await browser.newContext({ locale: 'nl-BE' });
+        const page = await context.newPage();
+
+        try {
+            // Log in by injecting the admin token (the order flow itself is not what we test here)
+            const token = await Token.createToken(admin);
+            const tokenString = JSON.stringify(new TokenStruct(token).encode({ version: Version }));
+            await page.addInitScript(({ organizationId, tokenString }) => {
+                window.localStorage.setItem('token-' + organizationId, tokenString);
+            }, { organizationId: organization.id, tokenString });
+
+            const dashboard = new DashboardPage(page);
+            await dashboard.openOrganizationDashboard({ organizationUri: organization.uri });
+            await dashboard.openTab(DashboardTab.Webshops);
+            await page.getByTestId('webshop-menu-item').filter({ hasText: webshop.meta.name }).click();
+            await page.getByTestId('open-orders-button').click();
+
+            const table = new TableHelper(page);
+            await table.waitForFirstRow();
+            await table.toggleSelectAllRows();
+            await table.clickAction('E-mailen');
+
+            // Compose a new email: default content + a French and an English translation
+            const subject = page.locator('#mail-subject');
+            await expect(subject).toBeVisible();
+
+            // The {{orderTable}} replacement renders a per-recipient order table whose column titles
+            // are localized, so we can also assert that recipient replacements are translated.
+            await subject.fill('Nederlands onderwerp');
+            await setEditorContent(page, 'Nederlandse inhoud {{orderTable}} {{unsubscribeUrl}}');
+
+            await switchToLanguage(page, 'Frans', 'FR');
+            await expect(subject).toHaveValue('Nederlands onderwerp'); // seeded from the default content
+            await subject.fill('Sujet français');
+            await setEditorContent(page, 'Contenu français {{orderTable}} {{unsubscribeUrl}}');
+
+            await switchToLanguage(page, 'Engels', 'EN');
+            await subject.fill('English subject');
+            await setEditorContent(page, 'English content {{orderTable}} {{unsubscribeUrl}}');
+
+            // Send it and confirm. Scope to the editor form (the orders view behind it has its own
+            // search form, so `form.first()` on the page would submit the wrong one).
+            const editorForm = page.locator('form').filter({ has: page.locator('#mail-subject') }).first();
+            await editorForm.evaluate((form: HTMLFormElement) => form.requestSubmit());
+            const confirm = page.getByTestId('centered-message');
+            await expect(confirm).toBeVisible();
+            await confirm.getByRole('button', { name: 'Versturen' }).click();
+
+            // Each recipient should get the content of its own language (French/English), or the
+            // default content when there is no translation for its language (Dutch)
+            await expect.poll(async () => (await EmailMocker.getSucceededEmails()).length, { timeout: 20_000 }).toBe(3);
+            const emails = await EmailMocker.getSucceededEmails();
+
+            const dutch = emails.find(e => e.to.includes(orders[0].email))!;
+            const french = emails.find(e => e.to.includes(orders[1].email))!;
+            const english = emails.find(e => e.to.includes(orders[2].email))!;
+
+            expect(dutch).toBeDefined();
+            expect(dutch.subject).toBe('Nederlands onderwerp');
+            expect(dutch.html).toContain('Nederlandse inhoud');
+
+            expect(french).toBeDefined();
+            expect(french.subject).toBe('Sujet français');
+            expect(french.html).toContain('Contenu français');
+
+            expect(english).toBeDefined();
+            expect(english.subject).toBe('English subject');
+            expect(english.html).toContain('English content');
+
+            // No cross-language leakage
+            expect(french.html).not.toContain('Nederlandse inhoud');
+            expect(french.html).not.toContain('English content');
+            expect(english.html).not.toContain('Contenu français');
+
+            // The recipient replacements are localized too: the order-table column titles
+            // ('Artikel' / 'Aantal') are rendered in each recipient's own language
+            expect(dutch.html).toContain('Artikel');
+            expect(dutch.html).toContain('Aantal');
+
+            expect(french.html).toContain('Article');
+            expect(french.html).toContain('Nombre');
+            expect(french.html).not.toContain('Artikel');
+
+            expect(english.html).toContain('Item');
+            expect(english.html).toContain('Amount');
+            expect(english.html).not.toContain('Artikel');
+        } finally {
+            await context.close();
+        }
+    });
+});

--- a/tests/playwright/src/tests/settings-email-templates.spec.ts
+++ b/tests/playwright/src/tests/settings-email-templates.spec.ts
@@ -200,6 +200,19 @@ test.describe('Settings email templates', () => {
         await expect(popup.locator('.ProseMirror').first()).toContainText(bodyText);
     }
 
+    /**
+     * Replace the whole editor body with `text`. The TipTap editor is a contenteditable, so
+     * selecting all + retyping is the reliable way to set its content.
+     */
+    async function setEditorContent(page: Page, text: string) {
+        const editor = activePopup(page).locator('.ProseMirror').first();
+        await editor.click();
+        await page.keyboard.press('ControlOrMeta+A');
+        await page.keyboard.press('Backspace');
+        await editor.pressSequentially(text);
+        await expect(editor).toContainText(text);
+    }
+
     async function expectSingleTemplateInDatabase({
         type,
         organizationId,
@@ -537,44 +550,141 @@ test.describe('Settings email templates', () => {
         template.json = editorJson('default body');
         await template.save();
 
-        await login(page, pages);
-        await pages.groupOverview({ group, organization }).goto();
-        await openGroupEmailTemplates(page);
-        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+        // Adding translations requires the 'email-translations' feature flag (the UI is hidden by default)
+        organization.privateMeta.featureFlags = ['email-translations'];
+        await organization.save();
 
-        const popup = activePopup(page);
-        const subjectInput = popup.locator('#mail-subject');
-        await expect(subjectInput).toHaveValue('Default subject');
+        try {
+            await login(page, pages);
+            await pages.groupOverview({ group, organization }).goto();
+            await openGroupEmailTemplates(page);
+            await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
 
-        // Add French: seeds the translation from the current content and switches to it
-        await selectLanguageMenuItem(page, 'Frans');
-        await expect(subjectInput).toHaveValue('Default subject');
-        await subjectInput.fill('Sujet français');
+            const popup = activePopup(page);
+            const subjectInput = popup.locator('#mail-subject');
+            await expect(subjectInput).toHaveValue('Default subject');
 
-        // Switching back to the default content restores the default subject
-        await selectLanguageMenuItem(page, 'Standaardtekst');
-        await expect(subjectInput).toHaveValue('Default subject');
+            // Add French: seeds the translation from the current content and switches to it
+            await selectLanguageMenuItem(page, 'Frans');
+            await expect(subjectInput).toHaveValue('Default subject');
+            await subjectInput.fill('Sujet français');
 
-        // And back to French
-        await selectLanguageMenuItem(page, 'Frans');
-        await expect(subjectInput).toHaveValue('Sujet français');
+            // Switching back to the default content restores the default subject
+            await selectLanguageMenuItem(page, 'Standaardtekst');
+            await expect(subjectInput).toHaveValue('Default subject');
 
-        await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
-        await expect(subjectInput).toHaveCount(0);
-        await saveTemplateList(page);
+            // And back to French
+            await selectLanguageMenuItem(page, 'Frans');
+            await expect(subjectInput).toHaveValue('Sujet français');
 
-        await expect.poll(async () => {
-            await template.refresh();
-            return {
-                subject: template.subject,
-                frenchSubject: template.translations.get(Language.French)?.subject,
-                frenchText: template.translations.get(Language.French)?.text,
-            };
-        }).toMatchObject({
-            subject: 'Default subject',
-            frenchSubject: 'Sujet français',
-            frenchText: expect.stringContaining('default body'),
-        });
+            await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
+            await expect(subjectInput).toHaveCount(0);
+            await saveTemplateList(page);
+
+            await expect.poll(async () => {
+                await template.refresh();
+                return {
+                    subject: template.subject,
+                    frenchSubject: template.translations.get(Language.French)?.subject,
+                    frenchText: template.translations.get(Language.French)?.text,
+                };
+            }).toMatchObject({
+                subject: 'Default subject',
+                frenchSubject: 'Sujet français',
+                frenchText: expect.stringContaining('default body'),
+            });
+        } finally {
+            organization.privateMeta.featureFlags = [];
+            await organization.save();
+        }
+    });
+
+    test('a new template keeps subject, editor content and html separate per language', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        // Adding translations requires the 'email-translations' feature flag (the UI is hidden by default)
+        organization.privateMeta.featureFlags = ['email-translations'];
+        await organization.save();
+
+        try {
+            await login(page, pages);
+            await pages.groupOverview({ group, organization }).goto();
+            await openGroupEmailTemplates(page);
+
+            // No template exists yet: this opens a brand new template
+            await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+            const popup = activePopup(page);
+            const subjectInput = popup.locator('#mail-subject');
+            const editor = popup.locator('.ProseMirror').first();
+            await expect(subjectInput).toBeVisible();
+
+            // Fill the default (untranslated) content
+            await subjectInput.fill('Default subject');
+            await setEditorContent(page, 'Default body');
+
+            // Add French: seeded from the current (default) content, then give it its own content
+            await selectLanguageMenuItem(page, 'Frans');
+            await expect(subjectInput).toHaveValue('Default subject');
+            await expect(editor).toContainText('Default body');
+            await subjectInput.fill('Sujet français');
+            await setEditorContent(page, 'Corps français');
+
+            // Back to the default content: subject and editor show the default again, not the French one
+            await selectLanguageMenuItem(page, 'Standaardtekst');
+            await expect(subjectInput).toHaveValue('Default subject');
+            await expect(editor).toContainText('Default body');
+            await expect(editor).not.toContainText('Corps français');
+
+            // And back to French: its own subject and editor content are restored
+            await selectLanguageMenuItem(page, 'Frans');
+            await expect(subjectInput).toHaveValue('Sujet français');
+            await expect(editor).toContainText('Corps français');
+            await expect(editor).not.toContainText('Default body');
+
+            await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
+            await expect(subjectInput).toHaveCount(0);
+            await saveTemplateList(page);
+
+            // The default and the French translation each keep their own subject / text / html
+            await expect.poll(async () => {
+                const templates = await EmailTemplate.where({
+                    type: EmailTemplateType.RegistrationConfirmation,
+                    organizationId: organization.id,
+                    groupId: group.id,
+                    webshopId: null,
+                });
+                const template = templates[0];
+                const french = template?.translations.get(Language.French);
+                return {
+                    count: templates.length,
+                    subject: template?.subject,
+                    text: template?.text,
+                    htmlHasDefault: template?.html?.includes('Default body') ?? false,
+                    htmlHasFrench: template?.html?.includes('Corps français') ?? false,
+                    frenchSubject: french?.subject,
+                    frenchText: french?.text,
+                    frenchHtmlHasFrench: french?.html?.includes('Corps français') ?? false,
+                    frenchHtmlHasDefault: french?.html?.includes('Default body') ?? false,
+                };
+            }).toEqual({
+                count: 1,
+                subject: 'Default subject',
+                text: 'Default body',
+                htmlHasDefault: true,
+                htmlHasFrench: false,
+                frenchSubject: 'Sujet français',
+                frenchText: 'Corps français',
+                frenchHtmlHasFrench: true,
+                frenchHtmlHasDefault: false,
+            });
+        } finally {
+            organization.privateMeta.featureFlags = [];
+            await organization.save();
+        }
     });
 
     test('warns when only one language of a translated template was changed', async ({ page, pages }) => {
@@ -668,6 +778,214 @@ test.describe('Settings email templates', () => {
             await template.refresh();
             return template.subject;
         }).toBe('Updated without translations');
+    });
+
+    test('reviewing translations switches to the untouched language instead of saving', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        template.translations = new Map([
+            [Language.French, EmailContent.create({
+                subject: 'Sujet existant',
+                html: '<p>corps français</p>',
+                text: 'corps français',
+                json: editorJson('corps français'),
+            })],
+        ]);
+        await template.save();
+
+        await login(page, pages);
+        await pages.groupOverview({ group, organization }).goto();
+        await openGroupEmailTemplates(page);
+        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+        const popup = activePopup(page);
+        const subjectInput = popup.locator('#mail-subject');
+        await expect(subjectInput).toHaveValue('Default subject');
+
+        // Only change the default content, leaving the French translation untouched
+        await subjectInput.fill('Updated default subject');
+        await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
+
+        // Choose to review the other languages instead of saving
+        const message = page.getByTestId('centered-message');
+        await expect(message).toBeVisible();
+        await message.getByRole('button', { name: 'Vertalingen nakijken' }).click();
+
+        // The editor switches to the untouched French translation and does not save
+        await expect(subjectInput).toHaveValue('Sujet existant');
+        await expect(subjectInput).toBeVisible();
+
+        // Nothing was persisted: the stored subject is still the original
+        await template.refresh();
+        expect(template.subject).toBe('Default subject');
+    });
+
+    test('a translation can be removed via the language menu', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        template.translations = new Map([
+            [Language.French, EmailContent.create({
+                subject: 'Sujet existant',
+                html: '<p>corps français</p>',
+                text: 'corps français',
+                json: editorJson('corps français'),
+            })],
+        ]);
+        await template.save();
+
+        // Existing translations keep the language button visible without the feature flag
+        await login(page, pages);
+        await pages.groupOverview({ group, organization }).goto();
+        await openGroupEmailTemplates(page);
+        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+        const popup = activePopup(page);
+        const subjectInput = popup.locator('#mail-subject');
+        await expect(subjectInput).toHaveValue('Default subject');
+
+        // Removing a translation is only offered for the language you are currently editing
+        await selectLanguageMenuItem(page, 'Frans');
+        await expect(subjectInput).toHaveValue('Sujet existant');
+
+        // Clicking French again (now the current language) removes the translation
+        await selectLanguageMenuItem(page, 'Frans');
+        const message = page.getByTestId('centered-message');
+        await expect(message).toBeVisible();
+        await message.getByRole('button', { name: 'Verwijderen' }).click();
+
+        // The editor returns to the default content
+        await expect(subjectInput).toHaveValue('Default subject');
+
+        await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
+        await expect(subjectInput).toHaveCount(0);
+        await saveTemplateList(page);
+
+        await expect.poll(async () => {
+            await template.refresh();
+            return template.translations.size;
+        }).toBe(0);
+    });
+
+    test('hides the translation UI by default', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        await template.save();
+
+        await login(page, pages);
+        await pages.groupOverview({ group, organization }).goto();
+        await openGroupEmailTemplates(page);
+        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+        const popup = activePopup(page);
+        await expect(popup.locator('#mail-subject')).toHaveValue('Default subject');
+
+        // Without the feature flag and without existing translations, the button is hidden
+        await expect(popup.getByTestId('email-language-button')).toHaveCount(0);
+    });
+
+    test('shows the translation UI when the email-translations flag is enabled', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        await template.save();
+
+        organization.privateMeta.featureFlags = ['email-translations'];
+        await organization.save();
+
+        try {
+            await login(page, pages);
+            await pages.groupOverview({ group, organization }).goto();
+            await openGroupEmailTemplates(page);
+            await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+            const popup = activePopup(page);
+            await expect(popup.locator('#mail-subject')).toHaveValue('Default subject');
+
+            // The feature flag turns the translation button on, even without existing translations
+            await expect(popup.getByTestId('email-language-button')).toBeVisible();
+        } finally {
+            organization.privateMeta.featureFlags = [];
+            await organization.save();
+        }
+    });
+
+    test('shows the translation UI when translations already exist', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        template.translations = new Map([
+            [Language.French, EmailContent.create({
+                subject: 'Sujet existant',
+                html: '<p>corps français</p>',
+                text: 'corps français',
+                json: editorJson('corps français'),
+            })],
+        ]);
+        await template.save();
+
+        // No feature flag: existing translations keep the button visible so they stay manageable
+        await login(page, pages);
+        await pages.groupOverview({ group, organization }).goto();
+        await openGroupEmailTemplates(page);
+        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+        const popup = activePopup(page);
+        await expect(popup.locator('#mail-subject')).toHaveValue('Default subject');
+
+        await expect(popup.getByTestId('email-language-button')).toBeVisible();
     });
 
     test('organization new template inherits platform defaults', async ({ page, pages }) => {

--- a/tests/playwright/src/tests/settings-email-templates.spec.ts
+++ b/tests/playwright/src/tests/settings-email-templates.spec.ts
@@ -6,7 +6,8 @@ import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import type { Organization, User } from '@stamhoofd/models';
 import { EmailTemplate, GroupFactory, OrganizationFactory, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
-import { EmailTemplateType, PermissionLevel, Permissions, STPackageStatus, STPackageType } from '@stamhoofd/structures';
+import { EmailContent, EmailTemplateType, PermissionLevel, Permissions, STPackageStatus, STPackageType } from '@stamhoofd/structures';
+import { Language } from '@stamhoofd/types/Language';
 import { TestUtils } from '@stamhoofd/test-utils';
 import type { Pages } from '../helpers/index.js';
 
@@ -18,6 +19,11 @@ test.describe('Settings email templates', () => {
 
     test.beforeAll(async () => {
         TestUtils.setPermanentEnvironment('userMode', 'organization');
+
+        // Multiple languages are needed to test email template translations.
+        // English is excluded: the browser locale of Playwright is English, and the
+        // dashboard would switch to English while the tests assert Dutch texts.
+        TestUtils.setPermanentEnvironment('locales', { BE: [Language.Dutch, Language.French] });
 
         organization = await new OrganizationFactory({}).create();
 
@@ -500,6 +506,168 @@ test.describe('Settings email templates', () => {
             expectedSubject: 'Platform webshop subject',
             expectedText: 'Platform webshop body',
         });
+    });
+
+    async function openLanguageMenu(page: Page) {
+        const popup = activePopup(page);
+        await popup.getByTestId('email-language-button').click();
+        const menu = page.locator('.context-menu-container:visible').last();
+        await expect(menu.locator('.context-menu-item').first()).toBeVisible();
+        return menu;
+    }
+
+    async function selectLanguageMenuItem(page: Page, name: string) {
+        const menu = await openLanguageMenu(page);
+        await menu.locator('.context-menu-item', { hasText: name }).first().click();
+    }
+
+    test('a translation can be added to an email template', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        await template.save();
+
+        await login(page, pages);
+        await pages.groupOverview({ group, organization }).goto();
+        await openGroupEmailTemplates(page);
+        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+        const popup = activePopup(page);
+        const subjectInput = popup.locator('#mail-subject');
+        await expect(subjectInput).toHaveValue('Default subject');
+
+        // Add French: seeds the translation from the current content and switches to it
+        await selectLanguageMenuItem(page, 'Frans');
+        await expect(subjectInput).toHaveValue('Default subject');
+        await subjectInput.fill('Sujet français');
+
+        // Switching back to the default content restores the default subject
+        await selectLanguageMenuItem(page, 'Standaardtekst');
+        await expect(subjectInput).toHaveValue('Default subject');
+
+        // And back to French
+        await selectLanguageMenuItem(page, 'Frans');
+        await expect(subjectInput).toHaveValue('Sujet français');
+
+        await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
+        await expect(subjectInput).toHaveCount(0);
+        await saveTemplateList(page);
+
+        await expect.poll(async () => {
+            await template.refresh();
+            return {
+                subject: template.subject,
+                frenchSubject: template.translations.get(Language.French)?.subject,
+                frenchText: template.translations.get(Language.French)?.text,
+            };
+        }).toMatchObject({
+            subject: 'Default subject',
+            frenchSubject: 'Sujet français',
+            frenchText: expect.stringContaining('default body'),
+        });
+    });
+
+    test('warns when only one language of a translated template was changed', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        template.translations = new Map([
+            [Language.French, EmailContent.create({
+                subject: 'Sujet existant',
+                html: '<p>corps français</p>',
+                text: 'corps français',
+                json: editorJson('corps français'),
+            })],
+        ]);
+        await template.save();
+
+        await login(page, pages);
+        await pages.groupOverview({ group, organization }).goto();
+        await openGroupEmailTemplates(page);
+        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+        const popup = activePopup(page);
+        const subjectInput = popup.locator('#mail-subject');
+        await expect(subjectInput).toHaveValue('Default subject');
+
+        // Only change the default content
+        await subjectInput.fill('Updated default subject');
+        await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
+
+        // A warning should appear because the French translation was not updated
+        const message = page.getByTestId('centered-message');
+        await expect(message).toBeVisible();
+        await message.getByRole('button', { name: 'Toch opslaan' }).click();
+
+        await expect(subjectInput).toHaveCount(0);
+        await saveTemplateList(page);
+
+        await expect.poll(async () => {
+            await template.refresh();
+            return {
+                subject: template.subject,
+                frenchSubject: template.translations.get(Language.French)?.subject,
+            };
+        }).toMatchObject({
+            subject: 'Updated default subject',
+            frenchSubject: 'Sujet existant',
+        });
+    });
+
+    test('does not warn when the template has no translations', async ({ page, pages }) => {
+        const group = await new GroupFactory({ organization }).create();
+        const organizationPeriod = await organization.getPeriod();
+        organizationPeriod.settings.rootCategory?.groupIds.push(group.id);
+        await organizationPeriod.save();
+
+        const template = new EmailTemplate();
+        template.subject = 'Default subject';
+        template.type = EmailTemplateType.RegistrationConfirmation;
+        template.organizationId = organization.id;
+        template.groupId = group.id;
+        template.html = '<p>default body</p>';
+        template.text = 'default body';
+        template.json = editorJson('default body');
+        await template.save();
+
+        await login(page, pages);
+        await pages.groupOverview({ group, organization }).goto();
+        await openGroupEmailTemplates(page);
+        await clickTemplate(page, EmailTemplateType.RegistrationConfirmation);
+
+        const popup = activePopup(page);
+        const subjectInput = popup.locator('#mail-subject');
+        await subjectInput.fill('Updated without translations');
+        await popup.locator('form').first().evaluate((form: HTMLFormElement) => form.requestSubmit());
+
+        // Saves directly, without a warning
+        await expect(subjectInput).toHaveCount(0);
+        await saveTemplateList(page);
+
+        await expect.poll(async () => {
+            await template.refresh();
+            return template.subject;
+        }).toBe('Updated without translations');
     });
 
     test('organization new template inherits platform defaults', async ({ page, pages }) => {


### PR DESCRIPTION
## What

Email templates and emails can now be written in a default language and overridden per language. Recipients receive the content in their own language when a translation exists, and the default content otherwise.

### Data model
- New `EmailContent` structure (`subject`, `html`, `text`, `json`) — the unit of translation is the whole content set, since `html`/`text` are derived from the editor `json`.
- `EmailTemplate` and `Email` keep their existing `subject/html/text/json` as the **untranslated default** and gain `translations: Map<Language, EmailContent>` (new versioned field via `NextVersion`, new JSON columns via migration).
- `Recipient` and `EmailRecipient` gain a nullable `language`. Nothing sets it yet — a follow-up PR adds `consumerLanguage` to the order model and wires up sources.

### Language selection is tightly locked to one template
Template resolution (webshop/group → organization → platform) is unchanged and happens **first**; language selection happens second, **within the resolved template only**. A missing language falls back to that template's default content, never to another template level: better correct content in the wrong language than wrong content in the right language.

- `getEmailBuilder` resolves `subject`/`html` per recipient (`translations` option, lazily cached per language).
- `sendEmailTemplate`/`getEmailBuilderForTemplate` pass the resolved template's translations through.
- `Email.setFromTemplate` copies translations (so automated template emails, e.g. balance emails, are fully translated), `sendSingleRecipient` selects per recipient, and the member portal subject/snippet (`getSubjectFor`/`getSnippetFor`) are language-aware.
- Sending validates translations: incomplete translations (`invalid_field`) and translations without `{{unsubscribeUrl}}` (`missing_unsubscribe_button`) are rejected.

### Editor UI
- New `EmailLanguageButton` (mirrors `TInputButton`'s menu) next to the subject input in both the template editor and the email composer: switch between languages, add a translation (seeded from the currently displayed content), or remove one (with confirmation).
- Shared `useEmailContentLanguage` composable keeps the subject input + TipTap editor in sync with the language being edited and writes everything into the view's patch (full-content `PatchMap` entries per language). The composer's throttled auto-save and the send request merge the derived `html`/`text` into the language the content was derived from (language captured before the async derivation, so switching mid-save can't corrupt another language).
- When saving an existing template (or sending an email) where only a subset of the pre-existing languages was changed, a confirmation asks to review the other translations ("Vertalingen nakijken") or continue anyway ("Toch opslaan"/"Toch verzenden"). Newly added or removed translations don't trigger this.
- Loading a template into the composer copies its translations; saving composer content as a template preserves them.

## Tests
- **structures**: encode/decode + old-client stripping, `PatchMap` inside `PatchableArray`, strict language selection, per-recipient subject/snippet.
- **models**: `sendEmailTemplate` per-recipient language selection, default fallback, no-cross-template fallback, `setFromTemplate` translation copy.
- **api**: PUT/PATCH of template translations (add/remove/keep), email translations patching, send validation for incomplete translations and missing unsubscribe buttons.
- **components (vitest)**: unit tests for the changed/stale language diffing helpers.
- **Playwright**: add a translation via the language button + switch back and forth + persisted to DB; stale-translation warning on save (and its absence without translations).

## Follow-ups (out of scope)
- Wiring recipient language sources (order `consumerLanguage`, later user/member language).
- Recipient de-duplication currently merges identical email addresses regardless of language; revisit when languages are actually set.
- A Playwright spec for the composer flow itself (the language machinery is shared with the template editor, which is e2e-covered; composer-specific merging is unit/endpoint-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786607361&installation_id=138085646&pr_number=607&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F607&signature=dfab6726caa4940dd65ddac57868d137a54da2f3d2552060c7b50fd9b886f56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->