### PR TITLE
UserPermissions: rename inheritTags, and give it its first tests

### DIFF
--- a/backend/app/api/src/email-recipient-loaders/payments.ts
+++ b/backend/app/api/src/email-recipient-loaders/payments.ts
@@ -307,7 +307,7 @@ async function getOrganizationRecipients(ids: { organizationId: string; payment:
             if (!organization) {
                 continue;
             }
-            const users = admins.filter(a => a.permissions?.forOrganization(organization, platform, { inheritTags: false })?.hasFullAccess());
+            const users = admins.filter(a => a.permissions?.forOrganization(organization, platform, { inheritFromPlatform: false })?.hasFullAccess());
 
             if (users.length === 0) {
                 console.warn('No admins found for organization with id ', organizationId, ' while fetching email recipients for payment with id ', payment.id);

--- a/backend/app/api/src/endpoints/auth/PatchUserEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/PatchUserEndpoint.ts
@@ -84,7 +84,7 @@ export class PatchUserEndpoint extends Endpoint<Params, Query, Body, ResponseBod
                 if (organization) {
                     editUser.permissions = UserPermissions.limitedPatch(editUser.permissions, request.body.permissions, organization.id);
 
-                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization, platform, { inheritTags: false })?.hasFullAccess()) && STAMHOOFD.environment !== 'development') {
+                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization, platform, { inheritFromPlatform: false })?.hasFullAccess()) && STAMHOOFD.environment !== 'development') {
                         throw new SimpleError({
                             code: 'permission_denied',
                             message: $t(`%DG`),

--- a/backend/app/api/src/endpoints/organization/dashboard/users/PatchApiUserEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/users/PatchApiUserEndpoint.ts
@@ -63,7 +63,7 @@ export class PatchApiUserEndpoint extends Endpoint<Params, Query, Body, Response
                 if (organization) {
                     editUser.permissions = UserPermissions.limitedPatch(editUser.permissions, request.body.permissions, organization.id);
 
-                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization, platform, { inheritTags: false })?.hasFullAccess())) {
+                    if (editUser.id === user.id && (!editUser.permissions || !editUser.permissions.forOrganization(organization, platform, { inheritFromPlatform: false })?.hasFullAccess())) {
                         throw new SimpleError({
                             code: 'permission_denied',
                             message: 'Je kan jezelf niet verwijderen als hoofdbeheerder',

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -794,7 +794,7 @@ export class AdminPermissionChecker {
 
             // Check if this user has permissions for the current scoped organization
             if (this.organization && await this.hasFullAccess(this.organization.id)) {
-                if (user.permissions?.forOrganization(this.organization, this.platform, { inheritTags: false })) {
+                if (user.permissions?.forOrganization(this.organization, this.platform, { inheritFromPlatform: false })) {
                     return true;
                 }
             }

--- a/backend/app/api/src/helpers/AuthenticatedStructures.ts
+++ b/backend/app/api/src/helpers/AuthenticatedStructures.ts
@@ -1133,7 +1133,7 @@ export class AuthenticatedStructures {
             } else if (balance.objectType === ReceivableBalanceType.user || balance.objectType === ReceivableBalanceType.userWithoutMembers) {
                 const user = users.find(m => m.id === balance.objectId) ?? null;
                 if (user) {
-                    const url = Context.organization && Context.organization.id === balance.organizationId ? 'https://' + getAppHost('registration', Context.organization, user.permissions?.forOrganization(Context.organization, platform, { inheritTags: false })?.isEmpty === false) : '';
+                    const url = Context.organization && Context.organization.id === balance.organizationId ? 'https://' + getAppHost('registration', Context.organization, user.permissions?.forOrganization(Context.organization, platform, { inheritFromPlatform: false })?.isEmpty === false) : '';
                     object = ReceivableBalanceObject.create({
                         id: balance.objectId,
                         name: user.name || user.email,

--- a/backend/app/api/src/services/RegistrationService.ts
+++ b/backend/app/api/src/services/RegistrationService.ts
@@ -168,7 +168,7 @@ export const RegistrationService = {
                 }),
                 Replacement.create({
                     token: 'registerUrl',
-                    value: 'https://' + getAppHost('registration', organization, user.permissions?.forOrganization(organization, platform, { inheritTags: false })?.isEmpty === false),
+                    value: 'https://' + getAppHost('registration', organization, user.permissions?.forOrganization(organization, platform, { inheritFromPlatform: false })?.isEmpty === false),
                 }),
                 Replacement.create({
                     token: 'groupName',

--- a/backend/shared/models/src/models/Organization.ts
+++ b/backend/shared/models/src/models/Organization.ts
@@ -870,7 +870,7 @@ export class Organization extends QueryableModel {
         const platform = await Platform.getSharedStruct();
 
         // Only full access
-        return admins.filter(a => a.permissions && a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess());
+        return admins.filter(a => a.permissions && a.permissions.forOrganization(this, platform, { inheritFromPlatform: false })?.hasFullAccess());
     }
 
     /**
@@ -879,7 +879,7 @@ export class Organization extends QueryableModel {
     async getFinanceAdmins() {
         const admins = await this.getAdmins();
         const platform = await Platform.getSharedStruct();
-        const filtered = admins.filter(a => a.permissions && (a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
+        const filtered = admins.filter(a => a.permissions && (a.permissions.forOrganization(this, platform, { inheritFromPlatform: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritFromPlatform: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
 
         // Only full access
         return filtered;
@@ -978,12 +978,12 @@ export class Organization extends QueryableModel {
         });
 
         const platform = await Platform.getSharedStruct();
-        const filtered = admins.filter(a => a.verified && a.permissions && !a.email.endsWith('@stamhoofd.be') && (a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
+        const filtered = admins.filter(a => a.verified && a.permissions && !a.email.endsWith('@stamhoofd.be') && (a.permissions.forOrganization(this, platform, { inheritFromPlatform: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritFromPlatform: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
 
         if (filtered.length > 0) {
             return filtered.map(f => f.email)[0];
         }
-        const filtered2 = admins.filter(a => a.verified && a.permissions && (a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritTags: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
+        const filtered2 = admins.filter(a => a.verified && a.permissions && (a.permissions.forOrganization(this, platform, { inheritFromPlatform: false })?.hasFullAccess() || a.permissions.forOrganization(this, platform, { inheritFromPlatform: false })?.hasAccessRight(AccessRight.OrganizationFinanceDirector)));
 
         if (filtered2.length > 0) {
             return filtered2.map(f => f.email)[0];

--- a/frontend/shared/components/src/admins/hooks/useAdmins.ts
+++ b/frontend/shared/components/src/admins/hooks/useAdmins.ts
@@ -29,7 +29,7 @@ export function usePermissionsCache() {
             const cacheEntry = cache.get(user);
             if (!cacheEntry) {
                 const c = {
-                    permissions: organization.value ? (user.permissions?.forOrganization(organization.value, platform.value, { inheritTags: false }) ?? null) : (user.permissions?.forPlatform(platform.value) ?? null),
+                    permissions: organization.value ? (user.permissions?.forOrganization(organization.value, platform.value, { inheritFromPlatform: false }) ?? null) : (user.permissions?.forPlatform(platform.value) ?? null),
                     unloadedPermissions: organization.value ? (user.permissions?.organizationPermissions.get(organization.value.id) ?? null) : (user.permissions?.globalPermissions ?? null),
                 };
                 cache.set(user, c);

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -83,11 +83,11 @@ export class ContextPermissions {
         if (!this.organization) {
             return this.platformPermissions;
         }
-        return unref(this.userPermissions)?.forOrganization(this.organization, this.platform, { inheritTags: this.allowInheritingPermissions }) ?? null;
+        return unref(this.userPermissions)?.forOrganization(this.organization, this.platform, { inheritFromPlatform: this.allowInheritingPermissions }) ?? null;
     }
 
     getPermissionsForOrganization(organization: OrganizationForPermissionCalculation) {
-        return unref(this.userPermissions)?.forOrganization(organization, this.platform, { inheritTags: this.allowInheritingPermissions }) ?? null;
+        return unref(this.userPermissions)?.forOrganization(organization, this.platform, { inheritFromPlatform: this.allowInheritingPermissions }) ?? null;
     }
 
     get unloadedPermissions(): Permissions | null {

--- a/shared/structures/src/UserPermissions.test.ts
+++ b/shared/structures/src/UserPermissions.test.ts
@@ -1,0 +1,355 @@
+import { AccessRight, AccessRightHelper } from './AccessRight.js';
+import { MemberResponsibility } from './MemberResponsibility.js';
+import { MemberResponsibilityRecordBase } from './members/MemberResponsibilityRecord.js';
+import { PermissionLevel } from './PermissionLevel.js';
+import { PermissionRole, PermissionRoleDetailed, PermissionRoleForResponsibility } from './PermissionRole.js';
+import { Permissions } from './Permissions.js';
+import { PermissionsResourceType } from './PermissionsResourceType.js';
+import { Platform, PlatformConfig, PlatformPrivateConfig } from './Platform.js';
+import { ResourcePermissions } from './ResourcePermissions.js';
+import type { OrganizationForPermissionCalculation } from './UserPermissions.js';
+import { UserPermissions } from './UserPermissions.js';
+
+/**
+ * Build the resources map that grants platform level permissions per organization tag.
+ * The empty string key means 'all tags'.
+ */
+function createTagResources(tagPermissions: Record<string, ResourcePermissions>) {
+    return new Map([
+        [PermissionsResourceType.OrganizationTags, new Map(Object.entries(tagPermissions))],
+    ]);
+}
+
+/**
+ * A user that only received permissions at the platform level, limited to specific organization tags.
+ */
+function createUserWithTagPermissions(tagPermissions: Record<string, ResourcePermissions>, organizationPermissions?: Record<string, Permissions>) {
+    return UserPermissions.create({
+        globalPermissions: Permissions.create({
+            resources: createTagResources(tagPermissions),
+        }),
+        organizationPermissions: new Map(Object.entries(organizationPermissions ?? {})),
+    });
+}
+
+function createPlatform(options?: { responsibilities?: MemberResponsibility[]; roles?: PermissionRoleDetailed[] }) {
+    return Platform.create({
+        config: PlatformConfig.create({
+            responsibilities: options?.responsibilities ?? [],
+        }),
+        privateConfig: PlatformPrivateConfig.create({
+            roles: options?.roles ?? [],
+        }),
+    });
+}
+
+function createOrganization(options?: { id?: string; tags?: string[]; roles?: PermissionRoleDetailed[]; responsibilities?: MemberResponsibility[] }): OrganizationForPermissionCalculation {
+    return {
+        id: options?.id ?? 'organization-1',
+        meta: {
+            tags: options?.tags ?? [],
+        },
+        privateMeta: {
+            roles: options?.roles ?? [],
+            responsibilities: options?.responsibilities ?? [],
+            inheritedResponsibilityRoles: [],
+        },
+    };
+}
+
+describe('Unit.UserPermissions', () => {
+    describe('forPlatform', () => {
+        test('returns null for a user without global permissions', () => {
+            const userPermissions = UserPermissions.create({});
+            expect(userPermissions.forPlatform(createPlatform())).toBeNull();
+        });
+
+        test('grants the prohibited organization level access rights to full platform admins', () => {
+            const prohibited = AccessRightHelper.prohibitedOrganizationLevelAccessRights();
+
+            // Sanity check: without prohibited rights this test would be meaningless
+            expect(prohibited.length).toBeGreaterThan(0);
+
+            const userPermissions = UserPermissions.create({
+                globalPermissions: Permissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            });
+
+            const result = userPermissions.forPlatform(createPlatform());
+
+            expect(result).not.toBeNull();
+            expect(result!.hasFullAccess()).toBe(true);
+
+            for (const right of prohibited) {
+                expect(result!.accessRights).toContain(right);
+                expect(result!.hasAccessRight(right)).toBe(true);
+            }
+        });
+
+        test('does not grant the prohibited organization level access rights to platform users without full access', () => {
+            const userPermissions = UserPermissions.create({
+                globalPermissions: Permissions.create({
+                    level: PermissionLevel.Write,
+                }),
+            });
+
+            const result = userPermissions.forPlatform(createPlatform());
+
+            expect(result).not.toBeNull();
+            expect(result!.hasFullAccess()).toBe(false);
+
+            for (const right of AccessRightHelper.prohibitedOrganizationLevelAccessRights()) {
+                expect(result!.accessRights).not.toContain(right);
+                expect(result!.hasAccessRight(right)).toBe(false);
+            }
+        });
+    });
+
+    describe('forOrganization', () => {
+        test('inherits the platform level permissions of a matching tag by default', () => {
+            const userPermissions = createUserWithTagPermissions({
+                'tag-a': ResourcePermissions.create({
+                    level: PermissionLevel.Write,
+                    accessRights: [AccessRight.MemberManageNRN],
+                }),
+            });
+            const platform = createPlatform();
+            const organization = createOrganization({ tags: ['tag-a'] });
+
+            for (const result of [
+                userPermissions.forOrganization(organization, platform),
+                userPermissions.forOrganization(organization, platform, { inheritFromPlatform: true }),
+            ]) {
+                expect(result).not.toBeNull();
+                expect(result!.hasWriteAccess()).toBe(true);
+                expect(result!.hasFullAccess()).toBe(false);
+                expect(result!.hasAccessRight(AccessRight.MemberManageNRN)).toBe(true);
+            }
+        });
+
+        test('does not inherit the platform level permissions when inheritFromPlatform is false', () => {
+            const userPermissions = createUserWithTagPermissions({
+                'tag-a': ResourcePermissions.create({
+                    level: PermissionLevel.Write,
+                    accessRights: [AccessRight.MemberManageNRN],
+                }),
+            });
+            const platform = createPlatform();
+            const organization = createOrganization({ tags: ['tag-a'] });
+
+            // Same user and same organization as the test above, which does get access
+            expect(userPermissions.forOrganization(organization, platform, { inheritFromPlatform: false })).toBeNull();
+        });
+
+        test('does not inherit the permissions of a tag the organization does not have', () => {
+            const userPermissions = createUserWithTagPermissions({
+                'tag-a': ResourcePermissions.create({
+                    level: PermissionLevel.Write,
+                }),
+            });
+
+            expect(
+                userPermissions.forOrganization(createOrganization({ tags: ['tag-b'] }), createPlatform()),
+            ).toBeNull();
+        });
+
+        test('applies platform permissions granted on the empty tag to an organization without tags', () => {
+            const userPermissions = createUserWithTagPermissions({
+                // The empty string means 'all organization tags'
+                '': ResourcePermissions.create({
+                    level: PermissionLevel.Read,
+                }),
+            });
+            const platform = createPlatform();
+
+            const untagged = userPermissions.forOrganization(createOrganization({ tags: [] }), platform);
+            expect(untagged).not.toBeNull();
+            expect(untagged!.hasReadAccess()).toBe(true);
+            expect(untagged!.hasWriteAccess()).toBe(false);
+
+            // ...and to tagged organizations too
+            const tagged = userPermissions.forOrganization(createOrganization({ tags: ['tag-a'] }), platform);
+            expect(tagged).not.toBeNull();
+            expect(tagged!.hasReadAccess()).toBe(true);
+        });
+
+        test('does not apply platform permissions of a specific tag to an organization without tags', () => {
+            const userPermissions = createUserWithTagPermissions({
+                'tag-a': ResourcePermissions.create({
+                    level: PermissionLevel.Read,
+                }),
+            });
+
+            expect(
+                userPermissions.forOrganization(createOrganization({ tags: [] }), createPlatform()),
+            ).toBeNull();
+        });
+
+        test('merges the permissions of all matching tags', () => {
+            const userPermissions = createUserWithTagPermissions({
+                'tag-a': ResourcePermissions.create({
+                    level: PermissionLevel.Read,
+                    accessRights: [AccessRight.MemberManageNRN],
+                }),
+                'tag-b': ResourcePermissions.create({
+                    level: PermissionLevel.Write,
+                    accessRights: [AccessRight.OrganizationEventNotificationReviewer],
+                }),
+                'tag-c': ResourcePermissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            });
+
+            const result = userPermissions.forOrganization(
+                createOrganization({ tags: ['tag-a', 'tag-b'] }),
+                createPlatform(),
+            );
+
+            expect(result).not.toBeNull();
+
+            // The highest level of all matching tags wins, the tag the organization doesn't have is ignored
+            expect(result!.hasWriteAccess()).toBe(true);
+            expect(result!.hasFullAccess()).toBe(false);
+
+            expect(result!.hasAccessRight(AccessRight.MemberManageNRN)).toBe(true);
+            expect(result!.hasAccessRight(AccessRight.OrganizationEventNotificationReviewer)).toBe(true);
+        });
+
+        test('returns null when there are no inherited and no organization specific permissions', () => {
+            const userPermissions = UserPermissions.create({
+                globalPermissions: Permissions.create({}),
+            });
+
+            expect(
+                userPermissions.forOrganization(createOrganization({ tags: ['tag-a'] }), createPlatform()),
+            ).toBeNull();
+        });
+
+        test('merges the organization specific permissions with the inherited permissions', () => {
+            const userPermissions = createUserWithTagPermissions(
+                {
+                    'tag-a': ResourcePermissions.create({
+                        level: PermissionLevel.Read,
+                        accessRights: [AccessRight.OrganizationEventNotificationReviewer],
+                    }),
+                },
+                {
+                    'organization-1': Permissions.create({
+                        level: PermissionLevel.Write,
+                    }),
+                },
+            );
+            const platform = createPlatform();
+            const organization = createOrganization({ id: 'organization-1', tags: ['tag-a'] });
+
+            const result = userPermissions.forOrganization(organization, platform);
+            expect(result).not.toBeNull();
+
+            // Write comes from the organization specific permissions, Read from the tag
+            expect(result!.hasWriteAccess()).toBe(true);
+
+            // Prohibited organization level access rights survive when they are inherited from the platform
+            expect(result!.hasAccessRight(AccessRight.OrganizationEventNotificationReviewer)).toBe(true);
+
+            // Without inheriting, only the organization specific permissions remain
+            const withoutInherit = userPermissions.forOrganization(organization, platform, { inheritFromPlatform: false });
+            expect(withoutInherit).not.toBeNull();
+            expect(withoutInherit!.hasWriteAccess()).toBe(true);
+            expect(withoutInherit!.hasAccessRight(AccessRight.OrganizationEventNotificationReviewer)).toBe(false);
+        });
+    });
+
+    describe('forWithoutInherit', () => {
+        test('returns null when the user has no permissions for the organization', () => {
+            const userPermissions = createUserWithTagPermissions({
+                'tag-a': ResourcePermissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            });
+
+            expect(
+                userPermissions.forWithoutInherit(createOrganization({ tags: ['tag-a'] }), createPlatform()),
+            ).toBeNull();
+        });
+
+        test('resolves responsibilities from the platform and ignores platform level tag permissions', () => {
+            const responsibility = MemberResponsibility.create({
+                id: 'responsibility-1',
+                name: 'Functienaam',
+                permissions: PermissionRoleForResponsibility.create({
+                    responsibilityId: 'responsibility-1',
+                    level: PermissionLevel.Write,
+                    accessRights: [AccessRight.MemberManageNRN],
+                }),
+            });
+
+            const userPermissions = createUserWithTagPermissions(
+                {
+                    'tag-a': ResourcePermissions.create({
+                        level: PermissionLevel.Full,
+                    }),
+                },
+                {
+                    'organization-1': Permissions.create({
+                        responsibilities: [
+                            MemberResponsibilityRecordBase.create({
+                                responsibilityId: responsibility.id,
+                                memberId: 'member-1',
+                                groupId: null,
+                                startDate: new Date(0),
+                                endDate: null,
+                            }),
+                        ],
+                    }),
+                },
+            );
+
+            const platform = createPlatform({ responsibilities: [responsibility] });
+            const organization = createOrganization({ id: 'organization-1', tags: ['tag-a'] });
+
+            const result = userPermissions.forWithoutInherit(organization, platform);
+            expect(result).not.toBeNull();
+
+            // The responsibility of the platform is resolved
+            expect(result!.hasWriteAccess()).toBe(true);
+            expect(result!.hasAccessRight(AccessRight.MemberManageNRN)).toBe(true);
+
+            // ...but the full access of the tag is not inherited
+            expect(result!.hasFullAccess()).toBe(false);
+
+            // While forOrganization does inherit it
+            expect(userPermissions.forOrganization(organization, platform)!.hasFullAccess()).toBe(true);
+        });
+
+        test('removes prohibited organization level access rights from organization roles', () => {
+            const role = PermissionRoleDetailed.create({
+                id: 'role-1',
+                name: 'Rolnaam',
+                level: PermissionLevel.Read,
+                accessRights: [AccessRight.OrganizationEventNotificationReviewer, AccessRight.MemberManageNRN],
+            });
+
+            const userPermissions = UserPermissions.create({
+                organizationPermissions: new Map([
+                    ['organization-1', Permissions.create({
+                        roles: [PermissionRole.create({ id: role.id, name: role.name })],
+                    })],
+                ]),
+            });
+
+            const result = userPermissions.forWithoutInherit(
+                createOrganization({ id: 'organization-1', roles: [role] }),
+                createPlatform(),
+            );
+
+            expect(result).not.toBeNull();
+            expect(result!.hasReadAccess()).toBe(true);
+            expect(result!.hasAccessRight(AccessRight.MemberManageNRN)).toBe(true);
+            expect(result!.hasAccessRight(AccessRight.OrganizationEventNotificationReviewer)).toBe(false);
+
+            // The original role is not altered
+            expect(role.accessRights).toEqual([AccessRight.OrganizationEventNotificationReviewer, AccessRight.MemberManageNRN]);
+        });
+    });
+});

--- a/shared/structures/src/UserPermissions.ts
+++ b/shared/structures/src/UserPermissions.ts
@@ -58,10 +58,13 @@ export class UserPermissions extends AutoEncoder {
         return base;
     }
 
-    forOrganization(organization: OrganizationForPermissionCalculation, platform: Platform, options?: { inheritTags?: boolean }): LoadedPermissions | null {
+    /**
+     * @param options.inheritFromPlatform Whether the permissions this user was granted at the platform level, and that apply to this organization, are included in the result. Defaults to true. Set to false to only take the permissions that were granted for this organization itself into account.
+     */
+    forOrganization(organization: OrganizationForPermissionCalculation, platform: Platform, options?: { inheritFromPlatform?: boolean }): LoadedPermissions | null {
         const base: LoadedPermissions = LoadedPermissions.create({});
 
-        if (options?.inheritTags ?? true) {
+        if (options?.inheritFromPlatform ?? true) {
             const platformPermissions = this.forPlatform(platform);
 
             if (platformPermissions) {


### PR DESCRIPTION
Your note on #658, plus the coverage that should have come with it.

### The rename

`forOrganization`'s `inheritTags` option becomes **`inheritFromPlatform`**. 15 call sites, pure rename, no behaviour change.

Your reasoning was right, and stronger than stated: **inheritance does not carry tag permissions — it carries the user's entire platform permission set.** `getMergedResourcePermissions` returns a *clone of the full platform permissions* with only the `OrganizationTags` resource map removed, then merges the matching tag entry back in. So a platform admin's global level, global access rights, and every other resource type (Groups, Webshops, Senders, …) all flow into every organization result too. `inheritTags` described neither the intent nor the implementation.

### The tests — the actual point of this PR

`UserPermissions` had **zero test coverage**. No test file in the repo referenced `forOrganization`. This class computes authorization, and #658 refactored it — splitting one optional `platform?` parameter into a required platform plus this flag — with the suite structurally unable to catch a mistake.

`UserPermissions.test.ts`, 14 tests, characterising **current** behaviour only.

The load-bearing pair:

| Test | Assertion |
|---|---|
| inherits by default / with `inheritFromPlatform: true` | same user + org → write access, `MemberManageNRN` |
| does **not** inherit with `inheritFromPlatform: false` | **same user + org → `null`** |

~12 backend call sites depend on the second, and they depended on it *implicitly* (omitting the argument, `undefined` being falsy), so nothing ever verified it. Also covered: the empty-tag fallback, multi-tag merging, the `null` case, org-specific merged with inherited, `forWithoutInherit` responsibility resolution, and the `hasFullAccess()` branch that adds `prohibitedOrganizationLevelAccessRights()`.

**Mutation-checked**, because a test that passes against broken code is worse than no test:

| Mutation | Result |
|---|---|
| invert the `inheritFromPlatform` condition | 6 tests fail, including both of the pair above |
| delete the `prohibitedOrganizationLevelAccessRights` block | exactly 1 test fails — the one written for it |
| invert `if (base.hasFullAccess())` | 8 tests fail (confirms the negative case isn't vacuous) |

### Documented, deliberately not fixed

- **The `''` resource key is overloaded.** In `getResourcePermissions` it means "all resources of this type"; in `forOrganization` it is *also* the substitute lookup key for an organization with no tags (`tags.length === 0 ? [''] : tags`). A permission granted on `''` therefore applies to untagged organizations *and* to every tagged one, indistinguishably. Worth knowing before the tenant backfill creates tenants with empty tag lists.
- **Prohibited rights are asymmetric.** `forWithoutInherit` strips `OrganizationEventNotificationReviewer` from org-level permissions, but `forOrganization` merges the platform base in *after* that strip, so a tag-granted reviewer right survives. Matches the existing code comment; both directions now pinned.
- `if (rp)` in `forOrganization` is dead code — `getMergedResourcePermissions` never returns null.

### Gates

`build:shared` · 0 import cycles · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — api 1038, models 93, sql 209, structures incl. **14 new** · `grep -rn inheritTags` → no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)