### PR TITLE
Broke the Platform <-> RegistrationPeriod import cycle

### DIFF
--- a/shared/structures/src/Platform.ts
+++ b/shared/structures/src/Platform.ts
@@ -12,6 +12,16 @@ import { DataPermissionsSettings, FinancialSupportSettings, OrganizationRecordsC
 import { OrganizationEmail } from './OrganizationEmail.js';
 import { OrganizationLevelRecordsConfiguration } from './OrganizationLevelRecordsConfiguration.js';
 import { PermissionRoleDetailed } from './PermissionRole.js';
+import { PlatformMembershipTypeBehaviour } from './PlatformMembershipTypeBehaviour.js';
+
+/**
+ * Re-exported so `export * from './Platform.js'` in index.ts keeps exposing it to consumers of
+ * @stamhoofd/structures. Import it from './PlatformMembershipTypeBehaviour.js' directly inside this
+ * package when the importing module must not depend on Platform.ts -- Platform.ts sits in a value
+ * import cycle with RegistrationPeriod, BundleDiscount and RegisterItem, so pulling it in from one
+ * of those modules reintroduces the cycle.
+ */
+export { PlatformMembershipTypeBehaviour } from './PlatformMembershipTypeBehaviour.js';
 import { ReduceablePrice } from './ReduceablePrice.js';
 import { RegistrationPeriod } from './RegistrationPeriod.js';
 import { RichText } from './RichText.js';
@@ -240,18 +250,6 @@ export class PlatformMembershipTypeConfig extends AutoEncoder {
     get name() {
         return Formatter.dateRange(this.startDate, this.endDate);
     }
-}
-
-export enum PlatformMembershipTypeBehaviour {
-    /**
-     * A membership that is valid for a certain period
-     */
-    Period = 'Period',
-
-    /**
-     * A membership that is valid for a certain number of days
-     */
-    Days = 'Days',
 }
 
 export class PlatformMembershipType extends AutoEncoder {

--- a/shared/structures/src/PlatformMembershipTypeBehaviour.ts
+++ b/shared/structures/src/PlatformMembershipTypeBehaviour.ts
@@ -1,0 +1,19 @@
+/**
+ * Lives in its own module rather than in Platform.ts to keep it importable without pulling in
+ * Platform.ts. Platform.ts sits in an import cycle
+ * (Platform -> RegistrationPeriod -> BundleDiscount -> RegisterItem), and every edge of that cycle
+ * is a real value dependency: `@field` decoders in Platform.ts and RegistrationPeriod.ts, and
+ * `instanceof RegisterItem` in BundleDiscount.ts. RegisterItem only ever needed this enum, so
+ * importing it from here is what keeps the cycle broken -- see the comment in Platform.ts.
+ */
+export enum PlatformMembershipTypeBehaviour {
+    /**
+     * A membership that is valid for a certain period
+     */
+    Period = 'Period',
+
+    /**
+     * A membership that is valid for a certain number of days
+     */
+    Days = 'Days',
+}

--- a/shared/structures/src/members/checkout/RegisterItem.ts
+++ b/shared/structures/src/members/checkout/RegisterItem.ts
@@ -11,7 +11,7 @@ import type { GroupCategory } from '../../GroupCategory.js';
 import { GroupOption, GroupOptionMenu, GroupPrice, WaitingListType } from '../../GroupSettings.js';
 import { GroupType } from '../../GroupType.js';
 import type { Organization } from '../../Organization.js';
-import { PlatformMembershipTypeBehaviour } from '../../Platform.js';
+import { PlatformMembershipTypeBehaviour } from '../../PlatformMembershipTypeBehaviour.js';
 import type { PriceBreakdown } from '../../PriceBreakdown.js';
 import type { RegistrationPeriod } from '../../RegistrationPeriod.js';
 import type { RegistrationPeriodBase } from '../../RegistrationPeriodBase.js';


### PR DESCRIPTION
shared/structures had one import cycle, and every edge of it was a real
value dependency:

    Platform -> RegistrationPeriod -> BundleDiscount -> RegisterItem -> Platform

Platform.ts and RegistrationPeriod.ts need each other's classes as `@field`
decoders at class-definition time, and BundleDiscount does `instanceof
RegisterItem`. So whenever the module graph is entered at RegistrationPeriod
first, Platform.ts evaluates `@field({ decoder: RegistrationPeriod })` while
RegistrationPeriod is still in its temporal dead zone:

    ReferenceError: Cannot access 'RegistrationPeriod' before initialization

RegisterItem only ever needed PlatformMembershipTypeBehaviour from
Platform.ts, so that enum moves to its own leaf module and RegisterItem
imports it from there. Platform.ts re-exports it, so `export * from
'./Platform.js'` in index.ts keeps the public API of @stamhoofd/structures
unchanged.

This was already broken: `cd frontend/shared/components && yarn vitest run`
fails all 23 suites on main and passes with this change. CI happened to get
a working module order, but the ordering is incidental -- making a
`Platform` import type-only anywhere causes tsc to elide it, which reorders
evaluation and surfaces the error. That is what broke #644.

Verified by analysing the emitted js in shared/structures/dist (so type-only
imports are already elided): 1 cycle before, 0 after.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787727888&installation_model_id=423362&pr_number=648&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F648&signature=65f327022df6c880185efa5e4944fec126bcca98d04f31eaf6dfe11f007c5256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->