### PR TITLE
Run the e2e tests against an already running MySQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Run ONLY via `yarn stam test e2e`, never invoke or build Playwright manually:
 - `yarn stam test e2e` — full build + suite
 - `yarn stam test e2e --grep @tag` — only tests matching a name/tag (playwright `--grep`)
 - `yarn stam test e2e --grep @tag --skip-build` — same, but skip `build:shared` + the API/frontend rebuild when only test files changed since the last run
+- `yarn stam test e2e --local-db` — connect to the MySQL already running on `127.0.0.1:3306` (port: `STAMHOOFD_E2E_MYSQL_PORT`) instead of starting MySQL containers
 
 Never use different commands to run tests. On environment issues (domains don't resolve, SSL errors, blank pages): STOP and ask the user to fix it.
 

--- a/shared/cli/README.md
+++ b/shared/cli/README.md
@@ -90,6 +90,8 @@ Useful environment variables:
 - `STAMHOOFD_PORT_OFFSET` overrides the deterministic port offset.
 - `STAMHOOFD_DOMAIN` overrides the shared local domain, defaulting to `stamhoofd`.
 - `MYSQL_PORT` overrides the local MySQL host port, defaulting to `3307`.
+- `STAMHOOFD_E2E_MYSQL_PORT` runs the e2e tests against a MySQL that is already running on `127.0.0.1` instead of starting a container for them (see Tests).
+- `STAMHOOFD_E2E_MYSQL_USER` and `STAMHOOFD_E2E_MYSQL_PASSWORD` override the credentials of that MySQL, defaulting to `root` / `root`.
 - `STAMHOOFD_MYSQL_INNODB_BUFFER_POOL_SIZE` tunes the MySQL container InnoDB buffer pool size (e.g. `512M`, `1G`), defaulting to `4G`.
 - `STAMHOOFD_MYSQL_INNODB_BUFFER_POOL_INSTANCES` tunes the MySQL container InnoDB buffer pool instances defaulting to `4`.
 - `STAMHOOFD_MYSQL_SORT_BUFFER_SIZE` tunes the MySQL container sort buffer size (e.g. `8M`), defaulting to `2M`.
@@ -183,6 +185,20 @@ yarn stam test e2e --clear
 
 Use `--workers <number>` to override Playwright's default worker count for a run.
 Use `--extra` to include tests tagged `@extra`.
+
+#### Running e2e tests without a MySQL container
+
+A MySQL that is already running on this machine can serve the e2e tests instead, which skips both the e2e MySQL container and the shared `stamhoofd-mysql` container (the e2e tests never use the development database):
+
+```bash
+yarn stam test e2e --local-db                          # MySQL on 127.0.0.1:3306
+STAMHOOFD_E2E_MYSQL_PORT=3307 yarn stam test e2e       # the shared stamhoofd-mysql container
+STAMHOOFD_E2E_MYSQL_PORT=3306 STAMHOOFD_E2E_MYSQL_USER=tests STAMHOOFD_E2E_MYSQL_PASSWORD=secret yarn stam test e2e
+```
+
+Set `STAMHOOFD_E2E_MYSQL_PORT` in your shell profile to make this the default, and pass `--no-local-db` for a single run that should use a container after all. The server has to be reachable already: the CLI never starts or stops it, and `--clear` drops the worker databases of the run instead of a data volume.
+
+The worker databases are named `stamhoofd-playwright[-<instance>]-<slot>`, after the slot a worker runs on. Since a run reserves a block of slots no other run on this machine uses, several runs can share one MySQL server without sharing a database. Unit tests still always use a container: they all use the same `stamhoofd-tests` database.
 
 Run the full validation flow with:
 

--- a/shared/cli/src/commands/test/e2e.ts
+++ b/shared/cli/src/commands/test/e2e.ts
@@ -1,6 +1,7 @@
 import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base-command.js';
 import { ciFlag } from '../../command-flags.js';
+import { defaultLocalMysqlPort, e2eMysqlPortVariable } from '../../config/test-database-config.js';
 import { testE2e } from '../../runtime/monorepo-runner.js';
 
 export default class TestE2e extends BaseCommand {
@@ -14,6 +15,7 @@ export default class TestE2e extends BaseCommand {
         'stam test e2e --ci',
         'stam test e2e --extra',
         'stam test e2e --workers 2',
+        'stam test e2e --local-db',
         'stam test e2e --ui --verbose',
     ];
 
@@ -23,6 +25,7 @@ export default class TestE2e extends BaseCommand {
         'clear': Flags.boolean({ default: false, description: 'Clear the persistent e2e database before running tests' }),
         'extra': Flags.boolean({ default: false, description: 'Include Playwright tests tagged @extra' }),
         'grep': Flags.string({ char: 'g', description: 'Only run tests matching this pattern/tag (passed to playwright --grep)' }),
+        'local-db': Flags.boolean({ allowNo: true, description: `Connect to the MySQL already running on 127.0.0.1 instead of starting an e2e MySQL container (port ${e2eMysqlPortVariable}, default ${defaultLocalMysqlPort})` }),
         'skip-build': Flags.boolean({ default: false, description: 'Skip build:shared, the API test pre-build, and the frontend build (only test files changed)' }),
         'ui': Flags.boolean({ default: false, description: 'Run Playwright in UI mode' }),
         'workers': Flags.integer({ description: 'Number of Playwright workers' }),
@@ -33,6 +36,6 @@ export default class TestE2e extends BaseCommand {
         if (flags.workers !== undefined && flags.workers < 1) {
             throw new Error('--workers must be at least 1');
         }
-        await testE2e(await this.createContext(flags), { ci: flags.ci, clear: flags.clear, extra: flags.extra, grep: flags.grep, skipBuild: flags['skip-build'], ui: flags.ui, workers: flags.workers });
+        await testE2e(await this.createContext(flags), { ci: flags.ci, clear: flags.clear, extra: flags.extra, grep: flags.grep, localDb: flags['local-db'], skipBuild: flags['skip-build'], ui: flags.ui, workers: flags.workers });
     }
 }

--- a/shared/cli/src/config/test-database-config.test.ts
+++ b/shared/cli/src/config/test-database-config.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    buildPlaywrightDatabasePrefix,
+    e2eMysqlPasswordVariable,
+    e2eMysqlPortVariable,
+    e2eMysqlUserVariable,
+    playwrightClearDatabasesVariable,
+    playwrightDatabaseCredentials,
+    playwrightDatabaseName,
+    playwrightDatabasePasswordVariable,
+    playwrightDatabasePrefixVariable,
+    playwrightDatabaseUserVariable,
+    resolveE2eMysqlTarget,
+    shouldClearPlaywrightDatabases,
+} from './test-database-config.js';
+
+const variables = [
+    e2eMysqlPortVariable,
+    e2eMysqlUserVariable,
+    e2eMysqlPasswordVariable,
+    playwrightDatabasePrefixVariable,
+    playwrightDatabaseUserVariable,
+    playwrightDatabasePasswordVariable,
+    playwrightClearDatabasesVariable,
+];
+
+afterEach(() => {
+    variables.forEach(variable => delete process.env[variable]);
+});
+
+describe('resolveE2eMysqlTarget', () => {
+    it('starts a container when nothing is configured', () => {
+        expect(resolveE2eMysqlTarget()).toEqual({ kind: 'container' });
+    });
+
+    it('uses a local MySQL on 3306 with --local-db', () => {
+        expect(resolveE2eMysqlTarget({ localDb: true })).toEqual({ kind: 'local', port: 3306, user: 'root', password: 'root' });
+    });
+
+    it('uses a local MySQL when a port is configured', () => {
+        process.env[e2eMysqlPortVariable] = '3307';
+
+        expect(resolveE2eMysqlTarget()).toEqual({ kind: 'local', port: 3307, user: 'root', password: 'root' });
+    });
+
+    it('takes the configured credentials', () => {
+        process.env[e2eMysqlPortVariable] = '3306';
+        process.env[e2eMysqlUserVariable] = 'tests';
+        process.env[e2eMysqlPasswordVariable] = '';
+
+        expect(resolveE2eMysqlTarget()).toEqual({ kind: 'local', port: 3306, user: 'tests', password: '' });
+    });
+
+    it('lets --no-local-db win over a configured port', () => {
+        process.env[e2eMysqlPortVariable] = '3306';
+
+        expect(resolveE2eMysqlTarget({ localDb: false })).toEqual({ kind: 'container' });
+    });
+
+    it('rejects a port that is not a TCP port', () => {
+        process.env[e2eMysqlPortVariable] = '3306abc';
+
+        expect(() => resolveE2eMysqlTarget()).toThrow(`Invalid ${e2eMysqlPortVariable}`);
+    });
+
+    it('rejects a port outside the TCP range', () => {
+        process.env[e2eMysqlPortVariable] = '70000';
+
+        expect(() => resolveE2eMysqlTarget()).toThrow(`Invalid ${e2eMysqlPortVariable}`);
+    });
+});
+
+describe('buildPlaywrightDatabasePrefix', () => {
+    it('keeps the bare name for the primary worktree', () => {
+        expect(buildPlaywrightDatabasePrefix({ name: 'stamhoofd', primary: true })).toBe('stamhoofd-playwright');
+    });
+
+    it('adds the instance name of another worktree', () => {
+        expect(buildPlaywrightDatabasePrefix({ name: 'stamhoofd-feature-sso', primary: false })).toBe('stamhoofd-playwright-stamhoofd-feature-sso');
+    });
+
+    it('keeps long instance names within the MySQL identifier limit', () => {
+        const prefix = buildPlaywrightDatabasePrefix({ name: 'stamhoofd-a-very-long-worktree-name-that-keeps-on-going', primary: false });
+
+        expect(playwrightDatabaseName(29, prefix).length).toBeLessThanOrEqual(64);
+        expect(prefix.startsWith('stamhoofd-playwright-stamhoofd-a-very-long-worktree')).toBe(true);
+    });
+
+    it('gives two long instance names different prefixes', () => {
+        const first = buildPlaywrightDatabasePrefix({ name: 'stamhoofd-a-very-long-worktree-name-that-keeps-on-going-one', primary: false });
+        const second = buildPlaywrightDatabasePrefix({ name: 'stamhoofd-a-very-long-worktree-name-that-keeps-on-going-two', primary: false });
+
+        expect(first).not.toBe(second);
+    });
+});
+
+describe('playwrightDatabaseName', () => {
+    it('names a database after its slot', () => {
+        process.env[playwrightDatabasePrefixVariable] = 'stamhoofd-playwright-stamhoofd-6';
+
+        expect(playwrightDatabaseName(4)).toBe('stamhoofd-playwright-stamhoofd-6-4');
+    });
+
+    it('falls back to the base name without a configured prefix', () => {
+        expect(playwrightDatabaseName(0)).toBe('stamhoofd-playwright-0');
+    });
+});
+
+describe('playwrightDatabaseCredentials', () => {
+    it('keeps the test environment defaults when nothing was passed', () => {
+        expect(playwrightDatabaseCredentials()).toEqual({ user: undefined, password: undefined });
+    });
+
+    it('reads an empty password as a configured password', () => {
+        process.env[playwrightDatabaseUserVariable] = 'tests';
+        process.env[playwrightDatabasePasswordVariable] = '';
+
+        expect(playwrightDatabaseCredentials()).toEqual({ user: 'tests', password: '' });
+    });
+});
+
+describe('shouldClearPlaywrightDatabases', () => {
+    it('only clears when asked to', () => {
+        expect(shouldClearPlaywrightDatabases()).toBe(false);
+
+        process.env[playwrightClearDatabasesVariable] = 'true';
+
+        expect(shouldClearPlaywrightDatabases()).toBe(true);
+    });
+});

--- a/shared/cli/src/config/test-database-config.ts
+++ b/shared/cli/src/config/test-database-config.ts
@@ -1,0 +1,135 @@
+import { checksum } from '../context/instance.js';
+import { mysqlInternalPort, mysqlRootPassword, mysqlRootUser } from './shared-service-config.js';
+
+/**
+ * Where a MySQL installed on this machine listens unless it was configured otherwise. The same port
+ * the containers use internally, but not the port they are mapped to on the host (see `buildPorts`).
+ */
+export const defaultLocalMysqlPort = mysqlInternalPort;
+
+/**
+ * Environment variables that point the e2e tests at a MySQL that is already running on this
+ * machine. Setting the port is what switches the mode: `stam test e2e` then skips its own MySQL
+ * container. `--local-db` / `--no-local-db` override this per run.
+ */
+export const e2eMysqlPortVariable = 'STAMHOOFD_E2E_MYSQL_PORT';
+export const e2eMysqlUserVariable = 'STAMHOOFD_E2E_MYSQL_USER';
+export const e2eMysqlPasswordVariable = 'STAMHOOFD_E2E_MYSQL_PASSWORD';
+
+/**
+ * The MySQL the e2e tests connect to.
+ *
+ * - `container`: `stam test e2e` starts a MySQL container of its own (namespaced per worktree, with
+ *   a data volume that persists between runs) and shuts it down afterwards.
+ * - `local`: a MySQL that is already running on this machine, on `127.0.0.1:<port>`. No container
+ *   is started or stopped, which saves the startup time and memory of a second MySQL server.
+ */
+export type E2eMysqlTarget
+    = | { kind: 'container' }
+        | { kind: 'local'; port: number; user: string; password: string };
+
+/**
+ * Whether this run uses its own MySQL container or one that is already running.
+ *
+ * `localDb` is the `--local-db` flag: `true` forces a local MySQL, `false` forces the container,
+ * and `undefined` (flag not passed) leaves the choice to the environment.
+ */
+export function resolveE2eMysqlTarget(options: { localDb?: boolean } = {}): E2eMysqlTarget {
+    const configuredPort = process.env[e2eMysqlPortVariable]?.trim();
+
+    if (options.localDb === false || (options.localDb === undefined && !configuredPort)) {
+        return { kind: 'container' };
+    }
+
+    return {
+        kind: 'local',
+        port: parsePort(configuredPort),
+        user: process.env[e2eMysqlUserVariable] ?? mysqlRootUser,
+        password: process.env[e2eMysqlPasswordVariable] ?? mysqlRootPassword,
+    };
+}
+
+/**
+ * The databases of the Playwright workers are named `<prefix>-<slot>`. The prefix reaches the
+ * Playwright process through this variable, which is set by `stam test e2e`.
+ */
+export const playwrightDatabasePrefixVariable = 'PLAYWRIGHT_DB_PREFIX';
+
+export const playwrightDatabaseBaseName = 'stamhoofd-playwright';
+
+/**
+ * Set by `stam test e2e --clear` when the run connects to a MySQL that keeps running afterwards:
+ * there is no data volume to drop, so the Playwright global setup drops the worker databases of
+ * this run before migrating them again.
+ */
+export const playwrightClearDatabasesVariable = 'PLAYWRIGHT_CLEAR_DATABASES';
+
+export function shouldClearPlaywrightDatabases(): boolean {
+    return process.env[playwrightClearDatabasesVariable] === 'true';
+}
+
+/**
+ * Credentials of the MySQL of this run, set by `stam test e2e` when they differ from the root/root
+ * of the test environment. Passed under their own names because the test environment overwrites
+ * `DB_USER`/`DB_PASS` in `process.env` with its own values whenever it is (re)loaded.
+ */
+export const playwrightDatabaseUserVariable = 'PLAYWRIGHT_DB_USER';
+export const playwrightDatabasePasswordVariable = 'PLAYWRIGHT_DB_PASSWORD';
+
+/**
+ * The credentials to connect with, if this run was given any. Undefined values keep the default of
+ * the test environment.
+ */
+export function playwrightDatabaseCredentials(): { user?: string; password?: string } {
+    return {
+        user: process.env[playwrightDatabaseUserVariable],
+        password: process.env[playwrightDatabasePasswordVariable],
+    };
+}
+
+/** MySQL identifiers are limited to 64 characters. */
+const maxDatabaseNameLength = 64;
+
+/** Room the slot suffix needs in a database name, e.g. `-29`. */
+const slotSuffixLength = 3;
+
+/**
+ * The prefix of the worker databases of this instance. Following the same convention as the
+ * development database, the primary worktree keeps the historical bare name and every other
+ * worktree appends its instance name, so a run never migrates the databases of a checkout that is
+ * on another branch.
+ */
+export function buildPlaywrightDatabasePrefix(instance: { name: string; primary: boolean }): string {
+    const prefix = instance.primary ? playwrightDatabaseBaseName : `${playwrightDatabaseBaseName}-${instance.name}`;
+    const maxLength = maxDatabaseNameLength - slotSuffixLength;
+
+    if (prefix.length <= maxLength) {
+        return prefix;
+    }
+
+    // A long workspace name would otherwise produce a name MySQL rejects. Keep it recognizable and
+    // still unique by trading the tail for a checksum of the full name.
+    const hash = checksum(prefix).toString(36);
+    return `${prefix.slice(0, maxLength - hash.length - 1)}-${hash}`;
+}
+
+/**
+ * The database of one Playwright slot. Derived from the slot, not from the worker index: a run
+ * reserves a block of slots that no other run on this machine uses, so runs started from several
+ * worktrees never share a database, even when they all connect to the same MySQL server.
+ */
+export function playwrightDatabaseName(slot: number, prefix: string = process.env[playwrightDatabasePrefixVariable]?.trim() || playwrightDatabaseBaseName): string {
+    return `${prefix}-${slot}`;
+}
+
+function parsePort(value: string | undefined): number {
+    if (value === undefined || value.length === 0) {
+        return defaultLocalMysqlPort;
+    }
+
+    const port = Number.parseInt(value, 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535 || String(port) !== value) {
+        throw new Error(`Invalid ${e2eMysqlPortVariable} "${value}": expected a TCP port number.`);
+    }
+    return port;
+}

--- a/shared/cli/src/context/instance.ts
+++ b/shared/cli/src/context/instance.ts
@@ -1,6 +1,6 @@
 import { slug } from './workspace.js';
 
-function checksum(value: string): number {
+export function checksum(value: string): number {
     let hash = 0;
     for (const char of value) {
         hash = ((hash << 5) - hash + char.charCodeAt(0)) | 0;

--- a/shared/cli/src/index.ts
+++ b/shared/cli/src/index.ts
@@ -3,6 +3,7 @@ export { buildDevelopmentEnvironment } from './config/development-config.js';
 export { createS3Client, type S3ClientEnvironment } from './config/s3-client.js';
 export { caddyAdminPort, localIpv4Host } from './config/shared-service-config.js';
 export { buildCaddyServiceProfile, buildSharedServiceProfile } from './config/shared-service-profile.js';
+export { playwrightDatabaseCredentials, playwrightDatabaseName, shouldClearPlaywrightDatabases } from './config/test-database-config.js';
 export { createContext } from './context/create-context.js';
 export { getProjectPath } from './context/project-path.js';
 export { pruneStaleRouteManifests, removeOwnRouteManifests, removeRouteManifest, writeRouteManifest, type CaddyRouteOptions } from './runtime/manifest-store.js';

--- a/shared/cli/src/runtime/monorepo-runner.ts
+++ b/shared/cli/src/runtime/monorepo-runner.ts
@@ -1,12 +1,16 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { buildBackendEnv } from '../config/build-config.js';
-import { caddyRootCaPath, localIpv4Host, localhostPortMappingDynamic, mysqlImage, mysqlInternalPort, mysqlRootPassword, mysqlRootUser, mysqlServerArgs } from '../config/shared-service-config.js';
+import { caddyRootCaPath, localIpv4Host, localhostPort, localhostPortMappingDynamic, mysqlImage, mysqlInternalPort, mysqlRootPassword, mysqlRootUser, mysqlServerArgs } from '../config/shared-service-config.js';
+import type { E2eMysqlTarget } from '../config/test-database-config.js';
+import { buildPlaywrightDatabasePrefix, e2eMysqlPortVariable, playwrightClearDatabasesVariable, playwrightDatabasePasswordVariable, playwrightDatabasePrefixVariable, playwrightDatabaseUserVariable, resolveE2eMysqlTarget } from '../config/test-database-config.js';
 import type { CliContext } from '../context/create-context.js';
+import { buildPorts } from '../context/ports.js';
 import { CaddyService } from '../services/definitions/caddy-service.js';
 import * as docker from '../services/docker.js';
 import { startSharedServices } from '../services/shared-services.js';
 import { run } from './command-runner.js';
+import { isPortListening } from './port-probe.js';
 
 const globalSharedPackages = [
     'shared/types',
@@ -31,22 +35,27 @@ const backendSharedPackages = [
     'backend/shared/middleware',
 ];
 
+/**
+ * The MySQL servers the tests use: the unit tests (`test`) and the e2e tests each get their own, so
+ * a unit run and an e2e run never wait for or wipe each other's data.
+ */
+const testMysqlKinds = {
+    test: 'test MySQL',
+    e2e: 'e2e MySQL',
+} as const;
+
+type TestMysqlKind = keyof typeof testMysqlKinds;
+
 // Namespace the test MySQL containers + data volumes by instance so each git worktree gets its own
 // and tests can run in parallel across worktrees. The primary worktree keeps the historical
 // `stamhoofd-*` names (its instance name is `stamhoofd`). The data volume persists between runs (so
 // initialized data + applied migrations are reused); the container itself is shut down after the run
 // and `--clear` wipes the volume for a fresh start.
-function testMysqlNames(context: CliContext): { container: string; volume: string } {
+function testMysqlNames(context: CliContext, kind: TestMysqlKind): { container: string; volume: string } {
+    const container = `${context.instance.name}-${kind}-mysql`;
     return {
-        container: `${context.instance.name}-test-mysql`,
-        volume: `${context.instance.name}-test-mysql-data`,
-    };
-}
-
-function e2eMysqlNames(context: CliContext): { container: string; volume: string } {
-    return {
-        container: `${context.instance.name}-e2e-mysql`,
-        volume: `${context.instance.name}-e2e-mysql-data`,
+        container,
+        volume: `${container}-data`,
     };
 }
 
@@ -134,7 +143,7 @@ export async function runUnitTests(context: CliContext, options: UnitTestOptions
     }
 
     const needsDatabase = packages.some(pkg => pkg.needsDatabase);
-    const dbPort = needsDatabase ? await startTestMysql(context, options.clear ?? false) : undefined;
+    const dbPort = needsDatabase ? await startTestMysql(context, 'test', options.clear ?? false) : undefined;
 
     // With multiple packages a filename/test-name filter will legitimately match nothing in some of
     // them, so don't let an empty package fail the whole run.
@@ -159,7 +168,7 @@ export async function runUnitTests(context: CliContext, options: UnitTestOptions
     } finally {
         // Shut down the container after the run; the data volume is kept for the next run.
         if (needsDatabase) {
-            await docker.removeContainer(testMysqlNames(context).container, context.verbose);
+            await docker.removeContainer(testMysqlNames(context, 'test').container, context.verbose);
         }
     }
 }
@@ -168,23 +177,26 @@ export async function testUnit(context: CliContext, ci: boolean): Promise<void> 
     await runUnitTests(context, { ci });
 }
 
-export async function testE2e(context: CliContext, options: { ci: boolean; clear: boolean; extra?: boolean; ui: boolean; workers?: number; grep?: string; skipBuild?: boolean }): Promise<void> {
-    const dbPort = await startE2eMysql(context, options.clear);
-    const { container: e2eContainer } = e2eMysqlNames(context);
+export async function testE2e(context: CliContext, options: { ci: boolean; clear: boolean; extra?: boolean; ui: boolean; workers?: number; grep?: string; skipBuild?: boolean; localDb?: boolean }): Promise<void> {
+    const mysql = resolveE2eMysqlTarget({ localDb: options.localDb });
+    const databaseEnv = await prepareE2eDatabase(context, mysql, options.clear);
     let shouldRestoreCaddy = false;
     if (!options.skipBuild) {
         await buildShared(context);
     }
     try {
-        await startSharedServices(context);
+        await startSharedServices(context, { skipMysql: mysql.kind === 'local' });
         shouldRestoreCaddy = true;
         if (!options.skipBuild) {
-            await run('yarn', ['--cwd', 'backend/app/api', '-s', 'build:playwright:pre'], { cwd: context.rootDir, env: { DB_PORT: dbPort }, verbose: context.verbose });
+            await run('yarn', ['--cwd', 'backend/app/api', '-s', 'build:playwright:pre'], { cwd: context.rootDir, env: databaseEnv, verbose: context.verbose });
         }
-        await run('yarn', ['--cwd', 'tests/playwright', '-s', 'test', ...(options.ui ? ['--ui'] : []), ...(options.grep === undefined ? [] : ['--grep', options.grep]), ...(options.workers === undefined ? [] : ['--workers', String(options.workers)])], { cwd: context.rootDir, env: { NX_DAEMON: 'false', CI: options.ci ? 'true' : undefined, DB_PORT: dbPort, NODE_EXTRA_CA_CERTS: caddyRootCaPath(), PLAYWRIGHT_INCLUDE_EXTRA: options.extra ? '1' : undefined, PLAYWRIGHT_WORKER_COUNT: options.workers === undefined ? undefined : String(options.workers), STAMHOOFD_SKIP_FRONTEND_BUILD: options.skipBuild ? 'true' : undefined }, verbose: context.verbose });
+        await run('yarn', ['--cwd', 'tests/playwright', '-s', 'test', ...(options.ui ? ['--ui'] : []), ...(options.grep === undefined ? [] : ['--grep', options.grep]), ...(options.workers === undefined ? [] : ['--workers', String(options.workers)])], { cwd: context.rootDir, env: { ...databaseEnv, NX_DAEMON: 'false', CI: options.ci ? 'true' : undefined, NODE_EXTRA_CA_CERTS: caddyRootCaPath(), PLAYWRIGHT_INCLUDE_EXTRA: options.extra ? '1' : undefined, PLAYWRIGHT_WORKER_COUNT: options.workers === undefined ? undefined : String(options.workers), STAMHOOFD_SKIP_FRONTEND_BUILD: options.skipBuild ? 'true' : undefined }, verbose: context.verbose });
     } finally {
         // Shut down the e2e MySQL container after the run; the data volume is kept for the next run.
-        await docker.removeContainer(e2eContainer, context.verbose);
+        // A MySQL that was already running is left alone: it is not ours to stop.
+        if (mysql.kind === 'container') {
+            await docker.removeContainer(testMysqlNames(context, 'e2e').container, context.verbose);
+        }
         if (shouldRestoreCaddy) {
             try {
                 await CaddyService.reload(context);
@@ -280,18 +292,47 @@ async function ensureTestMysql(context: CliContext, names: { container: string; 
     return dbPort;
 }
 
-async function startTestMysql(context: CliContext, clear: boolean): Promise<string> {
-    const names = testMysqlNames(context);
-    console.log(clear ? `Starting fresh test MySQL (${names.container})...` : `Starting test MySQL (${names.container})...`);
+/**
+ * Start the MySQL container of a test kind and return the host port it is mapped to.
+ */
+async function startTestMysql(context: CliContext, kind: TestMysqlKind, clear: boolean): Promise<string> {
+    const names = testMysqlNames(context, kind);
+    const label = testMysqlKinds[kind];
+    console.log(clear ? `Starting fresh ${label} (${names.container})...` : `Starting ${label} (${names.container})...`);
     const dbPort = await ensureTestMysql(context, names, clear);
-    console.log(`Test MySQL is mapped to ${localIpv4Host}:${dbPort}.`);
+    console.log(`Mapped ${label} to ${localIpv4Host}:${dbPort}.`);
     return dbPort;
 }
 
-async function startE2eMysql(context: CliContext, clear: boolean): Promise<string> {
-    const names = e2eMysqlNames(context);
-    console.log(clear ? `Starting fresh e2e MySQL (${names.container})...` : `Starting e2e MySQL (${names.container})...`);
-    const dbPort = await ensureTestMysql(context, names, clear);
-    console.log(`E2E MySQL is mapped to ${localIpv4Host}:${dbPort}.`);
-    return dbPort;
+/**
+ * Get the MySQL of this e2e run ready and return the environment the Playwright process needs to
+ * reach it: where to connect, which databases belong to this worktree, and whether they have to be
+ * dropped first.
+ */
+async function prepareE2eDatabase(context: CliContext, mysql: E2eMysqlTarget, clear: boolean): Promise<NodeJS.ProcessEnv> {
+    const databasePrefix = { [playwrightDatabasePrefixVariable]: buildPlaywrightDatabasePrefix(context.instance) };
+
+    if (mysql.kind === 'container') {
+        return { ...databasePrefix, DB_PORT: await startTestMysql(context, 'e2e', clear) };
+    }
+
+    if (!await isPortListening(mysql.port)) {
+        // The shared MySQL container is not started for a local run, so point at it by name when
+        // that is the server this run was configured to use.
+        const sharedHint = mysql.port === buildPorts(context).mysql ? ' That is the port of the shared MySQL container: `stam services up` starts it.' : '';
+        throw new Error(`No MySQL is listening on ${localhostPort(mysql.port)}.${sharedHint} Start it, point ${e2eMysqlPortVariable} at the port it listens on, or pass --no-local-db to run against an e2e MySQL container instead.`);
+    }
+
+    console.log(`Using the MySQL already running on ${localhostPort(mysql.port)}.`);
+
+    return {
+        ...databasePrefix,
+        DB_PORT: String(mysql.port),
+        [playwrightDatabaseUserVariable]: mysql.user,
+        [playwrightDatabasePasswordVariable]: mysql.password,
+        // There is no data volume to drop here, so `--clear` drops the worker databases themselves.
+        // The Playwright global setup does that: it knows which slots this run reserved, and a
+        // database of a run in another worktree must survive.
+        [playwrightClearDatabasesVariable]: clear ? 'true' : undefined,
+    };
 }

--- a/shared/cli/src/runtime/port-probe.ts
+++ b/shared/cli/src/runtime/port-probe.ts
@@ -22,6 +22,29 @@ export async function isPortAvailable(port: number, host: string = localIpv4Host
 }
 
 /**
+ * Whether something accepts TCP connections on a port.
+ *
+ * The inverse of `isPortAvailable` is not the same check: a bind probe only tells us the port is
+ * taken on the host we probed, while a server we want to talk to has to accept the connection. Used
+ * to tell "your MySQL is not running" apart from "your MySQL is running elsewhere".
+ */
+export async function isPortListening(port: number, host: string = localIpv4Host, timeoutMs = 1000): Promise<boolean> {
+    return await new Promise((resolve) => {
+        const socket = new net.Socket();
+
+        const finish = (listening: boolean) => {
+            socket.destroy();
+            resolve(listening);
+        };
+
+        socket.setTimeout(timeoutMs);
+        socket.once('error', () => finish(false));
+        socket.once('timeout', () => finish(false));
+        socket.connect(port, host, () => finish(true));
+    });
+}
+
+/**
  * The subset of `ports` that is already in use, in the order they were passed in.
  */
 export async function findBusyPorts(ports: number[], host: string = localIpv4Host): Promise<number[]> {

--- a/shared/cli/src/services/shared-services.test.ts
+++ b/shared/cli/src/services/shared-services.test.ts
@@ -9,7 +9,7 @@ import { MysqlService } from './definitions/mysql-service.js';
 import { RustfsService } from './definitions/rustfs-service.js';
 import { SsoService } from './definitions/sso-service.js';
 import { ContainerRuntime } from './docker.js';
-import { tailSharedLogs } from './shared-services.js';
+import { sharedServicesToStart, tailSharedLogs } from './shared-services.js';
 
 vi.mock('../runtime/command-runner.js', () => ({
     run: vi.fn(),
@@ -155,6 +155,14 @@ describe('shared service Docker args', () => {
         expect(detail).toContain(`HTTP ${localhostPort(caddyHttpPort)} -> ${localhostPort(caddyUnprivilegedHttpPort)}`);
         expect(detail).toContain(`HTTPS ${localhostPort(caddyHttpsPort)} -> ${localhostPort(caddyUnprivilegedHttpsPort)}`);
         expect(detail).toContain(`admin ${localhostPort(caddyAdminPort)}`);
+    });
+
+    it('starts every shared service by default', () => {
+        expect(sharedServicesToStart().map(service => service.key)).toEqual(['coredns', 'caddy', 'mysql', 'maildev', 'rustfs']);
+    });
+
+    it('leaves only MySQL out for a run that brings its own database', () => {
+        expect(sharedServicesToStart({ skipMysql: true }).map(service => service.key)).toEqual(['coredns', 'caddy', 'maildev', 'rustfs']);
     });
 
     it('tails all shared service logs through concurrently', async () => {

--- a/shared/cli/src/services/shared-services.ts
+++ b/shared/cli/src/services/shared-services.ts
@@ -7,11 +7,12 @@ import { run } from '../runtime/command-runner.js';
 import { CaddyService } from './definitions/caddy-service.js';
 import { CorednsService } from './definitions/coredns-service.js';
 import { MaildevService } from './definitions/maildev-service.js';
-import { MysqlService } from './definitions/mysql-service.js';
+import { MysqlService, mysqlService } from './definitions/mysql-service.js';
 import { RustfsService } from './definitions/rustfs-service.js';
 import * as docker from './docker.js';
 import { allRunning, printServicesStatus, removeSharedServicesManifest, restartServicesInteractive, startServices, startServicesInteractive, stopServices, stopServicesInteractive, writeSharedServicesManifest } from './manager.js';
 import { sharedServiceDefinitions } from './registry.js';
+import type { SharedServiceDefinition } from './service.js';
 
 export { CaddyService, CorednsService, MaildevService, MysqlService, RustfsService };
 
@@ -19,10 +20,26 @@ export async function sharedServicesRunning(context: CliContext): Promise<boolea
     return await allRunning(context, sharedServiceDefinitions);
 }
 
-export async function startSharedServices(context: CliContext): Promise<void> {
+export type StartSharedServicesOptions = {
+    /**
+     * Leave the shared MySQL container alone. Used by e2e runs that connect to a MySQL that is
+     * already running on this machine: they never touch the development database, so starting a
+     * server for it would only cost time and memory.
+     */
+    skipMysql?: boolean;
+};
+
+export function sharedServicesToStart(options: StartSharedServicesOptions = {}): SharedServiceDefinition[] {
+    if (!options.skipMysql) {
+        return sharedServiceDefinitions;
+    }
+    return sharedServiceDefinitions.filter(service => service.key !== mysqlService.key);
+}
+
+export async function startSharedServices(context: CliContext, options: StartSharedServicesOptions = {}): Promise<void> {
     await fs.mkdir(sharedDir(context), { recursive: true });
     await fs.mkdir(path.join(logsDir(context), 'shared'), { recursive: true });
-    await startServices(context, sharedServiceDefinitions);
+    await startServices(context, sharedServicesToStart(options));
     await writeSharedServicesManifest(context);
 }
 

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -37,8 +37,21 @@ Consequences worth knowing:
 - The number of workers has to be known before the tests start. Set `PLAYWRIGHT_WORKER_COUNT`
   (`stam test e2e --workers N` does this) instead of passing `--workers` to Playwright directly.
 - At most `slotPoolSize` (30) workers can run at the same time across all runs on one machine.
-- The databases are still named per worker index, not per slot, and the e2e MySQL container is per
-  worktree: two runs from the *same* worktree still collide. Run them from different worktrees.
+- Nothing may derive a port, domain or database name before the global setup reserved the block, so
+  the reservation happens before the frontend build and the migrations start.
+
+## Databases
+
+Each worker gets its own database, named `stamhoofd-playwright[-<instance>]-<slot>` after its slot,
+with the instance name of the worktree in it for every worktree except the primary one. So two runs
+never share a database, not even when they connect to the same MySQL server, and a checkout on
+another branch migrates its own databases. The prefix is passed in by `stam test e2e`
+(`PLAYWRIGHT_DB_PREFIX`), the databases are created and migrated in the global setup, and they are
+kept between runs so the migrations don't have to run again.
+
+By default `stam test e2e` starts a MySQL container for the run. With `--local-db` (or
+`STAMHOOFD_E2E_MYSQL_PORT`) it connects to a MySQL that is already running on `127.0.0.1` instead;
+see the CLI README. Only the connection changes: the databases and their names stay the same.
 
 ## Test file naming
 

--- a/tests/playwright/src/setup/global-setup.ts
+++ b/tests/playwright/src/setup/global-setup.ts
@@ -1,3 +1,4 @@
+import { shouldClearPlaywrightDatabases } from '@stamhoofd/cli';
 import { TestUtils } from '@stamhoofd/test-utils';
 import { CaddyHelper } from './helpers/CaddyHelper.js';
 import { DatabaseHelper } from './helpers/DatabaseHelper.js';
@@ -17,20 +18,25 @@ export default async function globalSetup() {
         );
     }
 
+    DatabaseHelper.applyCredentials();
+
     const frontendBuilder = new FrontendBuilder();
     const caddyHelper = new CaddyHelper();
+    const workerCount = getWorkerCount();
 
-    // The SSO server is only reachable once its Caddy route is in place, so it starts after the
-    // routes are configured. Runs next to the frontend build, which takes far longer.
-    const configureCaddyAndStartSso = async () => {
-        const workerCount = getWorkerCount();
-        if (!await caddyHelper.isRunning()) {
-            console.log('Starting CI Caddy...');
-            await caddyHelper.start();
-            console.log('CI Caddy started.');
-        }
-        await caddyHelper.configure(workerCount);
+    if (!await caddyHelper.isRunning()) {
+        console.log('Starting CI Caddy...');
+        await caddyHelper.start();
+        console.log('CI Caddy started.');
+    }
 
+    // Reserves the block of slots of this run: every port, domain and worker database is derived
+    // from it, so nothing may run before this completed.
+    await caddyHelper.configure(workerCount);
+
+    // The SSO server is only reachable once its Caddy route is in place. Runs next to the frontend
+    // build and the migrations, which take far longer.
+    const startSso = async () => {
         console.log('Starting SSO server...');
         await SsoHelper.start(workerCount);
         console.log('SSO server started.');
@@ -45,18 +51,22 @@ export default async function globalSetup() {
     };
 
     const migrateDatabases = async () => {
-        const workerCount = getWorkerCount();
         const { run: runMigrations } = await import('@stamhoofd/backend/migrate');
+        const clear = shouldClearPlaywrightDatabases();
 
         for (let workerId = 0; workerId < workerCount; workerId += 1) {
             const database = DatabaseHelper.getDatabaseName(workerId.toString());
+            if (clear) {
+                console.log(`Dropping ${database}...`);
+                await DatabaseHelper.dropDatabase(database);
+            }
             console.log(`Migrating ${database}...`);
             TestUtils.setEnvironment('DB_DATABASE', database);
             await runMigrations();
         }
     };
 
-    for (const promise of [configureCaddyAndStartSso(), buildFrontend(), migrateDatabases()]) {
+    for (const promise of [startSso(), buildFrontend(), migrateDatabases()]) {
         await promise;
     }
 }

--- a/tests/playwright/src/setup/helpers/DatabaseHelper.ts
+++ b/tests/playwright/src/setup/helpers/DatabaseHelper.ts
@@ -1,13 +1,56 @@
 import type { DatabaseInstance } from '@simonbackx/simple-database';
+import { playwrightDatabaseCredentials, playwrightDatabaseName } from '@stamhoofd/cli';
 import { TestUtils } from '@stamhoofd/test-utils';
+import { CaddyConfigHelper } from './CaddyConfigHelper.js';
 
 export class DatabaseHelper {
     private _database?: DatabaseInstance;
 
     constructor(private workerId: string) {}
 
+    /**
+     * The database of a worker is named after its slot, not after its worker index: a run reserves a
+     * block of slots no other run on this machine uses, so two runs never write to the same database
+     * — not even when they connect to the same MySQL server (`stam test e2e --local-db`). The name
+     * also carries the worktree of the run, so a checkout on another branch migrates its own
+     * databases. Only valid once the global setup reserved the block of this run.
+     */
     static getDatabaseName(workerId: string) {
-        return `stamhoofd-playwright-${workerId}`;
+        return playwrightDatabaseName(CaddyConfigHelper.getSlot(workerId));
+    }
+
+    /**
+     * Point the test environment at the MySQL of this run. Only needed for a MySQL that was already
+     * running on this machine (`stam test e2e --local-db`): it does not have to use the root/root of
+     * the containers the test environment defaults to. Has to run again after every
+     * `TestUtils.clearPermanentOverrides()`.
+     */
+    static applyCredentials() {
+        const { user, password } = playwrightDatabaseCredentials();
+
+        if (user !== undefined) {
+            TestUtils.setPermanentEnvironment('DB_USER', user);
+        }
+        if (password !== undefined) {
+            TestUtils.setPermanentEnvironment('DB_PASS', password);
+        }
+    }
+
+    /**
+     * Drop a worker database, so the next migration run starts from an empty one. Only used by the
+     * global setup: dropping a database a worker is connected to breaks that worker.
+     */
+    static async dropDatabase(name: string) {
+        const { DatabaseInstance } = await import('@simonbackx/simple-database');
+
+        // A pool without a selected database: the database we are about to drop cannot be the one we
+        // are connected to.
+        const globalDatabase = new DatabaseInstance({ database: null });
+        try {
+            await globalDatabase.statement(`DROP DATABASE IF EXISTS ${globalDatabase.escapeId(name)}`);
+        } finally {
+            await globalDatabase.end();
+        }
     }
 
     async clear() {

--- a/tests/playwright/src/setup/helpers/WorkerHelper.ts
+++ b/tests/playwright/src/setup/helpers/WorkerHelper.ts
@@ -154,6 +154,10 @@ class WorkerHelperInstance {
             TestUtils.setPermanentEnvironment(key as keyof BackendEnvironment, config[key as keyof BackendEnvironment]);
         }
 
+        // After the permanent overrides above: clearPermanentOverrides() dropped the ones of the
+        // previous load.
+        DatabaseHelper.applyCredentials();
+
         if (STAMHOOFD.singleOrganization) {
             throw new Error('Something went wrong while setting the environment: singleOrganization');
         }


### PR DESCRIPTION
`stam test e2e` starts a MySQL container per worktree, which costs startup time and memory on top of the shared `stamhoofd-mysql` container it starts anyway. This adds a config option to use a MySQL that is already running on the machine instead.

## The option

```bash
yarn stam test e2e --local-db                       # MySQL on 127.0.0.1:3306
STAMHOOFD_E2E_MYSQL_PORT=3307 yarn stam test e2e    # e.g. the shared stamhoofd-mysql container
yarn stam test e2e --no-local-db                    # force a container for a single run
```

Set `STAMHOOFD_E2E_MYSQL_PORT` in your shell profile to make it the default. `STAMHOOFD_E2E_MYSQL_USER` / `STAMHOOFD_E2E_MYSQL_PASSWORD` override the root/root the containers use.

In this mode no MySQL container is started at all — not the e2e one, and not the shared one either, because the e2e tests never touch the development database. The CLI never starts or stops the server: when nothing listens on the port the run fails right away with a message that names the fix instead of timing out later. `--clear` has no data volume to drop, so it drops the worker databases of the run before migrating them again.

## Database names

Worker databases go from `stamhoofd-playwright-<workerIndex>` to `stamhoofd-playwright[-<instance>]-<slot>`:

- **slot instead of worker index**: a run already reserves a block of slots that no other run on the machine holds (#656), so parallel runs from several worktrees never share a database, even when they all connect to the same server.
- **instance name for every non-primary worktree**, the same convention as the development database, so a checkout on another branch migrates its own databases instead of inheriting a foreign schema. Long worktree names are truncated with a checksum to stay inside the 64-character MySQL limit.

The prefix is built by the CLI and passed to Playwright. Because the names now derive from the slot block, the global setup reserves that block before the migrations start; the slow steps (SSO server, frontend build, migrations) still run concurrently.

Also collapsed the duplicated `testMysqlNames`/`e2eMysqlNames` and `startTestMysql`/`startE2eMysql` pairs into one helper parameterized by kind, with the same container and volume names as before.

Unit tests keep using a container: they all share one `stamhoofd-tests` database, so they would collide across worktrees on a shared server.

## Testing

- `yarn lint`, `yarn typecheck`, `yarn stam test cli` (new tests cover target resolution, prefix building and truncation, and the clear/credential handoff), `yarn stam test sql` for the unchanged unit-test container path.
- Real runs: `--local-db` (9/9 `@reset-password` tests, 2 workers, exactly the 2 reserved slot databases migrated, no MySQL container started), `--local-db --clear` (dropped and re-migrated), plain container mode (green), and a deliberately wrong user/password to confirm the credentials reach the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787760746&installation_model_id=423362&pr_number=657&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F657&signature=9333693337421f668130d4f75df4434d3941b6ac58d62832c0ae554261ef1da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->