### PR TITLE
Passed the platform into the unsubscribe route handler

### DIFF
--- a/frontend/app/web-app/src/useGlobalRoutes.ts
+++ b/frontend/app/web-app/src/useGlobalRoutes.ts
@@ -3,18 +3,20 @@ import { ComponentWithProperties, defineRoute, NavigationController, onCheckRout
 import { AsyncComponent } from '@stamhoofd/components/containers/AsyncComponent.ts';
 import { GlobalEventBus } from '@stamhoofd/components/EventBus.ts';
 import { useContext } from '@stamhoofd/components/hooks/useContext.ts';
+import { usePlatform } from '@stamhoofd/components/hooks/usePlatform.ts';
 import { CenteredMessage } from '@stamhoofd/components/overlays/CenteredMessage.ts';
 import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 import type { NavigationActions } from '@stamhoofd/components/types/NavigationActions.ts';
 import { NetworkManager } from '@stamhoofd/networking/NetworkManager';
-import type { PaymentGeneral } from '@stamhoofd/structures';
-import { EmailAddressSettings, PaymentStatus, Platform } from '@stamhoofd/structures';
+import type { PaymentGeneral, Platform } from '@stamhoofd/structures';
+import { EmailAddressSettings, PaymentStatus } from '@stamhoofd/structures';
 
 let didCheckGlobalRoutes = false;
 
 export function useGlobalRoutes() {
     const modalStackComponent = useModalStackComponent();
     const context = useContext();
+    const platform = usePlatform();
 
     defineRoute({
         url: 'reset-password',
@@ -111,7 +113,7 @@ export function useGlobalRoutes() {
             const type = initialQueryString.get('type') ?? 'all';
 
             if (id && token && ['all', 'marketing'].includes(type)) {
-                await unsubscribe(id, token, type as 'all' | 'marketing');
+                await unsubscribe(id, token, type as 'all' | 'marketing', platform.value);
             }
         }
 
@@ -119,7 +121,7 @@ export function useGlobalRoutes() {
     });
 }
 
-async function unsubscribe(id: string, token: string, type: 'all' | 'marketing') {
+async function unsubscribe(id: string, token: string, type: 'all' | 'marketing', platform: Platform) {
     const toast = new Toast($t(`%Ib`), 'spinner').setHide(null).show();
 
     try {
@@ -140,13 +142,13 @@ async function unsubscribe(id: string, token: string, type: 'all' | 'marketing')
         const fieldName = type === 'all' ? 'unsubscribedAll' : 'unsubscribedMarketing';
 
         if (details[fieldName]) {
-            if (!await CenteredMessage.confirm($t(`%Ic`), $t(`%Id`), $t(`%Ie`, { name: details.organization?.name ?? Platform.shared.config.name, email: details.email, complaintEmail: $t('%W') }))) {
+            if (!await CenteredMessage.confirm($t(`%Ic`), $t(`%Id`), $t(`%Ie`, { name: details.organization?.name ?? platform.config.name, email: details.email, complaintEmail: $t('%W') }))) {
                 return;
             }
 
             doUnsubscribe = false;
         } else {
-            if (!await CenteredMessage.confirm($t(`%If`), $t(`%Ig`), $t(`%Ih`, { name: details.organization?.name ?? Platform.shared.config.name, email: details.email }))) {
+            if (!await CenteredMessage.confirm($t(`%If`), $t(`%Ig`), $t(`%Ih`, { name: details.organization?.name ?? platform.config.name, email: details.email }))) {
                 return;
             }
             toast.show();


### PR DESCRIPTION
Part of removing every read of the `Platform.shared` process-global singleton
from the codebase, so the platform/tenant always arrives as an explicit value.

`unsubscribe` is a module-level function rather than a composable, so it cannot
call `usePlatform()` itself. It takes the platform as a parameter instead, read
from the `usePlatform()` ref in `useGlobalRoutes`, which runs in setup context.

Strict no-op: `usePlatform()` resolves to `PlatformManager.$platform`, the same
object `Platform.shared` returns.

This leaves SessionContext as the only remaining `Platform.shared` reader in the
frontend.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787731585&installation_model_id=423362&pr_number=652&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F652&signature=7e756b291da0eb23ac5a79c68de8e3880b0c4f195e242783b99a993c57022e5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->