### PR TITLE
AuthenticatedStructures + Document: take the platform explicitly

### DIFF
--- a/backend/app/api/src/helpers/AuthenticatedStructures.ts
+++ b/backend/app/api/src/helpers/AuthenticatedStructures.ts
@@ -3,7 +3,7 @@ import type { AuditLog, Document, EventNotification, MemberWithUsersRegistration
 import { BalanceItem, CachedBalance, Event, Group, Invoice, Member, MemberPlatformMembership, MemberResponsibilityRecord, Organization, OrganizationRegistrationPeriod, Payment, Platform as PlatformModel, Registration, RegistrationInvitation, RegistrationPeriod, User, Webshop } from '@stamhoofd/models';
 import type { PaymentGeneral } from '@stamhoofd/structures';
 import { BaseOrganization, getAppHost, OrganizationPrivateMetaData } from '@stamhoofd/structures';
-import { Payment as PaymentStruct, AuditLogReplacement, AuditLogReplacementType, AuditLog as AuditLogStruct, BalanceItem as BalanceItemStruct, DetailedReceivableBalance, Document as DocumentStruct, EventNotification as EventNotificationStruct, Event as EventStruct, GenericBalance, Group as GroupStruct, GroupType, InvitationGroupData, InvitationMemberData, InvoicedBalanceItem, InvoiceStruct, MemberPlatformMembership as MemberPlatformMembershipStruct, MemberRegistrationInvitation, MembersBlob, MemberWithRegistrationsBlob, NamedObject, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, Organization as OrganizationStruct, PaymentCustomer, PermissionLevel, Platform, PrivateOrder, PrivateWebshop, ReceivableBalanceObject, ReceivableBalanceObjectContact, ReceivableBalance as ReceivableBalanceStruct, ReceivableBalanceType, RegistrationInvitation as RegistrationInvitationStruct, RegistrationsBlob, RegistrationWithMemberBlob, TicketPrivate, UserWithMembers, WebshopPreview, Webshop as WebshopStruct } from '@stamhoofd/structures';
+import { Payment as PaymentStruct, AuditLogReplacement, AuditLogReplacementType, AuditLog as AuditLogStruct, BalanceItem as BalanceItemStruct, DetailedReceivableBalance, Document as DocumentStruct, EventNotification as EventNotificationStruct, Event as EventStruct, GenericBalance, Group as GroupStruct, GroupType, InvitationGroupData, InvitationMemberData, InvoicedBalanceItem, InvoiceStruct, MemberPlatformMembership as MemberPlatformMembershipStruct, MemberRegistrationInvitation, MembersBlob, MemberWithRegistrationsBlob, NamedObject, OrganizationRegistrationPeriod as OrganizationRegistrationPeriodStruct, Organization as OrganizationStruct, PaymentCustomer, PermissionLevel, PrivateOrder, PrivateWebshop, ReceivableBalanceObject, ReceivableBalanceObjectContact, ReceivableBalance as ReceivableBalanceStruct, ReceivableBalanceType, RegistrationInvitation as RegistrationInvitationStruct, RegistrationsBlob, RegistrationWithMemberBlob, TicketPrivate, UserWithMembers, WebshopPreview, Webshop as WebshopStruct } from '@stamhoofd/structures';
 import { Sorter } from '@stamhoofd/utility';
 
 import { SQL } from '@stamhoofd/sql';
@@ -465,11 +465,12 @@ export class AuthenticatedStructures {
             return MembersBlob.create({ members: [], organizations: [] });
         }
 
+        const platform = await PlatformModel.getSharedStruct();
         const organizations = new Map<string, Organization>();
         const relevantPeriodIds = Formatter.uniqueArray([
-            Platform.shared.period.previousPeriodId,
-            Platform.shared.period.id,
-            Platform.shared.period.nextPeriodId,
+            platform.period.previousPeriodId,
+            platform.period.id,
+            platform.period.nextPeriodId,
             Context.organization?.periodId ?? null,
         ].filter(id => id !== null)) as string[];
 
@@ -520,7 +521,7 @@ export class AuthenticatedStructures {
             organizationIds.push(STAMHOOFD.singleOrganization);
         }
 
-        const membershipOrganizationId = Platform.shared.membershipOrganizationId;
+        const membershipOrganizationId = platform.membershipOrganizationId;
         if (membershipOrganizationId && Context.auth.hasSomePlatformAccess()) {
             if (await Context.auth.hasSomeAccess(membershipOrganizationId)) {
                 organizationIds.push(membershipOrganizationId);
@@ -1205,7 +1206,7 @@ export class AuthenticatedStructures {
                     if (user.permissions?.forPlatform(platform) !== null) {
                         userStruct = NamedObject.create({
                             id: '',
-                            name: $t(`%wi`) + ' ' + Platform.shared.config.name,
+                            name: $t(`%wi`) + ' ' + platform.config.name,
                         });
                     } else {
                         userStruct = NamedObject.create({

--- a/backend/shared/models/src/models/Document.test.ts
+++ b/backend/shared/models/src/models/Document.test.ts
@@ -1,0 +1,96 @@
+import { Address, DocumentData, File, Image, OrganizationMetaData, PlatformConfig, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { Country } from '@stamhoofd/types/Country';
+import { Document } from './Document.js';
+import { Organization } from './Organization.js';
+
+function createImage(id: string) {
+    return Image.create({
+        id,
+        source: new File({
+            id,
+            server: 'https://files.example.com',
+            path: id + '.png',
+            size: 100,
+        }),
+    });
+}
+
+function createOrganization(meta?: Partial<{ horizontalLogo: Image | null; squareLogo: Image | null }>) {
+    const organization = new Organization();
+    organization.name = 'Test organization';
+    organization.meta = OrganizationMetaData.create({
+        horizontalLogo: meta?.horizontalLogo ?? null,
+        squareLogo: meta?.squareLogo ?? null,
+    });
+    organization.address = Address.create({
+        street: 'Demostraat',
+        number: '12',
+        city: 'Gent',
+        postalCode: '9000',
+        country: Country.Belgium,
+    });
+    return organization;
+}
+
+function createDocument() {
+    const document = new Document();
+    document.data = DocumentData.create({ name: 'Test document' });
+    return document;
+}
+
+function createPlatform(config: Partial<{ logoDocuments: Image | null; horizontalLogo: Image | null; squareLogo: Image | null }>) {
+    return PlatformStruct.create({
+        config: PlatformConfig.create({
+            logoDocuments: config.logoDocuments ?? null,
+            horizontalLogo: config.horizontalLogo ?? null,
+            squareLogo: config.squareLogo ?? null,
+        }),
+    });
+}
+
+describe('Model.Document', () => {
+    describe('buildContext', () => {
+        test('The platform logo falls back from logoDocuments to horizontalLogo to squareLogo', () => {
+            const logoDocuments = createImage('logo-documents');
+            const horizontalLogo = createImage('horizontal-logo');
+            const squareLogo = createImage('square-logo');
+
+            const organization = createOrganization();
+            const document = createDocument();
+
+            const all = document.buildContext(organization, createPlatform({ logoDocuments, horizontalLogo, squareLogo }));
+            expect(all['platform'].logo.id).toBe(logoDocuments.id);
+            expect(all['logo'].id).toBe(logoDocuments.id);
+
+            const withoutDocumentsLogo = document.buildContext(organization, createPlatform({ horizontalLogo, squareLogo }));
+            expect(withoutDocumentsLogo['platform'].logo.id).toBe(horizontalLogo.id);
+            expect(withoutDocumentsLogo['logo'].id).toBe(horizontalLogo.id);
+
+            const onlySquareLogo = document.buildContext(organization, createPlatform({ squareLogo }));
+            expect(onlySquareLogo['platform'].logo.id).toBe(squareLogo.id);
+            expect(onlySquareLogo['logo'].id).toBe(squareLogo.id);
+        });
+
+        test('No logo is added to the context when the platform and the organization have none', () => {
+            const context = createDocument().buildContext(createOrganization(), createPlatform({}));
+
+            expect(context['platform']).toBeUndefined();
+            expect(context['logo']).toBeUndefined();
+            expect(context['organization'].logo).toBeUndefined();
+        });
+
+        test('The organization logo takes precedence over the platform logo', () => {
+            const platformLogo = createImage('logo-documents');
+            const organizationLogo = createImage('organization-horizontal-logo');
+
+            const organization = createOrganization({ horizontalLogo: organizationLogo });
+            const context = createDocument().buildContext(organization, createPlatform({ logoDocuments: platformLogo }));
+
+            expect(context['logo'].id).toBe(organizationLogo.id);
+            expect(context['organization'].logo.id).toBe(organizationLogo.id);
+
+            // The platform logo remains available separately
+            expect(context['platform'].logo.id).toBe(platformLogo.id);
+        });
+    });
+});

--- a/backend/shared/models/src/models/Document.ts
+++ b/backend/shared/models/src/models/Document.ts
@@ -1,5 +1,6 @@
 import { column } from '@simonbackx/simple-database';
-import { DocumentData, DocumentStatus, Document as DocumentStruct, Platform, Version } from '@stamhoofd/structures';
+import type { Platform as PlatformStruct } from '@stamhoofd/structures';
+import { DocumentData, DocumentStatus, Document as DocumentStruct, Version } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -8,6 +9,7 @@ import { QueryableModel } from '@stamhoofd/sql';
 import { render } from '../helpers/Handlebars.js';
 import type { Member, MemberWithRegistrations, RegistrationWithMember } from './Member.js';
 import type { Organization } from './Organization.js';
+import { Platform } from './Platform.js';
 import { Registration } from './Registration.js';
 
 export class Document extends QueryableModel {
@@ -83,7 +85,7 @@ export class Document extends QueryableModel {
         return DocumentStruct.create(this);
     }
 
-    buildContext(organization: Organization) {
+    buildContext(organization: Organization, platform: PlatformStruct) {
         // Convert the field answers in a simplified javascript object
         const data: Record<string, any> = {
             id: this.id,
@@ -98,7 +100,7 @@ export class Document extends QueryableModel {
                 companyAddress: organization.meta.companies[0]?.address ?? organization.address,
             },
         };
-        const platformLogo = Platform.shared.config.logoDocuments ?? Platform.shared.config.horizontalLogo ?? Platform.shared.config.squareLogo;
+        const platformLogo = platform.config.logoDocuments ?? platform.config.horizontalLogo ?? platform.config.squareLogo;
         const organizationLogo = organization.meta.horizontalLogo ?? organization.meta.squareLogo;
         const logo = organizationLogo || platformLogo;
 
@@ -282,7 +284,8 @@ export class Document extends QueryableModel {
     // Rander handlebars template
     private async getRenderedHtmlForTemplate(organization: Organization, htmlTemplate: string): Promise<string | null> {
         try {
-            const context = this.buildContext(organization);
+            const platform = await Platform.getSharedStruct();
+            const context = this.buildContext(organization, platform);
             const renderedHtml = await render(htmlTemplate, context);
             return renderedHtml;
         } catch (e) {

--- a/backend/shared/models/src/models/DocumentTemplate.ts
+++ b/backend/shared/models/src/models/DocumentTemplate.ts
@@ -14,6 +14,7 @@ import { Group } from './Group.js';
 import type { RegistrationWithMember } from './Member.js';
 import { Member } from './Member.js';
 import type { Organization } from './Organization.js';
+import { Platform } from './Platform.js';
 import { Registration } from './Registration.js';
 import { User } from './User.js';
 
@@ -731,10 +732,12 @@ export class DocumentTemplate extends QueryableModel {
             lastNumber = document.number;
         }
 
+        const platform = await Platform.getSharedStruct();
+
         const data = {
             id: this.id,
             created_at: this.createdAt,
-            documents: documents.map(d => d.buildContext(organization)),
+            documents: documents.map(d => d.buildContext(organization, platform)),
             organization: {
                 name: organization.name,
                 companyName: organization.meta.companies[0]?.name || organization.name,


### PR DESCRIPTION
Phase 0 of the tenants work: removing every read of the `Platform.shared` process-global. Stacked on #659.

Removes the **last 6 `Platform.shared` reads outside `Platform.ts` itself**. After this, the only references left in the repo are the accessor definitions and three comments — the next PR deletes them and closes Phase 0.

### `AuthenticatedStructures` — 5 reads

All were already inside `async` methods, so they just take `await Platform.getSharedStruct()`.

- `membersBlob` read the global **four** times (three for `period.*`, one for `membershipOrganizationId`). Now hoists a single resolved platform and uses it for both.
- `auditLogs` is the interesting one: the read sat **four lines below** an existing `const platform = await PlatformModel.getSharedStruct()`, and one line below a `forPlatform(platform)` call already using it. It was simply inconsistent, not a threading problem. (This is the fourth time in this refactor that a "blocked" read turned out to be code that already had a platform in scope.)

### `Document.buildContext` — 3 reads on one line

`buildContext` is synchronous, so it takes a required `platform` parameter:

```ts
buildContext(organization: Organization, platform: PlatformStruct)
```

Both callers are async and resolve it themselves:

- `Document.getRenderedHtmlForTemplate` — resolved **inside the existing `try`**, deliberately. A hypothetical load failure then stays a logged `null` (the endpoint reports `failed_generating`) rather than becoming an uncaught throw, which matches the old never-throwing `Platform.shared`.
- `DocumentTemplate.buildContext` — resolves once and passes the same object into every `d.buildContext(organization, platform)`.

`Document.ts` gains an import of the *models* `Platform` and demotes the structures one to a type-only import aliased `PlatformStruct`. `MemberPlatformMembership`, `Email`, `EmailVerificationCode` and `PasswordToken` already import the models `Platform`, so this is an established pattern. Checked for an import cycle: `eslint`'s `import/no-cycle` produces identical output with and without the change (same two pre-existing warnings, none on the new import), and the dist-level cycle check through `Platform.js` still reports 0.

Phase 2 of the larger plan eventually moves this read out of `@stamhoofd/models` entirely ("pass the logo in from the document-building service"). Adding the parameter now is a step toward that.

### Why this is a production no-op

On the backend `Platform.shared` and `await Platform.getSharedStruct()` return the *same object*: `models/Platform.ts` does `clone.setShared()` then `this.sharedStruct = clone`. Nothing was switched to `getSharedPrivateStruct()`, which is a different struct and would have been a behaviour change.

### Tests

New `Document.test.ts`, 3 tests, DB-free:
1. the platform logo fallback chain `logoDocuments → horizontalLogo → squareLogo`, all three orderings;
2. no `platform` / `logo` keys when neither side has a logo;
3. the organization logo takes precedence for `context.logo`, while `context.platform.logo` still exposes the platform one separately.

Mutation-checked: reversing the `??` chain makes test 1 fail.

### Gates

`build:shared` · 0 import cycles through `Platform.js` · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — api **1038 passed**, models **93 passed**, sql **209 passed**, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)