### PR TITLE
Used the ContextPermissions platform instead of Platform.shared

### DIFF
--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -1,5 +1,5 @@
-import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationTag, PaymentGeneral, Permissions, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
-import { AccessRight, EventPermissionChecker, GroupType, PermissionLevel, PermissionsResourceType, Platform } from '@stamhoofd/structures';
+import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationTag, PaymentGeneral, Permissions, Platform, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
+import { AccessRight, EventPermissionChecker, GroupType, PermissionLevel, PermissionsResourceType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { toRaw, unref } from 'vue';
 
@@ -83,11 +83,11 @@ export class ContextPermissions {
         if (!this.organization) {
             return this.platformPermissions;
         }
-        return unref(this.userPermissions)?.forOrganization(this.organization, this.allowInheritingPermissions ? Platform.shared : null) ?? null;
+        return unref(this.userPermissions)?.forOrganization(this.organization, this.allowInheritingPermissions ? this.platform : null) ?? null;
     }
 
     getPermissionsForOrganization(organization: OrganizationForPermissionCalculation) {
-        return unref(this.userPermissions)?.forOrganization(organization, this.allowInheritingPermissions ? Platform.shared : null) ?? null;
+        return unref(this.userPermissions)?.forOrganization(organization, this.allowInheritingPermissions ? this.platform : null) ?? null;
     }
 
     get unloadedPermissions(): Permissions | null {


### PR DESCRIPTION
Part of removing every read of the `Platform.shared` process-global singleton
from the codebase, so the platform/tenant always arrives as an explicit value.

ContextPermissions already receives a platform as its third constructor
argument, stores it as `reactivePlatform`, exposes it through `get platform()`
and already uses it in `_platformPermissions`. These two `forOrganization`
calls were the only places in the class still reaching for the singleton.

Strict no-op: of the four construction sites, SessionContext passes
`Platform.shared` itself, `useScopedAuth` passes `usePlatform()` (the same
object), and the two remaining ones set `allowInheritingPermissions: false`,
so they pass `null` here either way.

Two incidental improvements, neither a behaviour change today:
- `get platform()` returns the raw object rather than the reactive proxy, which
  is what the class documents and what `_platformPermissions` already used, so
  both permission paths are now consistent.
- `useUninheritedPermissions` accepts a `patchedPlatform` override that these
  two lines previously ignored. It only ever runs with inheriting disabled, so
  nothing changes now, but the override would have been silently dropped if
  that ever stopped being true.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787731581&installation_model_id=423362&pr_number=651&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F651&signature=d418d9cd1f6e00eb0673ad63690a706ebe7db0ee729fbc524fdec7d6712abb94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->