### PR TITLE
🐛 Keep WebSockets alive when reloading Caddy in the CLI dev env

### DIFF
--- a/shared/cli/src/config/caddy-config.test.ts
+++ b/shared/cli/src/config/caddy-config.test.ts
@@ -45,6 +45,20 @@ describe('Caddy config', () => {
         expect(subjects).toContain('*.files.stamhoofd');
     });
 
+    it('keeps WebSockets alive across reloads by setting stream_close_delay on every reverse_proxy', async () => {
+        const config = await writeCaddyConfig(context(rootDir));
+        const caddyConfig = JSON.parse(await fs.readFile(config, 'utf8'));
+
+        const reverseProxies = caddyConfig.apps.http.servers.stamhoofd.routes
+            .flatMap((route: any) => route.handle)
+            .filter((handle: any) => handle.handler === 'reverse_proxy');
+
+        expect(reverseProxies.length).toBeGreaterThan(0);
+        for (const proxy of reverseProxies) {
+            expect(proxy.stream_close_delay).toBe('24h');
+        }
+    });
+
     it('can bind the admin API to the container interface', async () => {
         const config = await writeCaddyConfig(context(rootDir), { adminListenHost: '0.0.0.0' });
         const caddyConfig = JSON.parse(await fs.readFile(config, 'utf8'));

--- a/shared/cli/src/config/caddy-config.ts
+++ b/shared/cli/src/config/caddy-config.ts
@@ -7,6 +7,19 @@ import type { CaddyRouteOptions } from '../runtime/manifest-store.js';
 import { listActiveRouteManifests, sharedDir } from '../runtime/manifest-store.js';
 import { caddyAdminPort, caddyHttpPort, caddyHttpsPort, caddySetupAdminPort, caddySetupHttpPort, caddySetupHttpsPort, localIpv4Host, localhostPort } from './shared-service-config.js';
 
+/**
+ * By default Caddy closes active streaming requests (WebSockets) immediately
+ * whenever its config is reloaded. In the CLI dev environment we reload Caddy
+ * often (starting an instance, restarting services, the `--watch` flag), which
+ * would tear down long-lived WebSockets such as the Vite HMR channel on every
+ * reload. Setting `stream_close_delay` on the reverse_proxy keeps those streams
+ * open across reloads: a non-zero value tells Caddy not to close streaming
+ * requests when the config is unloaded, but to keep them open until the delay
+ * elapses. We use a very large delay so, for the lifetime of a dev session,
+ * WebSockets effectively survive reloads.
+ */
+const streamCloseDelay = '24h';
+
 export type CaddyRoute = {
     group?: string;
     match: (
@@ -16,6 +29,7 @@ export type CaddyRoute = {
         {
             handler: 'reverse_proxy';
             upstreams: Array<{ dial: string }>;
+            stream_close_delay?: string;
             headers?: {
                 request?: {
                     add?: Record<string, string[]>;
@@ -103,7 +117,7 @@ async function writeReadableConfig(configPath: string, content: string): Promise
 function route(hosts: string[], port: number, proxyHost: string): CaddyRoute {
     return {
         match: [{ host: hosts }],
-        handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: `${proxyHost}:${port}` }] }],
+        handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: `${proxyHost}:${port}` }], stream_close_delay: streamCloseDelay }],
     };
 }
 


### PR DESCRIPTION
## Problem

By default Caddy **closes active streaming requests (WebSockets) immediately** whenever its config is reloaded. In the CLI dev environment we reload Caddy often — starting an instance, restarting services, the `--watch` flag — which tore down long-lived WebSockets such as the **Vite HMR channel** on every reload, forcing full page reloads.

## Fix

Set Caddy's [`stream_close_delay`](https://caddyserver.com/docs/json/apps/http/servers/routes/handle/reverse_proxy/#stream_close_delay) on the `reverse_proxy` handler. Per Caddy's docs, a non-zero value means *"streaming requests such as WebSockets will not be closed when the proxy config is unloaded"* — exactly the reload behavior we want. Every CLI route flows through the single `route()` helper, so the option is applied uniformly (frontend HMR, api, renderer, shared services). A large delay (`24h`) makes WebSockets effectively survive reloads for the lifetime of a dev session.

## Testing

- New unit test asserts every `reverse_proxy` in the generated config carries `stream_close_delay`.
- Verified the generated config against the real `caddy:2` binary (`caddy validate`) → **Valid configuration**.
- `yarn lint` (0 errors) and typecheck pass.

> [!NOTE]
> Scoped to the CLI dev environment. The separate Playwright `CaddyConfigHelper` builds its own routes and was intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786650018&installation_id=138085646&pr_number=611&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F611&signature=e4f78e17c66c1137d78094d2d5a9a2b47b3f0505db6a94204e027af8711ceafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->