### PR TITLE
Excel loaders: build sheets from an explicit platform

### DIFF
--- a/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
@@ -6,7 +6,7 @@ import type { XlsxTransformerSheet } from '@stamhoofd/excel-writer';
 import { ArchiverWriterAdapter, exportToExcel, XlsxWriter } from '@stamhoofd/excel-writer';
 import { Platform, RateLimiter, sendEmailTemplate } from '@stamhoofd/models';
 import { QueueHandler } from '@stamhoofd/queues';
-import type { ExcelExportType, IPaginatedResponse, LimitedFilteredRequest } from '@stamhoofd/structures';
+import type { ExcelExportType, IPaginatedResponse, LimitedFilteredRequest, Platform as PlatformStruct } from '@stamhoofd/structures';
 import { EmailTemplateType, ExcelExportRequest, ExcelExportResponse, Replacement, Version } from '@stamhoofd/structures';
 import { sleep } from '@stamhoofd/utility';
 import { Context } from '../../../helpers/Context.js';
@@ -20,7 +20,12 @@ type ResponseBody = ExcelExportResponse;
 
 type ExcelExporter<T> = {
     fetch(request: LimitedFilteredRequest): Promise<IPaginatedResponse<T[], LimitedFilteredRequest>>;
-    sheets: XlsxTransformerSheet<T, unknown>[];
+
+    /**
+     * The sheet definitions depend on the platform: they are built per export request instead of
+     * once at module load, so the callbacks never have to read a process wide platform singleton.
+     */
+    getSheets(platform: PlatformStruct): XlsxTransformerSheet<T, unknown>[];
 };
 
 export const limiter = new RateLimiter({
@@ -146,6 +151,7 @@ export class ExportToExcelEndpoint extends Endpoint<Params, Query, Body, Respons
                 // Estimate how long it will take.
                 // If too long, we'll schedule it and write it to Digitalocean Spaces
                 // Otherwise we'll just return the file directly
+                const platform = await Platform.getSharedStruct();
                 const { file, stream } = await FileCache.getWriteStream('.xlsx');
 
                 const zipWriterAdapter = new ArchiverWriterAdapter(stream);
@@ -155,7 +161,7 @@ export class ExportToExcelEndpoint extends Endpoint<Params, Query, Body, Respons
                 request.filter.limit = STAMHOOFD.environment === 'development' ? 1000 : 100; // in development, we need to check if total count matches and pagination is working correctly
 
                 await exportToExcel({
-                    definitions: loader.sheets,
+                    definitions: loader.getSheets(platform),
                     writer,
                     dataGenerator: fetchToAsyncIterator(request.filter, loader, { signFiles: true }),
                     filter: request.workbookFilter,

--- a/backend/app/api/src/excel-loaders/balance-items.ts
+++ b/backend/app/api/src/excel-loaders/balance-items.ts
@@ -16,7 +16,7 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.BalanceItems, {
             results: await BalanceItem.getStructureWithPayments(data.results),
         });
     },
-    sheets: [
+    getSheets: () => [
         {
             id: 'balanceItems',
             name: $t(`%1LA`),

--- a/backend/app/api/src/excel-loaders/event-notifications.ts
+++ b/backend/app/api/src/excel-loaders/event-notifications.ts
@@ -1,14 +1,14 @@
 import type { XlsxTransformerSheet } from '@stamhoofd/excel-writer';
 import { XlsxBuiltInNumberFormat } from '@stamhoofd/excel-writer';
-import type { EventNotification, LimitedFilteredRequest } from '@stamhoofd/structures';
-import { EventNotificationStatus, EventNotificationStatusHelper, ExcelExportType, Platform as PlatformStruct } from '@stamhoofd/structures';
+import type { EventNotification, LimitedFilteredRequest, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { EventNotificationStatus, EventNotificationStatusHelper, ExcelExportType } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { GetEventNotificationsEndpoint } from '../endpoints/global/events/GetEventNotificationsEndpoint.js';
 import { ExportToExcelEndpoint } from '../endpoints/global/files/ExportToExcelEndpoint.js';
 import { XlsxTransformerColumnHelper } from '../helpers/XlsxTransformerColumnHelper.js';
 
 // Assign to a typed variable to assure we have correct type checking in place
-const sheet: XlsxTransformerSheet<EventNotification, EventNotification> = {
+const getSheet = (platform: PlatformStruct): XlsxTransformerSheet<EventNotification, EventNotification> => ({
     id: 'event-notifications',
     name: $t(`%1FR`),
     columns: [
@@ -118,18 +118,17 @@ const sheet: XlsxTransformerSheet<EventNotification, EventNotification> = {
             matchId: 'recordAnswers',
             getRecordAnswers: (notification: EventNotification) => notification.recordAnswers,
             getRecordCategories: () => {
-                const platform = PlatformStruct.shared;
                 return platform.config.eventNotificationTypes.flatMap(r => r.recordCategories);
             },
         }),
     ],
-};
+});
 
 ExportToExcelEndpoint.loaders.set(ExcelExportType.EventNotifications, {
     fetch: async (query: LimitedFilteredRequest) => {
         return await GetEventNotificationsEndpoint.buildData(query);
     },
-    sheets: [
-        sheet,
+    getSheets: platform => [
+        getSheet(platform),
     ],
 });

--- a/backend/app/api/src/excel-loaders/members.test.ts
+++ b/backend/app/api/src/excel-loaders/members.test.ts
@@ -1,7 +1,7 @@
 import type { XlsxTransformerConcreteColumn } from '@stamhoofd/excel-writer';
 import type { PlatformMember } from '@stamhoofd/structures';
 import { EmergencyContact, MemberDetails, MembersBlob, MemberWithRegistrationsBlob, Organization, Platform, PlatformFamily } from '@stamhoofd/structures';
-import { baseMemberColumns } from './members.js';
+import { getBaseMemberColumns } from './members.js';
 
 describe('Member excel export', () => {
     describe('emergencyContacts column', () => {
@@ -21,7 +21,7 @@ describe('Member excel export', () => {
         }
 
         function getColumn() {
-            const column = baseMemberColumns.find(c => 'id' in c && c.id === 'emergencyContacts') as XlsxTransformerConcreteColumn<PlatformMember> | undefined;
+            const column = getBaseMemberColumns(Platform.create({})).find(c => 'id' in c && c.id === 'emergencyContacts') as XlsxTransformerConcreteColumn<PlatformMember> | undefined;
 
             if (!column) {
                 throw new Error('Column emergencyContacts not found');

--- a/backend/app/api/src/excel-loaders/members.ts
+++ b/backend/app/api/src/excel-loaders/members.ts
@@ -1,8 +1,8 @@
 import type { XlsxTransformerColumn, XlsxTransformerSheet } from '@stamhoofd/excel-writer';
 import { XlsxBuiltInNumberFormat } from '@stamhoofd/excel-writer';
 import { Platform } from '@stamhoofd/models';
-import type { LimitedFilteredRequest, PlatformMember } from '@stamhoofd/structures';
-import { ExcelExportType, Gender, GroupType, MembershipStatus, PlatformFamily, Platform as PlatformStruct, UnencodeablePaginatedResponse } from '@stamhoofd/structures';
+import type { LimitedFilteredRequest, PlatformMember, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { ExcelExportType, Gender, GroupType, MembershipStatus, PlatformFamily, UnencodeablePaginatedResponse } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { ExportToExcelEndpoint } from '../endpoints/global/files/ExportToExcelEndpoint.js';
 import { GetMembersEndpoint } from '../endpoints/global/members/GetMembersEndpoint.js';
@@ -10,7 +10,7 @@ import { AuthenticatedStructures } from '../helpers/AuthenticatedStructures.js';
 import { Context } from '../helpers/Context.js';
 import { XlsxTransformerColumnHelper } from '../helpers/XlsxTransformerColumnHelper.js';
 
-export const baseMemberColumns: XlsxTransformerColumn<PlatformMember>[] = [
+export const getBaseMemberColumns = (platform: PlatformStruct): XlsxTransformerColumn<PlatformMember>[] => [
     {
         id: 'id',
         name: $t(`%d`),
@@ -244,7 +244,6 @@ export const baseMemberColumns: XlsxTransformerColumn<PlatformMember>[] = [
         matchId: 'recordAnswers',
         getRecordAnswers: ({ patchedMember: object }: PlatformMember) => object.details.recordAnswers,
         getRecordCategories: () => {
-            const platform = PlatformStruct.shared;
             const organization = Context.organization;
 
             return [
@@ -256,11 +255,11 @@ export const baseMemberColumns: XlsxTransformerColumn<PlatformMember>[] = [
 ];
 
 // Assign to a typed variable to assure we have correct type checking in place
-const sheet: XlsxTransformerSheet<PlatformMember, PlatformMember> = {
+const getSheet = (platform: PlatformStruct): XlsxTransformerSheet<PlatformMember, PlatformMember> => ({
     id: 'members',
     name: $t(`%1EH`),
     columns: [
-        ...baseMemberColumns,
+        ...getBaseMemberColumns(platform),
         {
             id: 'group',
             name: $t(`%wH`),
@@ -281,7 +280,7 @@ const sheet: XlsxTransformerSheet<PlatformMember, PlatformMember> = {
             getValue: (member: PlatformMember) => {
                 const groups = member.filterRegistrations({ currentPeriod: true, types: [GroupType.Membership], organizationId: Context.organization?.id });
                 const defaultAgeGroupIds = Formatter.uniqueArray(groups.filter(o => o.group.defaultAgeGroupId));
-                const defaultAgeGroups = defaultAgeGroupIds.map(o => PlatformStruct.shared.config.defaultAgeGroups.find(g => g.id === o.group.defaultAgeGroupId)?.name ?? $t(`%wJ`));
+                const defaultAgeGroups = defaultAgeGroupIds.map(o => platform.config.defaultAgeGroups.find(g => g.id === o.group.defaultAgeGroupId)?.name ?? $t(`%wJ`));
                 const str = Formatter.joinLast(Formatter.uniqueArray(defaultAgeGroups).sort(), ', ', ' ' + $t(`%M1`) + ' ') || Context.i18n.$t('%5D');
 
                 return {
@@ -472,7 +471,7 @@ const sheet: XlsxTransformerSheet<PlatformMember, PlatformMember> = {
             },
         },
     ],
-};
+});
 
 ExportToExcelEndpoint.loaders.set(ExcelExportType.Members, {
     fetch: async (query: LimitedFilteredRequest) => {
@@ -486,8 +485,8 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.Members, {
             next: result.next,
         });
     },
-    sheets: [
-        sheet,
+    getSheets: platform => [
+        getSheet(platform),
     ],
 });
 

--- a/backend/app/api/src/excel-loaders/organizations.ts
+++ b/backend/app/api/src/excel-loaders/organizations.ts
@@ -1,8 +1,8 @@
 import { ArrayDecoder, field } from '@simonbackx/simple-encoding';
 import type { XlsxTransformerSheet } from '@stamhoofd/excel-writer';
-import { Group, Member, MemberResponsibilityRecord } from '@stamhoofd/models';
-import type { LimitedFilteredRequest, Premise } from '@stamhoofd/structures';
-import { ExcelExportType, MemberResponsibilityRecord as MemberResponsibilityRecordStruct, MemberWithRegistrationsBlob, Organization as OrganizationStruct, PaginatedResponse, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { Group, Member, MemberResponsibilityRecord, Platform } from '@stamhoofd/models';
+import type { LimitedFilteredRequest, Platform as PlatformStruct, Premise } from '@stamhoofd/structures';
+import { ExcelExportType, MemberResponsibilityRecord as MemberResponsibilityRecordStruct, MemberWithRegistrationsBlob, Organization as OrganizationStruct, PaginatedResponse } from '@stamhoofd/structures';
 import { Formatter, Sorter } from '@stamhoofd/utility';
 import { GetOrganizationsEndpoint } from '../endpoints/admin/organizations/GetOrganizationsEndpoint.js';
 import { ExportToExcelEndpoint } from '../endpoints/global/files/ExportToExcelEndpoint.js';
@@ -27,7 +27,7 @@ class MemberResponsibilityRecordWithMemberAndOrganization extends MemberResponsi
 type Object = OrganizationWithResponsibilities;
 
 // Assign to a typed variable to assure we have correct type checking in place
-const sheet: XlsxTransformerSheet<Object, Object> = {
+const getSheet = (platform: PlatformStruct): XlsxTransformerSheet<Object, Object> => ({
     id: 'organizations',
     name: $t(`%wP`),
     columns: [
@@ -60,8 +60,6 @@ const sheet: XlsxTransformerSheet<Object, Object> = {
             name: $t(`%13`),
             width: 50,
             getValue: (object: Object) => {
-                const platform = PlatformStruct.shared;
-
                 return {
                     value: object.meta.tags.map(tag => platform.config.tags.find(t => t.id === tag)?.name ?? $t(`%Gr`)).join(', '),
                 };
@@ -76,17 +74,15 @@ const sheet: XlsxTransformerSheet<Object, Object> = {
             matchId: 'recordAnswers',
             getRecordAnswers: (object: Object) => object.getRecordAnswers(),
             getRecordCategories: () => {
-                const platform = PlatformStruct.shared;
-
                 return [
                     ...platform.config.organizationLevelRecordsConfiguration.recordCategories,
                 ];
             },
         }),
     ],
-};
+});
 
-const responsibilities: XlsxTransformerSheet<Object, MemberResponsibilityRecordWithMemberAndOrganization> = {
+const getResponsibilitiesSheet = (platform: PlatformStruct): XlsxTransformerSheet<Object, MemberResponsibilityRecordWithMemberAndOrganization> => ({
     id: 'responsibilities',
     name: $t(`%7D`),
     transform(organization) {
@@ -125,7 +121,6 @@ const responsibilities: XlsxTransformerSheet<Object, MemberResponsibilityRecordW
             name: $t(`%H2`),
             width: 50,
             getValue: (object: MemberResponsibilityRecordWithMemberAndOrganization) => {
-                const platform = PlatformStruct.shared;
                 const responsibility = platform.config.responsibilities.find(r => r.id === object.responsibilityId) ?? object.organization.privateMeta?.responsibilities.find(r => r.id === object.responsibilityId);
 
                 if (!responsibility) {
@@ -168,10 +163,10 @@ const responsibilities: XlsxTransformerSheet<Object, MemberResponsibilityRecordW
             getAddress: object => object.member.details.address ?? object.member.details.parents[0]?.address ?? object.member.details.parents[1]?.address ?? null,
         }),
     ],
-};
+});
 
 type PremiseWithOrganization = { organization: Object; premise: Premise };
-const premises: XlsxTransformerSheet<Object, PremiseWithOrganization> = {
+const getPremisesSheet = (platform: PlatformStruct): XlsxTransformerSheet<Object, PremiseWithOrganization> => ({
     id: 'premises',
     name: $t(`%6c`),
     transform(organization) {
@@ -219,7 +214,6 @@ const premises: XlsxTransformerSheet<Object, PremiseWithOrganization> = {
             width: 20,
             getValue: (object: PremiseWithOrganization) => {
                 const ids = object.premise.premiseTypeIds;
-                const platform = PlatformStruct.shared;
                 return {
                     value: ids.map(id => platform.config.premiseTypes.find(t => t.id === id)?.name ?? $t(`%Gr`)).join(', '),
                 };
@@ -230,7 +224,7 @@ const premises: XlsxTransformerSheet<Object, PremiseWithOrganization> = {
             getAddress: object => object.premise.address,
         }),
     ],
-};
+});
 
 ExportToExcelEndpoint.loaders.set(ExcelExportType.Organizations, {
     fetch: async (query: LimitedFilteredRequest) => {
@@ -253,7 +247,7 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.Organizations, {
         const groups = await Group.getByIDs(...groupIds);
         const memberStructs = await AuthenticatedStructures.members(members);
         const groupStructs = await AuthenticatedStructures.groups(groups);
-        const platform = PlatformStruct.shared;
+        const platform = await Platform.getSharedStruct();
 
         const mappedOrganizations = organizations.results.map((o) => {
             const resp = responsibilities.filter(r => r.organizationId === o.id);
@@ -295,9 +289,9 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.Organizations, {
             next: organizations.next,
         });
     },
-    sheets: [
-        sheet,
-        responsibilities,
-        premises,
+    getSheets: platform => [
+        getSheet(platform),
+        getResponsibilitiesSheet(platform),
+        getPremisesSheet(platform),
     ],
 });

--- a/backend/app/api/src/excel-loaders/payments.ts
+++ b/backend/app/api/src/excel-loaders/payments.ts
@@ -62,7 +62,7 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.Payments, {
             }),
         });
     },
-    sheets: [
+    getSheets: () => [
         {
             id: 'payments',
             name: $t(`%1JH`),

--- a/backend/app/api/src/excel-loaders/platform-memberships.ts
+++ b/backend/app/api/src/excel-loaders/platform-memberships.ts
@@ -1,12 +1,12 @@
 import type { XlsxTransformerSheet } from '@stamhoofd/excel-writer';
 import { XlsxBuiltInNumberFormat } from '@stamhoofd/excel-writer';
-import type { LimitedFilteredRequest, PlatformMembership } from '@stamhoofd/structures';
-import { ExcelExportType, PaginatedResponse, Platform } from '@stamhoofd/structures';
+import type { LimitedFilteredRequest, PlatformMembership, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { ExcelExportType, PaginatedResponse } from '@stamhoofd/structures';
 import { ExportToExcelEndpoint } from '../endpoints/global/files/ExportToExcelEndpoint.js';
 import { GetPlatformMembershipsEndpoint } from '../endpoints/global/platform-memberships/GetPlatformMembershipsEndpoint.js';
 
 // Assign to a typed variable to assure we have correct type checking in place
-const sheet: XlsxTransformerSheet<PlatformMembership> = {
+const getSheet = (platform: PlatformStruct): XlsxTransformerSheet<PlatformMembership> => ({
     id: 'platform-memberships',
     name: $t('%1EI'),
     columns: [
@@ -23,7 +23,7 @@ const sheet: XlsxTransformerSheet<PlatformMembership> = {
             name: $t('%1LP'),
             width: 40,
             getValue: (membership: PlatformMembership) => {
-                const membershipType = Platform.shared.config.membershipTypes.find(m => m.id === membership.membershipTypeId);
+                const membershipType = platform.config.membershipTypes.find(m => m.id === membership.membershipTypeId);
                 const value = membershipType ? membershipType.name : '';
                 return { value };
             },
@@ -244,7 +244,7 @@ const sheet: XlsxTransformerSheet<PlatformMembership> = {
             }),
         },
     ],
-};
+});
 
 ExportToExcelEndpoint.loaders.set(ExcelExportType.PlatformMemberships, {
     fetch: async (query: LimitedFilteredRequest) => {
@@ -255,7 +255,7 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.PlatformMemberships, {
             next: data.next,
         });
     },
-    sheets: [
-        sheet,
+    getSheets: platform => [
+        getSheet(platform),
     ],
 });

--- a/backend/app/api/src/excel-loaders/platform-sheets.test.ts
+++ b/backend/app/api/src/excel-loaders/platform-sheets.test.ts
@@ -1,0 +1,113 @@
+import type { XlsxTransformerColumn, XlsxTransformerConcreteColumn } from '@stamhoofd/excel-writer';
+import { isXlsxTransformerConcreteColumn } from '@stamhoofd/excel-writer';
+import { EventNotificationType, ExcelExportType, Organization, OrganizationMetaData, OrganizationTag, Platform, PlatformConfig, PlatformMembership, PlatformMembershipMemberDetails, PlatformMembershipOrganizationDetails, PlatformMembershipType, RecordCategory, RecordSettings, RecordType, TranslatedString } from '@stamhoofd/structures';
+import { ExportToExcelEndpoint } from '../endpoints/global/files/ExportToExcelEndpoint.js';
+import './index.js';
+
+/**
+ * The sheets are built per export request, so every callback should read the platform it was built
+ * with instead of a process wide singleton.
+ */
+describe('Excel loaders platform argument', () => {
+    function getColumns(type: ExcelExportType, platform: Platform, sheetId: string): XlsxTransformerColumn<unknown>[] {
+        const loader = ExportToExcelEndpoint.loaders.get(type);
+
+        if (!loader) {
+            throw new Error('Loader ' + type + ' not registered');
+        }
+
+        const sheet = loader.getSheets(platform).find(s => s.id === sheetId);
+
+        if (!sheet) {
+            throw new Error('Sheet ' + sheetId + ' not found');
+        }
+
+        return sheet.columns;
+    }
+
+    function getColumn(type: ExcelExportType, platform: Platform, sheetId: string, columnId: string): XlsxTransformerConcreteColumn<unknown> {
+        const column = getColumns(type, platform, sheetId).find(c => isXlsxTransformerConcreteColumn(c) && c.id === columnId);
+
+        if (!column || !isXlsxTransformerConcreteColumn(column)) {
+            throw new Error('Column ' + columnId + ' not found');
+        }
+
+        return column;
+    }
+
+    function createPlatformWithTag(tagName: string) {
+        return Platform.create({
+            config: PlatformConfig.create({
+                tags: [
+                    OrganizationTag.create({ id: 'tag-1', name: tagName }),
+                ],
+            }),
+        });
+    }
+
+    it('reads the organization tags from the platform the sheets were built with', () => {
+        const organization = Organization.create({
+            meta: OrganizationMetaData.create({ tags: ['tag-1'] }),
+        });
+
+        const first = getColumn(ExcelExportType.Organizations, createPlatformWithTag('Gewest Noord'), 'organizations', 'tags');
+        expect(first.getValue(organization).value).toBe('Gewest Noord');
+
+        // Building the sheets again with another platform should not reuse the first platform
+        const second = getColumn(ExcelExportType.Organizations, createPlatformWithTag('Gewest Zuid'), 'organizations', 'tags');
+        expect(second.getValue(organization).value).toBe('Gewest Zuid');
+    });
+
+    it('reads the membership type from the platform the sheets were built with', () => {
+        const platform = Platform.create({
+            config: PlatformConfig.create({
+                membershipTypes: [
+                    PlatformMembershipType.create({ id: 'type-1', name: 'Aansluiting' }),
+                ],
+            }),
+        });
+
+        const membership = PlatformMembership.create({
+            memberId: 'member-1',
+            membershipTypeId: 'type-1',
+            organizationId: 'organization-1',
+            periodId: 'period-1',
+            member: PlatformMembershipMemberDetails.create({ firstName: 'John', lastName: 'Doe', memberNumber: null }),
+            organization: PlatformMembershipOrganizationDetails.create({}),
+            balanceItem: null,
+        });
+
+        const column = getColumn(ExcelExportType.PlatformMemberships, platform, 'platform-memberships', 'type');
+        expect(column.getValue(membership).value).toBe('Aansluiting');
+    });
+
+    it('reads the record categories of an event notification from the platform the sheets were built with', () => {
+        const platform = Platform.create({
+            config: PlatformConfig.create({
+                eventNotificationTypes: [
+                    EventNotificationType.create({
+                        recordCategories: [
+                            RecordCategory.create({
+                                name: new TranslatedString('Kamp'),
+                                records: [
+                                    RecordSettings.create({
+                                        id: 'record-1',
+                                        name: new TranslatedString('Aantal deelnemers'),
+                                        type: RecordType.Text,
+                                    }),
+                                ],
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+        });
+
+        const columns = getColumns(ExcelExportType.EventNotifications, platform, 'event-notifications');
+        const matched = columns.flatMap(c => isXlsxTransformerConcreteColumn(c) ? [] : (c.match('recordAnswers.record-1') ?? []));
+
+        expect(matched).toHaveLength(1);
+        expect(matched[0].name).toBe('Aantal deelnemers');
+        expect(matched[0].category).toBe('Kamp');
+    });
+});

--- a/backend/app/api/src/excel-loaders/receivable-balances.ts
+++ b/backend/app/api/src/excel-loaders/receivable-balances.ts
@@ -19,7 +19,7 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.ReceivableBalances, {
             ...data,
         });
     },
-    sheets: [
+    getSheets: () => [
         {
             id: 'receivableBalances',
             name: $t(`%99`),

--- a/backend/app/api/src/excel-loaders/registrations.ts
+++ b/backend/app/api/src/excel-loaders/registrations.ts
@@ -1,17 +1,17 @@
 import type { XlsxTransformerSheet } from '@stamhoofd/excel-writer';
 import { XlsxBuiltInNumberFormat } from '@stamhoofd/excel-writer';
 import { Platform } from '@stamhoofd/models';
-import type { LimitedFilteredRequest, PlatformMember } from '@stamhoofd/structures';
-import { ExcelExportType, getGroupTypeName, PlatformRegistration, Platform as PlatformStruct, UnencodeablePaginatedResponse } from '@stamhoofd/structures';
+import type { LimitedFilteredRequest, PlatformMember, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { ExcelExportType, getGroupTypeName, PlatformRegistration, UnencodeablePaginatedResponse } from '@stamhoofd/structures';
 import { ExportToExcelEndpoint } from '../endpoints/global/files/ExportToExcelEndpoint.js';
 import { GetRegistrationsEndpoint } from '../endpoints/global/registration/GetRegistrationsEndpoint.js';
 import { AuthenticatedStructures } from '../helpers/AuthenticatedStructures.js';
 import { Context } from '../helpers/Context.js';
 import { XlsxTransformerColumnHelper } from '../helpers/XlsxTransformerColumnHelper.js';
-import { baseMemberColumns } from './members.js';
+import { getBaseMemberColumns } from './members.js';
 
 // Assign to a typed variable to assure we have correct type checking in place
-const sheet: XlsxTransformerSheet<PlatformMember, PlatformRegistration> = {
+const getSheet = (platform: PlatformStruct): XlsxTransformerSheet<PlatformMember, PlatformRegistration> => ({
     id: 'registrations',
     name: $t('%1EI'),
     columns: [
@@ -294,7 +294,7 @@ const sheet: XlsxTransformerSheet<PlatformMember, PlatformRegistration> = {
                 ];
             },
         },
-        ...baseMemberColumns.map(column => XlsxTransformerColumnHelper.transformColumnForProperty({
+        ...getBaseMemberColumns(platform).map(column => XlsxTransformerColumnHelper.transformColumnForProperty({
             column,
             key: 'member',
             getPropertyValue: (registration: PlatformRegistration) => registration.member,
@@ -341,7 +341,7 @@ const sheet: XlsxTransformerSheet<PlatformMember, PlatformRegistration> = {
                     };
                 }
                 return {
-                    value: PlatformStruct.shared.config.defaultAgeGroups.find(g => g.id === defaultAgeGroupId)?.name ?? $t(`%wJ`),
+                    value: platform.config.defaultAgeGroups.find(g => g.id === defaultAgeGroupId)?.name ?? $t(`%wJ`),
                 };
             },
         },
@@ -356,7 +356,7 @@ const sheet: XlsxTransformerSheet<PlatformMember, PlatformRegistration> = {
             },
         },
     ],
-};
+});
 
 ExportToExcelEndpoint.loaders.set(ExcelExportType.Registrations, {
     fetch: async (query: LimitedFilteredRequest) => {
@@ -370,7 +370,7 @@ ExportToExcelEndpoint.loaders.set(ExcelExportType.Registrations, {
             next: result.next,
         });
     },
-    sheets: [
-        sheet,
+    getSheets: platform => [
+        getSheet(platform),
     ],
 });


### PR DESCRIPTION
Phase 0 of the tenants work: removing every read of the `Platform.shared` process-global. Stacked on #658.

Removes the **12 `Platform.shared` reads in `backend/app/api/src/excel-loaders/`**.

### Why this isn't just `await Platform.getSharedStruct()`

Most of these reads sit inside **synchronous** callbacks (`getValue: (object) => …`, `getRecordCategories: () => …`) belonging to **module-level** sheet definitions. The interface is:

```ts
// shared/excel-writer/src/interfaces.ts:8
getValue(object: T): CellValue;
```

Synchronous, one argument, no context object. So the platform can be neither awaited *inside* the callback nor hoisted *above* it — at module-evaluation time there is no platform yet.

### The change

The sheet list becomes a function of the platform:

```ts
type ExcelExporter<T> = {
    fetch(request: LimitedFilteredRequest): Promise<IPaginatedResponse<T[], LimitedFilteredRequest>>;
    getSheets(platform: PlatformStruct): XlsxTransformerSheet<T, unknown>[];
};
```

This is cheap because there is exactly **one** consumer — `ExportToExcelEndpoint` — which resolves the platform once per export job with `await Platform.getSharedStruct()` and passes it in. Each loader turns its module-level `const sheet = {…}` into `const getSheet = (platform) => ({…})`.

All 8 loaders take the signature change. The three that need no platform (`balance-items`, `receivable-balances`, `payments`) simply ignore the argument. **`shared/excel-writer` is not touched.**

### Why this is a production no-op

On the backend `Platform.shared` and `await Platform.getSharedStruct()` return the *same object*: `backend/shared/models/src/models/Platform.ts` does `clone.setShared()` and then `this.sharedStruct = clone`. Same platform data reaches the same callbacks, per request.

### Tests

New `platform-sheets.test.ts`, 3 tests. The first is the important one: it builds the same sheet twice with two *different* platforms and asserts the rendered cell value differs. That is exactly what regresses if a platform is ever captured at module load instead of per request — the bug this refactor exists to prevent.

### Noticed, deliberately left alone

- `ExportToExcelEndpoint.ts:94` has a bare `await Platform.getSharedStruct();` whose return value is discarded — it exists only to warm `Platform.shared` for synchronous readers. Removing it while other sync readers still exist would be a behaviour change, so it goes in the final singleton-deletion PR, where the typechecker can prove nothing reads it.
- `members.ts` `getRecordCategories` still reads `Context.organization`, a different process-global. Out of scope here.
- `organizations.ts` had a local `const responsibilities` inside `fetch` that shadowed the module-level `responsibilities` sheet const. Renaming the sheet to `getResponsibilitiesSheet` removed the shadowing — no behaviour change, but one less foot-gun.

### Gates

`build:shared` · 0 import cycles through `Platform.js` · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — **1038 passed** | 8 skipped | 5 todo

`grep -rn "Platform\.shared\|PlatformStruct\.shared" backend/app/api/src/excel-loaders/` → no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)