### PR TITLE
Passed the platform into the member column helpers

### DIFF
--- a/frontend/shared/components/src/members/classes/getSelectablePdfData.ts
+++ b/frontend/shared/components/src/members/classes/getSelectablePdfData.ts
@@ -1,7 +1,7 @@
 import type { SelectableColumn } from '@stamhoofd/frontend-excel-export/SelectableColumn';
 import type { ContextPermissions } from '@stamhoofd/networking/ContextPermissions';
-import type { EmergencyContact, Group, Organization, Parent, PlatformMember, RecordSettings } from '@stamhoofd/structures';
-import { AccessRight, getFinancialSupportSettingsOrDefault, getGenderName, GroupType, ParentTypeHelper, Platform, RecordCategory, RecordCheckboxAnswer, RecordChooseOneAnswer, RecordMultipleChoiceAnswer, RecordType } from '@stamhoofd/structures';
+import type { EmergencyContact, Group, Organization, Parent, Platform, PlatformMember, RecordSettings } from '@stamhoofd/structures';
+import { AccessRight, getFinancialSupportSettingsOrDefault, getGenderName, GroupType, ParentTypeHelper, RecordCategory, RecordCheckboxAnswer, RecordChooseOneAnswer, RecordMultipleChoiceAnswer, RecordType } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { SelectablePdfData } from '../../export/SelectablePdfData';
 
@@ -191,7 +191,7 @@ export function getSelectablePdfData({ platform, organization, auth, groupColumn
                                     );
                                     const defaultAgeGroups = defaultAgeGroupIds.map(
                                         o =>
-                                            Platform.shared.config.defaultAgeGroups.find(
+                                            platform.config.defaultAgeGroups.find(
                                                 g => g.id === o.group.defaultAgeGroupId,
                                             )?.name ?? $t(`%wJ`),
                                     );

--- a/frontend/shared/components/src/members/helpers/getRegistrationColumns.ts
+++ b/frontend/shared/components/src/members/helpers/getRegistrationColumns.ts
@@ -1,12 +1,12 @@
 import { Column } from '#tables/classes/Column.ts';
 import type { ContextPermissions } from '@stamhoofd/networking/ContextPermissions';
-import type { AppType, Group, GroupCategoryTree, Organization, PlatformRegistration, RecordAnswer, RegisterItemOption } from '@stamhoofd/structures';
-import { ContinuousMembershipStatus, getGroupTypeName, GroupType, MembershipStatus, PermissionLevel, Platform } from '@stamhoofd/structures';
+import type { AppType, Group, GroupCategoryTree, Organization, Platform, PlatformRegistration, RecordAnswer, RegisterItemOption } from '@stamhoofd/structures';
+import { ContinuousMembershipStatus, getGroupTypeName, GroupType, MembershipStatus, PermissionLevel } from '@stamhoofd/structures';
 import { Formatter, Sorter } from '@stamhoofd/utility';
 
 type ObjectType = PlatformRegistration;
 
-export function getRegistrationColumns({ organization, dateRange, group, groups, filterPeriodId, auth, category, app, waitingList, financialRead }: { organization: Organization | null; dateRange?: { start: Date; end: Date } | null; group?: Group | null; groups: Group[]; filterPeriodId: string; periodId?: string | null; auth: ContextPermissions; category?: GroupCategoryTree | null; app: AppType | 'auto'; waitingList: boolean | null; financialRead: boolean }) {
+export function getRegistrationColumns({ platform, organization, dateRange, group, groups, filterPeriodId, auth, category, app, waitingList, financialRead }: { platform: Platform; organization: Organization | null; dateRange?: { start: Date; end: Date } | null; group?: Group | null; groups: Group[]; filterPeriodId: string; periodId?: string | null; auth: ContextPermissions; category?: GroupCategoryTree | null; app: AppType | 'auto'; waitingList: boolean | null; financialRead: boolean }) {
     const isPlatform = STAMHOOFD.userMode === 'platform';
 
     const allColumns: (Column<ObjectType, any> | null)[] = [
@@ -576,7 +576,7 @@ export function getRegistrationColumns({ organization, dateRange, group, groups,
                     if (!g) {
                         return $t('%1FW');
                     }
-                    return Platform.shared.config.defaultAgeGroups.find(a => a.id === g)?.name.toString() || $t('%Gr');
+                    return platform.config.defaultAgeGroups.find(a => a.id === g)?.name.toString() || $t('%Gr');
                 },
                 getStyle: g => !g ? 'gray' : '',
                 minimumWidth: 100,

--- a/frontend/shared/components/src/registrations/RegistrationsTableView.vue
+++ b/frontend/shared/components/src/registrations/RegistrationsTableView.vue
@@ -312,6 +312,7 @@ const { sgvSyncOpen, sgvSyncWarning } = useSGVSync(
 );
 
 const allColumns: Column<ObjectType, any>[] = getRegistrationColumns({
+    platform: platform.value,
     dateRange: props.dateRange,
     group: props.group,
     periodId: props.periodId,


### PR DESCRIPTION
Part of removing every read of the `Platform.shared` process-global singleton
from the codebase, so the platform/tenant always arrives as an explicit value.

`getSelectablePdfData` already received a `platform` parameter and already used
it for the record categories and the financial support settings, so the
`Platform.shared` read for the default age groups was a plain inconsistency.

`getRegistrationColumns` gains a required `platform` parameter. Its single
caller, RegistrationsTableView, already had a `usePlatform()` ref in scope.

Strict no-op: `usePlatform()` resolves to `PlatformManager.$platform`, which is
the same object `Platform.shared` returns (PlatformManager calls `setShared()`
on it).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787729618&installation_model_id=423362&pr_number=649&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F649&signature=9ff92fbd592a34a10de47632356890ca46024f0648d887838bd11ede7137713b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->