### PR TITLE
🐛 ready label flow on PR with already done CI didn't trigger

### DIFF
--- a/.github/workflows/auto-ready.yml
+++ b/.github/workflows/auto-ready.yml
@@ -8,8 +8,7 @@ jobs:
   check_and_ready:
     name: 'Mark ready if CI already passed'
     runs-on: ubuntu-latest
-    # Only act when the specific label was just added to a draft PR
-    if: github.event.label.name == 'ready if CI succeeds' && github.event.pull_request.draft == true
+    if: github.event.label.name == 'ready if CI succeeds'
     permissions:
       contents: write
       pull-requests: write
@@ -25,10 +24,17 @@ jobs:
           STATUS=$(gh api "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&status=completed&per_page=1" \
             --jq '.workflow_runs[0].conclusion // empty')
 
-          if [ "$STATUS" = "success" ]; then
-            gh pr ready "$PR_NUMBER" || true
-            gh pr edit "$PR_NUMBER" --remove-label "ready if CI succeeds" || true
-            echo "CI already passed — marked PR #$PR_NUMBER as ready for review and removed the label"
-          else
+          if [ "$STATUS" != "success" ]; then
             echo "CI has not passed yet for $SHA (conclusion: ${STATUS:-none}). Will convert when CI completes."
+            exit 0
           fi
+
+          # CI already passed. Convert to ready-for-review if still a draft, and
+          # drop the label either way so it doesn't linger.
+          IS_DRAFT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json isDraft --jq '.isDraft')
+          if [ "$IS_DRAFT" = "true" ]; then
+            gh pr ready "$PR_NUMBER" --repo "$REPO" || true
+            echo "CI already passed — marked PR #$PR_NUMBER as ready for review"
+          fi
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "ready if CI succeeds" || true
+          echo "Removed the label from PR #$PR_NUMBER"


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786723083&installation_id=138085646&pr_number=617&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F617&signature=d6b4e31bbb2b4de8ab1987ce4f7cc0453a042bf16898445db93e3429045a5a47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->