### PR TITLE
Constructed PlatformFamily from usePlatform() instead of Platform.shared

### DIFF
--- a/frontend/shared/components/src/groups/EditGroupView.vue
+++ b/frontend/shared/components/src/groups/EditGroupView.vue
@@ -780,7 +780,7 @@ import type { AutoEncoderPatchType, PartialWithoutMethods, PatchableArrayAutoEnc
 import { PatchableArray } from '@simonbackx/simple-encoding';
 import { useNavigate, usePop, usePresent } from '@simonbackx/vue-app-navigation';
 import type { DefaultAgeGroup, Image, MemberProperty, RecordCategory } from '@stamhoofd/structures';
-import { BooleanStatus, getGroupStatusName, Group, GroupGenderType, GroupOption, GroupOptionMenu, GroupPrice, GroupPrivateSettings, GroupSettings, GroupStatus, GroupType, LimitedFilteredRequest, MemberDetails, MemberWithRegistrationsBlob, Organization, OrganizationRecordsConfiguration, OrganizationRegistrationPeriod, Platform, PlatformFamily, PlatformMember, RegisterItem, ResolutionFit, ResolutionRequest, TranslatedString, WaitingListType } from '@stamhoofd/structures';
+import { BooleanStatus, getGroupStatusName, Group, GroupGenderType, GroupOption, GroupOptionMenu, GroupPrice, GroupPrivateSettings, GroupSettings, GroupStatus, GroupType, LimitedFilteredRequest, MemberDetails, MemberWithRegistrationsBlob, Organization, OrganizationRecordsConfiguration, OrganizationRegistrationPeriod, PlatformFamily, PlatformMember, RegisterItem, ResolutionFit, ResolutionRequest, TranslatedString, WaitingListType } from '@stamhoofd/structures';
 import { Country } from '@stamhoofd/types/Country';
 import { Formatter, StringCompare } from '@stamhoofd/utility';
 import { computed, onMounted, ref } from 'vue';
@@ -1763,7 +1763,7 @@ function getAgeGroupSelectionText(ageGroup: DefaultAgeGroup) {
 const getRegisterItemFilterBuilders = useRegisterItemFilterBuilders();
 
 const family = new PlatformFamily({
-    platform: Platform.shared,
+    platform: platform.value,
     contextOrganization: organization.value,
 });
 

--- a/frontend/shared/components/src/records/RecordsConfigurationView.vue
+++ b/frontend/shared/components/src/records/RecordsConfigurationView.vue
@@ -64,8 +64,9 @@ import { useAppContext } from '#context/appContext.ts';
 import { useErrors } from '#errors/useErrors.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import { usePatch } from '#hooks/usePatch.ts';
+import { usePlatform } from '#hooks/usePlatform.ts';
 import type { PropertyFilter, RecordCategory } from '@stamhoofd/structures';
-import { BooleanStatus, MemberDetails, MemberWithRegistrationsBlob, OrganizationRecordsConfiguration, Platform, PlatformFamily, PlatformMember } from '@stamhoofd/structures';
+import { BooleanStatus, MemberDetails, MemberWithRegistrationsBlob, OrganizationRecordsConfiguration, PlatformFamily, PlatformMember } from '@stamhoofd/structures';
 import { computed, ref } from 'vue';
 import { usePlatformMemberFilterBuilders } from '../filters/filter-builders/members';
 import { RecordEditorSettings, RecordEditorType } from './RecordEditorSettings';
@@ -91,12 +92,13 @@ const pop = usePop();
 const { patch, patched, addPatch, hasChanges } = usePatch(props.recordsConfiguration);
 
 const organization = useOrganization();
+const platform = usePlatform();
 const app = useAppContext();
 const getPlatformMemberFilterBuilders = usePlatformMemberFilterBuilders();
 
 const settings = computed(() => {
     const family = new PlatformFamily({
-        platform: Platform.shared,
+        platform: platform.value,
         contextOrganization: organization.value,
     });
     const ss = new RecordEditorSettings({

--- a/frontend/shared/components/src/records/components/InheritedRecordsConfigurationBox.vue
+++ b/frontend/shared/components/src/records/components/InheritedRecordsConfigurationBox.vue
@@ -84,8 +84,9 @@ import { propertyFilterToString } from '#filters/UIFilter.ts';
 import { useEmitPatch } from '#hooks/useEmitPatch.ts';
 import { useFinancialSupportSettings } from '#groups/hooks/useFinancialSupportSettings.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
+import { usePlatform } from '#hooks/usePlatform.ts';
 import type { MemberPropertyWithFilter, Organization, OrganizationRecordsConfiguration, PatchAnswers, RecordCategory } from '@stamhoofd/structures';
-import { BooleanStatus, MemberDetails, MemberWithRegistrationsBlob, Platform, PlatformFamily, PlatformMember, PropertyFilter } from '@stamhoofd/structures';
+import { BooleanStatus, MemberDetails, MemberWithRegistrationsBlob, PlatformFamily, PlatformMember, PropertyFilter } from '@stamhoofd/structures';
 import { computed, ref, watchEffect } from 'vue';
 import { getMemberFilterBuildersForInheritedRecords } from '../../filters/filter-builders/members';
 
@@ -110,13 +111,14 @@ const { patched, addPatch } = useEmitPatch<OrganizationRecordsConfiguration>(pro
 
 const baseOrg = useOrganization();
 const organization = computed(() => props.overrideOrganization ?? baseOrg.value);
+const platform = usePlatform();
 const present = usePresent();
 const filterBuilders = getMemberFilterBuildersForInheritedRecords();
 const filterBuilder = filterBuilders[0];
 const { financialSupportSettings } = useFinancialSupportSettings();
 
 const family = new PlatformFamily({
-    platform: Platform.shared,
+    platform: platform.value,
     contextOrganization: organization.value,
 });
 


### PR DESCRIPTION
The three components that build a PlatformFamily for the record editor
passed the `Platform.shared` global. They now pass the
PlatformManager-managed platform via `usePlatform()`, like every other
PlatformFamily construction site already does.

This matters more than the earlier steps in this series: PlatformMember
and the checkout now read `family.platform`, so these construction sites
are what determine which platform that logic sees.

No behaviour change. The value is the same object today, and reactivity is
unchanged -- EditGroupView and InheritedRecordsConfigurationBox build the
family once in setup, exactly as before. In RecordsConfigurationView the
construction already sat inside a computed, so it now also tracks platform
changes, which it previously could not.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787650269&installation_model_id=423362&pr_number=646&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F646&signature=4db514ea63f6a5ed7ce6b0bb308419ca45cc9338a5862c40ecb87e01dd3ae582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->