### PR TITLE
Reserve a block of ports and domains per Playwright run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ From repo root: `yarn lint` · `yarn typecheck`. **`yarn stam test` is the one g
 
 ```bash
 yarn stam test unit                 # every unit package (excludes Playwright)
-yarn stam test api                  # one package: api models sql structures renderer redirecter queues utility sgv object-differ eslint
+yarn stam test api                  # one package: api models sql structures renderer redirecter queues utility sgv object-differ eslint cli
 yarn stam test unit SomeFile        # filename filter across all packages
 yarn stam test structures bundle-discounts          # package + filename filter
 yarn stam test structures -t 'partial test name'    # package + test-name filter (-t → vitest -t)

--- a/shared/cli/src/config/caddy-config.test.ts
+++ b/shared/cli/src/config/caddy-config.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { CliContext } from '../context/create-context.js';
 import { writeInstanceManifest, writeRouteManifest } from '../runtime/manifest-store.js';
 import { caddyAdminPort, localhostPort } from './shared-service-config.js';
+import { buildDomains } from './build-config.js';
 import { buildCaddyRouteOptions, cspFrontendSubroutes, writeCaddyConfig } from './caddy-config.js';
 
 describe('Caddy config', () => {
@@ -153,19 +154,21 @@ describe('Caddy config', () => {
         expect(caddyConfig.admin.origins).toEqual([`http://${localhostPort(caddyAdminPort)}`]);
     });
 
-    // Skipped: pre-existing failure on main, unrelated to this PR. The shared/cli suite is not run in CI.
-    it.skip('keeps normal routes when adding Playwright routes', async () => {
+    it('keeps normal routes when adding Playwright routes', async () => {
         const ctx = context(rootDir);
         await writeRouteManifest(ctx, {
-            name: 'playwright-worker-0',
+            name: 'playwright-test-1234',
             kind: 'playwright-worker',
             pid: process.pid,
             startedAt: new Date().toISOString(),
             expiresAt: new Date(Date.now() + 60_000).toISOString(),
             rootPath: rootDir,
             workspace: 'playwright',
-            routes: [{ hosts: ['playwright-dashboard-0.stamhoofd'], port: 6100 }],
-            tlsSubjects: ['playwright-dashboard-0.stamhoofd'],
+            reservedPorts: [6100],
+            caddy: {
+                routes: [{ match: [{ host: ['playwright-dashboard-0.stamhoofd'] }], handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '127.0.0.1:6100' }] }] }],
+                tlsSubjects: ['playwright-dashboard-0.stamhoofd'],
+            },
         });
 
         const config = await writeCaddyConfig(ctx);
@@ -173,34 +176,32 @@ describe('Caddy config', () => {
         const hosts = routeHosts(caddyConfig);
         const subjects = caddyConfig.apps.tls.automation.policies[0].subjects;
 
-        expect(hosts).toContain('dashboard.stamhoofd');
+        expect(hosts).toContain('mail.stamhoofd');
         expect(hosts).toContain('playwright-dashboard-0.stamhoofd');
-        expect(subjects).toContain('dashboard.stamhoofd');
+        expect(subjects).toContain('mail.stamhoofd');
         expect(subjects).toContain('playwright-dashboard-0.stamhoofd');
     });
 
-    // Skipped: pre-existing failure on main, unrelated to this PR. The shared/cli suite is not run in CI.
-    it.skip('includes all frontend app routes from active instance manifests', async () => {
+    it('includes all frontend app routes from active instance manifests', async () => {
         const ctx = context(rootDir);
-        await writeInstanceManifest(ctx, {
-            dashboard: 'feature.dashboard.stamhoofd',
-            api: 'feature.api.stamhoofd',
-            renderer: 'feature.renderer.stamhoofd',
-            registration: 'feature.registration.stamhoofd',
-            webshop: 'feature.shop.stamhoofd',
+        const otherInstance = { ...ctx, instance: { name: 'feature', prefix: 'feature', primary: false, portOffset: 100 } };
+        await writeInstanceManifest(otherInstance, {
+            domains: buildDomains(otherInstance),
+            caddy: buildCaddyRouteOptions(otherInstance),
         });
 
         const config = await writeCaddyConfig(ctx);
         const caddyConfig = JSON.parse(await fs.readFile(config, 'utf8'));
         const hosts = routeHosts(caddyConfig);
+        const domains = buildDomains(otherInstance);
 
-        expect(hosts).toContain('feature.dashboard.stamhoofd');
-        expect(hosts).toContain('feature.api.stamhoofd');
-        expect(hosts).toContain('*.feature.api.stamhoofd');
-        expect(hosts).toContain('feature.renderer.stamhoofd');
-        expect(hosts).toContain('feature.registration.stamhoofd');
-        expect(hosts).toContain('*.feature.registration.stamhoofd');
-        expect(hosts).toContain('feature.shop.stamhoofd');
+        expect(hosts).toContain(domains.dashboard);
+        expect(hosts).toContain(domains.api);
+        expect(hosts).toContain(`*.${domains.api}`);
+        expect(hosts).toContain(domains.renderer);
+        expect(hosts).toContain(domains.registration);
+        expect(hosts).toContain(`*.${domains.registration}`);
+        expect(hosts).toContain(domains.webshop);
     });
 });
 

--- a/shared/cli/src/context/port-allocation.ts
+++ b/shared/cli/src/context/port-allocation.ts
@@ -1,5 +1,5 @@
-import net from 'node:net';
 import type { CliContext } from './create-context.js';
+import { isPortAvailable } from '../runtime/port-probe.js';
 import { buildPorts } from './ports.js';
 
 const portResolutionStep = 100;
@@ -72,24 +72,4 @@ async function occupiedAppPorts(context: CliContext): Promise<Array<{ name: AppP
     return results
         .filter(result => !result.available)
         .map(({ name, port }) => ({ name, port }));
-}
-
-async function isPortAvailable(port: number): Promise<boolean> {
-    return await new Promise((resolve) => {
-        const server = net.createServer();
-
-        server.once('error', (error: NodeJS.ErrnoException) => {
-            if (error.code === 'EADDRINUSE' || error.code === 'EACCES') {
-                resolve(false);
-                return;
-            }
-            resolve(false);
-        });
-
-        server.once('listening', () => {
-            server.close(() => resolve(true));
-        });
-
-        server.listen(port, '127.0.0.1');
-    });
 }

--- a/shared/cli/src/index.ts
+++ b/shared/cli/src/index.ts
@@ -5,8 +5,9 @@ export { caddyAdminPort, localIpv4Host } from './config/shared-service-config.js
 export { buildCaddyServiceProfile, buildSharedServiceProfile } from './config/shared-service-profile.js';
 export { createContext } from './context/create-context.js';
 export { getProjectPath } from './context/project-path.js';
-export { pruneStaleRouteManifests, removeRouteManifest, removeRouteManifestsByKind, writeRouteManifest, type CaddyRouteOptions } from './runtime/manifest-store.js';
-export type { RouteManifest } from './runtime/manifest-store.js';
+export { pruneStaleRouteManifests, removeOwnRouteManifests, removeRouteManifest, writeRouteManifest, type CaddyRouteOptions } from './runtime/manifest-store.js';
+export type { RouteManifest, RouteManifestInput } from './runtime/manifest-store.js';
+export type { ReserveRouteManifestOptions, RouteManifestConflict } from './runtime/route-reservation.js';
 export { CaddyService } from './services/definitions/caddy-service.js';
 export { SsoService, type SsoServiceVariant } from './services/definitions/sso-service.js';
 export { ssoClientId, ssoClientSecret, ssoRealm, ssoUserEmail, ssoUserName, ssoUserPassword } from './services/sso-config.js';

--- a/shared/cli/src/runtime/file-lock.test.ts
+++ b/shared/cli/src/runtime/file-lock.test.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { withFileLock } from './file-lock.js';
+
+describe('withFileLock', () => {
+    let lockPath: string;
+
+    beforeEach(async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'stam-cli-lock-'));
+        lockPath = path.join(dir, 'nested', 'reload.lock');
+    });
+
+    it('runs handlers one after another and cleans up the lock file', async () => {
+        const events: string[] = [];
+        const handler = async (name: string) => await withFileLock(lockPath, async () => {
+            events.push(`${name}:start`);
+            await new Promise(resolve => setTimeout(resolve, 25));
+            events.push(`${name}:end`);
+        });
+
+        await Promise.all([handler('a'), handler('b')]);
+
+        expect(events).toEqual(events[0] === 'a:start'
+            ? ['a:start', 'a:end', 'b:start', 'b:end']
+            : ['b:start', 'b:end', 'a:start', 'a:end']);
+        await expect(fs.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('releases the lock when the handler throws', async () => {
+        await expect(withFileLock(lockPath, () => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+
+        await expect(fs.stat(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
+        await expect(withFileLock(lockPath, () => Promise.resolve('ok'))).resolves.toBe('ok');
+    });
+
+    it('takes over a lock of a process that no longer exists', async () => {
+        await fs.mkdir(path.dirname(lockPath), { recursive: true });
+        await fs.writeFile(lockPath, JSON.stringify({ pid: 2 ** 30, startedAt: new Date().toISOString() }));
+
+        await expect(withFileLock(lockPath, () => Promise.resolve('ok'), { timeoutMs: 5_000 })).resolves.toBe('ok');
+    });
+
+    it('takes over a lock that is older than the stale timeout', async () => {
+        await writeForeignLock(new Date(Date.now() - 10_000));
+
+        await expect(withFileLock(lockPath, () => Promise.resolve('ok'), { staleMs: 1_000, timeoutMs: 30_000 })).resolves.toBe('ok');
+    });
+
+    it('waits for a lock that is still held, and steals it after the timeout', async () => {
+        await writeForeignLock(new Date());
+        const start = Date.now();
+
+        await expect(withFileLock(lockPath, () => Promise.resolve('ok'), { timeoutMs: 300 })).resolves.toBe('ok');
+        expect(Date.now() - start).toBeGreaterThanOrEqual(300);
+    });
+
+    it('takes over a lock file that cannot be read', async () => {
+        await fs.mkdir(path.dirname(lockPath), { recursive: true });
+        await fs.writeFile(lockPath, 'not json');
+
+        await expect(withFileLock(lockPath, () => Promise.resolve('ok'), { timeoutMs: 30_000 })).resolves.toBe('ok');
+    });
+
+    /**
+     * A lock held by a process that is alive but is not this one: pid 1 always exists, and
+     * signalling it fails with EPERM, which counts as alive.
+     */
+    async function writeForeignLock(startedAt: Date) {
+        await fs.mkdir(path.dirname(lockPath), { recursive: true });
+        await fs.writeFile(lockPath, JSON.stringify({ pid: 1, startedAt: startedAt.toISOString() }));
+    }
+});

--- a/shared/cli/src/runtime/file-lock.ts
+++ b/shared/cli/src/runtime/file-lock.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+type LockFile = {
+    pid: number;
+    startedAt: string;
+};
+
+const defaultTimeoutMs = 60_000;
+const defaultStaleMs = 120_000;
+const pollIntervalMs = 50;
+
+/**
+ * Run `handler` while holding an advisory lock file, so concurrent CLI processes (dev sessions,
+ * e2e runs in other worktrees) never interleave a read-modify-write of shared state such as the
+ * Caddy config. Locks from dead processes and locks older than `staleMs` are taken over, and after
+ * `timeoutMs` the lock is stolen rather than failing the caller: a stuck lock file must never make
+ * `stam dev` or an e2e run unusable.
+ */
+export async function withFileLock<T>(lockPath: string, handler: () => Promise<T>, options: { timeoutMs?: number; staleMs?: number } = {}): Promise<T> {
+    const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
+    const staleMs = options.staleMs ?? defaultStaleMs;
+    await acquireLock(lockPath, timeoutMs, staleMs);
+
+    try {
+        return await handler();
+    }
+    finally {
+        await fs.rm(lockPath, { force: true }).catch(() => undefined);
+    }
+}
+
+async function acquireLock(lockPath: string, timeoutMs: number, staleMs: number): Promise<void> {
+    const start = Date.now();
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+
+    while (true) {
+        if (await writeLock(lockPath)) {
+            return;
+        }
+
+        const holder = await readLock(lockPath);
+        // A lock held by this process itself is taken over right away: the CLI is single threaded,
+        // so a nested call can only mean the outer call is waiting on us.
+        const expired = holder === undefined
+            || holder.pid === process.pid
+            || !processIsAlive(holder.pid)
+            || Date.now() - Date.parse(holder.startedAt) > staleMs;
+
+        if (expired || Date.now() - start > timeoutMs) {
+            await fs.rm(lockPath, { force: true }).catch(() => undefined);
+        }
+
+        await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    }
+}
+
+async function writeLock(lockPath: string): Promise<boolean> {
+    const contents: LockFile = { pid: process.pid, startedAt: new Date().toISOString() };
+    try {
+        await fs.writeFile(lockPath, JSON.stringify(contents), { flag: 'wx' });
+        return true;
+    }
+    catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+            return false;
+        }
+        throw error;
+    }
+}
+
+async function readLock(lockPath: string): Promise<LockFile | undefined> {
+    try {
+        const raw = JSON.parse(await fs.readFile(lockPath, 'utf-8')) as Partial<LockFile>;
+        if (typeof raw.pid !== 'number' || typeof raw.startedAt !== 'string' || Number.isNaN(Date.parse(raw.startedAt))) {
+            return undefined;
+        }
+        return { pid: raw.pid, startedAt: raw.startedAt };
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function processIsAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    }
+    catch (error) {
+        // EPERM means the process exists but belongs to someone else.
+        return (error as NodeJS.ErrnoException).code === 'EPERM';
+    }
+}

--- a/shared/cli/src/runtime/manifest-store.test.ts
+++ b/shared/cli/src/runtime/manifest-store.test.ts
@@ -3,9 +3,10 @@ import path from 'node:path';
 import os from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CliContext } from '../context/create-context.js';
-import { listActiveRouteManifests, listInstanceManifests, writeRouteManifest } from './manifest-store.js';
+import type { RouteManifestInput } from './manifest-store.js';
+import { listActiveRouteManifests, listInstanceManifests, removeOwnRouteManifests, writeRouteManifest } from './manifest-store.js';
 
-describe.skip('manifest store', () => {
+describe('manifest store', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
@@ -51,35 +52,16 @@ describe.skip('manifest store', () => {
 
     it('returns active route manifests', async () => {
         const context = await testContext();
-        await writeRouteManifest(context, {
-            name: 'playwright-worker-0',
-            kind: 'playwright-worker',
-            pid: process.pid,
-            startedAt: new Date().toISOString(),
-            expiresAt: new Date(Date.now() + 60_000).toISOString(),
-            rootPath: '/repo',
-            workspace: 'playwright',
-            routes: [{ hosts: ['playwright-dashboard-0.stamhoofd'], port: 6100 }],
-            tlsSubjects: ['playwright-dashboard-0.stamhoofd'],
-        });
+        await writeRouteManifest(context, routeManifest({ pid: process.pid }));
 
         await expect(listActiveRouteManifests(context)).resolves.toMatchObject([
-            { name: 'playwright-worker-0', kind: 'playwright-worker' },
+            { name: 'playwright-worker-0', kind: 'playwright-worker', reservedPorts: [6000, 6100] },
         ]);
     });
 
     it('ignores and removes expired route manifests', async () => {
         const context = await testContext();
-        await writeRouteManifest(context, {
-            name: 'playwright-worker-0',
-            kind: 'playwright-worker',
-            startedAt: new Date().toISOString(),
-            expiresAt: new Date(Date.now() - 60_000).toISOString(),
-            rootPath: '/repo',
-            workspace: 'playwright',
-            routes: [{ hosts: ['playwright-dashboard-0.stamhoofd'], port: 6100 }],
-            tlsSubjects: ['playwright-dashboard-0.stamhoofd'],
-        });
+        await writeRouteManifest(context, routeManifest({ expiresAt: new Date(Date.now() - 60_000) }));
 
         await expect(listActiveRouteManifests(context)).resolves.toEqual([]);
         await expect(fs.stat(path.join(context.generatedDir, 'instances', 'playwright-worker-0.json'))).rejects.toMatchObject({ code: 'ENOENT' });
@@ -93,22 +75,39 @@ describe.skip('manifest store', () => {
             }
             return true;
         }) as typeof process.kill);
-        await writeRouteManifest(context, {
-            name: 'playwright-worker-0',
-            kind: 'playwright-worker',
-            pid: 123456,
-            startedAt: new Date().toISOString(),
-            expiresAt: new Date(Date.now() + 60_000).toISOString(),
-            rootPath: '/repo',
-            workspace: 'playwright',
-            routes: [{ hosts: ['playwright-dashboard-0.stamhoofd'], port: 6100 }],
-            tlsSubjects: ['playwright-dashboard-0.stamhoofd'],
-        });
+        await writeRouteManifest(context, routeManifest({ pid: 123456 }));
 
         await expect(listActiveRouteManifests(context)).resolves.toEqual([]);
         await expect(fs.stat(path.join(context.generatedDir, 'instances', 'playwright-worker-0.json'))).rejects.toMatchObject({ code: 'ENOENT' });
     });
+
+    it('removes only the route manifests of this process', async () => {
+        const context = await testContext();
+        await writeRouteManifest(context, { ...routeManifest({ pid: process.pid }), name: 'own-run' });
+        await writeRouteManifest(context, { ...routeManifest({ pid: 1 }), name: 'other-run' });
+
+        await removeOwnRouteManifests(context, 'playwright-worker');
+
+        await expect(listActiveRouteManifests(context)).resolves.toMatchObject([{ name: 'other-run' }]);
+    });
 });
+
+function routeManifest(options: { pid?: number; expiresAt?: Date } = {}): RouteManifestInput {
+    return {
+        name: 'playwright-worker-0',
+        kind: 'playwright-worker',
+        pid: options.pid,
+        startedAt: new Date().toISOString(),
+        expiresAt: (options.expiresAt ?? new Date(Date.now() + 60_000)).toISOString(),
+        rootPath: '/repo',
+        workspace: 'playwright',
+        reservedPorts: [6000, 6100],
+        caddy: {
+            routes: [{ match: [{ host: ['playwright-dashboard-0.stamhoofd'] }], handle: [{ handler: 'reverse_proxy', upstreams: [{ dial: '127.0.0.1:6100' }] }] }],
+            tlsSubjects: ['playwright-dashboard-0.stamhoofd'],
+        },
+    };
+}
 
 async function testContext(): Promise<CliContext> {
     const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stam-cli-manifest-'));

--- a/shared/cli/src/runtime/manifest-store.ts
+++ b/shared/cli/src/runtime/manifest-store.ts
@@ -34,6 +34,7 @@ export type InstanceManifest = {
     rootPath: string;
     domains: Domains;
     ports: ReturnType<typeof buildPorts>;
+    reservedPorts?: number[];
     caddy?: CaddyRouteOptions;
 };
 
@@ -48,10 +49,17 @@ export type RouteManifest = {
     expiresAt?: string;
     rootPath: string;
     workspace: string;
+    /**
+     * Every host port this manifest claims for as long as it is active. Other processes read these
+     * to pick a port range of their own without scanning the route configs, see
+     * `CaddyService.findRouteManifestConflicts`.
+     */
+    reservedPorts?: number[];
     caddy: CaddyRouteOptions;
 };
 
 export async function writeInstanceManifest(context: CliContext, options: { domains: Domains; caddy?: CaddyRouteOptions }): Promise<void> {
+    const ports = buildPorts(context);
     const manifest: InstanceManifest = {
         version: CurrentManifestVersion,
         name: context.instance.name,
@@ -65,7 +73,10 @@ export async function writeInstanceManifest(context: CliContext, options: { doma
         startedAt: new Date().toISOString(),
         rootPath: context.rootDir,
         domains: options?.domains,
-        ports: buildPorts(context),
+        ports,
+        // Only the ports this instance owns: the shared services (MySQL, MailDev, ...) are used by
+        // every instance at once, so claiming them would block anyone else from starting.
+        reservedPorts: [ports.webApp, ports.webshop, ports.api, ports.renderer, ports.sso],
         caddy: options?.caddy,
     };
     await fs.mkdir(instanceDir(context), { recursive: true });
@@ -76,19 +87,32 @@ export async function removeInstanceManifest(context: CliContext): Promise<void>
     await fs.rm(instancePath(context, context.instance.name), { force: true });
 }
 
-export async function writeRouteManifest(context: CliContext, manifest: RouteManifest): Promise<void> {
+/**
+ * The fields a caller provides: the manifest version is stamped here, so writers never have to
+ * know which version the store is on.
+ */
+export type RouteManifestInput = Omit<RouteManifest, 'version'>;
+
+export async function writeRouteManifest(context: CliContext, manifest: RouteManifestInput): Promise<RouteManifest> {
+    const stored: RouteManifest = { ...manifest, version: CurrentManifestVersion };
     await fs.mkdir(instanceDir(context), { recursive: true });
-    await fs.writeFile(instancePath(context, manifest.name), JSON.stringify(manifest, null, 4));
+    await fs.writeFile(instancePath(context, stored.name), JSON.stringify(stored, null, 4));
+    return stored;
 }
 
 export async function removeRouteManifest(context: CliContext, name: string): Promise<void> {
     await fs.rm(instancePath(context, name), { force: true });
 }
 
-export async function removeRouteManifestsByKind(context: CliContext, kind: RouteManifestKind): Promise<void> {
+/**
+ * Remove every manifest of a kind that was written by this same process. Manifests of other
+ * processes are never touched: they may belong to an e2e run or dev session that is still using
+ * those routes and ports.
+ */
+export async function removeOwnRouteManifests(context: CliContext, kind: RouteManifestKind): Promise<void> {
     const manifests = await listRouteManifestEntries(context);
     await Promise.all(manifests
-        .filter(entry => entry.manifest?.kind === kind)
+        .filter(entry => entry.manifest?.kind === kind && entry.manifest.pid === process.pid)
         .map(entry => fs.rm(entry.path, { force: true })));
 }
 
@@ -162,6 +186,7 @@ export function instanceManifestToRouteManifest(manifest: InstanceManifest): Rou
         startedAt: manifest.startedAt,
         rootPath: manifest.rootPath,
         workspace: manifest.workspace,
+        reservedPorts: manifest.reservedPorts,
         caddy: manifest.caddy ?? {
             routes: [],
             tlsSubjects: [],
@@ -245,7 +270,8 @@ function processIsAlive(pid: number): boolean {
     try {
         process.kill(pid, 0);
         return true;
-    } catch {
-        return false;
+    } catch (error) {
+        // EPERM means the process exists but belongs to someone else.
+        return (error as NodeJS.ErrnoException).code === 'EPERM';
     }
 }

--- a/shared/cli/src/runtime/monorepo-runner.ts
+++ b/shared/cli/src/runtime/monorepo-runner.ts
@@ -64,6 +64,7 @@ export type UnitTestPackage = {
 // runs vitest, then add it here with the correct `needsDatabase` (true if its vitest setup/tests
 // query `Database` from @simonbackx/simple-database).
 export const unitTestPackages: UnitTestPackage[] = [
+    { name: 'cli', path: 'shared/cli', needsDatabase: false },
     { name: 'structures', path: 'shared/structures', needsDatabase: false, typecheck: true },
     { name: 'object-differ', path: 'shared/object-differ', needsDatabase: false },
     { name: 'sgv', path: 'shared/sgv', needsDatabase: false },

--- a/shared/cli/src/runtime/port-probe.ts
+++ b/shared/cli/src/runtime/port-probe.ts
@@ -1,0 +1,30 @@
+import net from 'node:net';
+import { localIpv4Host } from '../config/shared-service-config.js';
+
+/**
+ * Whether a TCP port can still be bound on this machine.
+ *
+ * Binding is the only check that also sees processes the manifest store knows nothing about (an
+ * unrelated server, a leftover process, an e2e run started from a checkout with its own generated
+ * directory), so port bookkeeping always combines the manifests with this probe.
+ */
+export async function isPortAvailable(port: number, host: string = localIpv4Host): Promise<boolean> {
+    return await new Promise((resolve) => {
+        const server = net.createServer();
+
+        server.once('error', () => resolve(false));
+        server.once('listening', () => {
+            server.close(() => resolve(true));
+        });
+
+        server.listen(port, host);
+    });
+}
+
+/**
+ * The subset of `ports` that is already in use, in the order they were passed in.
+ */
+export async function findBusyPorts(ports: number[], host: string = localIpv4Host): Promise<number[]> {
+    const results = await Promise.all(ports.map(async port => ({ port, available: await isPortAvailable(port, host) })));
+    return results.filter(result => !result.available).map(result => result.port);
+}

--- a/shared/cli/src/runtime/route-reservation.test.ts
+++ b/shared/cli/src/runtime/route-reservation.test.ts
@@ -1,0 +1,189 @@
+import net from 'node:net';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliContext } from '../context/create-context.js';
+import type { RouteManifestInput } from './manifest-store.js';
+import * as manifestStore from './manifest-store.js';
+import { findRouteManifestConflicts, reserveRouteManifest } from './route-reservation.js';
+
+vi.mock('./manifest-store.js', async importOriginal => ({
+    ...await importOriginal<typeof manifestStore>(),
+    listActiveRouteManifests: vi.fn(),
+}));
+
+const original = await vi.importActual<typeof manifestStore>('./manifest-store.js');
+
+// A pid that is guaranteed not to be running, so its manifest counts as stale.
+const deadPid = 2 ** 30;
+
+// Only the race test replaces this; everything else reads the manifests from disk as usual.
+beforeEach(() => {
+    vi.mocked(manifestStore.listActiveRouteManifests).mockImplementation(async (context, options) => await original.listActiveRouteManifests(context, options));
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('findRouteManifestConflicts', () => {
+    it('only reports manifests that claim one of the same ports', async () => {
+        const context = await testContext();
+        await original.writeRouteManifest(context, manifest({ name: 'other-run', reservedPorts: [6002, 6003] }));
+        await original.writeRouteManifest(context, manifest({ name: 'far-away-run', reservedPorts: [6010] }));
+
+        const conflicts = await findRouteManifestConflicts(context, manifest({ name: 'my-run', reservedPorts: [6000, 6001, 6002] }));
+
+        expect(conflicts).toHaveLength(1);
+        expect(conflicts[0].manifest.name).toBe('other-run');
+        expect(conflicts[0].ports).toEqual([6002]);
+    });
+
+    it('ignores the manifest of the run itself and manifests without reserved ports', async () => {
+        const context = await testContext();
+        await original.writeRouteManifest(context, manifest({ name: 'my-run', reservedPorts: [6000] }));
+        await original.writeRouteManifest(context, manifest({ name: 'legacy-run', reservedPorts: undefined }));
+
+        await expect(findRouteManifestConflicts(context, manifest({ name: 'my-run', reservedPorts: [6000] }))).resolves.toEqual([]);
+    });
+});
+
+describe('reserveRouteManifest', () => {
+    it('claims the first range and writes its manifest', async () => {
+        const context = await testContext();
+
+        const reserved = await reserveRouteManifest(context, { buildManifest: buildBlock('my-run') });
+
+        expect(reserved.reservedPorts).toEqual([6000, 6001]);
+        expect(reserved.version).toBeDefined();
+        await expect(original.listActiveRouteManifests(context)).resolves.toMatchObject([{ name: 'my-run', reservedPorts: [6000, 6001] }]);
+    });
+
+    it('skips ranges that another active manifest reserves', async () => {
+        const context = await testContext();
+        await original.writeRouteManifest(context, manifest({ name: 'other-run', reservedPorts: [6001, 6002] }));
+
+        const reserved = await reserveRouteManifest(context, { buildManifest: buildBlock('my-run') });
+
+        expect(reserved.reservedPorts).toEqual([6004, 6005]);
+    });
+
+    it('reuses ranges of manifests whose process is gone', async () => {
+        const context = await testContext();
+        await original.writeRouteManifest(context, manifest({ name: 'crashed-run', reservedPorts: [6000, 6001], pid: deadPid }));
+
+        const reserved = await reserveRouteManifest(context, { buildManifest: buildBlock('my-run') });
+
+        expect(reserved.reservedPorts).toEqual([6000, 6001]);
+    });
+
+    it('skips ranges with a port that is already bound', async () => {
+        const context = await testContext();
+        const taken = await listenOnFreePort();
+
+        try {
+            const reserved = await reserveRouteManifest(context, {
+                buildManifest: attempt => attempt > 1 ? undefined : manifest({ name: 'my-run', reservedPorts: attempt === 0 ? [taken.port] : [taken.port + 1000] }),
+            });
+
+            expect(reserved.reservedPorts).toEqual([taken.port + 1000]);
+        }
+        finally {
+            await taken.close();
+        }
+    });
+
+    it('gives up its manifest when another run claimed the same ports first', async () => {
+        const context = await testContext();
+        const competitor = manifest({ name: 'other-run', reservedPorts: [6000, 6001], startedAt: new Date(Date.now() - 60_000).toISOString() });
+
+        // The competitor writes its manifest right after we checked, so it only shows up in the
+        // verification that follows our own write.
+        let checks = 0;
+        vi.mocked(manifestStore.listActiveRouteManifests).mockImplementation(async (ctx) => {
+            checks += 1;
+            if (checks > 1) {
+                await original.writeRouteManifest(ctx, competitor);
+            }
+            return await original.listActiveRouteManifests(ctx);
+        });
+
+        const reserved = await reserveRouteManifest(context, { buildManifest: buildBlock('my-run') });
+
+        expect(reserved.reservedPorts).toEqual([6002, 6003]);
+        const active = await original.listActiveRouteManifests(context);
+        expect(active.map(item => item.name).sort()).toEqual(['my-run', 'other-run']);
+    });
+
+    it('reports the blocked ranges when nothing is free', async () => {
+        const context = await testContext();
+        await original.writeRouteManifest(context, manifest({ name: 'other-run', reservedPorts: [6000, 6001] }));
+
+        await expect(reserveRouteManifest(context, {
+            buildManifest: attempt => attempt > 0 ? undefined : manifest({ name: 'my-run', reservedPorts: [6000, 6001] }),
+        })).rejects.toThrow(/ports 6000, 6001 reserved by other-run/);
+    });
+});
+
+/**
+ * Builds consecutive two-port ranges, the way a Playwright run walks through its slots.
+ */
+function buildBlock(name: string, maxAttempt = 4) {
+    return (attempt: number): RouteManifestInput | undefined => {
+        if (attempt > maxAttempt) {
+            return undefined;
+        }
+        return manifest({ name, reservedPorts: [6000 + attempt * 2, 6001 + attempt * 2] });
+    };
+}
+
+function manifest(options: { name: string; reservedPorts?: number[]; pid?: number; startedAt?: string }): RouteManifestInput {
+    return {
+        name: options.name,
+        kind: 'playwright-worker',
+        pid: options.pid ?? process.pid,
+        startedAt: options.startedAt ?? new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        rootPath: '/repo',
+        workspace: 'playwright',
+        reservedPorts: options.reservedPorts,
+        caddy: { routes: [], tlsSubjects: [] },
+    };
+}
+
+/**
+ * Occupy a free port so the reservation has to skip it.
+ */
+async function listenOnFreePort(): Promise<{ port: number; close: () => Promise<void> }> {
+    const server = net.createServer();
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+        throw new Error('Expected a TCP address');
+    }
+
+    return {
+        port: address.port,
+        close: async () => {
+            await new Promise<void>(resolve => server.close(() => resolve()));
+        },
+    };
+}
+
+async function testContext(): Promise<CliContext> {
+    const generatedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stam-cli-reservation-'));
+    return {
+        rootDir: '/repo',
+        generatedDir,
+        env: 'stamhoofd',
+        workspace: 'main',
+        verbose: false,
+        instance: {
+            name: 'stamhoofd',
+            prefix: '',
+            primary: true,
+            portOffset: 0,
+        },
+    };
+}

--- a/shared/cli/src/runtime/route-reservation.ts
+++ b/shared/cli/src/runtime/route-reservation.ts
@@ -1,0 +1,129 @@
+import type { CliContext } from '../context/create-context.js';
+import type { RouteManifest, RouteManifestInput } from './manifest-store.js';
+import { listActiveRouteManifests, pruneStaleRouteManifests, removeRouteManifest, writeRouteManifest } from './manifest-store.js';
+import { findBusyPorts } from './port-probe.js';
+
+export type RouteManifestConflict = {
+    /** The manifest that already claims these ports. */
+    manifest: RouteManifest;
+    ports: number[];
+};
+
+export type ReserveRouteManifestOptions = {
+    /**
+     * Builds the manifest for attempt `attempt` (0-based), each one claiming a different port
+     * range. Return undefined once no range is left to try.
+     */
+    buildManifest: (attempt: number) => RouteManifestInput | undefined;
+};
+
+/**
+ * How long to wait between writing a manifest and verifying it again. A process that ran its own
+ * check just before our file landed still has to write its manifest; the pause makes it very
+ * likely we see that write, so exactly one of the two backs off (see `losesRaceAgainst`).
+ */
+const settleMs = 250;
+
+/**
+ * The active manifests whose reserved ports overlap the ports of `candidate`. Manifests with the
+ * same name are ignored: that one is the candidate itself (a previous attempt of this same run).
+ */
+export async function findRouteManifestConflicts(context: CliContext, candidate: RouteManifestInput): Promise<RouteManifestConflict[]> {
+    const wanted = new Set(candidate.reservedPorts ?? []);
+    if (wanted.size === 0) {
+        return [];
+    }
+
+    const manifests = await listActiveRouteManifests(context);
+    return manifests
+        .filter(manifest => manifest.name !== candidate.name)
+        .map(manifest => ({ manifest, ports: (manifest.reservedPorts ?? []).filter(port => wanted.has(port)) }))
+        .filter(conflict => conflict.ports.length > 0);
+}
+
+/**
+ * Claim a port range for this process by writing a route manifest for it.
+ *
+ * Ranges are tried in the order `buildManifest` produces them, and a range is only claimed when
+ * both checks pass: no active manifest reserves any of its ports, and every port can actually be
+ * bound right now (which also covers processes that never wrote a manifest). The manifest is
+ * written first and verified afterwards, so two processes that pick the same free range at the
+ * same time do not both keep it: the one that started later removes its manifest and moves on.
+ */
+export async function reserveRouteManifest(context: CliContext, options: ReserveRouteManifestOptions): Promise<RouteManifest> {
+    const blocked: string[] = [];
+
+    // Manifests of crashed runs would keep their ports claimed forever.
+    await pruneStaleRouteManifests(context);
+
+    for (let attempt = 0; ; attempt += 1) {
+        const candidate = options.buildManifest(attempt);
+        if (!candidate) {
+            throw new Error(`Could not reserve a free port range${blocked.length === 0 ? '' : `. Tried ${blocked.length} ranges: ${describeBlocked(blocked)}`}`);
+        }
+
+        const blockedBy = await describeBlockers(context, candidate);
+        if (blockedBy) {
+            blocked.push(blockedBy);
+            continue;
+        }
+
+        const written = await writeRouteManifest(context, candidate);
+        await new Promise(resolve => setTimeout(resolve, settleMs));
+
+        const lostAgainst = (await findRouteManifestConflicts(context, candidate))
+            .filter(conflict => losesRaceAgainst(candidate, conflict.manifest));
+
+        if (lostAgainst.length === 0) {
+            return written;
+        }
+
+        // Another process claimed (part of) this range at the same time and started first.
+        await removeRouteManifest(context, candidate.name);
+        blocked.push(`${describePorts(lostAgainst.flatMap(conflict => conflict.ports))} claimed by ${lostAgainst.map(conflict => conflict.manifest.name).join(', ')}`);
+    }
+}
+
+async function describeBlockers(context: CliContext, candidate: RouteManifestInput): Promise<string | undefined> {
+    const conflicts = await findRouteManifestConflicts(context, candidate);
+    if (conflicts.length > 0) {
+        return `${describePorts(conflicts.flatMap(conflict => conflict.ports))} reserved by ${conflicts.map(conflict => conflict.manifest.name).join(', ')}`;
+    }
+
+    const busy = await findBusyPorts(candidate.reservedPorts ?? []);
+    if (busy.length > 0) {
+        return `${describePorts(busy)} already in use`;
+    }
+
+    return undefined;
+}
+
+/**
+ * Deterministic tiebreak for two manifests that claim the same ports: the one that started first
+ * keeps the range, and equal timestamps fall back to the name so both processes reach the same
+ * conclusion. The later one gives up, whichever side is asking.
+ */
+function losesRaceAgainst(candidate: RouteManifestInput, other: RouteManifest): boolean {
+    const candidateStart = Date.parse(candidate.startedAt);
+    const otherStart = Date.parse(other.startedAt);
+
+    if (candidateStart !== otherStart) {
+        return candidateStart > otherStart;
+    }
+    return candidate.name > other.name;
+}
+
+/**
+ * The reasons of the first few ranges: a run reserves dozens of ports, so listing every range in
+ * full turns the error into a wall of numbers.
+ */
+function describeBlocked(blocked: string[]): string {
+    const shown = blocked.slice(0, 3);
+    return `${shown.join('; ')}${blocked.length > shown.length ? `; ...` : ''}`;
+}
+
+function describePorts(ports: number[]): string {
+    const unique = [...new Set(ports)].sort((a, b) => a - b);
+    const shown = unique.slice(0, 4);
+    return `port${unique.length === 1 ? '' : 's'} ${shown.join(', ')}${unique.length > shown.length ? `, ... (${unique.length} total)` : ''}`;
+}

--- a/shared/cli/src/services/definitions/caddy-service.ts
+++ b/shared/cli/src/services/definitions/caddy-service.ts
@@ -5,8 +5,11 @@ import { caddyAdminPort, caddyBaseImage, caddyBuilderImage, caddyConfigPath, cad
 import type { SharedServiceProfile } from '../../config/shared-service-profile.js';
 import { buildCaddyServiceProfile, buildSharedServiceProfile, SharedServiceCaddyRunMode } from '../../config/shared-service-profile.js';
 import type { CliContext } from '../../context/create-context.js';
-import type { CaddyRouteOptions } from '../../runtime/manifest-store.js';
+import { withFileLock } from '../../runtime/file-lock.js';
+import type { CaddyRouteOptions, RouteManifest, RouteManifestInput } from '../../runtime/manifest-store.js';
 import { sharedDir } from '../../runtime/manifest-store.js';
+import type { ReserveRouteManifestOptions, RouteManifestConflict } from '../../runtime/route-reservation.js';
+import { findRouteManifestConflicts, reserveRouteManifest } from '../../runtime/route-reservation.js';
 import { SharedDockerService } from '../docker-service.js';
 import * as docker from '../docker.js';
 import type { ServiceStatus } from '../service.js';
@@ -15,6 +18,36 @@ type CaddyPrepared = {
     config: string;
     dataDir: string;
 };
+
+/**
+ * Whether this process is already inside the config lock, so a reload that has to start the
+ * container (which renders the config again in `prepare`) does not wait on the lock it holds
+ * itself. The CLI renders the config from one place at a time, so this never hides a genuinely
+ * concurrent render within the same process.
+ */
+let configLockDepth = 0;
+
+/**
+ * Serialize everything that renders the shared Caddy config.
+ *
+ * The config is a full rewrite of the routing table of every active manifest, and the container
+ * watches the file, so writing it is what applies it. Without this lock two processes (a dev
+ * session starting while an e2e run in another worktree configures its routes) can each render a
+ * config from the manifests they saw and the last write silently drops the routes of the other.
+ */
+async function withConfigLock<T>(context: CliContext, handler: () => Promise<T>): Promise<T> {
+    if (configLockDepth > 0) {
+        return await handler();
+    }
+
+    configLockDepth += 1;
+    try {
+        return await withFileLock(path.join(sharedDir(context), 'caddy-config.lock'), handler);
+    }
+    finally {
+        configLockDepth -= 1;
+    }
+}
 
 export class CaddyService extends SharedDockerService<CaddyPrepared> {
     static readonly container = caddyContainer;
@@ -36,7 +69,9 @@ export class CaddyService extends SharedDockerService<CaddyPrepared> {
     }
 
     async prepare(context: CliContext): Promise<CaddyPrepared> {
-        const config = await CaddyService.writeRuntimeConfig(context);
+        // Rendering the config already applies it: the container watches the file. So this write
+        // takes the same lock as a reload, see withConfigLock.
+        const config = await withConfigLock(context, async () => await CaddyService.writeRuntimeConfig(context));
         const dataDir = CaddyService.dataDir();
         await fs.mkdir(dataDir, { recursive: true });
         await CaddyService.ensureImage(context);
@@ -61,15 +96,38 @@ export class CaddyService extends SharedDockerService<CaddyPrepared> {
         return CaddyService.dockerArgs(prepared.config, prepared.dataDir, profile, { disableLabel: runtime === docker.ContainerRuntime.Podman });
     }
 
+    /**
+     * Render the config of every active manifest and apply it to the running container.
+     */
     static async reload(context: CliContext): Promise<void> {
-        const config = await CaddyService.writeRuntimeConfig(context);
-        await CaddyService.ensureImage(context);
-        await CaddyService.validateConfig(config, context);
-        if (await docker.containerIsRunning(CaddyService.container)) {
-            await docker.run(['exec', CaddyService.container, 'caddy', 'reload', '--config', caddyConfigPath, '--address', localhostPort(caddyAdminPort), '--force'], { quiet: true, verbose: context.verbose });
-            return;
-        }
-        await caddyService.start(context, undefined);
+        await withConfigLock(context, async () => {
+            const config = await CaddyService.writeRuntimeConfig(context);
+            await CaddyService.ensureImage(context);
+            await CaddyService.validateConfig(config, context);
+            if (await docker.containerIsRunning(CaddyService.container)) {
+                await docker.run(['exec', CaddyService.container, 'caddy', 'reload', '--config', caddyConfigPath, '--address', localhostPort(caddyAdminPort), '--force'], { quiet: true, verbose: context.verbose });
+                return;
+            }
+            await caddyService.start(context, undefined);
+        });
+    }
+
+    /**
+     * The active manifests that already claim one of the ports of `manifest`. Ask this before
+     * adding a manifest of your own: overlapping ports mean the two would fight over the same
+     * servers (and, for Playwright workers, over the same domains).
+     */
+    static async findRouteManifestConflicts(context: CliContext, manifest: RouteManifestInput): Promise<RouteManifestConflict[]> {
+        return await findRouteManifestConflicts(context, manifest);
+    }
+
+    /**
+     * Claim a free port range for this process, retrying other ranges while they conflict with an
+     * active manifest or with a port that is already bound. Give the range back with
+     * `removeOwnRouteManifests` followed by a reload.
+     */
+    static async reserveRouteManifest(context: CliContext, options: ReserveRouteManifestOptions): Promise<RouteManifest> {
+        return await reserveRouteManifest(context, options);
     }
 
     static buildRouteOptions(context: CliContext): CaddyRouteOptions {

--- a/shared/cli/src/services/definitions/sso-service.ts
+++ b/shared/cli/src/services/definitions/sso-service.ts
@@ -3,6 +3,7 @@ import { buildPorts } from '../../context/ports.js';
 import { keycloakImage, localIpv4Host, ssoInternalPort } from '../../config/shared-service-config.js';
 import type { CliContext } from '../../context/create-context.js';
 import { DockerService } from '../docker-service.js';
+import * as docker from '../docker.js';
 import { ssoAdminPassword, ssoAdminUser, ssoRealm, writeKeycloakRealm } from '../sso-config.js';
 
 type SsoStartOptions = {
@@ -130,6 +131,24 @@ export class SsoService extends DockerService<SsoStartOptions, SsoPrepared> {
 
     static container(context: { instance: { name: string } }, variant?: string): string {
         return `${context.instance.name}-keycloak${variant ? `-${variant}` : ''}`;
+    }
+
+    /**
+     * Remove the containers of sibling variants, e.g. the server of an e2e run that crashed before
+     * its teardown. Variant names carry the slots a run reserved, so a leaked container is not
+     * replaced by the next run (which reserves other slots) and would keep both its memory and its
+     * port for as long as the machine is up. Only variants starting with `variantPrefix` are
+     * removed, so this never touches the SSO server of `stam sso start`.
+     */
+    async removeOtherVariants(context: CliContext, variantPrefix: string): Promise<void> {
+        const own = this.getContainer(context);
+        const containers = await docker.listContainerNames(SsoService.container(context, variantPrefix));
+
+        for (const container of containers) {
+            if (container !== own) {
+                await docker.removeContainer(container, context.verbose);
+            }
+        }
     }
 }
 

--- a/shared/cli/src/services/docker.ts
+++ b/shared/cli/src/services/docker.ts
@@ -33,6 +33,14 @@ export async function removeContainer(name: string, verbose = false): Promise<vo
     await run(['rm', '-f', name], { quiet: true, allowFailure: true, verbose });
 }
 
+/**
+ * Every container (running or not) whose name starts with `prefix`.
+ */
+export async function listContainerNames(prefix: string): Promise<string[]> {
+    const result = await run(['ps', '-a', '--filter', `name=^${prefix}`, '--format', '{{.Names}}'], { capture: true, quiet: true, allowFailure: true });
+    return result.stdout.split('\n').map(name => name.trim()).filter(name => name.startsWith(prefix));
+}
+
 export async function getContainerLogs(name: string, options: { tail?: number } = {}): Promise<string> {
     const result = await run(['logs', '--tail', String(options.tail ?? 50), name], { capture: true, allowFailure: true });
     return [result.stdout, result.stderr].filter(Boolean).join('\n').trim();

--- a/shared/cli/src/services/shared-services.test.ts
+++ b/shared/cli/src/services/shared-services.test.ts
@@ -112,6 +112,25 @@ describe('shared service Docker args', () => {
         expect(service.getIssuer(context)).toBe('https://playwright-sso.stamhoofd/dex/realms/stamhoofd');
     });
 
+    it('removes the containers of other variants of the same family, but not of other families', async () => {
+        const context = {
+            rootDir: '/tmp/stamhoofd',
+            env: 'stamhoofd',
+            verbose: false,
+            instance: { name: 'stamhoofd', prefix: 'stamhoofd', portOffset: 0, primary: true },
+        } as any;
+        vi.mocked(run).mockResolvedValue({ status: 0, stdout: 'stamhoofd-keycloak-playwright-0\nstamhoofd-keycloak-playwright-5\n', stderr: '' } as any);
+
+        const service = new SsoService({ name: 'playwright-5', port: 6405, hostname: 'playwright-sso-5.stamhoofd' });
+        await service.removeOtherVariants(context, 'playwright');
+
+        const commands = vi.mocked(run).mock.calls.map(call => (call[1] as string[]).join(' '));
+        expect(commands).toContainEqual(expect.stringContaining('name=^stamhoofd-keycloak-playwright'));
+        expect(commands).toContainEqual('rm -f stamhoofd-keycloak-playwright-0');
+        expect(commands).not.toContainEqual('rm -f stamhoofd-keycloak-playwright-5');
+        expect(commands).not.toContainEqual('rm -f stamhoofd-keycloak');
+    });
+
     it('builds macOS Docker bridge args for Caddy', () => {
         const args = CaddyService.dockerArgs('/tmp/caddy.json', '/tmp/data', buildSharedServiceProfile(ContainerRuntime.Docker, 'darwin'));
 

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -18,6 +18,28 @@ The user for the worker can be acquired by calling `WorkderData.user`.
 `WorkerData.configureUser` contains helper methods to configure the user.
 The user can be reset by calling `WorkerData.resetUser`, or `WorkderData.resetDatabase` if other data should be reset also.
 
+## Ports and domains (running several e2e runs at once)
+
+Every worker gets a *slot*: its API/dashboard/registration/webshop ports (`6000`, `6100`, `6200`,
+`6300` + slot) and its domains (`playwright-<service>-<slot>.stamhoofd`) are all derived from it.
+
+A run does not start at slot 0 but reserves a block of consecutive slots, one per worker, in the
+global setup: `CaddyService.reserveRouteManifest` walks through the blocks and takes the first one
+that no other route manifest reserves *and* whose ports can all be bound. The block it settled on
+is written to a route manifest (`playwright-<instance>-<pid>`) that the CLI merges into the shared
+Caddy config, and passed to the workers through `PLAYWRIGHT_SLOT_OFFSET`. So a run started from
+another worktree, or while `stam dev` is running, gets its own ports, domains and SSO server
+instead of fighting over the same ones. The manifest is removed again in the global teardown, and
+manifests of a run that crashed are ignored as soon as its process is gone.
+
+Consequences worth knowing:
+
+- The number of workers has to be known before the tests start. Set `PLAYWRIGHT_WORKER_COUNT`
+  (`stam test e2e --workers N` does this) instead of passing `--workers` to Playwright directly.
+- At most `slotPoolSize` (30) workers can run at the same time across all runs on one machine.
+- The databases are still named per worker index, not per slot, and the e2e MySQL container is per
+  worktree: two runs from the *same* worktree still collide. Run them from different worktrees.
+
 ## Test file naming
 
 Seperate test files for each userMode exist.

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { getWorkerCount } from './src/setup/helpers/WorkerCount.js';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -14,8 +15,8 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 1 : 0,
-    /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 2 : undefined,
+    /* Must match the number of slots the global setup reserves, see WorkerCount. */
+    workers: getWorkerCount(),
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'line',
 

--- a/tests/playwright/src/setup/global-setup.ts
+++ b/tests/playwright/src/setup/global-setup.ts
@@ -1,10 +1,10 @@
-import os from 'node:os';
 import { TestUtils } from '@stamhoofd/test-utils';
 import { CaddyHelper } from './helpers/CaddyHelper.js';
 import { DatabaseHelper } from './helpers/DatabaseHelper.js';
 import { FrontendBuilder } from './helpers/FrontendBuilder.js';
 import { PlaywrightHooks } from './helpers/PlaywrightHooks.js';
 import { SsoHelper } from './helpers/SsoHelper.js';
+import { getWorkerCount } from './helpers/WorkerCount.js';
 
 // Make sure initial env is loaded
 
@@ -23,7 +23,7 @@ export default async function globalSetup() {
     // The SSO server is only reachable once its Caddy route is in place, so it starts after the
     // routes are configured. Runs next to the frontend build, which takes far longer.
     const configureCaddyAndStartSso = async () => {
-        const workerCount = getExpectedWorkerCount();
+        const workerCount = getWorkerCount();
         if (!await caddyHelper.isRunning()) {
             console.log('Starting CI Caddy...');
             await caddyHelper.start();
@@ -32,7 +32,7 @@ export default async function globalSetup() {
         await caddyHelper.configure(workerCount);
 
         console.log('Starting SSO server...');
-        await SsoHelper.start();
+        await SsoHelper.start(workerCount);
         console.log('SSO server started.');
     };
 
@@ -45,7 +45,7 @@ export default async function globalSetup() {
     };
 
     const migrateDatabases = async () => {
-        const workerCount = getExpectedWorkerCount();
+        const workerCount = getWorkerCount();
         const { run: runMigrations } = await import('@stamhoofd/backend/migrate');
 
         for (let workerId = 0; workerId < workerCount; workerId += 1) {
@@ -59,17 +59,4 @@ export default async function globalSetup() {
     for (const promise of [configureCaddyAndStartSso(), buildFrontend(), migrateDatabases()]) {
         await promise;
     }
-}
-
-function getExpectedWorkerCount() {
-    const explicitWorkerCount = process.env.PLAYWRIGHT_WORKER_COUNT ? parseInt(process.env.PLAYWRIGHT_WORKER_COUNT) : undefined;
-    if (explicitWorkerCount !== undefined && Number.isFinite(explicitWorkerCount) && explicitWorkerCount > 0) {
-        return explicitWorkerCount;
-    }
-
-    if (process.env.CI) {
-        return 2;
-    }
-
-    return Math.max(1, Math.floor(os.availableParallelism() / 2));
 }

--- a/tests/playwright/src/setup/helpers/CaddyConfigHelper.ts
+++ b/tests/playwright/src/setup/helpers/CaddyConfigHelper.ts
@@ -4,11 +4,20 @@ import type { CaddyRoute, CaddyRouteOptions } from '@stamhoofd/cli';
 import { cspFrontendSubroutes, ssoRealm } from '@stamhoofd/cli';
 
 /**
- * Old domains and ports will get reused
- *
- * E.g. worker 32 will use same domains and ports as worker 2
+ * Every port and domain of a worker is derived from its slot, not from its worker id: an e2e run
+ * reserves a block of `workerCount` consecutive slots (see CaddyHelper) so runs started from other
+ * worktrees never end up on the same ports or domains. This is the number of slots that exist on
+ * one machine, so at most this many Playwright workers can run at the same time across all runs.
  */
-const maximumRunners = 30;
+export const slotPoolSize = 30;
+
+const portBases = {
+    api: 6000,
+    dashboard: 6100,
+    registration: 6200,
+    webshop: 6300,
+    sso: 6400,
+} as const;
 
 /**
  * Helper to create caddy configuration for playwright
@@ -17,10 +26,45 @@ export class CaddyConfigHelper {
     static readonly GROUP_PREFIX = 'playwright';
 
     /**
+     * The first slot of the block this run reserved. Set once by the global setup and read back in
+     * every worker process, which Playwright forks after the global setup ran.
+     */
+    static getSlotOffset(): number {
+        const offset = Number.parseInt(process.env.PLAYWRIGHT_SLOT_OFFSET ?? '0', 10);
+        return Number.isFinite(offset) && offset >= 0 ? offset : 0;
+    }
+
+    /**
+     * Record the block this run reserved: `count` slots starting at `offset`.
+     */
+    static setSlotBlock(offset: number, count: number) {
+        process.env.PLAYWRIGHT_SLOT_OFFSET = offset.toString();
+        process.env.PLAYWRIGHT_SLOT_COUNT = count.toString();
+    }
+
+    /**
+     * The slot a worker runs on: its ports and domains are all derived from this number.
+     */
+    static getSlot(workerId: string) {
+        const worker = parseInt(workerId);
+        const reserved = Number.parseInt(process.env.PLAYWRIGHT_SLOT_COUNT ?? '', 10);
+
+        if (Number.isFinite(reserved) && worker >= reserved) {
+            throw new Error(`Worker ${workerId} has no reserved slot: this run reserved ${reserved} slots. Set PLAYWRIGHT_WORKER_COUNT instead of overriding --workers.`);
+        }
+
+        const slot = this.getSlotOffset() + worker;
+        if (!Number.isFinite(slot) || slot < 0 || slot >= slotPoolSize) {
+            throw new Error(`Worker ${workerId} maps to slot ${slot}, which is outside the pool of ${slotPoolSize} slots`);
+        }
+        return slot;
+    }
+
+    /**
      * Get the group name for the caddy routes
      */
     static getGroup(service: string, workerId: string) {
-        return `${this.GROUP_PREFIX}-${service}-${workerId}`;
+        return `${this.GROUP_PREFIX}-${service}-${this.getSlot(workerId)}`;
     }
 
     /**
@@ -30,7 +74,7 @@ export class CaddyConfigHelper {
         service: 'api' | 'dashboard' | 'registration' | 'webshop' | 'renderer',
         workerId: string,
     ) {
-        return `playwright-${service}-${this.cycledWorkerId(workerId)}.stamhoofd`;
+        return `playwright-${service}-${this.getSlot(workerId)}.stamhoofd`;
     }
 
     static getCustomDomainTld(
@@ -38,7 +82,7 @@ export class CaddyConfigHelper {
     ) {
         // IMPORTANT: custom registration domains may never end with getDomain('registration', workerId)
         // otherwise, the backend will try to resolve by URI, not by domain
-        return `playwright-custom-${this.cycledWorkerId(workerId)}.stamhoofd`;
+        return `playwright-custom-${this.getSlot(workerId)}.stamhoofd`;
     }
 
     static getRegistrationCustomDomain(
@@ -64,22 +108,27 @@ export class CaddyConfigHelper {
         return `${prefix}.${this.getCustomDomainTld(workerId)}`;
     }
 
-    static cycledWorkerId(workerId: string) {
-        const asNumber = parseInt(workerId);
-        return asNumber % maximumRunners;
-    }
-
     /**
-     * Host of the SSO (Keycloak) server used by the e2e tests. One server is shared by all
-     * workers, and it deliberately does not reuse the `sso.<domain>` host of `stam sso start`: a
-     * test run must never restart the SSO server a developer started for manual testing.
+     * Host of the SSO (Keycloak) server used by the e2e tests. One server is shared by all workers
+     * of a run, but not between runs: the host and port carry the slot offset of the run, so an
+     * e2e run in another worktree gets its own server. It deliberately does not reuse the
+     * `sso.<domain>` host of `stam sso start` either: a test run must never restart the SSO server
+     * a developer started for manual testing.
      */
     static getSsoDomain() {
-        return 'playwright-sso.stamhoofd';
+        return `playwright-sso-${this.getSlotOffset()}.stamhoofd`;
     }
 
     static getSsoPort() {
-        return 6400;
+        return portBases.sso + this.getSlotOffset();
+    }
+
+    /**
+     * Suffix that keeps the container and realm files of this run apart from those of a run in
+     * another worktree.
+     */
+    static getSsoVariantName() {
+        return `playwright-${this.getSlotOffset()}`;
     }
 
     /**
@@ -92,12 +141,12 @@ export class CaddyConfigHelper {
 
     /**
      * The redirect URI the backend of a worker hands to the SSO server. Keycloak only redirects
-     * back to URIs listed in the realm, and one SSO server serves every worker, so the realm
-     * allows the callback of every worker.
+     * back to URIs listed in the realm, and one SSO server serves every worker of this run, so the
+     * realm allows the callback of every worker.
      */
-    static getSsoRedirectUris() {
+    static getSsoRedirectUris(workerCount: number) {
         const uris: string[] = [];
-        for (let workerId = 0; workerId < maximumRunners; workerId += 1) {
+        for (let workerId = 0; workerId < workerCount; workerId += 1) {
             uris.push(`${this.getUrl('api', workerId.toString())}/openid/callback`);
         }
         return uris;
@@ -117,12 +166,31 @@ export class CaddyConfigHelper {
     static getPort(
         service: 'api',
         workerId: string) {
-        return 6000 + this.cycledWorkerId(workerId);
+        return portBases[service] + this.getSlot(workerId);
     }
 
     static getFrontendPort(service: FrontendProjectName, workerId: string) {
-        const offset = service === 'dashboard' ? 6100 : service === 'registration' ? 6200 : 6300;
-        return offset + this.cycledWorkerId(workerId);
+        return portBases[service] + this.getSlot(workerId);
+    }
+
+    /**
+     * Every host port this run needs: the ports of all its workers plus the shared SSO server.
+     * Reserved in the route manifest so a run in another worktree picks a different block.
+     */
+    static getReservedPorts(workerCount: number) {
+        const ports: number[] = [this.getSsoPort()];
+
+        for (let workerId = 0; workerId < workerCount; workerId += 1) {
+            const id = workerId.toString();
+            ports.push(
+                this.getPort('api', id),
+                this.getFrontendPort('dashboard', id),
+                this.getFrontendPort('registration', id),
+                this.getFrontendPort('webshop', id),
+            );
+        }
+
+        return ports;
     }
 
     /**
@@ -282,12 +350,14 @@ export class CaddyConfigHelper {
     }
 
     /**
-     * Create the default playwright caddy config
+     * Create the caddy routes of this run: only the workers it actually starts, on the slots it
+     * reserved. Routes of runs in other worktrees live in their own manifest and are merged in by
+     * the CLI when it renders the shared Caddy config.
      */
-    static createRouteOptions(options: { proxyHost: string }): CaddyRouteOptions {
+    static createRouteOptions(options: { proxyHost: string; workerCount: number }): CaddyRouteOptions {
         const routes: CaddyRoute[] = [this.createSsoRoute(options.proxyHost)];
 
-        for (let workerId = 0; workerId < maximumRunners; workerId += 1) {
+        for (let workerId = 0; workerId < options.workerCount; workerId += 1) {
             routes.push(
                 ...this.createFrontendRoutes('dashboard', workerId.toString(), options.proxyHost),
                 // registration must come before webshop: its terminal 'inschrijven.*' custom-domain
@@ -312,7 +382,7 @@ export class CaddyConfigHelper {
     /**
      * Create the default playwright caddy config
      */
-    static createDefault(options: { adminListen: string; adminOrigin: string; httpListen: string; httpsListen: string; proxyHost: string }) {
+    static createDefault(options: { adminListen: string; adminOrigin: string; httpListen: string; httpsListen: string; proxyHost: string; workerCount: number }) {
         const { routes, tlsSubjects } = this.createRouteOptions(options);
 
         const config = {

--- a/tests/playwright/src/setup/helpers/CaddyHelper.ts
+++ b/tests/playwright/src/setup/helpers/CaddyHelper.ts
@@ -1,12 +1,20 @@
 import { exec as execCallback } from 'node:child_process';
 import { promisify } from 'node:util';
-import { buildSharedServiceProfile, CaddyService, caddyAdminPort, createContext, getContainerRuntime, localIpv4Host, pruneStaleRouteManifests, removeRouteManifestsByKind, writeRouteManifest, buildCaddyServiceProfile } from '@stamhoofd/cli';
-import type { RouteManifest } from '@stamhoofd/cli';
-import { CaddyConfigHelper } from './CaddyConfigHelper.js';
+import { buildSharedServiceProfile, CaddyService, caddyAdminPort, createContext, getContainerRuntime, localIpv4Host, removeOwnRouteManifests, buildCaddyServiceProfile } from '@stamhoofd/cli';
+import type { RouteManifestInput } from '@stamhoofd/cli';
+import { CaddyConfigHelper, slotPoolSize } from './CaddyConfigHelper.js';
 import { ProcessInfo } from './ProcessInfo.js';
 import { STChildProcess } from './STChildProcess.js';
 
 const exec = promisify(execCallback);
+
+/**
+ * A reservation outlives the run that made it only if that run crashed hard: the manifest is
+ * removed on teardown and ignored as soon as the process is gone. The expiry is the last resort
+ * for a machine that was put to sleep mid-run and woke up with the pid recycled.
+ */
+const reservationLifetimeMs = 2 * 60 * 60 * 1000;
+const routesActiveTimeoutMs = 60_000;
 
 type CaddyRuntime = {
     adminUrl: string;
@@ -40,6 +48,9 @@ export class CaddyHelper {
             return;
         }
 
+        // This Caddy was started by this run and serves nothing else, so the first slots are free.
+        CaddyConfigHelper.setSlotBlock(0, workerCount);
+
         // post the initial config
         console.log('Start posting caddy config...');
         await this.postConfig(
@@ -49,6 +60,7 @@ export class CaddyHelper {
                 httpListen: this.caddyRuntime.httpListen,
                 httpsListen: this.caddyRuntime.httpsListen,
                 proxyHost: this.caddyRuntime.proxyHost,
+                workerCount,
             }),
         );
         console.log('Done posting caddy config.');
@@ -61,7 +73,9 @@ export class CaddyHelper {
         }
 
         const context = await createContext({ env: 'stamhoofd', verbose: false });
-        await removeRouteManifestsByKind(context, 'playwright-worker');
+
+        // Only the reservation of this run: a run in another worktree is still using its own slots.
+        await removeOwnRouteManifests(context, 'playwright-worker');
         await CaddyService.reload(context);
     }
 
@@ -94,37 +108,86 @@ export class CaddyHelper {
         }
     }
 
+    /**
+     * Claim a block of slots for this run and add its routes to the shared Caddy.
+     *
+     * The block is picked by the CLI: it tries consecutive blocks until it finds one that no other
+     * manifest reserves and whose ports can all be bound, then writes the manifest for it. Only
+     * after that are the ports and domains of this run fixed, so nothing may derive a port or
+     * domain before this ran (which is why the slot offset is set from inside the candidate).
+     */
     private async configureSharedCaddy(workerCount: number) {
         const context = await createContext({ env: 'stamhoofd', verbose: false });
-        await pruneStaleRouteManifests(context);
-        await removeRouteManifestsByKind(context, 'playwright-worker');
 
-        for (let workerId = 0; workerId < workerCount; workerId += 1) {
-            await writeRouteManifest(context, this.createWorkerManifest(workerId));
-        }
+        // Leftovers of an earlier setup attempt in this same process.
+        await removeOwnRouteManifests(context, 'playwright-worker');
 
-        await CaddyService.reload(context);
-    }
-
-    private createWorkerManifest(workerId: number): RouteManifest {
-        const id = workerId.toString();
-        const profile = buildCaddyServiceProfile();
-
-        const caddy = CaddyConfigHelper.createRouteOptions({
-            proxyHost: profile.caddyProxyHost,
+        const manifest = await CaddyService.reserveRouteManifest(context, {
+            buildManifest: attempt => this.createRunManifest(context.instance.name, attempt, workerCount),
         });
 
+        const offset = CaddyConfigHelper.getSlotOffset();
+        console.log(`Reserved playwright slots ${offset}-${offset + workerCount - 1} (${manifest.name}).`);
+
+        await CaddyService.reload(context);
+        await this.waitUntilRoutesActive(workerCount);
+    }
+
+    /**
+     * The manifest of this run for attempt `attempt`: the same manifest every time, but starting
+     * at the next slot. Returns undefined once the remaining slots no longer fit this run.
+     */
+    private createRunManifest(instanceName: string, attempt: number, workerCount: number): RouteManifestInput | undefined {
+        if (attempt + workerCount > slotPoolSize) {
+            return undefined;
+        }
+
+        CaddyConfigHelper.setSlotBlock(attempt, workerCount);
+        const profile = buildCaddyServiceProfile();
+
         return {
-            version: '2',
-            name: `playwright-worker-${id}`,
+            // One manifest per run (not per worker): all workers share the same reserved block.
+            name: `playwright-${instanceName}-${process.pid}`,
             kind: 'playwright-worker',
             pid: process.pid,
             startedAt: new Date().toISOString(),
-            expiresAt: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+            expiresAt: new Date(Date.now() + reservationLifetimeMs).toISOString(),
             rootPath: process.cwd(),
             workspace: 'playwright',
-            caddy,
+            reservedPorts: CaddyConfigHelper.getReservedPorts(workerCount),
+            caddy: CaddyConfigHelper.createRouteOptions({
+                proxyHost: profile.caddyProxyHost,
+                workerCount,
+            }),
         };
+    }
+
+    /**
+     * Wait until the shared Caddy serves the hosts of this run. A reload is applied asynchronously
+     * and another process may be reloading at the same time, so the services must not start (and
+     * report an unreachable URL) before the routes are really in place.
+     */
+    private async waitUntilRoutesActive(workerCount: number) {
+        const expectedHosts = [CaddyConfigHelper.getSsoDomain()];
+        for (let workerId = 0; workerId < workerCount; workerId += 1) {
+            expectedHosts.push(CaddyConfigHelper.getDomain('api', workerId.toString()));
+        }
+
+        const start = Date.now();
+        let missing: string[] = expectedHosts;
+
+        while (Date.now() - start < routesActiveTimeoutMs) {
+            const configured = JSON.stringify(await this.getRoutes());
+            // The hosts sit in matchers of nested subroutes, so a lookup in the serialized routes
+            // is both simpler and stricter than walking every handler type.
+            missing = expectedHosts.filter(host => !configured.includes(`"${host}"`));
+            if (missing.length === 0) {
+                return;
+            }
+            await new Promise(resolve => setTimeout(resolve, 250));
+        }
+
+        throw new Error(`Timed out waiting for Caddy to serve the routes of this run. Missing: ${missing.join(', ')}`);
     }
 
     private async postConfig(caddyConfig: any) {

--- a/tests/playwright/src/setup/helpers/FrontendService.ts
+++ b/tests/playwright/src/setup/helpers/FrontendService.ts
@@ -85,9 +85,20 @@ export class FrontendService implements ServiceHelper {
         });
 
         await new Promise<void>((resolveListen, rejectListen) => {
-            server.once('error', rejectListen);
+            const onError = (error: NodeJS.ErrnoException) => {
+                if (error.code === 'EADDRINUSE') {
+                    // The port was reserved for this run (see CaddyHelper), so something outside
+                    // the reservation took it: another process bound it after the reservation, or
+                    // a previous run of this worker did not shut its server down.
+                    rejectListen(new Error(`Port ${port} of worker ${this.workerId} (${this.name}) was reserved for this run but is already in use`));
+                    return;
+                }
+                rejectListen(error);
+            };
+
+            server.once('error', onError);
             server.listen(port, '127.0.0.1', () => {
-                server.off('error', rejectListen);
+                server.off('error', onError);
                 resolveListen();
             });
         });

--- a/tests/playwright/src/setup/helpers/NetworkHelper.ts
+++ b/tests/playwright/src/setup/helpers/NetworkHelper.ts
@@ -1,13 +1,19 @@
 export class NetworkHelper {
     /**
-     * Try to fetch the url until it is reachable
-     * @param url url to fetch
+     * Try to fetch the url until it is reachable.
+     *
+     * The timeout is generous on purpose: several e2e runs (from different worktrees) can boot
+     * their backends at the same time on one machine, which makes a start-up that normally takes
+     * seconds take a lot longer. Failures are only logged every few seconds, so a slow start does
+     * not bury the rest of the output while a real failure is still reported with its last error.
      */
     static async waitForUrl(
         url: string,
-        { timeoutMs = 60000, intervalMs = 250 } = {},
+        { timeoutMs = 120_000, intervalMs = 250, logIntervalMs = 5_000 } = {},
     ): Promise<void> {
         const start = Date.now();
+        let lastError = 'no response';
+        let lastLog = 0;
 
         while (true) {
             try {
@@ -15,17 +21,21 @@ export class NetworkHelper {
                 if (res.status === 200) {
                     return;
                 }
+                lastError = `status ${res.status}`;
             }
             catch (error: any) {
-                console.log('Failed to waitForUrl: ', url);
-                console.error('name:', error.name); // e.g., TypeError
-                console.error('message:', error.message);
-                console.error('cause: ', error.cause);
                 // ignore connection errors
+                lastError = `${error.name}: ${error.message}${error.cause ? ` (${String(error.cause)})` : ''}`;
             }
 
-            if (Date.now() - start > timeoutMs) {
-                throw new Error(`Timed out waiting for ${url} to be reachable`);
+            const elapsed = Date.now() - start;
+            if (elapsed > timeoutMs) {
+                throw new Error(`Timed out waiting for ${url} to be reachable after ${Math.round(elapsed / 1000)}s: ${lastError}`);
+            }
+
+            if (elapsed - lastLog >= logIntervalMs) {
+                lastLog = elapsed;
+                console.log(`Still waiting for ${url} (${Math.round(elapsed / 1000)}s): ${lastError}`);
             }
 
             await new Promise(r => setTimeout(r, intervalMs));

--- a/tests/playwright/src/setup/helpers/SsoHelper.ts
+++ b/tests/playwright/src/setup/helpers/SsoHelper.ts
@@ -10,23 +10,35 @@ import { CaddyConfigHelper } from './CaddyConfigHelper.js';
  * exported by `@stamhoofd/cli` (ssoClientId, ssoClientSecret).
  */
 export class SsoHelper {
-    private static service = new SsoService({
-        name: 'playwright',
-        port: CaddyConfigHelper.getSsoPort(),
-        hostname: CaddyConfigHelper.getSsoDomain(),
-    });
+    /**
+     * Built on demand, never cached: the hostname and port follow the slots this run reserved,
+     * which are only known once the Caddy routes are configured.
+     */
+    private static get service() {
+        return new SsoService({
+            name: CaddyConfigHelper.getSsoVariantName(),
+            port: CaddyConfigHelper.getSsoPort(),
+            hostname: CaddyConfigHelper.getSsoDomain(),
+        });
+    }
 
     /**
      * Requires the Caddy route for the SSO host to be configured already: readiness is checked
      * through Caddy, the same way the backends reach the server.
      */
-    static async start(): Promise<void> {
+    static async start(workerCount: number): Promise<void> {
         const context = await createContext({ env: 'stamhoofd', verbose: false });
-        await this.service.start(context, {
-            redirectUris: CaddyConfigHelper.getSsoRedirectUris(),
+        const service = this.service;
+
+        // Servers of earlier runs of this worktree that crashed before their teardown: their name
+        // carries the slots they reserved, so nothing else would ever replace them.
+        await service.removeOtherVariants(context, CaddyConfigHelper.GROUP_PREFIX);
+
+        await service.start(context, {
+            redirectUris: CaddyConfigHelper.getSsoRedirectUris(workerCount),
             background: true,
         });
-        await this.service.waitUntilReady(context);
+        await service.waitUntilReady(context);
     }
 
     static async stop(): Promise<void> {

--- a/tests/playwright/src/setup/helpers/WorkerCount.ts
+++ b/tests/playwright/src/setup/helpers/WorkerCount.ts
@@ -1,0 +1,21 @@
+import os from 'node:os';
+
+/**
+ * How many Playwright workers this run uses.
+ *
+ * The global setup reserves exactly this many slots (ports + domains), so the number Playwright
+ * runs with has to be the same number: it is read here and passed to Playwright through the
+ * `workers` config option, instead of letting Playwright fall back to its own default.
+ */
+export function getWorkerCount(): number {
+    const configured = process.env.PLAYWRIGHT_WORKER_COUNT ? Number.parseInt(process.env.PLAYWRIGHT_WORKER_COUNT, 10) : undefined;
+    if (configured !== undefined && Number.isFinite(configured) && configured > 0) {
+        return configured;
+    }
+
+    if (process.env.CI) {
+        return 2;
+    }
+
+    return Math.max(1, Math.floor(os.availableParallelism() / 2));
+}


### PR DESCRIPTION
## Why

E2E runs from different worktrees used the same fixed ports (`6000 + parallelIndex`, `6100`/`6200`/`6300` for the frontends, `6400` for SSO) and the same domains, and each run deleted **every** `playwright-worker` route manifest at setup and teardown. A second run therefore either failed with `EADDRINUSE`, or removed the Caddy routes of the run that was already going — which surfaces as tests timing out on a blank page ("Expected dashboard after login, got login").

## What

A run now reserves a block of consecutive **slots** up front. Every port and domain is derived from the slot, so one block is all a run needs to be isolated.

- `CaddyService.reserveRouteManifest` walks the candidate blocks and claims the first one that no active route manifest reserves **and** whose ports can all be bound. The bind check also catches processes that never wrote a manifest. The manifest is written before it is verified again, so two runs that pick the same free block at the same moment do not both keep it: the one that started later gives its manifest back and moves on.
- Route manifests carry `reservedPorts` instead of having to scan the routes inside them. Dev instances publish theirs too, so an e2e run never lands on the ports of a `stam dev` session.
- A run writes one manifest with only its own routes, waits until Caddy really serves them before starting the services, and removes only its own manifest again (`removeRouteManifestsByKind` → `removeOwnRouteManifests`). The SSO server follows the block as well (port, hostname, container), and SSO containers leaked by a crashed run are cleaned up.
- Rendering the shared Caddy config now takes a lock file: the container watches the config, so writing it is what applies it, and two processes rendering at the same time dropped each other's routes.
- The number of workers has to be known before the tests start, so it comes from one place (`WorkerCount`) that both the Playwright config and the global setup use.

Known limit, documented in the Playwright README: two runs from the *same* worktree still collide, because the databases are named per worker index and the e2e MySQL container is per worktree.

## Tests

- New unit tests for the reservation (conflict detection, skipping bound ports, reusing the block of a crashed run, losing the race, exhausted pool), the lock file, and the manifest store. Three stale skipped tests in that area were fixed and re-enabled, and `shared/cli` was added to `stam test` so they actually run (~2s).
- `yarn lint`, `yarn typecheck` and `yarn stam test unit` pass.
- Three `stam test e2e --grep @routing` runs, 118 passed each: baseline, one with slots 0-4 held by a simulated run from another worktree (correctly moved to slots 5-9), and one that verifies the SSO container cleanup and that teardown leaves the manifests of other runs alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787757209&installation_model_id=423362&pr_number=656&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F656&signature=2bbf86a60022e78c57079782eb811f929b2863478bea15ab50786d1f003cc59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->