### PR TITLE
Injected a platform aware uuid resolver for audit logs

### DIFF
--- a/backend/shared/models/src/models/Platform.ts
+++ b/backend/shared/models/src/models/Platform.ts
@@ -2,7 +2,8 @@ import { column } from '@simonbackx/simple-database';
 import { SimpleError } from '@simonbackx/simple-errors';
 import { QueueHandler } from '@stamhoofd/queues';
 import { QueryableModel } from '@stamhoofd/sql';
-import { PlatformConfig, PlatformPrivateConfig, PlatformServerConfig, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { AuditLogReplacementDependencies, PlatformConfig, PlatformPrivateConfig, PlatformServerConfig, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { uuidToName } from '@stamhoofd/structures/helpers/uuidToName.js';
 import { deepFreeze } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 import { RegistrationPeriod } from './RegistrationPeriod.js';
@@ -164,6 +165,13 @@ export class Platform extends QueryableModel {
         const clone = struct.clone();
         clone.privateConfig = null;
         clone.setShared();
+
+        // Audit logs render uuids from a bare id, so they cannot receive a platform through their
+        // call chain. Bind the resolver to the same struct that backs Platform.shared here, so it
+        // is refreshed together with the caches. Uses the public struct on purpose: resolving
+        // privateConfig roles would change the names that get persisted in audit logs.
+        AuditLogReplacementDependencies.uuidToName = uuid => uuidToName(uuid, clone);
+
         this.sharedStruct = clone;
     }
 

--- a/frontend/shared/networking/src/loadPlatform.ts
+++ b/frontend/shared/networking/src/loadPlatform.ts
@@ -1,6 +1,7 @@
 import type { Decoder } from '@simonbackx/simple-encoding';
 import { ObjectData, VersionBox, VersionBoxDecoder } from '@simonbackx/simple-encoding';
-import { Platform, Version } from '@stamhoofd/structures';
+import { AuditLogReplacementDependencies, Platform, Version } from '@stamhoofd/structures';
+import { uuidToName } from '@stamhoofd/structures/helpers/uuidToName.js';
 import { NetworkManager } from './NetworkManager';
 import { Storage } from './Storage';
 
@@ -59,8 +60,11 @@ async function fetchPublicPlatform(): Promise<Platform> {
  *
  * The returned platform is the app level platform: it is handed to the SessionContext, which never
  * replaces the reference (updatePlatform uses deepSet). Because of that stability, this is also
- * where Platform.shared is stamped, exactly once per app level platform. That global is still read
- * by UserPermissions, which has no platform passed to it yet.
+ * where the two things that cannot be passed a platform get bound, exactly once per app level
+ * platform:
+ * - Platform.shared, still read by UserPermissions.
+ * - The audit log uuid resolver, which renders a uuid from a bare id deep inside
+ *   AuditLogReplacement and cannot receive a platform through its call chain.
  *
  * Throwaway sessions (e.g. the account switcher) reuse the app level platform instead of calling
  * this, so they never stamp anything.
@@ -70,6 +74,7 @@ export async function loadPlatform(): Promise<{ platform: Platform; fromCache: b
     const platform = cached ?? (await fetchPublicPlatform());
 
     platform.setShared();
+    AuditLogReplacementDependencies.uuidToName = uuid => uuidToName(uuid, platform);
 
     // The caller needs to know whether this is a possibly stale cached platform, so it can decide
     // whether a refresh is still needed: a platform we just fetched does not need one.

--- a/shared/structures/src/circular-dependencies/AuditLogReplacementDependencies.ts
+++ b/shared/structures/src/circular-dependencies/AuditLogReplacementDependencies.ts
@@ -9,7 +9,6 @@ import { DocumentStatus, DocumentStatusHelper } from '../Document.js';
 import { EmailTemplate, EmailTemplateType } from '../email/EmailTemplate.js';
 import { EventNotificationStatus, EventNotificationStatusHelper } from '../EventNotificationStatus.js';
 import { GroupStatus, getGroupStatusName } from '../Group.js';
-import { uuidToName } from '../helpers/uuidToName.js';
 import { Gender, getGenderName } from '../members/Gender.js';
 import { ParentType, ParentTypeHelper } from '../members/ParentType.js';
 import { OrganizationType, OrganizationTypeHelper } from '../OrganizationType.js';
@@ -38,4 +37,6 @@ registerAuditLogEnum('EmailTemplateType', EmailTemplateType, EmailTemplate.getTy
 registerAuditLogEnum('EventNotificationStatus', EventNotificationStatus, EventNotificationStatusHelper.getName);
 registerAuditLogEnum('Language', Language, LanguageHelper.getName);
 
-AuditLogReplacementDependencies.uuidToName = uuidToName;
+// AuditLogReplacementDependencies.uuidToName is deliberately not registered here: resolving a uuid
+// to a name needs a platform, and this module runs on import of @stamhoofd/structures, where there
+// is none. The api and the frontend each register a resolver bound to their own platform instead.

--- a/shared/structures/src/helpers/uuidToName.ts
+++ b/shared/structures/src/helpers/uuidToName.ts
@@ -1,17 +1,25 @@
-import { Platform } from '../Platform.js';
+import type { Platform } from '../Platform.js';
 
-export function uuidToName(uuid: string) {
+/**
+ * Resolves a uuid to a human readable name using the platform configuration.
+ *
+ * This takes the platform explicitly instead of reading a global. Callers that cannot pass one
+ * (AuditLogReplacement renders uuids from a bare id) go through the
+ * AuditLogReplacementDependencies.uuidToName injection slot, which the api and the frontend each
+ * fill in with a resolver bound to their own platform.
+ */
+export function uuidToName(uuid: string, platform: Platform) {
     // Look up in UUID library list
     const objectLists
      = [
-         Platform.shared.config.premiseTypes,
-         Platform.shared.config.eventTypes,
-         Platform.shared.config.defaultAgeGroups,
-         Platform.shared.config.tags,
-         Platform.shared.config.recordsConfiguration.recordCategories,
-         Platform.shared.config.membershipTypes,
-         Platform.shared.config.responsibilities,
-         Platform.shared.privateConfig?.roles ?? [],
+         platform.config.premiseTypes,
+         platform.config.eventTypes,
+         platform.config.defaultAgeGroups,
+         platform.config.tags,
+         platform.config.recordsConfiguration.recordCategories,
+         platform.config.membershipTypes,
+         platform.config.responsibilities,
+         platform.privateConfig?.roles ?? [],
 
      ];
 


### PR DESCRIPTION
Part of removing every read of the `Platform.shared` process-global singleton.

`uuidToName` now takes the platform explicitly. Its callers cannot: audit log
replacements render a uuid from a bare id, deep inside AuditLogReplacement and
ObjectDiffer, neither of which should have to know about a platform. So instead
of threading one through them, the existing
`AuditLogReplacementDependencies.uuidToName` injection slot keeps its
`(uuid) => string | null` shape and each app fills it in with a resolver bound to
its own platform.

The registration sits next to the existing `setShared()` call on both sides, so
the resolver and the singleton are always refreshed together. The backend binds
the public struct on purpose: resolving privateConfig roles would change the
names that get persisted in audit logs.

The frontend closes over PlatformManager's `$platform`, which is the session
context's platform and never gets replaced, so a single registration stays
correct.

Strict no-op: both sides bind the same object `Platform.shared` returned, and
before either registration runs the singleton was an empty platform that
resolved nothing anyway.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787739084&installation_model_id=423362&pr_number=655&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F655&signature=e1966e4578b6781306820007441a1146b362c0a3ffd12c687929a67b2649bcd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->