### PR TITLE
Used the member platform in the checkout instead of Platform.shared

### DIFF
--- a/shared/structures/src/members/checkout/RegisterCart.ts
+++ b/shared/structures/src/members/checkout/RegisterCart.ts
@@ -2,7 +2,6 @@ import { ArrayDecoder, AutoEncoder, field, StringDecoder } from '@simonbackx/sim
 import { isSimpleError, isSimpleErrors, SimpleError, SimpleErrors } from '@simonbackx/simple-errors';
 import type { BalanceItem } from '../../BalanceItem.js';
 import type { BundleDiscountCalculation } from '../../BundleDiscount.js';
-import { Platform } from '../../Platform.js';
 import { BalanceItemCartItem } from './BalanceItemCartItem.js';
 import type { RegisterCheckout, RegisterContext } from './RegisterCheckout.js';
 import { IDRegisterItem } from './RegisterItem.js';
@@ -381,7 +380,7 @@ export class RegisterCart {
                 continue;
             }
 
-            const platform = Platform.shared;
+            const platform = registration.member.platform;
 
             const periodId = registration.registration.group.periodId;
             const period = periodId === platform.period.id ? platform.period : (periodId === singleOrganization.period.period.id ? singleOrganization.period.period : registration.registration.group.settings.period);

--- a/shared/structures/src/members/checkout/RegisterItem.ts
+++ b/shared/structures/src/members/checkout/RegisterItem.ts
@@ -11,7 +11,7 @@ import type { GroupCategory } from '../../GroupCategory.js';
 import { GroupOption, GroupOptionMenu, GroupPrice, WaitingListType } from '../../GroupSettings.js';
 import { GroupType } from '../../GroupType.js';
 import type { Organization } from '../../Organization.js';
-import { Platform, PlatformMembershipTypeBehaviour } from '../../Platform.js';
+import { PlatformMembershipTypeBehaviour } from '../../Platform.js';
 import type { PriceBreakdown } from '../../PriceBreakdown.js';
 import type { RegistrationPeriod } from '../../RegistrationPeriod.js';
 import type { RegistrationPeriodBase } from '../../RegistrationPeriodBase.js';
@@ -697,7 +697,7 @@ export class RegisterItem implements ObjectWithRecords {
             });
 
             if (!hasGroup && !this.checkout.cart.items.find(item => item.member.id === this.member.id && item.group.defaultAgeGroupId && this.group.settings.requireDefaultAgeGroupIds.includes(item.group.defaultAgeGroupId))) {
-                const defaultAgeGroups = this.group.settings.requireDefaultAgeGroupIds.map(id => Platform.shared.config.defaultAgeGroups.find(d => d.id === id)).filter(d => !!d).map(d => d!.name);
+                const defaultAgeGroups = this.group.settings.requireDefaultAgeGroupIds.map(id => this.member.platform.config.defaultAgeGroups.find(d => d.id === id)).filter(d => !!d).map(d => d!.name);
                 return $t('%1GO', {
                     firstName: this.member.patchedMember.details.firstName,
                     aOrB: defaultAgeGroups.length > 0 ? Formatter.joinLast(defaultAgeGroups, ', ', ' ' + $t('%GT') + ' ') : $t('%1GN'),


### PR DESCRIPTION
RegisterCart.validate() iterates `deleteRegistrations`, which is typed
`RegistrationWithPlatformMember[]`, and RegisterItem holds a `member:
PlatformMember`. Both therefore already have a PlatformMember in scope,
whose `.platform` is the explicitly-provided platform for that family.

Strict no-op: PlatformFamily is always constructed with the same object
`setShared()` installs, so `member.platform === Platform.shared` today.

Also drops the now-unused `Platform` imports from both files.

Continues removing the `Platform.shared` process global, which blocks
per-request tenant resolution.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787649314&installation_model_id=423362&pr_number=642&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F642&signature=e1c4faafa8e9ccdb665bc1adcb59be10986438ffc3326a26062c60f9e9f7906e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->