### PR TITLE
Used the family platform in PlatformMember instead of Platform.shared

### DIFF
--- a/shared/structures/src/members/PlatformMember.ts
+++ b/shared/structures/src/members/PlatformMember.ts
@@ -867,7 +867,7 @@ export class PlatformMember implements ObjectWithRecords {
                 // Need permission to view financial support
                 let foundPermissions = false;
                 for (const organization of this.filterOrganizations({ currentPeriod: options?.scopeGroups ? undefined : true, groups: options?.scopeGroups })) {
-                    if (options.checkPermissions.user.permissions?.forOrganization(organization, Platform.shared)?.hasAccessRight(options.checkPermissions.level === PermissionLevel.Read ? AccessRight.MemberReadFinancialData : AccessRight.MemberWriteFinancialData)) {
+                    if (options.checkPermissions.user.permissions?.forOrganization(organization, this.platform)?.hasAccessRight(options.checkPermissions.level === PermissionLevel.Read ? AccessRight.MemberReadFinancialData : AccessRight.MemberWriteFinancialData)) {
                         foundPermissions = true;
                         break;
                     }
@@ -884,7 +884,7 @@ export class PlatformMember implements ObjectWithRecords {
                 // Need permission to view financial support
                 let foundPermissions = false;
                 for (const organization of this.filterOrganizations({ currentPeriod: options?.scopeGroups ? undefined : true, groups: options?.scopeGroups })) {
-                    if (options.checkPermissions.user.permissions?.forOrganization(organization, Platform.shared)?.hasAccessRight(AccessRight.MemberManageNRN)) {
+                    if (options.checkPermissions.user.permissions?.forOrganization(organization, this.platform)?.hasAccessRight(AccessRight.MemberManageNRN)) {
                         foundPermissions = true;
                         break;
                     }
@@ -1417,7 +1417,7 @@ export class PlatformMember implements ObjectWithRecords {
                             // Check permissions
                             // we need at least permission in one organization where this member is registered
                             for (const organization of scopedOrganizations) {
-                                const organizationPermissions = checkPermissions.user.permissions.forOrganization(organization, Platform.shared);
+                                const organizationPermissions = checkPermissions.user.permissions.forOrganization(organization, this.platform);
 
                                 if (!organizationPermissions) {
                                     continue;


### PR DESCRIPTION
PlatformFamily already carries an explicit `platform`, and PlatformMember
already exposes it via `get platform()` (used at three other call sites).
These three reads of the `Platform.shared` global were inconsistencies.

Strict no-op: every PlatformFamily construction site passes exactly the
object that `setShared()` installs -- `await Platform.getSharedStruct()` on
the backend, the PlatformManager-managed platform on the frontend.

First step towards removing the `Platform.shared` process global, which
blocks per-request tenant resolution.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787648803&installation_model_id=423362&pr_number=641&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F641&signature=6511fb1bdfa0ffdfbd47c55274e63b91e36e5eee9a09249ef0e0ea8206bae9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->