### PR TITLE
UiTPAS: use org credentials if present

### DIFF
--- a/backend/app/api/src/endpoints/organization/webshops/RetrieveUitpasSocialTariffPriceEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/RetrieveUitpasSocialTariffPriceEndpoint.ts
@@ -75,7 +75,8 @@ export class RetrieveUitpasSocialTariffPricesEndpoint extends Endpoint<Params, Q
                     human: $t('%189'),
                 });
             }
-            await UitpasService.checkUitpasNumbers(request.body.uitpasNumbers); // Throws if invalid
+            const organization = await Context.setOrganizationScope({ willAuthenticate: false });
+            await UitpasService.checkUitpasNumbers(organization.id, request.body.uitpasNumbers); // Throws if invalid
             const uitpasPriceCheckResponse = UitpasPriceCheckResponse.create({
                 prices: request.body.uitpasNumbers.map(_ => reducedPrice), // All reduced prices are the same in this non-official flow
             });

--- a/backend/app/api/src/helpers/UitpasTokenRepository.ts
+++ b/backend/app/api/src/helpers/UitpasTokenRepository.ts
@@ -175,6 +175,17 @@ export class UitpasTokenRepository {
         return model; // return new model
     }
 
+    static async getAccessTokenForWithPlatformFallback(orgId: string, forceRefresh: boolean = false): Promise<string> {
+        try {
+            return await UitpasTokenRepository.getAccessTokenFor(orgId, forceRefresh);
+        } catch (error) {
+            if (error instanceof SimpleError && error.code === 'uitpas_api_not_configured_for_this_organization') {
+                return await UitpasTokenRepository.getAccessTokenFor(null, forceRefresh); // fallback to platform
+            }
+            throw error;
+        }
+    }
+
     /**
      * Get the access token for the organization or platform.
      * @param organizationId the organization ID for which to get the access token. If null, it means the platform.

--- a/backend/app/api/src/helpers/UitpasTokenRepository.ts
+++ b/backend/app/api/src/helpers/UitpasTokenRepository.ts
@@ -66,13 +66,13 @@ export class UitpasTokenRepository {
     /**
      * organizationId (null means platform) -> UitpasTokenRepository or null if no creds are configured for this org/platform
      */
-    private static knownTokens: Map<string | null, UitpasTokenRepository | null> = new Map();
+    private static knownRepos: Map<string | null, UitpasTokenRepository | null> = new Map();
 
     /**
      * @returns null if no creds configured, undefined if not found in memory, UitpasTokenRepository if found in memory
      */
     private static getRepoFromMemory(organizationId: string | null): UitpasTokenRepository | undefined | null {
-        return UitpasTokenRepository.knownTokens.get(organizationId);
+        return UitpasTokenRepository.knownRepos.get(organizationId);
     }
 
     private static async getModelFromDb(organizationId: string | null) {
@@ -158,7 +158,7 @@ export class UitpasTokenRepository {
     }
 
     private static setRepoInMemory(organizationId: string | null, repo: UitpasTokenRepository | null) {
-        UitpasTokenRepository.knownTokens.set(organizationId, repo);
+        UitpasTokenRepository.knownRepos.set(organizationId, repo);
     }
 
     private static async setModelInDb(organizationId: string | null, model: UitpasClientCredential) {

--- a/backend/app/api/src/helpers/UitpasTokenRepository.ts
+++ b/backend/app/api/src/helpers/UitpasTokenRepository.ts
@@ -276,9 +276,6 @@ export class UitpasTokenRepository {
     static async clearClientCredentialsFor(organizationId: string | null): Promise<boolean> {
         return await UitpasTokenRepository.handleInQueue(organizationId, async () => {
             const cached = UitpasTokenRepository.getRepoFromMemory(organizationId);
-            if (cached === null) {
-                return false; // nothing to clear
-            }
             if (cached) {
                 // in memory, thus also in db
                 await cached.uitpasClientCredential.delete(); // remove from db
@@ -288,6 +285,9 @@ export class UitpasTokenRepository {
             // not in memory, maybe in db
             const model = await UitpasTokenRepository.getModelFromDb(organizationId);
             if (model) {
+                if (cached === null) {
+                    console.warn(`Clearing UiTPAS client credentials for organization with id ${organizationId} although it was not in memory, but found in database. This is a bug, memory and database are out of sync.`);
+                }
                 await model.delete(); // remove from database
                 return true;
             }

--- a/backend/app/api/src/helpers/UitpasTokenRepository.ts
+++ b/backend/app/api/src/helpers/UitpasTokenRepository.ts
@@ -282,7 +282,7 @@ export class UitpasTokenRepository {
             if (cached) {
                 // in memory, thus also in db
                 await cached.uitpasClientCredential.delete(); // remove from db
-                UitpasTokenRepository.knownTokens.delete(organizationId); // remove from memory
+                UitpasTokenRepository.setRepoInMemory(organizationId, null); // remove from memory
                 return true;
             }
             // not in memory, maybe in db

--- a/backend/app/api/src/helpers/UitpasTokenRepository.ts
+++ b/backend/app/api/src/helpers/UitpasTokenRepository.ts
@@ -230,16 +230,36 @@ export class UitpasTokenRepository {
         });
     }
 
-    static async getClientIdFor(organizationId: string | null): Promise<string> {
-        const repo = UitpasTokenRepository.getRepoFromMemory(organizationId);
-        if (!repo) {
-            const model = await UitpasClientCredential.select().where('organizationId', organizationId).first(false);
-            if (!model) {
-                return ''; // no client ID and secret configured
+    static async getClientIdFor(organizationId: string): Promise<string> {
+        const tryFromMemory = (): string | undefined => {
+            const cached = UitpasTokenRepository.getRepoFromMemory(organizationId);
+            if (cached === null) {
+                return '';
             }
-            return model.clientId; // client ID configured, but not in memory
+            if (cached) {
+                return cached.uitpasClientCredential.clientId;
+            }
+        };
+
+        const memoryResult = tryFromMemory();
+        if (typeof memoryResult === 'string') {
+            return memoryResult; // client ID found in memory
         }
-        return repo.uitpasClientCredential.clientId; // client ID configured and in memory
+
+        return await UitpasTokenRepository.handleInQueue(organizationId, async () => {
+            // re-search memory, as another call to this function might have populated it while we were waiting in the queue
+            const memoryResult = tryFromMemory();
+            if (typeof memoryResult === 'string') {
+                return memoryResult; // client ID found in memory
+            }
+            const model = await UitpasTokenRepository.getModelFromDb(organizationId);
+            if (!model) {
+                UitpasTokenRepository.setRepoInMemory(organizationId, null); // remember there are no creds configured
+                return '';
+            }
+            UitpasTokenRepository.setRepoInMemory(organizationId, new UitpasTokenRepository(model)); // store in memory
+            return model.clientId; // client ID configured, now also in memory
+        });
     }
 
     static async clearClientCredentialsFor(organizationId: string | null): Promise<boolean> {

--- a/backend/app/api/src/helpers/UitpasTokenRepository.ts
+++ b/backend/app/api/src/helpers/UitpasTokenRepository.ts
@@ -64,12 +64,15 @@ export class UitpasTokenRepository {
     }
 
     /**
-     * organizationId (null means platform) -> UitpasTokenRepository
+     * organizationId (null means platform) -> UitpasTokenRepository or null if no creds are configured for this org/platform
      */
-    static knownTokens: Map<string | null, UitpasTokenRepository> = new Map();
+    private static knownTokens: Map<string | null, UitpasTokenRepository | null> = new Map();
 
-    private static getRepoFromMemory(organizationId: string | null): UitpasTokenRepository | null {
-        return UitpasTokenRepository.knownTokens.get(organizationId) ?? null;
+    /**
+     * @returns null if no creds configured, undefined if not found in memory, UitpasTokenRepository if found in memory
+     */
+    private static getRepoFromMemory(organizationId: string | null): UitpasTokenRepository | undefined | null {
+        return UitpasTokenRepository.knownTokens.get(organizationId);
     }
 
     private static async getModelFromDb(organizationId: string | null) {
@@ -154,9 +157,8 @@ export class UitpasTokenRepository {
         return this.accessToken;
     }
 
-    private static setRepoInMemory(organizationId: string | null, repo: UitpasTokenRepository) {
+    private static setRepoInMemory(organizationId: string | null, repo: UitpasTokenRepository | null) {
         UitpasTokenRepository.knownTokens.set(organizationId, repo);
-        return repo;
     }
 
     private static async setModelInDb(organizationId: string | null, model: UitpasClientCredential) {
@@ -180,33 +182,51 @@ export class UitpasTokenRepository {
      * @returns Promise<string> the access token for the organization or platform
      * @throws SimpleError if the token cannot be obtained or the API is not configured
      */
-    static async getAccessTokenFor(organizationId: string | null = null, forceRefresh: boolean = false): Promise<string> {
-        let repo = UitpasTokenRepository.getRepoFromMemory(organizationId);
-        if (repo && repo.accessToken && !forceRefresh && repo.expiresOn > new Date()) {
-            return repo.accessToken;
+    static async getAccessTokenFor(organizationId: string | null, forceRefresh: boolean = false): Promise<string> {
+        const notConfiguredError = new SimpleError({
+            code: 'uitpas_api_not_configured_for_this_organization',
+            message: `UiTPAS api not configured for organization with id ${organizationId}`,
+            human: $t('%1BJ'),
+        });
+
+        const tryFromMemory = (): string | UitpasTokenRepository | undefined => {
+            const cached = UitpasTokenRepository.getRepoFromMemory(organizationId);
+            if (cached === null) {
+                throw notConfiguredError;
+            }
+            if (cached && cached.accessToken && !forceRefresh && cached.expiresOn > new Date()) {
+                return cached.accessToken;
+            }
+            return cached; // not found in memory or expired or no access token or forceRefresh
+        };
+
+        const memoryResult = tryFromMemory();
+        if (typeof memoryResult === 'string') {
+            return memoryResult; // access token found in memory
         }
 
         // Prevent multiple concurrent requests for the same organization, asking for an access token to the UiTPAS API.
         // The queue can only run one at a time for the same organizationId
         return await UitpasTokenRepository.handleInQueue(organizationId, async () => {
             // we re-search for the repo, as another call to this funcion might have added while we we're waiting in the queue
-            repo = UitpasTokenRepository.getRepoFromMemory(organizationId);
-            if (repo && repo.accessToken && !forceRefresh && repo.expiresOn > new Date()) {
-                return repo.accessToken;
+            let repo: UitpasTokenRepository;
+            const memoryResult = tryFromMemory();
+            if (typeof memoryResult === 'string') {
+                return memoryResult; // access token found in memory
             }
-            if (!repo) {
+            if (!memoryResult) {
                 const model = await UitpasTokenRepository.getModelFromDb(organizationId);
                 if (!model) {
-                    throw new SimpleError({
-                        code: 'uitpas_api_not_configured_for_this_organization',
-                        message: `UiTPAS api not configured for organization with id ${organizationId}`,
-                        human: $t('%1BJ'),
-                    });
+                    UitpasTokenRepository.setRepoInMemory(organizationId, null);
+                    throw notConfiguredError;
                 }
-                repo = UitpasTokenRepository.setRepoInMemory(organizationId, new UitpasTokenRepository(model)); // store in memory
+                repo = new UitpasTokenRepository(model);
+                UitpasTokenRepository.setRepoInMemory(organizationId, repo);
+            } else {
+                repo = memoryResult;
             }
             // ask for a new access token
-            return repo.getNewAccessToken();
+            return await repo.getNewAccessToken();
         });
     }
 
@@ -224,10 +244,13 @@ export class UitpasTokenRepository {
 
     static async clearClientCredentialsFor(organizationId: string | null): Promise<boolean> {
         return await UitpasTokenRepository.handleInQueue(organizationId, async () => {
-            const repo = UitpasTokenRepository.getRepoFromMemory(organizationId);
-            if (repo) {
+            const cached = UitpasTokenRepository.getRepoFromMemory(organizationId);
+            if (cached === null) {
+                return false; // nothing to clear
+            }
+            if (cached) {
                 // in memory, thus also in db
-                await repo.uitpasClientCredential.delete(); // remove from db
+                await cached.uitpasClientCredential.delete(); // remove from db
                 UitpasTokenRepository.knownTokens.delete(organizationId); // remove from memory
                 return true;
             }

--- a/backend/app/api/src/services/uitpas/UitpasService.test.ts
+++ b/backend/app/api/src/services/uitpas/UitpasService.test.ts
@@ -4,19 +4,19 @@ import { UitpasService } from './UitpasService.js';
 describe.skip('UitpasService', () => {
     it('should validate a correct Uitpas number with kansentarief', async () => {
         const validNumbers = ['0900000067513'];
-        await expect(UitpasService.checkUitpasNumbers(validNumbers)).resolves.toBeUndefined();
+        await expect(UitpasService.checkUitpasNumbers('unexisting-org-id', validNumbers)).resolves.toBeUndefined();
     });
 
     it('should throw an error for an invalid Uitpas number', async () => {
         const invalidNumbers = ['1234567890123'];
-        await expect(UitpasService.checkUitpasNumbers(invalidNumbers)).rejects.toThrow(
+        await expect(UitpasService.checkUitpasNumbers('unexisting-org-id', invalidNumbers)).rejects.toThrow(
             STExpect.simpleError({ code: 'unsuccessful_but_expected_response_retrieving_pass_by_uitpas_number' }),
         );
     });
 
     it('should throw an error for a Uitpas number with kansentarief expired', async () => {
         const expiredNumbers = ['0900000058918'];
-        await expect(UitpasService.checkUitpasNumbers(expiredNumbers)).rejects.toThrow(
+        await expect(UitpasService.checkUitpasNumbers('unexisting-org-id', expiredNumbers)).rejects.toThrow(
             STExpect.simpleError({ code: 'uitpas_number_issue' }),
         );
     });

--- a/backend/app/api/src/services/uitpas/UitpasService.ts
+++ b/backend/app/api/src/services/uitpas/UitpasService.ts
@@ -327,7 +327,7 @@ export class UitpasService {
      * @param organizationId
      * @returns clientId or empty string if not configured
      */
-    static async getClientIdFor(organizationId: string | null): Promise<string> {
+    static async getClientIdFor(organizationId: string): Promise<string> {
         // Get the uitpas client credentials for the organization
         return await UitpasTokenRepository.getClientIdFor(organizationId);
     }

--- a/backend/app/api/src/services/uitpas/UitpasService.ts
+++ b/backend/app/api/src/services/uitpas/UitpasService.ts
@@ -309,7 +309,7 @@ export class UitpasService {
 
     static async searchUitpasOrganizers(name: string): Promise<UitpasOrganizersResponse> {
         // https://docs.publiq.be/docs/uitpas/uitpas-api/reference/operations/list-organizers
-        const access_token = await UitpasTokenRepository.getAccessTokenFor(); // uses platform credentials
+        const access_token = await UitpasTokenRepository.getAccessTokenFor(null); // always use platform credentials
         return await searchUitpasOrganizers(access_token, name);
     }
 
@@ -338,9 +338,9 @@ export class UitpasService {
      * The field of the error will be the index of the uitpas number in the array.
      * @param uitpasNumbers The uitpas numbers to check
      */
-    static async checkUitpasNumbers(uitpasNumbers: string[]) {
+    static async checkUitpasNumbers(organizationId: string, uitpasNumbers: string[]) {
         // https://docs.publiq.be/docs/uitpas/uitpas-api/reference/operations/get-a-pass
-        const access_token = await UitpasTokenRepository.getAccessTokenFor(); // use platform credentials
+        const access_token = await UitpasTokenRepository.getAccessTokenForWithPlatformFallback(organizationId);
         return await checkUitpasNumbers(access_token, uitpasNumbers);
     }
 
@@ -350,7 +350,7 @@ export class UitpasService {
     static async getPassByUitpasNumber(uitpasNumber: string): Promise<GetPassResponse> {
         let access_token!: string;
         try {
-            access_token = await UitpasTokenRepository.getAccessTokenFor(); // use platform credentials
+            access_token = await UitpasTokenRepository.getAccessTokenFor(null); // always use platform credentials (for now)
         } catch (e) {
             if (isSimpleError(e) && e.hasCode('uitpas_api_not_configured_for_platform')) {
                 console.error('UiTPAS API has not been configured for this platform, so defaulting to an unknown status for number ', uitpasNumber);
@@ -387,8 +387,8 @@ export class UitpasService {
     }
 
     static async validateCart(organizationId: string, webshopId: string, cart: Cart, exisitingOrderId?: string): Promise<Cart> {
-        let access_token_org: string | null = null;
-        let access_token_platform: string | null = null;
+        let access_token: string | undefined;
+        const unofficialsToBeChecked: string[][] = [];
         for (const item of cart.items) {
             if (item.uitpasNumbers.length === 0) {
                 continue;
@@ -416,8 +416,8 @@ export class UitpasService {
                     });
                 }
 
-                access_token_org = access_token_org ?? await UitpasTokenRepository.getAccessTokenFor(organizationId);
-                const verified = await getSocialTariffForUitpasNumbers(access_token_org, item.uitpasNumbers.map(p => p.uitpasNumber), basePrice, item.product.uitpasEvent.url);
+                access_token = access_token ?? await UitpasTokenRepository.getAccessTokenFor(organizationId);
+                const verified = await getSocialTariffForUitpasNumbers(access_token, item.uitpasNumbers.map(p => p.uitpasNumber), basePrice, item.product.uitpasEvent.url);
                 if (verified.length < item.uitpasNumbers.length) {
                     throw new SimpleError({
                         code: 'uitpas_social_tariff_price_mismatch',
@@ -441,9 +441,14 @@ export class UitpasService {
                     }
                 }
             } else {
-                // non-official flow
-                access_token_platform = access_token_platform ?? await UitpasTokenRepository.getAccessTokenFor();
-                await checkUitpasNumbers(access_token_platform, item.uitpasNumbers.map(p => p.uitpasNumber));
+                // non-official flow: do all checks after official flows (for maximum token re-usage), but retaining index numbering for error reporting
+                unofficialsToBeChecked.push(item.uitpasNumbers.map(p => p.uitpasNumber));
+            }
+        }
+        if (unofficialsToBeChecked.length > 0) {
+            const token = access_token ?? await UitpasTokenRepository.getAccessTokenForWithPlatformFallback(organizationId);
+            for (const uitpasNumbers of unofficialsToBeChecked) {
+                await checkUitpasNumbers(token, uitpasNumbers);
             }
         }
         return cart;

--- a/backend/app/api/src/services/uitpas/checkPermissionsFor.ts
+++ b/backend/app/api/src/services/uitpas/checkPermissionsFor.ts
@@ -74,21 +74,22 @@ export async function checkPermissionsFor(access_token: string, organizationId: 
         });
     });
     assertIsPermissionsResponse(json);
-    const neededPermissions = !organizationId
-        ? [{
-                permission: 'PASSES_READ',
-                human: 'Basis UiTPAS informatie ophalen met UiTPAS nummer',
-            }]
-        : [{
-                permission: 'TARIFFS_READ',
-                human: 'Tarieven opvragen',
-            }, {
-                permission: 'TICKETSALES_REGISTER',
-                human: 'Ticketsales registreren',
-            }, {
-                permission: 'TICKETSALES_SEARCH',
-                human: 'Ticketsales zoeken',
-            }];
+    const neededPermissions = [{
+        permission: 'PASSES_READ',
+        human: 'Basis UiTPAS informatie ophalen met UiTPAS nummer',
+    }];
+    if (organizationId) {
+        neededPermissions.push(...[{
+            permission: 'TARIFFS_READ',
+            human: 'Tarieven opvragen',
+        }, {
+            permission: 'TICKETSALES_REGISTER',
+            human: 'Ticketsales registreren',
+        }, {
+            permission: 'TICKETSALES_SEARCH',
+            human: 'Ticketsales zoeken',
+        }]);
+    }
     const item = json.find(item => item.organizer.id === uitpasOrganizerId);
     if (!item) {
         const organizers = Formatter.joinLast(json.map(i => i.organizer.name), ', ', ' ' + $t('%1BM') + ' ');


### PR DESCRIPTION
* UitpasTokenRepository aangepast zodat in-memory blijft of een organsatie UiTPAS-credentials heeft (zodanig dat meerdere keren access token vragen voor zelfde organisatie geen db-query meer is) (**zie commit 2**)
* bij het checken van UiTPAS-nummers en het valideren van een winkelmandje proberen we de credentials van de vereniging te gebruiken. Als die er niet zijn, gebruiken we die van platform. (**zie commit 3**)
* in production zouden eens alle credentials moeten gecheckt worden of ze de juiste permissions hebben (**zie commit 1**)

```bash
TOKEN=$(curl --silent --request POST \
  --url https://account.uitid.be/oauth/token \
  --header 'Content-Type: application/json' \
  --data "{
    \"client_id\": \"$CLIENT_ID\",
    \"client_secret\": \"$CLIENT_SECRET\",
    \"grant_type\": \"client_credentials\"
  }" | jq -r '.access_token')
curl --request GET \
  --url https://api.uitpas.be/permissions \
  --header 'Accept: application/json, application/problem+json' \
  --header "Authorization: Bearer $TOKEN"
```

en het resultaat zo zou moeten zijn:

```json
[
    {
        "organizer": {
            "id": "19516706-9003-47fc-9607-44065ea0b489",
            "name": "156e FOS De Havik"
        },
        "permissions": [
            "TICKETSALES_SEARCH",
            "TARIFFS_READ",
            "PASSES_READ",
            "TICKETSALES_REGISTER",
        ]
    }
]
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786716178&installation_id=138085646&pr_number=616&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F616&signature=9c754a2f69ab11d1d500be1cd9f6033642006ea161e7789b1481054595e5bcc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->