### PR TITLE
Passed the platform into manualFeatureFlag

### DIFF
--- a/frontend/app/admin/src/App.vue
+++ b/frontend/app/admin/src/App.vue
@@ -177,7 +177,7 @@ function getRoot() {
             }
 
             if (isPlatform) {
-                if (platformManager.value.$platform.config.eventTypes.length > 0 && !manualFeatureFlag('disable-events', context.value)) {
+                if (platformManager.value.$platform.config.eventTypes.length > 0 && !manualFeatureFlag('disable-events', context.value, platformManager.value.$platform)) {
                     tabs.push(calendarTab);
                 }
             }
@@ -200,7 +200,7 @@ function getRoot() {
                 }
             }
 
-            if (manualFeatureFlag('event-notifications', context.value) && context.value.auth.hasAccessRightForSomeResourceOfType(PermissionsResourceType.OrganizationTags, AccessRight.OrganizationEventNotificationReviewer)) {
+            if (manualFeatureFlag('event-notifications', context.value, platformManager.value.$platform) && context.value.auth.hasAccessRightForSomeResourceOfType(PermissionsResourceType.OrganizationTags, AccessRight.OrganizationEventNotificationReviewer)) {
                 // Feature is still in development so not visible for everyone
                 moreTab.items.push(eventNotificationsTab);
             }

--- a/frontend/app/dashboard/src/App.vue
+++ b/frontend/app/dashboard/src/App.vue
@@ -241,7 +241,7 @@ function getRoot() {
             if (organization?.meta.packages.useMembers) {
                 tabs.push(membersTab);
 
-                if (!manualFeatureFlag('disable-events', context.value) && organization.meta.enableCalendar !== false) {
+                if (!manualFeatureFlag('disable-events', context.value, platformManager.value.$platform) && organization.meta.enableCalendar !== false) {
                     const eventTypes = getEventTypes({ platform: platformManager.value.$platform, organization });
                     if (eventTypes.length > 0) {
                         tabs.push(calendarTab);

--- a/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderActionBuilder.ts
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderActionBuilder.ts
@@ -11,7 +11,7 @@ import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 import type { TableAction, TableActionSelection } from '@stamhoofd/components/tables/classes/TableAction.ts';
 import { AsyncTableAction, InMemoryTableAction, MenuTableAction } from '@stamhoofd/components/tables/classes/TableAction.ts';
 import type { OrganizationManager } from '@stamhoofd/networking/OrganizationManager';
-import type { ExcelWorkbookFilter, PrivateOrderWithTickets } from '@stamhoofd/structures';
+import type { ExcelWorkbookFilter, Platform, PrivateOrderWithTickets } from '@stamhoofd/structures';
 import { EmailRecipientSubfilter, OrderStatus, OrderStatusHelper, Payment, PaymentGeneral, PaymentMethod, PaymentStatus, PrivateOrder, TicketPrivate } from '@stamhoofd/structures';
 import { EmailRecipientFilterType } from '@stamhoofd/structures/email/EmailRecipientFilterType.js';
 import type { WebshopManager } from '../WebshopManager';
@@ -20,6 +20,7 @@ import { OrderRequiredFilterHelper } from './OrderRequiredFilterHelper';
 export class OrderActionBuilder {
     webshopManager: WebshopManager;
     organizationManager: OrganizationManager;
+    platform: Platform;
 
     present: ReturnType<typeof usePresent>;
 
@@ -27,10 +28,12 @@ export class OrderActionBuilder {
         present: ReturnType<typeof usePresent>;
         webshopManager: WebshopManager;
         organizationManager: OrganizationManager;
+        platform: Platform;
     }) {
         this.present = settings.present;
         this.webshopManager = settings.webshopManager;
         this.organizationManager = settings.organizationManager;
+        this.platform = settings.platform;
     }
 
     getStatusActions(): TableAction<PrivateOrder>[] {
@@ -335,7 +338,7 @@ export class OrderActionBuilder {
 
         const { getSelectableWorkbook } = await import('./excel/getSelectableWorkbook');
 
-        if (!manualFeatureFlag('webshop-orders-excel-export-ui', this.organizationManager.$context)) {
+        if (!manualFeatureFlag('webshop-orders-excel-export-ui', this.organizationManager.$context, this.platform)) {
             // Export immediately with all columns and sheets, without the settings UI
             // (same behaviour as before the settings UI existed, so without the tickets sheet)
             const { exportOrdersToExcel } = await import('./excel/exportOrdersToExcel');

--- a/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/orders/OrderView.vue
@@ -329,6 +329,7 @@ import EmailAddress from '@stamhoofd/components/email/EmailAddress.vue';
 import { GlobalEventBus } from '@stamhoofd/components/EventBus.ts';
 import { useAuth } from '@stamhoofd/components/hooks/useAuth.ts';
 import { useBackForward } from '@stamhoofd/components/hooks/useBackForward.ts';
+import { usePlatform } from '@stamhoofd/components/hooks/usePlatform.ts';
 import STList from '@stamhoofd/components/layout/STList.vue';
 import STListItem from '@stamhoofd/components/layout/STListItem.vue';
 import STNavigationBar from '@stamhoofd/components/navigation/STNavigationBar.vue';
@@ -362,6 +363,7 @@ const props = withDefaults(defineProps<{
 const present = usePresent();
 const pop = usePop();
 const organizationManager = useOrganizationManager();
+const platform = usePlatform();
 
 const { hasNext, hasPrevious, goBack, goForward } = useBackForward('initialOrder', props);
 
@@ -480,6 +482,7 @@ const actionBuilder = new OrderActionBuilder({
     present: usePresent(),
     organizationManager: organizationManager.value,
     webshopManager: props.webshopManager,
+    platform: platform.value,
 });
 
 const statusName = computed(() => {

--- a/frontend/app/dashboard/src/views/dashboard/webshop/orders/WebshopOrdersView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/orders/WebshopOrdersView.vue
@@ -24,6 +24,7 @@ import { GlobalEventBus } from '@stamhoofd/components/EventBus.ts';
 import { getWebshopOrderUIFilterBuilders } from '@stamhoofd/components/filters/filter-builders/orders.ts';
 import type { UIFilterBuilders } from '@stamhoofd/components/filters/UIFilter.ts';
 import { useIsMobile } from '@stamhoofd/components/hooks/useIsMobile.ts';
+import { usePlatform } from '@stamhoofd/components/hooks/usePlatform.ts';
 import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 import { Column } from '@stamhoofd/components/tables/classes/Column.ts';
 import { InMemoryTableAction } from '@stamhoofd/components/tables/classes/TableAction.ts';
@@ -60,6 +61,7 @@ const show = useShow();
 const present = usePresent();
 const isMobile = useIsMobile();
 const requestOwner = useRequestOwner();
+const platform = usePlatform();
 
 const preview = computed(() => props.webshopManager.preview);
 const hasSingleTickets = computed(() => preview.value.hasSingleTickets);
@@ -79,6 +81,7 @@ const actions = computed(() => {
         present,
         organizationManager: organizationManager.value,
         webshopManager: props.webshopManager,
+        platform: platform.value,
     });
 
     const results = [

--- a/frontend/app/dashboard/src/views/dashboard/webshop/tickets/status/ValidTicketView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/tickets/status/ValidTicketView.vue
@@ -373,6 +373,7 @@ import { AsyncComponent } from '@stamhoofd/components/containers/AsyncComponent.
 import { GlobalEventBus } from '@stamhoofd/components/EventBus.ts';
 import { useAuth } from '@stamhoofd/components/hooks/useAuth.ts';
 import { useContext } from '@stamhoofd/components/hooks/useContext.ts';
+import { usePlatform } from '@stamhoofd/components/hooks/usePlatform.ts';
 import STList from '@stamhoofd/components/layout/STList.vue';
 import STListItem from '@stamhoofd/components/layout/STListItem.vue';
 import STNavigationBar from '@stamhoofd/components/navigation/STNavigationBar.vue';
@@ -410,6 +411,7 @@ const pop = usePop();
 const canPop = useCanPop();
 const context = useContext();
 const organizationManager = useOrganizationManager();
+const platform = usePlatform();
 
 const webshop = computed(() => props.webshopManager.webshop);
 props.webshopManager.loadWebshopIfNeeded(false, true).catch(console.error);
@@ -446,6 +448,7 @@ const actionBuilder = computed(() => new OrderActionBuilder({
     present: usePresent(),
     organizationManager: organizationManager.value,
     webshopManager: props.webshopManager,
+    platform: platform.value,
 }));
 
 const statusName = computed(() => OrderStatusHelper.getName(props.order.status));

--- a/frontend/shared/components/src/hooks/useEventsEnabled.ts
+++ b/frontend/shared/components/src/hooks/useEventsEnabled.ts
@@ -4,6 +4,7 @@ import { useContext } from './useContext';
 import { useEventTypes } from './useEventTypes';
 import { manualFeatureFlag } from './useFeatureFlag';
 import { useOrganization } from './useOrganization';
+import { usePlatform } from './usePlatform';
 
 /**
  * Whether the events/calendar feature should be shown for the current context.
@@ -17,13 +18,14 @@ export function useEventsEnabled(): ComputedRef<boolean> {
     const eventTypes = useEventTypes();
     const context = useContext();
     const organization = useOrganization();
+    const platform = usePlatform();
 
     return computed(() => {
         if (eventTypes.value.length === 0) {
             return false;
         }
 
-        if (manualFeatureFlag('disable-events', context.value)) {
+        if (manualFeatureFlag('disable-events', context.value, platform.value)) {
             return false;
         }
 

--- a/frontend/shared/components/src/hooks/useFeatureFlag.ts
+++ b/frontend/shared/components/src/hooks/useFeatureFlag.ts
@@ -1,5 +1,6 @@
 import type { SessionContext } from '@stamhoofd/networking/SessionContext';
-import { Organization, OrganizationPrivateMetaData, Platform } from '@stamhoofd/structures';
+import type { Platform } from '@stamhoofd/structures';
+import { Organization, OrganizationPrivateMetaData } from '@stamhoofd/structures';
 import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 import { usePatchOrganization } from '../organizations/usePatchOrganization';
@@ -29,8 +30,8 @@ export function useFeatureFlagComputed(flag: string): ComputedRef<boolean> {
     return computed(() => getFeatureFlag(flag));
 }
 
-export function manualFeatureFlag(flag: string, context: SessionContext, organization?: Organization | null): boolean {
-    return checkFeatureFlag(flag, context, Platform.shared, organization ?? context.organization ?? null);
+export function manualFeatureFlag(flag: string, context: SessionContext, platform: Platform, organization?: Organization | null): boolean {
+    return checkFeatureFlag(flag, context, platform, organization ?? context.organization ?? null);
 }
 
 export function useSetFeatureFlag(): (flag: string, value: boolean) => Promise<void> {

--- a/frontend/shared/components/src/members/classes/getSelectablePdfData.ts
+++ b/frontend/shared/components/src/members/classes/getSelectablePdfData.ts
@@ -1,7 +1,7 @@
 import type { SelectableColumn } from '@stamhoofd/frontend-excel-export/SelectableColumn';
 import type { ContextPermissions } from '@stamhoofd/networking/ContextPermissions';
-import type { EmergencyContact, Group, Organization, Parent, PlatformMember, RecordSettings } from '@stamhoofd/structures';
-import { AccessRight, getFinancialSupportSettingsOrDefault, getGenderName, GroupType, ParentTypeHelper, Platform, RecordCategory, RecordCheckboxAnswer, RecordChooseOneAnswer, RecordMultipleChoiceAnswer, RecordType } from '@stamhoofd/structures';
+import type { EmergencyContact, Group, Organization, Parent, Platform, PlatformMember, RecordSettings } from '@stamhoofd/structures';
+import { AccessRight, getFinancialSupportSettingsOrDefault, getGenderName, GroupType, ParentTypeHelper, RecordCategory, RecordCheckboxAnswer, RecordChooseOneAnswer, RecordMultipleChoiceAnswer, RecordType } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { SelectablePdfData } from '../../export/SelectablePdfData';
 
@@ -191,7 +191,7 @@ export function getSelectablePdfData({ platform, organization, auth, groupColumn
                                     );
                                     const defaultAgeGroups = defaultAgeGroupIds.map(
                                         o =>
-                                            Platform.shared.config.defaultAgeGroups.find(
+                                            platform.config.defaultAgeGroups.find(
                                                 g => g.id === o.group.defaultAgeGroupId,
                                             )?.name ?? $t(`%wJ`),
                                     );

--- a/frontend/shared/components/src/members/helpers/getRegistrationColumns.ts
+++ b/frontend/shared/components/src/members/helpers/getRegistrationColumns.ts
@@ -1,12 +1,12 @@
 import { Column } from '#tables/classes/Column.ts';
 import type { ContextPermissions } from '@stamhoofd/networking/ContextPermissions';
-import type { AppType, Group, GroupCategoryTree, Organization, PlatformRegistration, RecordAnswer, RegisterItemOption } from '@stamhoofd/structures';
-import { ContinuousMembershipStatus, getGroupTypeName, GroupType, MembershipStatus, PermissionLevel, Platform } from '@stamhoofd/structures';
+import type { AppType, Group, GroupCategoryTree, Organization, Platform, PlatformRegistration, RecordAnswer, RegisterItemOption } from '@stamhoofd/structures';
+import { ContinuousMembershipStatus, getGroupTypeName, GroupType, MembershipStatus, PermissionLevel } from '@stamhoofd/structures';
 import { Formatter, Sorter } from '@stamhoofd/utility';
 
 type ObjectType = PlatformRegistration;
 
-export function getRegistrationColumns({ organization, dateRange, group, groups, filterPeriodId, auth, category, app, waitingList, financialRead }: { organization: Organization | null; dateRange?: { start: Date; end: Date } | null; group?: Group | null; groups: Group[]; filterPeriodId: string; periodId?: string | null; auth: ContextPermissions; category?: GroupCategoryTree | null; app: AppType | 'auto'; waitingList: boolean | null; financialRead: boolean }) {
+export function getRegistrationColumns({ platform, organization, dateRange, group, groups, filterPeriodId, auth, category, app, waitingList, financialRead }: { platform: Platform; organization: Organization | null; dateRange?: { start: Date; end: Date } | null; group?: Group | null; groups: Group[]; filterPeriodId: string; periodId?: string | null; auth: ContextPermissions; category?: GroupCategoryTree | null; app: AppType | 'auto'; waitingList: boolean | null; financialRead: boolean }) {
     const isPlatform = STAMHOOFD.userMode === 'platform';
 
     const allColumns: (Column<ObjectType, any> | null)[] = [
@@ -576,7 +576,7 @@ export function getRegistrationColumns({ organization, dateRange, group, groups,
                     if (!g) {
                         return $t('%1FW');
                     }
-                    return Platform.shared.config.defaultAgeGroups.find(a => a.id === g)?.name.toString() || $t('%Gr');
+                    return platform.config.defaultAgeGroups.find(a => a.id === g)?.name.toString() || $t('%Gr');
                 },
                 getStyle: g => !g ? 'gray' : '',
                 minimumWidth: 100,

--- a/frontend/shared/components/src/registrations/RegistrationsTableView.vue
+++ b/frontend/shared/components/src/registrations/RegistrationsTableView.vue
@@ -312,6 +312,7 @@ const { sgvSyncOpen, sgvSyncWarning } = useSGVSync(
 );
 
 const allColumns: Column<ObjectType, any>[] = getRegistrationColumns({
+    platform: platform.value,
     dateRange: props.dateRange,
     group: props.group,
     periodId: props.periodId,


### PR DESCRIPTION
Part of removing every read of the `Platform.shared` process-global singleton
from the codebase, so the platform/tenant always arrives as an explicit value.

`manualFeatureFlag` is the non-composable variant of `useFeatureFlag`, so it
cannot reach for `usePlatform()` itself and read the singleton instead. It now
takes the platform as a required parameter, placed after `context` to match the
parameter order of the `checkFeatureFlag` it delegates to, and to keep the
optional `organization` last.

Four of the five call sites already had a platform in scope. The fifth,
OrderActionBuilder, is a plain class, so it gains a `platform` field like
MemberActionBuilder already has, passed in from its three construction sites.

Strict no-op: `usePlatform()` and `platformManager.$platform` are the same object
`Platform.shared` returns, and `PlatformManager.forceUpdate` refreshes it with
`deepSet`, mutating in place rather than replacing the reference. Holding it in
a field is therefore equivalent to reading the singleton at call time.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787730537&installation_model_id=423362&pr_number=650&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F650&signature=99110446f710f4c64d779065e30fe8d3e02e51590cce02c760800dcb90ac4e85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->