### PR TITLE
Passed the platform into MemberAdmin.getResponsibilities

### DIFF
--- a/frontend/shared/components/src/admins/InternalAdminsBox.vue
+++ b/frontend/shared/components/src/admins/InternalAdminsBox.vue
@@ -38,7 +38,7 @@
                 {{ member.users.map(u => u.email).join(', ') }}
             </p>
             <p class="style-description-small">
-                {{ Formatter.joinLast(member.getResponsibilities(organization), ', ', ' en ') }}
+                {{ Formatter.joinLast(member.getResponsibilities(organization, platform), ', ', ' en ') }}
             </p>
 
             <template #right>
@@ -65,6 +65,7 @@ import { AsyncComponent } from '#containers/AsyncComponent.ts';
 import PromiseView from '#containers/PromiseView.vue';
 import { useMembersObjectFetcher } from '#fetchers/useMembersObjectFetcher.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
+import { usePlatform } from '#hooks/usePlatform.ts';
 import { useUser } from '#hooks/useUser.ts';
 import type { MemberAdmin, PlatformMember } from '@stamhoofd/structures';
 import { LimitedFilteredRequest } from '@stamhoofd/structures';
@@ -74,6 +75,7 @@ import { useAdmins } from './hooks/useAdmins';
 
 const me = useUser();
 const organization = useOrganization();
+const platform = usePlatform();
 const { memberHasFullAccess, memberHasNoRoles, sortedMembers } = useAdmins();
 const MAX_VISIBLE_DEFAULT = 5;
 const searchQuery = ref('');

--- a/shared/structures/src/MemberAdmin.ts
+++ b/shared/structures/src/MemberAdmin.ts
@@ -1,6 +1,6 @@
 import type { MemberResponsibilityRecordBase } from './members/MemberResponsibilityRecord.js';
 import type { Organization } from './Organization.js';
-import { Platform } from './Platform.js';
+import type { Platform } from './Platform.js';
 import type { User } from './User.js';
 
 export class MemberAdmin {
@@ -19,7 +19,7 @@ export class MemberAdmin {
         return withName ? withName.name : this.users[0].email;
     }
 
-    getResponsibilities(organization: Organization | null) {
+    getResponsibilities(organization: Organization | null, platform: Platform) {
         const responsibilities = new Map<string, MemberResponsibilityRecordBase>();
 
         for (const user of this.users) {
@@ -40,7 +40,7 @@ export class MemberAdmin {
                 }
             }
 
-            const name = Platform.shared.config.responsibilities.find(res => res.id === r.responsibilityId)?.name;
+            const name = platform.config.responsibilities.find(res => res.id === r.responsibilityId)?.name;
             if (name) {
                 return [name];
             }


### PR DESCRIPTION
The method already receives the organization it should resolve
responsibilities against; it now receives the platform the same way
instead of reaching for the `Platform.shared` global. It has exactly one
caller (InternalAdminsBox.vue), which gains `usePlatform()`.

Strict no-op: the caller passes the PlatformManager-managed platform,
which is the same object `setShared()` installs.

Continues removing the `Platform.shared` process global, which blocks
per-request tenant resolution.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787649915&installation_model_id=423362&pr_number=645&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F645&signature=7a4fcc4cea7dcbca35bdd97e2377969b861e980e4be4b8f3f50d445ee89d7cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->