### PR TITLE
Delete the Platform singleton

### DIFF
--- a/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/files/ExportToExcelEndpoint.ts
@@ -91,8 +91,6 @@ export class ExportToExcelEndpoint extends Endpoint<Params, Query, Body, Respons
         limiter.track(user.id, 1);
         let sendEmail = false;
 
-        await Platform.getSharedStruct();
-
         const result = await Promise.race([
             this.job(loader, request.body, request.params.type, user.id).then(async (url: string) => {
                 if (sendEmail) {

--- a/backend/shared/models/src/models/Platform.ts
+++ b/backend/shared/models/src/models/Platform.ts
@@ -164,12 +164,11 @@ export class Platform extends QueryableModel {
 
         const clone = struct.clone();
         clone.privateConfig = null;
-        clone.setShared();
 
         // Audit logs render uuids from a bare id, so they cannot receive a platform through their
-        // call chain. Bind the resolver to the same struct that backs Platform.shared here, so it
-        // is refreshed together with the caches. Uses the public struct on purpose: resolving
-        // privateConfig roles would change the names that get persisted in audit logs.
+        // call chain. Bind the resolver to the struct we are about to cache, so it is refreshed
+        // together with the caches. Uses the public struct on purpose: resolving privateConfig
+        // roles would change the names that get persisted in audit logs.
         AuditLogReplacementDependencies.uuidToName = uuid => uuidToName(uuid, clone);
 
         this.sharedStruct = clone;

--- a/frontend/shared/networking/src/SessionContext.ts
+++ b/frontend/shared/networking/src/SessionContext.ts
@@ -39,7 +39,7 @@ export class SessionContext implements RequestMiddleware {
 
     /**
      * Never replace this reference: use updatePlatform to keep it stable
-     * (Platform.shared and usePlatform() keep a reference to this object)
+     * (usePlatform() and the audit log uuid resolver keep a reference to this object)
      */
     platform: Platform;
     user: UserWithMembers | null = null;

--- a/frontend/shared/networking/src/loadPlatform.ts
+++ b/frontend/shared/networking/src/loadPlatform.ts
@@ -60,11 +60,9 @@ async function fetchPublicPlatform(): Promise<Platform> {
  *
  * The returned platform is the app level platform: it is handed to the SessionContext, which never
  * replaces the reference (updatePlatform uses deepSet). Because of that stability, this is also
- * where the two things that cannot be passed a platform get bound, exactly once per app level
- * platform:
- * - Platform.shared, still read by UserPermissions.
- * - The audit log uuid resolver, which renders a uuid from a bare id deep inside
- *   AuditLogReplacement and cannot receive a platform through its call chain.
+ * where the audit log uuid resolver gets bound, exactly once per app level platform: it renders a
+ * uuid from a bare id deep inside AuditLogReplacement and cannot receive a platform through its
+ * call chain.
  *
  * Throwaway sessions (e.g. the account switcher) reuse the app level platform instead of calling
  * this, so they never stamp anything.
@@ -73,7 +71,6 @@ export async function loadPlatform(): Promise<{ platform: Platform; fromCache: b
     const cached = await loadPlatformFromStorage();
     const platform = cached ?? (await fetchPublicPlatform());
 
-    platform.setShared();
     AuditLogReplacementDependencies.uuidToName = uuid => uuidToName(uuid, platform);
 
     // The caller needs to know whether this is a possibly stale cached platform, so it can decide

--- a/shared/structures/src/Platform.ts
+++ b/shared/structures/src/Platform.ts
@@ -549,8 +549,6 @@ export class PlatformConfig extends AutoEncoder {
 }
 
 export class Platform extends AutoEncoder {
-    static instance: Platform | null = null;
-
     @field({ decoder: PlatformConfig })
     config: PlatformConfig = PlatformConfig.create({});
 
@@ -577,24 +575,5 @@ export class Platform extends AutoEncoder {
      */
     getRoles() {
         return this.privateConfig?.roles ?? [];
-    }
-
-    static get shared(): Platform {
-        if (!Platform.instance) {
-            Platform.instance = Platform.create({});
-        }
-        return Platform.instance;
-    }
-
-    static get optionalShared(): Platform | null {
-        return Platform.instance;
-    }
-
-    static clearShared() {
-        Platform.instance = null;
-    }
-
-    setShared() {
-        Platform.instance = this;
     }
 }


### PR DESCRIPTION
**Closes Phase 0 of the tenants work.** Stacked on #661. After this there is no way to read "the platform" from a process global anywhere in the codebase.

### Deleted from `shared/structures/src/Platform.ts`

```ts
static instance: Platform | null = null;
static get shared(): Platform          // lazily created an empty Platform if unset
static get optionalShared(): Platform | null
static clearShared()
setShared()
```

…plus the only two things that ever fed it:

- `frontend/shared/networking/src/loadPlatform.ts` — `platform.setShared()`
- `backend/shared/models/src/models/Platform.ts` — `clone.setShared()` in `setCachesFromModel`

Every consumer now either receives a platform explicitly or resolves one via `Platform.getSharedStruct()` on the backend. The audit-log uuid resolver injection stays exactly where it was — it is bound to the same object, just no longer alongside a `setShared()`.

### Also removed: a dead warm-up

`ExportToExcelEndpoint.handle()` had a bare `await Platform.getSharedStruct();` with its result discarded. It existed only to populate `Platform.shared` before the synchronous excel `getValue` callbacks ran; those take an explicit platform since #659. Verified nothing else depended on it: all three model caches (`shared`, `sharedStruct`, `sharedPrivateStruct`) are `private static` behind async on-demand accessors, so there is no synchronous reader to warm for.

**One observable difference, stated plainly:** that `await` sat immediately before a `Promise.race([job, sleep(3000)])`, so on a cold cache the platform load did not count against the 3-second budget. It now happens inside `job()` and does. A cold-cache export could therefore fall back to email delivery marginally more often. The fallback is graceful and `getSharedStruct()` is a single indexed query, so this is deliberate rather than something to work around by keeping a call whose stated purpose no longer exists.

### Comments

Updated the three comments that referenced `Platform.shared` (`loadPlatform.ts`, `SessionContext.ts`, `models/Platform.ts`) so the grep is genuinely clean rather than clean-except-for-lies.

### Not a wire change

The singleton was never encoded, so no structures version bump.

### Verification

```
grep -rn "Platform\.shared\|PlatformStruct\.shared\|Platform\.instance\|optionalShared\|clearShared\|setShared" \
  --include="*.ts" --include="*.vue" frontend/ shared/ backend/ tests/
→ no matches
```

Gates: `build:shared` · 0 import cycles through `Platform.js` · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — api **1038**, models **93**, sql **209**, renderer **35**, redirecter **5** · components vitest **253 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)