### PR TITLE
🐛 Fixed pre-wrap for group description in RegisterItemView

### DIFF
--- a/frontend/shared/components/src/members/RegisterItemView.vue
+++ b/frontend/shared/components/src/members/RegisterItemView.vue
@@ -37,7 +37,7 @@
         </p>
 
         <template v-if="item.replaceRegistrations.length === 0">
-            <p v-if="item.group.settings.description.toString()" class="style-description-block" v-text="item.group.settings.description.toString()" />
+            <p v-if="item.group.settings.description.toString()" class="style-description-block pre-wrap" v-text="item.group.settings.description.toString()" />
             <p v-else class="style-description-block" v-text="$t('%e9', {member: item.member.patchedMember.firstName})" />
         </template>
 


### PR DESCRIPTION
fixes STA-1354

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786868753&installation_id=138085646&pr_number=622&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F622&signature=6ca23504e0ce4b19603f58400a2c330348820459583e657b84ac951c995aebaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->