### PR TITLE
Playwright test for the SSO login flow on platform accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,9 @@ jobs:
     env:
       SPACES_CI_BUCKET: stamhoofd-ci-traces
       SPACES_CI_REGION: ams3
+      # The SSO tests start a Keycloak container from the CLI. Runners ship both docker and
+      # podman, and the auto-detection prefers podman, so pin the runtime we actually verified.
+      STAMHOOFD_CONTAINER_RUNTIME: docker
     services:
       mysql:
         image: mysql:8.4@sha256:8dbcf531a03aade657e181b9cf2f1d1803ce621a1d55610cb44cb531ab7d7db6
@@ -437,6 +440,11 @@ jobs:
         certutil -N -d sql:$HOME/.pki/nssdb --empty-password
     - name: Add trusted CA certificate to NSS
       run: certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n Caddy_Local_Authority -i /usr/local/share/ca-certificates/Caddy_Local_Authority*
+    # The Playwright global setup starts a local SSO server (Keycloak) that the SSO login tests
+    # sign in on. Pull it up front so a cold registry pull cannot eat into the setup timeout.
+    # Keep the tag in sync with keycloakImage in shared/cli/src/config/shared-service-config.ts.
+    - name: Pull SSO server image
+      run: docker pull quay.io/keycloak/keycloak:26.0.7
     - name: Download shared build output
       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:

--- a/frontend/shared/components/src/auth/LoginMethodButton.vue
+++ b/frontend/shared/components/src/auth/LoginMethodButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <button class="button full" :class="primary ? 'primary' : 'secundary'" type="button" :disabled="disabled">
+    <button class="button full" :class="primary ? 'primary' : 'secundary'" type="button" :disabled="disabled" :data-testid="'login-method-button-' + provider">
         <span v-if="provider === LoginProviderType.Google" class="icon">
             <img src="@stamhoofd/assets/images/partners/icons/google.svg">
         </span>

--- a/shared/cli/README.md
+++ b/shared/cli/README.md
@@ -168,6 +168,7 @@ Run Playwright tests with:
 
 ```bash
 yarn stam test e2e                                   # full build + suite
+yarn stam test e2e --ui                              # run with interactive UI to view and pause tests
 yarn stam test e2e --grep @tag                       # only tests matching a name/tag (playwright --grep)
 yarn stam test e2e --grep @tag --skip-build          # skip build:shared + API/frontend rebuild (only test files changed)
 ```

--- a/shared/cli/README.md
+++ b/shared/cli/README.md
@@ -150,6 +150,8 @@ yarn stam sso start "https://<organization-id>.api.stamhoofd/openid/callback"
 
 The command imports a local realm with the printed client and test user.
 
+`yarn stam test e2e` starts a second Keycloak from the same `SsoService`, on its own container, port (6400) and host (`playwright-sso.stamhoofd`), with a realm that allows the `/openid/callback` of every Playwright worker. It is started and stopped by the Playwright global setup, so it never restarts the server you started for manual testing. Like the other e2e services it binds a fixed port, so only one e2e run can be up at a time.
+
 ### Tests
 
 `yarn stam test` runs `build:shared` first and only starts a MySQL container when a selected package needs one. That container runs off a data volume that persists between runs (so the data dir + migrations are reused, mapped `DB_PORT`), and it is shut down after the run. Both the container and volume are namespaced per worktree so runs don't collide:

--- a/shared/cli/src/commands/sso/start.test.ts
+++ b/shared/cli/src/commands/sso/start.test.ts
@@ -36,7 +36,7 @@ describe('SsoStart command', () => {
         expect(log).toHaveBeenCalledWith(expect.stringContaining(`Redirect URI:  ${redirectUri}`));
         expect(log).toHaveBeenCalledWith(expect.stringContaining('Client secret: stamhoofd-local-secret'));
         expect(CaddyService.reload).toHaveBeenCalledWith(createContext());
-        expect(ssoService.start).toHaveBeenCalledWith(createContext(), { redirectUri, background: false });
+        expect(ssoService.start).toHaveBeenCalledWith(createContext(), { redirectUris: [redirectUri], background: false });
     });
 
     it('starts shared services first when they are not running', async () => {
@@ -48,7 +48,7 @@ describe('SsoStart command', () => {
         await command.run();
 
         expect(startServices).toHaveBeenCalledWith(createContext(), sharedServiceDefinitions);
-        expect(ssoService.start).toHaveBeenCalledWith(createContext(), { redirectUri, background: true });
+        expect(ssoService.start).toHaveBeenCalledWith(createContext(), { redirectUris: [redirectUri], background: true });
     });
 });
 

--- a/shared/cli/src/commands/sso/start.ts
+++ b/shared/cli/src/commands/sso/start.ts
@@ -29,6 +29,6 @@ export default class SsoStart extends BaseCommand {
             await startServices(context, sharedServiceDefinitions);
         }
         await CaddyService.reload(context);
-        await ssoService.start(context, { redirectUri: args.redirectUri, background: flags.background });
+        await ssoService.start(context, { redirectUris: [args.redirectUri], background: flags.background });
     }
 }

--- a/shared/cli/src/config/shared-service-config.ts
+++ b/shared/cli/src/config/shared-service-config.ts
@@ -20,6 +20,12 @@ export const rustfsImage = 'docker.io/rustfs/rustfs:latest';
 export const corednsImage = 'docker.io/coredns/coredns:1.11.3';
 
 /**
+ * The local SSO server. Kept in sync with the image the Playwright CI job pre-pulls
+ * (.github/workflows/ci.yml).
+ */
+export const keycloakImage = 'quay.io/keycloak/keycloak:26.0.7';
+
+/**
  * The Caddy config uses the `replace_response` handler (webshop strict-dynamic CSP nonce),
  * which is not part of the stock Caddy image. We build a small custom image on demand that
  * compiles those plugins in via xcaddy, starting from the official Caddy builder + runtime

--- a/shared/cli/src/index.ts
+++ b/shared/cli/src/index.ts
@@ -8,6 +8,8 @@ export { getProjectPath } from './context/project-path.js';
 export { pruneStaleRouteManifests, removeRouteManifest, removeRouteManifestsByKind, writeRouteManifest, type CaddyRouteOptions } from './runtime/manifest-store.js';
 export type { RouteManifest } from './runtime/manifest-store.js';
 export { CaddyService } from './services/definitions/caddy-service.js';
+export { SsoService, type SsoServiceVariant } from './services/definitions/sso-service.js';
+export { ssoClientId, ssoClientSecret, ssoRealm, ssoUserEmail, ssoUserName, ssoUserPassword } from './services/sso-config.js';
 export type { CaddyRoute } from './config/caddy-config.js';
 export { CSP_NONCE_PLACEHOLDER, cspFrontendSubroutes } from './config/caddy-config.js';
 export { getContainerRuntime } from './services/docker.js';

--- a/shared/cli/src/services/definitions/sso-service.ts
+++ b/shared/cli/src/services/definitions/sso-service.ts
@@ -1,13 +1,31 @@
 import { buildDomains } from '../../config/build-config.js';
 import { buildPorts } from '../../context/ports.js';
-import { localIpv4Host, ssoInternalPort } from '../../config/shared-service-config.js';
+import { keycloakImage, localIpv4Host, ssoInternalPort } from '../../config/shared-service-config.js';
 import type { CliContext } from '../../context/create-context.js';
 import { DockerService } from '../docker-service.js';
-import { ssoAdminPassword, ssoAdminUser, writeKeycloakRealm } from '../sso-config.js';
+import { ssoAdminPassword, ssoAdminUser, ssoRealm, writeKeycloakRealm } from '../sso-config.js';
 
 type SsoStartOptions = {
-    redirectUri: string;
+    /**
+     * Every URI the client is allowed to redirect back to. Keycloak rejects the authorization
+     * request when the redirect URI the backend sends is not listed here.
+     */
+    redirectUris: string[];
     background?: boolean;
+};
+
+/**
+ * Runs a second SSO server next to the one `stam sso start` manages. The Playwright suite needs
+ * its own hostname, port, container and realm file so an e2e run never restarts (or is restarted
+ * by) the SSO server a developer started for manual testing.
+ */
+export type SsoServiceVariant = {
+    /** Suffix for the container name, e.g. 'playwright' → <instance>-keycloak-playwright */
+    name: string;
+    /** Host port the container publishes on. */
+    port: number;
+    /** Public hostname the server is reachable on (proxied by Caddy). */
+    hostname: string;
 };
 
 type SsoPrepared = {
@@ -15,21 +33,34 @@ type SsoPrepared = {
 };
 
 export class SsoService extends DockerService<SsoStartOptions, SsoPrepared> {
-    readonly key = 'sso';
-    readonly name = 'SSO';
+    readonly key: string;
+    readonly name: string;
     override readonly runQuiet = false;
 
+    constructor(private readonly variant: SsoServiceVariant | null = null) {
+        super();
+        this.key = variant ? `sso-${variant.name}` : 'sso';
+        this.name = variant ? `SSO (${variant.name})` : 'SSO';
+    }
+
     getContainer(context: CliContext): string {
-        return SsoService.container(context);
+        return SsoService.container(context, this.variant?.name);
     }
 
     getDetail(context: CliContext): string {
-        const domains = buildDomains(context);
-        return `https://${domains.sso}/dex/admin`;
+        return `https://${this.getHostname(context)}/dex/admin`;
+    }
+
+    /**
+     * The OpenID Connect issuer of the imported realm: what you configure as the issuer in the
+     * Stamhoofd SSO settings.
+     */
+    getIssuer(context: CliContext): string {
+        return `https://${this.getHostname(context)}/dex/realms/${ssoRealm}`;
     }
 
     async prepare(context: CliContext, options: SsoStartOptions): Promise<SsoPrepared> {
-        return { importDir: await writeKeycloakRealm(context, options.redirectUri) };
+        return { importDir: await writeKeycloakRealm(context, options.redirectUris, { dirName: this.variant ? `keycloak-${this.variant.name}` : undefined }) };
     }
 
     canReuse(): boolean {
@@ -37,8 +68,6 @@ export class SsoService extends DockerService<SsoStartOptions, SsoPrepared> {
     }
 
     getDockerArgs(context: CliContext, options: SsoStartOptions, prepared: SsoPrepared): string[] {
-        const domains = buildDomains(context);
-        const ports = buildPorts(context);
         const args = ['run'];
         if (options.background) {
             args.push('-d');
@@ -46,13 +75,72 @@ export class SsoService extends DockerService<SsoStartOptions, SsoPrepared> {
         else {
             args.push('--rm');
         }
-        args.push('--name', SsoService.container(context), '-p', `${localIpv4Host}:${ports.sso}:${ssoInternalPort}`, '-e', `KC_BOOTSTRAP_ADMIN_USERNAME=${ssoAdminUser}`, '-e', `KC_BOOTSTRAP_ADMIN_PASSWORD=${ssoAdminPassword}`, '-e', 'KC_HTTP_RELATIVE_PATH=/dex', '-v', `${prepared.importDir}:/opt/keycloak/data/import:ro,Z`, 'quay.io/keycloak/keycloak:26.0.7', 'start-dev', '--import-realm', '--hostname', `https://${domains.sso}/dex`, '--proxy-headers=xforwarded');
+        args.push('--name', this.getContainer(context), '-p', `${localIpv4Host}:${this.getPort(context)}:${ssoInternalPort}`, '-e', `KC_BOOTSTRAP_ADMIN_USERNAME=${ssoAdminUser}`, '-e', `KC_BOOTSTRAP_ADMIN_PASSWORD=${ssoAdminPassword}`, '-e', 'KC_HTTP_RELATIVE_PATH=/dex', '-v', `${prepared.importDir}:/opt/keycloak/data/import:ro,Z`, keycloakImage, 'start-dev', '--import-realm', '--hostname', `https://${this.getHostname(context)}/dex`, '--proxy-headers=xforwarded');
         return args;
     }
 
-    static container(context: { instance: { name: string } }): string {
-        return `${context.instance.name}-keycloak`;
+    /**
+     * Keycloak accepts TCP connections well before the realm import finished, so poll the realm's
+     * discovery document instead of the container state. Goes through Caddy, which is how the
+     * backend reaches the server too.
+     *
+     * The document has to name our issuer: Caddy answers an empty 200 for a host it has no route
+     * for, so a bare status check would pass while nothing is reachable at all.
+     */
+    async waitUntilReady(context: CliContext, options: { timeoutMs?: number } = {}): Promise<void> {
+        const issuer = this.getIssuer(context);
+        const url = `${issuer}/.well-known/openid-configuration`;
+        const timeoutMs = options.timeoutMs ?? 120_000;
+        const start = Date.now();
+        let lastError = 'no response';
+
+        while (Date.now() - start < timeoutMs) {
+            try {
+                const response = await fetch(url, { signal: AbortSignal.timeout(2_000) });
+                if (!response.ok) {
+                    lastError = `status ${response.status}`;
+                }
+                else {
+                    const body = await response.text();
+                    const discovered = parseIssuer(body);
+                    if (discovered === issuer) {
+                        return;
+                    }
+                    lastError = discovered === undefined
+                        ? `response is not an OpenID discovery document (${body.length} bytes): is Caddy routing ${new URL(issuer).host}?`
+                        : `discovery document reports issuer ${discovered}`;
+                }
+            }
+            catch (error) {
+                lastError = error instanceof Error ? error.message : String(error);
+            }
+            await new Promise(resolve => setTimeout(resolve, 500));
+        }
+
+        throw new Error(`Timed out waiting for ${this.name} to become ready at ${url} (${lastError})`);
+    }
+
+    private getHostname(context: CliContext): string {
+        return this.variant?.hostname ?? buildDomains(context).sso;
+    }
+
+    private getPort(context: CliContext): number {
+        return this.variant?.port ?? buildPorts(context).sso;
+    }
+
+    static container(context: { instance: { name: string } }, variant?: string): string {
+        return `${context.instance.name}-keycloak${variant ? `-${variant}` : ''}`;
     }
 }
 
 export const ssoService = new SsoService();
+
+function parseIssuer(body: string): string | undefined {
+    try {
+        const parsed = JSON.parse(body) as { issuer?: unknown };
+        return typeof parsed.issuer === 'string' ? parsed.issuer : undefined;
+    }
+    catch {
+        return undefined;
+    }
+}

--- a/shared/cli/src/services/docker.test.ts
+++ b/shared/cli/src/services/docker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { run as runCommand } from '../runtime/command-runner.js';
 import * as docker from './docker.js';
 
@@ -10,6 +10,27 @@ describe('container runtime selection', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         docker.resetContainerRuntimeCacheForTests();
+        delete process.env.STAMHOOFD_CONTAINER_RUNTIME;
+    });
+
+    afterEach(() => {
+        delete process.env.STAMHOOFD_CONTAINER_RUNTIME;
+    });
+
+    it('uses the runtime pinned through STAMHOOFD_CONTAINER_RUNTIME', async () => {
+        process.env.STAMHOOFD_CONTAINER_RUNTIME = 'Docker';
+
+        await expect(docker.getContainerRuntime()).resolves.toBe(docker.ContainerRuntime.Docker);
+
+        expect(runCommand).toHaveBeenCalledExactlyOnceWith('docker', ['info'], { quiet: true });
+    });
+
+    it('rejects an unknown pinned runtime', async () => {
+        process.env.STAMHOOFD_CONTAINER_RUNTIME = 'containerd';
+
+        await expect(docker.getContainerRuntime()).rejects.toThrow('Unknown STAMHOOFD_CONTAINER_RUNTIME');
+
+        expect(runCommand).not.toHaveBeenCalled();
     });
 
     it('prefers podman and caches the selected runtime', async () => {

--- a/shared/cli/src/services/docker.ts
+++ b/shared/cli/src/services/docker.ts
@@ -100,6 +100,18 @@ export function resetContainerRuntimeCacheForTests(): void {
 }
 
 async function resolveContainerRuntime(): Promise<ContainerRuntime> {
+    // Both runtimes are often installed side by side (GitHub Actions runners ship podman as well
+    // as docker), so allow pinning one instead of relying on the auto-detection order.
+    const configured = process.env.STAMHOOFD_CONTAINER_RUNTIME?.trim().toLowerCase();
+    if (configured) {
+        const supported: string[] = [ContainerRuntime.Docker, ContainerRuntime.Podman];
+        if (!supported.includes(configured)) {
+            throw new Error(`Unknown STAMHOOFD_CONTAINER_RUNTIME "${configured}": expected ${supported.map(runtime => `"${runtime}"`).join(' or ')}`);
+        }
+        await commandRunner.run(configured, ['info'], { quiet: true });
+        return configured as ContainerRuntime;
+    }
+
     const podmanVersion = await commandRunner.run('podman', ['--version'], { capture: true, allowFailure: true });
     if (podmanVersion.status === 0) {
         await commandRunner.run('podman', ['info'], { quiet: true });

--- a/shared/cli/src/services/shared-services.test.ts
+++ b/shared/cli/src/services/shared-services.test.ts
@@ -85,9 +85,31 @@ describe('shared service Docker args', () => {
                 primary: true,
             },
         } as any;
-        const args = new SsoService().getDockerArgs(context, { redirectUri: 'https://example.com/openid/callback' }, { importDir: '/tmp/keycloak' });
+        const args = new SsoService().getDockerArgs(context, { redirectUris: ['https://example.com/openid/callback'] }, { importDir: '/tmp/keycloak' });
 
         expect(args).toContain('/tmp/keycloak:/opt/keycloak/data/import:ro,Z');
+        expect(args).toContain('stamhoofd-keycloak');
+        expect(args).toContain('127.0.0.1:5556:8080');
+    });
+
+    it('builds SSO args for a variant on its own container, port and hostname', () => {
+        const context = {
+            rootDir: '/tmp/stamhoofd',
+            env: 'stamhoofd',
+            instance: {
+                name: 'stamhoofd',
+                prefix: 'stamhoofd',
+                portOffset: 0,
+                primary: true,
+            },
+        } as any;
+        const service = new SsoService({ name: 'playwright', port: 6400, hostname: 'playwright-sso.stamhoofd' });
+        const args = service.getDockerArgs(context, { redirectUris: ['https://example.com/openid/callback'] }, { importDir: '/tmp/keycloak' });
+
+        expect(args).toContain('stamhoofd-keycloak-playwright');
+        expect(args).toContain('127.0.0.1:6400:8080');
+        expect(args).toContain('https://playwright-sso.stamhoofd/dex');
+        expect(service.getIssuer(context)).toBe('https://playwright-sso.stamhoofd/dex/realms/stamhoofd');
     });
 
     it('builds macOS Docker bridge args for Caddy', () => {

--- a/shared/cli/src/services/sso-config.test.ts
+++ b/shared/cli/src/services/sso-config.test.ts
@@ -12,4 +12,16 @@ describe('buildKeycloakRealm', () => {
         expect(realm.users[0].email).toBe(ssoUserEmail);
         expect(realm.users[0].credentials[0].temporary).toBe(false);
     });
+
+    it('allows every given redirect uri', () => {
+        const realm = buildKeycloakRealm([
+            'https://playwright-api-0.stamhoofd/openid/callback',
+            'https://playwright-api-1.stamhoofd/openid/callback',
+        ]) as any;
+
+        expect(realm.clients[0].redirectUris).toEqual([
+            'https://playwright-api-0.stamhoofd/openid/callback',
+            'https://playwright-api-1.stamhoofd/openid/callback',
+        ]);
+    });
 });

--- a/shared/cli/src/services/sso-config.ts
+++ b/shared/cli/src/services/sso-config.ts
@@ -41,7 +41,7 @@ Commands:
   stam sso start "${resolvedRedirectUri}"`;
 }
 
-export function buildKeycloakRealm(redirectUri: string): Record<string, unknown> {
+export function buildKeycloakRealm(redirectUris: string | string[]): Record<string, unknown> {
     const [firstName, lastName] = splitName(ssoUserName);
 
     return {
@@ -69,7 +69,7 @@ export function buildKeycloakRealm(redirectUri: string): Record<string, unknown>
                 implicitFlowEnabled: false,
                 directAccessGrantsEnabled: false,
                 serviceAccountsEnabled: false,
-                redirectUris: [redirectUri],
+                redirectUris: Array.isArray(redirectUris) ? redirectUris : [redirectUris],
                 webOrigins: ['+'],
                 defaultClientScopes: ['web-origins', 'acr', 'profile', 'roles', 'email'],
                 optionalClientScopes: ['address', 'phone', 'offline_access', 'microprofile-jwt'],
@@ -100,11 +100,16 @@ export function buildKeycloakRealm(redirectUri: string): Record<string, unknown>
     };
 }
 
-export async function writeKeycloakRealm(context: CliContext, redirectUri: string): Promise<string> {
-    const importDir = path.join(context.generatedDir, 'instances', context.instance.name, 'keycloak');
+/**
+ * Write the realm Keycloak imports on boot. `dirName` keeps realms of different SSO servers
+ * apart: the Playwright server allows other redirect URIs than the one `stam sso start`
+ * configures, and both may exist for the same instance.
+ */
+export async function writeKeycloakRealm(context: CliContext, redirectUris: string | string[], options: { dirName?: string } = {}): Promise<string> {
+    const importDir = path.join(context.generatedDir, 'instances', context.instance.name, options.dirName ?? 'keycloak');
     const file = path.join(importDir, 'stamhoofd-realm.json');
     await fs.mkdir(importDir, { recursive: true });
-    await fs.writeFile(file, JSON.stringify(buildKeycloakRealm(redirectUri), null, 4));
+    await fs.writeFile(file, JSON.stringify(buildKeycloakRealm(redirectUris), null, 4));
     return importDir;
 }
 

--- a/tests/playwright/src/setup/global-setup.ts
+++ b/tests/playwright/src/setup/global-setup.ts
@@ -4,6 +4,7 @@ import { CaddyHelper } from './helpers/CaddyHelper.js';
 import { DatabaseHelper } from './helpers/DatabaseHelper.js';
 import { FrontendBuilder } from './helpers/FrontendBuilder.js';
 import { PlaywrightHooks } from './helpers/PlaywrightHooks.js';
+import { SsoHelper } from './helpers/SsoHelper.js';
 
 // Make sure initial env is loaded
 
@@ -19,7 +20,9 @@ export default async function globalSetup() {
     const frontendBuilder = new FrontendBuilder();
     const caddyHelper = new CaddyHelper();
 
-    const configureCaddy = async () => {
+    // The SSO server is only reachable once its Caddy route is in place, so it starts after the
+    // routes are configured. Runs next to the frontend build, which takes far longer.
+    const configureCaddyAndStartSso = async () => {
         const workerCount = getExpectedWorkerCount();
         if (!await caddyHelper.isRunning()) {
             console.log('Starting CI Caddy...');
@@ -27,6 +30,10 @@ export default async function globalSetup() {
             console.log('CI Caddy started.');
         }
         await caddyHelper.configure(workerCount);
+
+        console.log('Starting SSO server...');
+        await SsoHelper.start();
+        console.log('SSO server started.');
     };
 
     const buildFrontend = async () => {
@@ -49,7 +56,7 @@ export default async function globalSetup() {
         }
     };
 
-    for (const promise of [configureCaddy(), buildFrontend(), migrateDatabases()]) {
+    for (const promise of [configureCaddyAndStartSso(), buildFrontend(), migrateDatabases()]) {
         await promise;
     }
 }

--- a/tests/playwright/src/setup/global-teardown.ts
+++ b/tests/playwright/src/setup/global-teardown.ts
@@ -1,7 +1,17 @@
 import { CaddyHelper } from './helpers/CaddyHelper.js';
 import { ProcessInfo } from './helpers/ProcessInfo.js';
+import { SsoHelper } from './helpers/SsoHelper.js';
 
 export default async function globalTeardown() {
+    console.log('Stopping SSO server...');
+    try {
+        await SsoHelper.stop();
+    }
+    catch (error) {
+        // Never let a leftover container fail the run: it is replaced on the next start anyway.
+        console.warn(`Failed to stop the SSO server: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
     console.log(ProcessInfo.didStartCaddy ? 'Stopping CI Caddy...' : 'Removing Playwright Caddy routes...');
     await new CaddyHelper().cleanup();
 }

--- a/tests/playwright/src/setup/helpers/CaddyConfigHelper.ts
+++ b/tests/playwright/src/setup/helpers/CaddyConfigHelper.ts
@@ -1,7 +1,7 @@
 import { Formatter } from '@stamhoofd/utility';
 import type { FrontendProjectName } from './FrontendService.js';
 import type { CaddyRoute, CaddyRouteOptions } from '@stamhoofd/cli';
-import { cspFrontendSubroutes } from '@stamhoofd/cli';
+import { cspFrontendSubroutes, ssoRealm } from '@stamhoofd/cli';
 
 /**
  * Old domains and ports will get reused
@@ -67,6 +67,40 @@ export class CaddyConfigHelper {
     static cycledWorkerId(workerId: string) {
         const asNumber = parseInt(workerId);
         return asNumber % maximumRunners;
+    }
+
+    /**
+     * Host of the SSO (Keycloak) server used by the e2e tests. One server is shared by all
+     * workers, and it deliberately does not reuse the `sso.<domain>` host of `stam sso start`: a
+     * test run must never restart the SSO server a developer started for manual testing.
+     */
+    static getSsoDomain() {
+        return 'playwright-sso.stamhoofd';
+    }
+
+    static getSsoPort() {
+        return 6400;
+    }
+
+    /**
+     * OpenID Connect issuer of the realm imported by the SSO server, to configure as the issuer in
+     * the Stamhoofd SSO settings.
+     */
+    static getSsoIssuer() {
+        return `https://${this.getSsoDomain()}/dex/realms/${ssoRealm}`;
+    }
+
+    /**
+     * The redirect URI the backend of a worker hands to the SSO server. Keycloak only redirects
+     * back to URIs listed in the realm, and one SSO server serves every worker, so the realm
+     * allows the callback of every worker.
+     */
+    static getSsoRedirectUris() {
+        const uris: string[] = [];
+        for (let workerId = 0; workerId < maximumRunners; workerId += 1) {
+            uris.push(`${this.getUrl('api', workerId.toString())}/openid/callback`);
+        }
+        return uris;
     }
 
     /**
@@ -222,10 +256,36 @@ export class CaddyConfigHelper {
     }
 
     /**
+     * Route to the SSO (Keycloak) server. Not per worker: one server serves every worker, and both
+     * the browser and the backends reach it over HTTPS through Caddy (Keycloak is started with
+     * `--proxy-headers=xforwarded`, so it builds its URLs from the headers Caddy sets).
+     */
+    static createSsoRoute(proxyHost: string): CaddyRoute {
+        return {
+            group: `${this.GROUP_PREFIX}-sso`,
+            match: [
+                {
+                    host: [this.getSsoDomain()],
+                },
+            ],
+            handle: [
+                {
+                    handler: 'reverse_proxy',
+                    upstreams: [
+                        {
+                            dial: `${proxyHost}:${this.getSsoPort()}`,
+                        },
+                    ],
+                },
+            ],
+        };
+    }
+
+    /**
      * Create the default playwright caddy config
      */
     static createRouteOptions(options: { proxyHost: string }): CaddyRouteOptions {
-        const routes: CaddyRoute[] = [];
+        const routes: CaddyRoute[] = [this.createSsoRoute(options.proxyHost)];
 
         for (let workerId = 0; workerId < maximumRunners; workerId += 1) {
             routes.push(

--- a/tests/playwright/src/setup/helpers/SsoHelper.ts
+++ b/tests/playwright/src/setup/helpers/SsoHelper.ts
@@ -1,0 +1,36 @@
+import { createContext, SsoService } from '@stamhoofd/cli';
+import { CaddyConfigHelper } from './CaddyConfigHelper.js';
+
+/**
+ * The local SSO server (Keycloak) from the CLI, started once per e2e run and shared by all workers.
+ * It runs under its own container name, port and hostname, so it never interferes with the SSO
+ * server `stam sso start` manages for manual testing.
+ *
+ * Configure it in a test with `CaddyConfigHelper.getSsoIssuer()` plus the client credentials
+ * exported by `@stamhoofd/cli` (ssoClientId, ssoClientSecret).
+ */
+export class SsoHelper {
+    private static service = new SsoService({
+        name: 'playwright',
+        port: CaddyConfigHelper.getSsoPort(),
+        hostname: CaddyConfigHelper.getSsoDomain(),
+    });
+
+    /**
+     * Requires the Caddy route for the SSO host to be configured already: readiness is checked
+     * through Caddy, the same way the backends reach the server.
+     */
+    static async start(): Promise<void> {
+        const context = await createContext({ env: 'stamhoofd', verbose: false });
+        await this.service.start(context, {
+            redirectUris: CaddyConfigHelper.getSsoRedirectUris(),
+            background: true,
+        });
+        await this.service.waitUntilReady(context);
+    }
+
+    static async stop(): Promise<void> {
+        const context = await createContext({ env: 'stamhoofd', verbose: false });
+        await this.service.stop(context);
+    }
+}

--- a/tests/playwright/src/tests/sso-login-platform.spec.ts
+++ b/tests/playwright/src/tests/sso-login-platform.spec.ts
@@ -1,0 +1,119 @@
+// test should always be imported first
+import { setup, test } from '../test-fixtures/base.js';
+setup();
+
+// other imports
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { ssoClientId, ssoClientSecret, ssoUserEmail, ssoUserPassword } from '@stamhoofd/cli';
+import { Platform, User, UserFactory } from '@stamhoofd/models';
+import { LoginMethod, LoginMethodConfig, LoginProviderType, OpenIDClientConfiguration, PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { WorkerData } from '../helpers/index.js';
+import { CaddyConfigHelper } from '../setup/helpers/CaddyConfigHelper.js';
+
+/**
+ * Logging in on a platform account through the local SSO server (Keycloak) that is started for
+ * the whole e2e run (see SsoHelper). The realm holds a single test user, so every test starts
+ * from an empty users table.
+ */
+test.describe('SSO login', () => {
+    test.beforeAll(() => {
+        TestUtils.setPermanentEnvironment('userMode', 'platform');
+    });
+
+    test.beforeEach(async () => {
+        // Each test decides whether the SSO user already exists, so drop the users of the previous test.
+        await WorkerData.resetDatabase();
+        await enableSSOForPlatform();
+    });
+
+    test.afterAll(async () => {
+        await WorkerData.resetDatabase();
+    });
+
+    test('creates an account for a user that signs in for the first time', async ({ page, pages }) => {
+        await pages.dashboard.goto();
+        await signInThroughSSO(page);
+
+        // A platform user without permissions lands in the member portal.
+        await expect(page.getByTestId('members-start-view')).toBeVisible({ timeout: 30_000 });
+
+        const user = await User.getForRegister(null, ssoUserEmail);
+        expect(user).toBeDefined();
+        expect(user!.firstName).toBe('Local');
+        expect(user!.lastName).toBe('SSO User');
+        expect(user!.verified).toBe(true);
+
+        // The account is SSO-only: no password was set, and the provider is linked.
+        expect(user!.hasPasswordBasedAccount()).toBe(false);
+        expect(user!.meta?.loginProviderIds.get(LoginProviderType.SSO)).toBeTruthy();
+    });
+
+    test('signs in on an existing account and links the SSO provider to it', async ({ page, pages }) => {
+        // An admin that was invited but never picked a password: their account is claimed by SSO.
+        const existingUser = await new UserFactory({
+            email: ssoUserEmail,
+            password: null,
+            firstName: 'Invited',
+            lastName: 'Admin',
+            globalPermissions: Permissions.create({
+                level: PermissionLevel.Full,
+            }),
+        }).create();
+
+        await pages.dashboard.goto();
+        await signInThroughSSO(page);
+
+        // An admin ends up in the organization selection instead of the member portal.
+        await expect(page.getByTestId('organization-search-input')).toBeVisible({ timeout: 30_000 });
+
+        const user = await User.getForRegister(null, ssoUserEmail);
+        expect(user).toBeDefined();
+
+        // Same account, so the permissions are kept instead of a second account being created.
+        expect(user!.id).toBe(existingUser.id);
+        expect(user!.permissions?.globalPermissions?.level).toBe(PermissionLevel.Full);
+        expect(user!.meta?.loginProviderIds.get(LoginProviderType.SSO)).toBeTruthy();
+    });
+});
+
+/**
+ * Point the platform at the SSO server of the e2e run. Password login stays enabled, so the login
+ * view shows both options instead of redirecting to the SSO server automatically.
+ */
+async function enableSSOForPlatform() {
+    const platform = await Platform.getForEditing();
+
+    platform.config.loginMethods = new Map([
+        [LoginMethod.Password, LoginMethodConfig.create({})],
+        [LoginMethod.SSO, LoginMethodConfig.create({ loginButtonText: 'Inloggen via SSO' })],
+    ]);
+
+    // No redirectUri: the backend defaults to the /openid/callback of its own API domain, which is
+    // the URI the realm of this worker allows (see CaddyConfigHelper.getSsoRedirectUris).
+    platform.serverConfig.ssoConfiguration = OpenIDClientConfiguration.create({
+        issuer: CaddyConfigHelper.getSsoIssuer(),
+        clientId: ssoClientId,
+        clientSecret: ssoClientSecret,
+    });
+
+    await platform.save();
+}
+
+/**
+ * Start the flow from the Stamhoofd login view and sign in on the Keycloak login page. Keycloak
+ * posts the result back to the API (response_mode=form_post), which redirects to the dashboard.
+ */
+async function signInThroughSSO(page: Page) {
+    await page.getByTestId(`login-method-button-${LoginProviderType.SSO}`).click();
+
+    // Keycloak's own login form
+    await page.locator('#kc-form-login').waitFor();
+    await page.locator('#username').fill(ssoUserEmail);
+    await page.locator('#password').fill(ssoUserPassword);
+    await page.locator('#kc-login').click();
+
+    // Back on the dashboard with the refresh token the callback added to the redirect.
+    await page.waitForURL(url => url.origin === WorkerData.urls.dashboard, { timeout: 30_000 });
+}


### PR DESCRIPTION
## What

An e2e test for logging in on a platform account through SSO, reusing the local SSO server (Keycloak) the CLI already manages.

The Playwright global setup starts a **second** Keycloak from the same `SsoService`, under its own container name, port (6400) and host (`playwright-sso.stamhoofd`), with a realm that allows the `/openid/callback` of every worker. It never touches the server a developer started with `stam sso start`.

Two tests, covering both branches of the callback:
- signing in for the first time creates the account (name, e-mail and provider link from the ID token/userinfo, no password);
- signing in on an existing admin that never picked a password links the provider to that account instead of creating a second one, keeping its permissions.

This exercises the full round trip, including the `response_mode=form_post` callback from Keycloak to the API — the leg whose session cookie regressed on the recent `sameSite: 'lax'` change (c1923672b).

## CLI changes

- `SsoService` takes an optional variant (container suffix, port, hostname) so a second server can run next to the one `stam sso start` manages; the realm file is written to its own directory.
- The realm accepts a list of redirect URIs instead of one, since one server serves every worker.
- `waitUntilReady` polls the realm's discovery document and checks the `issuer` it reports. A bare status check is not enough: Caddy answers an empty 200 for a host it has no route for, so the server looked ready while nothing was reachable.
- `STAMHOOFD_CONTAINER_RUNTIME` pins docker or podman instead of relying on the auto-detection order.

## CI

Pulls `quay.io/keycloak/keycloak:26.0.7` up front and sets `STAMHOOFD_CONTAINER_RUNTIME: docker` — runners ship podman as well, and the detection prefers it.

## Verification

- Both SSO tests pass locally (`stam test e2e --grep "SSO login"`).
- `yarn lint`, `yarn typecheck` and the CLI unit tests are green.
- **The full e2e suite has not been run clean.** Every attempt collided with a concurrent e2e run from another worktree: the harness binds fixed ports (`EADDRINUSE` on 6000-6004) and `removeRouteManifestsByKind` removes *all* Playwright Caddy manifests, including those of a run still in progress. Before that took over, the suite was at 249/285 with no failures.

## Known limitation

The SSO server binds a fixed port like the rest of the harness, so only one e2e run can be up at a time. A slot-based allocation (each run claims a free block of ports/hostnames) was prototyped and verified working — one run claimed slots 5-9 while another held 0-4 — but dropped from this PR to keep it to the SSO test. Worth doing separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787736391&installation_model_id=423362&pr_number=654&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F654&signature=cb8f1044cb03ba269aefb20ec33f9b41d8113cf28c0c24ae8d084c184a848e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->