### PR TITLE
🐛 Fixed collapsed seats in the webshop seating overview

### DIFF
--- a/frontend/shared/components/src/views/SeatSelectionBox.vue
+++ b/frontend/shared/components/src/views/SeatSelectionBox.vue
@@ -68,7 +68,7 @@ import { useIsMobile } from '#hooks/useIsMobile.ts';
 import type { SeatingPlan, SeatingPlanRow, SeatingPlanSeat, SeatingPlanSection } from '@stamhoofd/structures';
 import { CartReservedSeat, ReservedSeat, SeatingSizeConfiguration, SeatMarkings } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watchEffect } from 'vue';
 
 import { Toast } from '../overlays/Toast';
 
@@ -132,15 +132,19 @@ const defaultSizeConfig = computed(() => {
     return config;
 });
 
+const sizeConfig = computed(() => props.sizeConfig ?? defaultSizeConfig.value);
 const rows = computed(() => props.seatingPlanSection.rows);
-const size = computed(() => props.seatingPlanSection.calculateSize(props.sizeConfig ?? defaultSizeConfig.value));
+const size = computed(() => props.seatingPlanSection.calculateSize(sizeConfig.value));
 
-function updatePositions() {
-    props.seatingPlanSection.updatePositions(props.sizeConfig ?? defaultSizeConfig.value);
-}
-
-updatePositions();
-watch(() => props.seatingPlanSection, updatePositions);
+/**
+ * The drawing positions are cached on the rows and seats themselves, and those are replaced with
+ * freshly decoded ones (with empty positions) every time the webshop is updated in place - e.g. when
+ * it is reloaded in the background while this view is open. Recalculate the positions whenever the
+ * rows or seats change, instead of only when the section itself is replaced.
+ */
+watchEffect(() => {
+    props.seatingPlanSection.updatePositions(sizeConfig.value);
+});
 
 if (props.amount && props.setSeats) {
     const updatedSeats = props.seats.filter(seat => props.seatingPlan.isValidSeat(seat, props.reservedSeats));

--- a/tests/playwright/src/tests/webshop-seating.spec.ts
+++ b/tests/playwright/src/tests/webshop-seating.spec.ts
@@ -1,0 +1,111 @@
+// test should always be imported first
+import { setup, test } from '../test-fixtures/base.js';
+setup();
+
+// other imports
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { STPackageService } from '@stamhoofd/backend/tests/helpers';
+import type { User } from '@stamhoofd/models';
+import { Organization, OrganizationFactory, Token, UserFactory } from '@stamhoofd/models';
+import { PaymentMethod, PermissionLevel, Permissions, STPackageBundle, Token as TokenStruct, Version, WebshopTicketType } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { WebshopOrderFlow } from '../flows/WebshopOrderFlow.js';
+import { DashboardPage, DashboardTab, WorkerData } from '../helpers/index.js';
+import { TestWebshops } from '../helpers/test-data/TestWebshops.js';
+
+async function loginAs({ page, user }: { page: Page; user: User }) {
+    const token = await Token.createToken(user);
+    const tokenString = JSON.stringify(new TokenStruct(token).encode({ version: Version }));
+    const organizationId = user.organizationId;
+
+    await page.addInitScript(({ organizationId, tokenString }) => {
+        if (organizationId) {
+            window.localStorage.setItem('token-' + organizationId, tokenString);
+        }
+        else {
+            window.localStorage.setItem('token-platform', tokenString);
+        }
+    }, { organizationId, tokenString });
+}
+
+test.describe('Webshop seating overview (organization mode) @webshop-seating', () => {
+    test.beforeAll(() => {
+        TestUtils.setPermanentEnvironment('userMode', 'organization');
+    });
+
+    test('The seating overview keeps drawing the seats while the webshop is reloaded', async ({ page, browser }) => {
+        const organization = await new OrganizationFactory({
+            name: `SeatShop${WorkerData.id}`,
+            packages: [STPackageBundle.Webshops],
+        }).create();
+
+        // Recalculate meta.packages so the public webshop is not rendered as "closed"
+        await STPackageService.updateOrganizationPackages(organization.id);
+        const refreshed = (await Organization.getByID(organization.id))!;
+
+        const { webshop } = await TestWebshops.create({
+            organization: refreshed,
+            name: `Seat shop ${WorkerData.id}`,
+            ticketType: WebshopTicketType.Tickets,
+            productCount: 1,
+            cartEnabled: false,
+            withSeatingPlan: true,
+            price: 0,
+            paymentMethods: [PaymentMethod.PointOfSale],
+        });
+
+        const seatCount = webshop.meta.seatingPlans[0].sections[0].rows.flatMap(row => row.seats).length;
+
+        // A customer orders two seats, so the seating overview also has an order to load
+        const flow = new WebshopOrderFlow(page, { cartEnabled: false });
+        await flow.goto(WorkerData.urls.webshopUri(webshop.uri));
+        await flow.addProduct('Product 1', { seats: 2 });
+        await flow.goToCheckout();
+        await flow.fillCustomer();
+        await flow.confirmPayment();
+        await flow.expectTicketsDownloadable();
+
+        // The admin opens the seating overview of the webshop
+        const admin = await new UserFactory({
+            email: `admin-${WorkerData.id}-${Date.now()}@test.be`,
+            organization: refreshed,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+
+        const adminContext = await browser.newContext();
+        const adminPage = await adminContext.newPage();
+        await loginAs({ page: adminPage, user: admin });
+
+        const dashboard = new DashboardPage(adminPage);
+        await dashboard.openOrganizationDashboard({ organizationUri: refreshed.uri });
+        await dashboard.openTab(DashboardTab.Webshops);
+        await adminPage.getByTestId('webshop-menu-item').filter({ hasText: webshop.meta.name }).click();
+        await adminPage.getByRole('heading', { name: 'Zaaloverzicht' }).click();
+
+        const seats = adminPage.getByTestId('seat-button');
+        await expect(seats.first()).toBeVisible();
+
+        // Loading the orders reloads the webshop in the background, which replaces the rows and seats
+        // of the seating plan with newly decoded ones. The seats should keep their size and position.
+        await adminPage.waitForTimeout(3000);
+
+        const boxes = await seats.evaluateAll(elements => elements.map((element) => {
+            const { width, height, x, y } = element.getBoundingClientRect();
+            return { width, height, x, y };
+        }));
+
+        expect(boxes.length).toBe(seatCount);
+
+        for (const box of boxes) {
+            expect(box.width).toBeGreaterThan(10);
+            expect(box.height).toBeGreaterThan(10);
+        }
+
+        // No two seats are drawn on top of each other
+        const positions = new Set(boxes.map(box => `${box.x}x${box.y}`));
+        expect(positions.size).toBe(boxes.length);
+
+        await adminContext.close();
+    });
+});


### PR DESCRIPTION
fixes STA-1327

What was wrong
--------------
The drawing positions (x, y, width, height) of a seating plan are cached on the row and seat objects themselves. SeatSelectionBox only calculated them once at setup, and again whenever the seating plan section object itself was replaced.

While the seating overview is open, the dashboard reloads the webshop in the background (every order fetch calls loadWebshopIfNeeded with forceBackground). That update is applied in place with deepSet: the section keeps its identity because it has an id, but rows and seats have no id, so they are replaced with freshly decoded objects whose cached positions are all zero. Nothing recalculated them, so every seat collapsed into a 0x0 box drawn at the same position.

The fix
-------
updatePositions now runs inside a watchEffect, so the positions are recalculated whenever the rows or seats (or the size configuration) change, instead of only when the section object is swapped.

Verification
------------
Added a Playwright test that places a seated order, opens the seating overview as an admin, waits for the background reload of the webshop and asserts that every seat still has a real size and that no two seats are drawn on top of each other. It fails without the fix (seat width 0) and passes with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786629778&installation_id=138085646&pr_number=609&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F609&signature=1e60c0922a6b0468c4b74309806041e7f6118a16f0414c06e5e41163b61a50a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->