### PR TITLE
UserPermissions: require an explicit platform, split out inheritTags

### DIFF
--- a/backend/app/api/src/email-recipient-loaders/payments.ts
+++ b/backend/app/api/src/email-recipient-loaders/payments.ts
@@ -1,5 +1,5 @@
 import type { RecipientLoader } from '@stamhoofd/models';
-import { BalanceItem, BalanceItemPayment, Email, Member, MemberResponsibilityRecord, Organization, Payment, User } from '@stamhoofd/models';
+import { BalanceItem, BalanceItemPayment, Email, Member, MemberResponsibilityRecord, Organization, Payment, Platform, User } from '@stamhoofd/models';
 import { compileToSQLFilter, SQL } from '@stamhoofd/sql';
 import type { LimitedFilteredRequest, PaymentGeneral, StamhoofdFilter } from '@stamhoofd/structures';
 import { CountFilteredRequest, EmailRecipient, PaginatedResponse, PaymentMethod } from '@stamhoofd/structures';
@@ -301,12 +301,13 @@ async function getOrganizationRecipients(ids: { organizationId: string; payment:
     if (subFilter === null) {
         // Use full admins instead
         const admins = await User.getAdmins(allOrganizationIds, { verified: true });
+        const platform = await Platform.getSharedStruct();
         for (const { organizationId, payment } of ids) {
             const organization = organizationMap.get(organizationId);
             if (!organization) {
                 continue;
             }
-            const users = admins.filter(a => a.permissions?.forOrganization(organization)?.hasFullAccess());
+            const users = admins.filter(a => a.permissions?.forOrganization(organization, platform, { inheritTags: false })?.hasFullAccess());
 
             if (users.length === 0) {
                 console.warn('No admins found for organization with id ', organizationId, ' while fetching email recipients for payment with id ', payment.id);

--- a/backend/app/api/src/endpoints/auth/PatchUserEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/PatchUserEndpoint.ts
@@ -79,10 +79,12 @@ export class PatchUserEndpoint extends Endpoint<Params, Query, Body, ResponseBod
             }
 
             if (request.body.permissions) {
+                const platform = await Platform.getSharedStruct();
+
                 if (organization) {
                     editUser.permissions = UserPermissions.limitedPatch(editUser.permissions, request.body.permissions, organization.id);
 
-                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization)?.hasFullAccess()) && STAMHOOFD.environment !== 'development') {
+                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization, platform, { inheritTags: false })?.hasFullAccess()) && STAMHOOFD.environment !== 'development') {
                         throw new SimpleError({
                             code: 'permission_denied',
                             message: $t(`%DG`),
@@ -99,7 +101,7 @@ export class PatchUserEndpoint extends Endpoint<Params, Query, Body, ResponseBod
                         editUser.permissions = null;
                     }
 
-                    if (editUser.id === user.id && !editUser.permissions?.platform?.hasFullAccess() && STAMHOOFD.environment !== 'development') {
+                    if (editUser.id === user.id && !editUser.permissions?.forPlatform(platform)?.hasFullAccess() && STAMHOOFD.environment !== 'development') {
                         throw new SimpleError({
                             code: 'permission_denied',
                             message: $t(`%DG`),

--- a/backend/app/api/src/endpoints/organization/dashboard/users/PatchApiUserEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/users/PatchApiUserEndpoint.ts
@@ -3,7 +3,7 @@ import { isPatch } from '@simonbackx/simple-encoding';
 import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { Token, User } from '@stamhoofd/models';
+import { Platform, Token, User } from '@stamhoofd/models';
 import { ApiUser, PermissionLevel, UserMeta, UserPermissions } from '@stamhoofd/structures';
 import { Context } from '../../../../helpers/Context.js';
 
@@ -58,10 +58,12 @@ export class PatchApiUserEndpoint extends Endpoint<Params, Query, Body, Response
             }
 
             if (request.body.permissions) {
+                const platform = await Platform.getSharedStruct();
+
                 if (organization) {
                     editUser.permissions = UserPermissions.limitedPatch(editUser.permissions, request.body.permissions, organization.id);
 
-                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization)?.hasFullAccess())) {
+                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization, platform, { inheritTags: false })?.hasFullAccess())) {
                         throw new SimpleError({
                             code: 'permission_denied',
                             message: 'Je kan jezelf niet verwijderen als hoofdbeheerder',
@@ -74,7 +76,7 @@ export class PatchApiUserEndpoint extends Endpoint<Params, Query, Body, Response
                         editUser.permissions = request.body.permissions.isPut() ? request.body.permissions : null;
                     }
 
-                    if (editUser.id === user.id && !editUser.permissions?.platform?.hasFullAccess()) {
+                    if (editUser.id === user.id && !editUser.permissions?.forPlatform(platform)?.hasFullAccess()) {
                         throw new SimpleError({
                             code: 'permission_denied',
                             message: 'Je kan jezelf niet verwijderen als hoofdbeheerder',

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -794,7 +794,7 @@ export class AdminPermissionChecker {
 
             // Check if this user has permissions for the current scoped organization
             if (this.organization && await this.hasFullAccess(this.organization.id)) {
-                if (user.permissions?.forOrganization(this.organization)) {
+                if (user.permissions?.forOrganization(this.organization, this.platform, { inheritTags: false })) {
                     return true;
                 }
             }

--- a/backend/app/api/src/helpers/AuthenticatedStructures.ts
+++ b/backend/app/api/src/helpers/AuthenticatedStructures.ts
@@ -1,6 +1,6 @@
 import { SimpleError } from '@simonbackx/simple-errors';
 import type { AuditLog, Document, EventNotification, MemberWithUsersRegistrationsAndGroups, Order, Ticket } from '@stamhoofd/models';
-import { BalanceItem, CachedBalance, Event, Group, Invoice, Member, MemberPlatformMembership, MemberResponsibilityRecord, Organization, OrganizationRegistrationPeriod, Payment, Registration, RegistrationInvitation, RegistrationPeriod, User, Webshop } from '@stamhoofd/models';
+import { BalanceItem, CachedBalance, Event, Group, Invoice, Member, MemberPlatformMembership, MemberResponsibilityRecord, Organization, OrganizationRegistrationPeriod, Payment, Platform as PlatformModel, Registration, RegistrationInvitation, RegistrationPeriod, User, Webshop } from '@stamhoofd/models';
 import type { PaymentGeneral } from '@stamhoofd/structures';
 import { BaseOrganization, getAppHost, OrganizationPrivateMetaData } from '@stamhoofd/structures';
 import { Payment as PaymentStruct, AuditLogReplacement, AuditLogReplacementType, AuditLog as AuditLogStruct, BalanceItem as BalanceItemStruct, DetailedReceivableBalance, Document as DocumentStruct, EventNotification as EventNotificationStruct, Event as EventStruct, GenericBalance, Group as GroupStruct, GroupType, InvitationGroupData, InvitationMemberData, InvoicedBalanceItem, InvoiceStruct, MemberPlatformMembership as MemberPlatformMembershipStruct, MemberRegistrationInvitation, MembersBlob, MemberWithRegistrationsBlob, NamedObject, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, Organization as OrganizationStruct, PaymentCustomer, PermissionLevel, Platform, PrivateOrder, PrivateWebshop, ReceivableBalanceObject, ReceivableBalanceObjectContact, ReceivableBalance as ReceivableBalanceStruct, ReceivableBalanceType, RegistrationInvitation as RegistrationInvitationStruct, RegistrationsBlob, RegistrationWithMemberBlob, TicketPrivate, UserWithMembers, WebshopPreview, Webshop as WebshopStruct } from '@stamhoofd/structures';
@@ -1007,6 +1007,7 @@ export class AuthenticatedStructures {
             ...balances.filter(b => b.objectType === ReceivableBalanceType.user || b.objectType === ReceivableBalanceType.userWithoutMembers).map(b => b.objectId),
         ]);
         const users = userIds.length > 0 ? await User.getByIDs(...userIds) : [];
+        const platform = await PlatformModel.getSharedStruct();
 
         const result: { balance: CachedBalance; object: ReceivableBalanceObject }[] = [];
 
@@ -1131,7 +1132,7 @@ export class AuthenticatedStructures {
             } else if (balance.objectType === ReceivableBalanceType.user || balance.objectType === ReceivableBalanceType.userWithoutMembers) {
                 const user = users.find(m => m.id === balance.objectId) ?? null;
                 if (user) {
-                    const url = Context.organization && Context.organization.id === balance.organizationId ? 'https://' + getAppHost('registration', Context.organization, user.permissions?.forOrganization(Context.organization)?.isEmpty === false) : '';
+                    const url = Context.organization && Context.organization.id === balance.organizationId ? 'https://' + getAppHost('registration', Context.organization, user.permissions?.forOrganization(Context.organization, platform, { inheritTags: false })?.isEmpty === false) : '';
                     object = ReceivableBalanceObject.create({
                         id: balance.objectId,
                         name: user.name || user.email,
@@ -1193,6 +1194,7 @@ export class AuthenticatedStructures {
         const users = await User.getByIDs(...userIds);
         const organizationsIds = Formatter.uniqueArray(logs.map(l => l.organizationId).filter(id => id !== null));
         const organizations = await Organization.getByIDs(...organizationsIds);
+        const platform = await PlatformModel.getSharedStruct();
 
         for (const log of logs) {
             const user = log.userId ? (users.find(u => u.id === log.userId) ?? null) : null;
@@ -1200,7 +1202,7 @@ export class AuthenticatedStructures {
 
             if (user) {
                 if (!await Context.auth.canAccessUser(user)) {
-                    if (user.permissions?.platform !== null) {
+                    if (user.permissions?.forPlatform(platform) !== null) {
                         userStruct = NamedObject.create({
                             id: '',
                             name: $t(`%wi`) + ' ' + Platform.shared.config.name,

--- a/backend/app/api/src/services/RegistrationService.ts
+++ b/backend/app/api/src/services/RegistrationService.ts
@@ -1,6 +1,6 @@
 import { ManyToOneRelation } from '@simonbackx/simple-database';
 import { encodeObject } from '@simonbackx/simple-encoding';
-import { BalanceItem, Document, Group, Member, Organization, Registration, RegistrationInvitation, sendEmailTemplate } from '@stamhoofd/models';
+import { BalanceItem, Document, Group, Member, Organization, Platform, Registration, RegistrationInvitation, sendEmailTemplate } from '@stamhoofd/models';
 import { QueueHandler } from '@stamhoofd/queues';
 import { AppliedRegistrationDiscount, AuditLogSource, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, EmailTemplateType, getAppHost, GroupType, Recipient, Replacement, StockReservation, Version } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
@@ -150,6 +150,7 @@ export const RegistrationService = {
         }
 
         const allowedEmails = member.details.getNotificationEmails();
+        const platform = await Platform.getSharedStruct();
 
         return member.users.map(user => Recipient.create({
             firstName: user.firstName,
@@ -167,7 +168,7 @@ export const RegistrationService = {
                 }),
                 Replacement.create({
                     token: 'registerUrl',
-                    value: 'https://' + getAppHost('registration', organization, user.permissions?.forOrganization(organization)?.isEmpty === false),
+                    value: 'https://' + getAppHost('registration', organization, user.permissions?.forOrganization(organization, platform, { inheritTags: false })?.isEmpty === false),
                 }),
                 Replacement.create({
                     token: 'groupName',

--- a/backend/shared/models/src/models/Organization.ts
+++ b/backend/shared/models/src/models/Organization.ts
@@ -18,6 +18,7 @@ import { OrganizationServerMetaData } from '../structures/OrganizationServerMeta
 import { Event } from './Event.js';
 import { Group } from './Group.js';
 import { OrganizationRegistrationPeriod } from './OrganizationRegistrationPeriod.js';
+import { Platform } from './Platform.js';
 import { Registration } from './Registration.js';
 import { StripeAccount } from './StripeAccount.js';
 import { Token } from './Token.js';
@@ -866,9 +867,10 @@ export class Organization extends QueryableModel {
      */
     async getFullAdmins() {
         const admins = await this.getAdmins();
+        const platform = await Platform.getSharedStruct();
 
         // Only full access
-        return admins.filter(a => a.permissions && a.permissions.forOrganization(this)?.hasFullAccess());
+        return admins.filter(a => a.permissions && a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess());
     }
 
     /**
@@ -876,7 +878,8 @@ export class Organization extends QueryableModel {
      */
     async getFinanceAdmins() {
         const admins = await this.getAdmins();
-        const filtered = admins.filter(a => a.permissions && (a.permissions.forOrganization(this)?.hasFullAccess() || a.permissions.forOrganization(this)?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
+        const platform = await Platform.getSharedStruct();
+        const filtered = admins.filter(a => a.permissions && (a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
 
         // Only full access
         return filtered;
@@ -974,12 +977,13 @@ export class Organization extends QueryableModel {
             );
         });
 
-        const filtered = admins.filter(a => a.verified && a.permissions && !a.email.endsWith('@stamhoofd.be') && (a.permissions.forOrganization(this)?.hasFullAccess() || a.permissions.forOrganization(this)?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
+        const platform = await Platform.getSharedStruct();
+        const filtered = admins.filter(a => a.verified && a.permissions && !a.email.endsWith('@stamhoofd.be') && (a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
 
         if (filtered.length > 0) {
             return filtered.map(f => f.email)[0];
         }
-        const filtered2 = admins.filter(a => a.verified && a.permissions && (a.permissions.forOrganization(this)?.hasFullAccess() || a.permissions.forOrganization(this)?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
+        const filtered2 = admins.filter(a => a.verified && a.permissions && (a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
 
         if (filtered2.length > 0) {
             return filtered2.map(f => f.email)[0];

--- a/frontend/shared/components/src/admins/hooks/useAdmins.ts
+++ b/frontend/shared/components/src/admins/hooks/useAdmins.ts
@@ -29,7 +29,7 @@ export function usePermissionsCache() {
             const cacheEntry = cache.get(user);
             if (!cacheEntry) {
                 const c = {
-                    permissions: organization.value ? (user.permissions?.forOrganization(organization.value, null) ?? null) : (user.permissions?.forPlatform(platform.value) ?? null),
+                    permissions: organization.value ? (user.permissions?.forOrganization(organization.value, platform.value, { inheritTags: false }) ?? null) : (user.permissions?.forPlatform(platform.value) ?? null),
                     unloadedPermissions: organization.value ? (user.permissions?.organizationPermissions.get(organization.value.id) ?? null) : (user.permissions?.globalPermissions ?? null),
                 };
                 cache.set(user, c);

--- a/frontend/shared/components/src/filters/filter-builders/members.ts
+++ b/frontend/shared/components/src/filters/filter-builders/members.ts
@@ -77,7 +77,7 @@ export function createMemberWithRegistrationsBlobFilterBuilders({ organization, 
         recordsConfiguration,
     );
 
-    if (user?.permissions?.platform !== null) {
+    if (user?.permissions?.forPlatform(platform) !== null) {
         all.push(
             new MultipleChoiceFilterBuilder({
                 name: $t('%7D'),
@@ -652,7 +652,7 @@ export function createMemberWithRegistrationsBlobFilterBuilders({ organization, 
         }
     }
 
-    if (user?.permissions?.platform !== null) {
+    if (user?.permissions?.forPlatform(platform) !== null) {
         const responsibilitiesFilters: typeof all = [];
 
         responsibilitiesFilters.push(
@@ -890,7 +890,7 @@ export function useAdvancedPlatformMembershipUIFilterBuilders(): { loading: Ref<
         filterBuilders: computed(() => {
             const platform = $platform.value;
             const user = $user.value;
-            const hasPlatformPermissions = (user?.permissions?.platform !== null);
+            const hasPlatformPermissions = (user?.permissions?.forPlatform(platform) !== null);
 
             const all: UIFilterBuilder[] = [];
             all.push(

--- a/frontend/shared/components/src/filters/filter-builders/organizations.ts
+++ b/frontend/shared/components/src/filters/filter-builders/organizations.ts
@@ -344,7 +344,7 @@ export function useGetOrganizationUIFilterBuilders(options: { onlyBaseFilters?: 
             })),
         ];
 
-        if (user?.permissions?.platform !== null) {
+        if (user?.permissions?.forPlatform(platform.value) !== null) {
             all.push(
                 new MultipleChoiceFilterBuilder({
                     name: $t('%3G'),

--- a/frontend/shared/components/src/filters/filter-builders/registrations.ts
+++ b/frontend/shared/components/src/filters/filter-builders/registrations.ts
@@ -35,7 +35,7 @@ export function useAdvancedRegistrationsUIFilterBuilders() {
     const getRegistrationFilters: RegistrationFilterBuilderFactory = ({ periodId }: RegistrationFilterBuilderFactoryOptions = {}) => computed(() => {
         const platform = $platform.value;
         const user = $user.value;
-        const hasPlatformPermissions = (STAMHOOFD.userMode === 'platform' || app === 'admin') && (user?.permissions?.platform !== null);
+        const hasPlatformPermissions = (STAMHOOFD.userMode === 'platform' || app === 'admin') && (user?.permissions?.forPlatform(platform) !== null);
 
         const all: UIFilterBuilder[] = [];
 

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -83,11 +83,11 @@ export class ContextPermissions {
         if (!this.organization) {
             return this.platformPermissions;
         }
-        return unref(this.userPermissions)?.forOrganization(this.organization, this.allowInheritingPermissions ? this.platform : null) ?? null;
+        return unref(this.userPermissions)?.forOrganization(this.organization, this.platform, { inheritTags: this.allowInheritingPermissions }) ?? null;
     }
 
     getPermissionsForOrganization(organization: OrganizationForPermissionCalculation) {
-        return unref(this.userPermissions)?.forOrganization(organization, this.allowInheritingPermissions ? this.platform : null) ?? null;
+        return unref(this.userPermissions)?.forOrganization(organization, this.platform, { inheritTags: this.allowInheritingPermissions }) ?? null;
     }
 
     get unloadedPermissions(): Permissions | null {

--- a/shared/structures/src/UserPermissions.ts
+++ b/shared/structures/src/UserPermissions.ts
@@ -8,7 +8,7 @@ import { PermissionLevel } from './PermissionLevel.js';
 import type { PermissionRoleDetailed, PermissionRoleForResponsibility } from './PermissionRole.js';
 import { Permissions } from './Permissions.js';
 import { PermissionsResourceType } from './PermissionsResourceType.js';
-import { Platform } from './Platform.js';
+import type { Platform } from './Platform.js';
 
 export type OrganizationForPermissionCalculation = {
     id: string;
@@ -30,10 +30,6 @@ export class UserPermissions extends AutoEncoder {
     organizationPermissions: Map<string, Permissions> = new Map();
 
     // Current list of groups
-
-    get platform(): LoadedPermissions | null {
-        return this.forPlatform(Platform.shared);
-    }
 
     forPlatform(platform: Platform): LoadedPermissions | null {
         if (!this.globalPermissions) {
@@ -62,10 +58,10 @@ export class UserPermissions extends AutoEncoder {
         return base;
     }
 
-    forOrganization(organization: OrganizationForPermissionCalculation, platform?: Platform | null): LoadedPermissions | null {
+    forOrganization(organization: OrganizationForPermissionCalculation, platform: Platform, options?: { inheritTags?: boolean }): LoadedPermissions | null {
         const base: LoadedPermissions = LoadedPermissions.create({});
 
-        if (platform) {
+        if (options?.inheritTags ?? true) {
             const platformPermissions = this.forPlatform(platform);
 
             if (platformPermissions) {
@@ -80,7 +76,7 @@ export class UserPermissions extends AutoEncoder {
             }
         }
 
-        const specific = this.forWithoutInherit(organization);
+        const specific = this.forWithoutInherit(organization, platform);
 
         if (!specific) {
             if (base.isEmpty) {
@@ -92,14 +88,14 @@ export class UserPermissions extends AutoEncoder {
         return specific;
     }
 
-    forWithoutInherit(organization: OrganizationForPermissionCalculation): LoadedPermissions | null {
+    forWithoutInherit(organization: OrganizationForPermissionCalculation, platform: Platform): LoadedPermissions | null {
         const permissions = this.organizationPermissions.get(organization.id) ?? null;
         if (!permissions) {
             return null;
         }
         const organizationRoles = organization?.privateMeta?.roles ?? [];
         const inheritedResponsibilityRoles = organization?.privateMeta?.inheritedResponsibilityRoles ?? [];
-        const allResponsibilities = [...Platform.shared.config.responsibilities, ...(organization?.privateMeta?.responsibilities ?? [])];
+        const allResponsibilities = [...platform.config.responsibilities, ...(organization?.privateMeta?.responsibilities ?? [])];
 
         // Clone all external data to avoid mutating them because of the removeAccessRights call
         const result = LoadedPermissions.from(permissions.clone(), organizationRoles.map(r => r.clone()), inheritedResponsibilityRoles.map(r => r.clone()), allResponsibilities.map(r => r.clone()));


### PR DESCRIPTION
Phase 0 of the tenants work: removing every read of the `Platform.shared` process-global.

This removes the **last two `Platform.shared` reads in `@stamhoofd/structures`**.

### What changes

- Deletes the `get platform()` accessor on `UserPermissions`. Its consumers already hold a platform and now call `forPlatform(platform)` explicitly.
- `forWithoutInherit(organization, platform)` — required platform (it read the global to resolve responsibilities).
- `forOrganization(organization, platform, options?)` — required platform, plus an explicit `inheritTags` option.

The old signature was `forOrganization(organization, platform?)`, where the optional parameter conflated **two** things: *which platform to use*, and *whether to merge tag-based resource permissions*. Callers that wanted to disable inheritance passed `null`. Those are now separate.

### Why this is a production no-op

Call sites fall into three groups:

| Group | Before | After |
|---|---|---|
| Already passed a platform | inherited tags | unchanged (`inheritTags` defaults to `true`) |
| Passed `null` to disable inheritance | no tag inheritance | `{ inheritTags: false }` |
| **Omitted the argument** | `undefined` is falsy → **no** tag inheritance | `{ inheritTags: false }` |

The third group is the one worth checking during review: ~12 backend sites called `forOrganization(organization)` with no second argument, so they have never inherited tag-based permissions. Passing them a platform *without* `inheritTags: false` would have silently **granted** permissions those paths do not have today. All of them are explicitly opted out.

The six such call sites in `models/Organization.ts` sit inside synchronous `.filter()` callbacks, so the platform is hoisted and awaited above the filter rather than making the callbacks async.

### Noticed, deliberately not changed

`AdminPermissionChecker.ts` `canAccessUser` does not inherit tags, while the equivalent check earlier in the same class does. The asymmetry is preserved exactly as-is, but it looks unintentional and is worth a separate look.

### Gates

`build:shared` · 0 import cycles through `Platform.js` · `yarn typecheck` · `yarn lint` · `yarn stam test unit` (1035 passed) · components vitest (253 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)