### PR TITLE
Passed the platform into Event.getEventNotificationTypes

### DIFF
--- a/frontend/shared/components/src/events/EventOverview.vue
+++ b/frontend/shared/components/src/events/EventOverview.vue
@@ -152,7 +152,7 @@
                                 </STListItem>
 
                                 <template v-if="eventOrganization">
-                                    <EventNotificationRow v-for="type of event.eventNotificationTypes" :key="type.id" class="container" :type="type" :event="event" :organization="eventOrganization" />
+                                    <EventNotificationRow v-for="type of event.getEventNotificationTypes(platform)" :key="type.id" class="container" :type="type" :event="event" :organization="eventOrganization" />
                                 </template>
                             </STList>
                         </div>

--- a/shared/structures/src/Event.ts
+++ b/shared/structures/src/Event.ts
@@ -142,8 +142,8 @@ export class Event extends AutoEncoder {
         return queue;
     }
 
-    get eventNotificationTypes() {
-        return Platform.shared.config.eventNotificationTypes.filter(t => t.eventTypeIds.includes(this.typeId));
+    getEventNotificationTypes(platform: Platform) {
+        return platform.config.eventNotificationTypes.filter(t => t.eventTypeIds.includes(this.typeId));
     }
 
     static decodeField(...args: Parameters<typeof AutoEncoder.decode>) {


### PR DESCRIPTION
Turned the `eventNotificationTypes` getter into a method taking an explicit
platform. It had exactly one consumer (EventOverview.vue), which already
has `usePlatform()` in scope; every other read of
`config.eventNotificationTypes` in the codebase already goes through an
explicit platform.

Strict no-op: the single caller passes the PlatformManager-managed
platform, which is the same object `setShared()` installs.

Continues removing the `Platform.shared` process global, which blocks
per-request tenant resolution.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787649609&installation_model_id=423362&pr_number=644&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F644&signature=cea9bbfbdfe46fc87ab41175afa93bf1950b946a04e57fdef81db4686b2bba36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->