### PR TITLE
Move password recovery and verification emails out of models

### DIFF
--- a/backend/app/api/package.json
+++ b/backend/app/api/package.json
@@ -19,6 +19,12 @@
             "import": "./dist/src/boot.js",
             "require": "./dist/src/boot.js"
         },
+        "./services/*": {
+            "types": "./dist/src/services/*.d.ts",
+            "import": "./dist/src/services/*.js",
+            "require": "./dist/src/services/*.js",
+            "@stamhoofd/source": "./src/services/*.ts"
+        },
         "./tests/helpers": {
             "types": "./dist/tests/helpers/index.d.ts",
             "import": "./dist/tests/helpers/index.js",

--- a/backend/app/api/src/endpoints/auth/CreateAdminEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/CreateAdminEndpoint.ts
@@ -2,13 +2,14 @@ import type { Decoder } from '@simonbackx/simple-encoding';
 import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { PasswordToken, Platform, sendEmailTemplate, User } from '@stamhoofd/models';
+import { Platform, sendEmailTemplate, User } from '@stamhoofd/models';
 import type { UserWithMembers } from '@stamhoofd/structures';
 import { EmailTemplateType, Recipient, Replacement, UserPermissions, User as UserStruct } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 
 import { AuthenticatedStructures } from '../../helpers/AuthenticatedStructures.js';
 import { Context } from '../../helpers/Context.js';
+import { PasswordForgotService } from '../../services/PasswordForgotService.js';
 type Params = Record<string, never>;
 type Query = undefined;
 type Body = UserStruct;
@@ -117,7 +118,7 @@ export class CreateAdminEndpoint extends Endpoint<Params, Query, Body, ResponseB
         validUntil.setTime(validUntil.getTime() + 7 * 24 * 3600 * 1000);
 
         const dateTime = Formatter.dateTime(validUntil);
-        const recoveryUrl = await PasswordToken.getPasswordRecoveryUrl(admin, organization, request.i18n, validUntil);
+        const recoveryUrl = await PasswordForgotService.getPasswordRecoveryUrl(admin, organization, request.i18n, validUntil);
         const platformName = ((await Platform.getSharedStruct()).config.name);
 
         const name = organization?.name ?? platformName;

--- a/backend/app/api/src/endpoints/auth/CreateTokenEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/CreateTokenEndpoint.ts
@@ -6,6 +6,7 @@ import type { ChallengeGrantStruct, PasswordGrantStruct, PasswordTokenGrantStruc
 import { CreateTokenStruct, LoginMethod, SignupResponse, Token as TokenStruct } from '@stamhoofd/structures';
 
 import { Context } from '../../helpers/Context.js';
+import { VerificationCodeService } from '../../services/VerificationCodeService.js';
 
 type Params = Record<string, never>;
 type Query = undefined;
@@ -127,7 +128,7 @@ export class CreateTokenEndpoint extends Endpoint<Params, Query, Body, ResponseB
                 // if not: throw a validation error (e-mail validation is required)
                 if (!user.verified) {
                     const code = await EmailVerificationCode.createFor(user, user.email);
-                    code.send(user, organization, request.i18n).catch(console.error);
+                    VerificationCodeService.send(code, user, organization, request.i18n).catch(console.error);
 
                     throw new SimpleError({
                         code: 'verify_email',

--- a/backend/app/api/src/endpoints/auth/ForgotPasswordEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/ForgotPasswordEndpoint.ts
@@ -1,11 +1,12 @@
 import type { Decoder } from '@simonbackx/simple-encoding';
 import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
-import { PasswordToken, Platform, sendEmailTemplate, User } from '@stamhoofd/models';
+import { Platform, sendEmailTemplate, User } from '@stamhoofd/models';
 import { EmailTemplateType, ForgotPasswordRequest, LoginMethod, Recipient, Replacement } from '@stamhoofd/structures';
 
 import { SimpleError } from '@simonbackx/simple-errors';
 import { Context } from '../../helpers/Context.js';
+import { PasswordForgotService } from '../../services/PasswordForgotService.js';
 
 type Params = Record<string, never>;
 type Query = undefined;
@@ -72,7 +73,7 @@ export class ForgotPasswordEndpoint extends Endpoint<Params, Query, Body, Respon
             return new Response(undefined);
         }
 
-        const recoveryUrl = await PasswordToken.getPasswordRecoveryUrl(user, organization, request.i18n);
+        const recoveryUrl = await PasswordForgotService.getPasswordRecoveryUrl(user, organization, request.i18n);
 
         // Create e-mail builder
         await sendEmailTemplate(organization, {

--- a/backend/app/api/src/endpoints/auth/PatchUserEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/PatchUserEndpoint.ts
@@ -10,6 +10,7 @@ import { LoginMethod, NewUser, PermissionLevel, SignupResponse, UserPermissions 
 import { Context } from '../../helpers/Context.js';
 import { MemberUserSyncer } from '../../helpers/MemberUserSyncer.js';
 import { AuthenticatedStructures } from '../../helpers/AuthenticatedStructures.js';
+import { VerificationCodeService } from '../../services/VerificationCodeService.js';
 
 type Params = { id: string };
 type Query = undefined;
@@ -189,7 +190,7 @@ export class PatchUserEndpoint extends Endpoint<Params, Query, Body, ResponseBod
                 // Create an validation code
                 // We always need the code, to return it. Also on password recovery -> may not be visible to the client whether the user exists or not
                 const code = await EmailVerificationCode.createFor(editUser, request.body.email);
-                code.send(editUser, organization, request.i18n, editUser.id === user.id).catch(console.error);
+                VerificationCodeService.send(code, editUser, organization, request.i18n, editUser.id === user.id).catch(console.error);
 
                 throw new SimpleError({
                     code: 'verify_email',

--- a/backend/app/api/src/endpoints/auth/RetryEmailVerificationEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/RetryEmailVerificationEndpoint.ts
@@ -5,6 +5,7 @@ import { EmailVerificationCode } from '@stamhoofd/models';
 import { PollEmailVerificationRequest, PollEmailVerificationResponse } from '@stamhoofd/structures';
 
 import { Context } from '../../helpers/Context.js';
+import { VerificationCodeService } from '../../services/VerificationCodeService.js';
 
 type Params = Record<string, never>;
 type Query = undefined;
@@ -32,7 +33,7 @@ export class PollEmailVerificationEndpoint extends Endpoint<Params, Query, Body,
         const valid = await EmailVerificationCode.poll(organization?.id ?? null, request.body.token);
 
         if (valid) {
-            EmailVerificationCode.resend(organization, request.body.token, request.i18n).catch(console.error);
+            VerificationCodeService.resend(organization, request.body.token, request.i18n).catch(console.error);
         }
 
         return new Response(PollEmailVerificationResponse.create({

--- a/backend/app/api/src/endpoints/auth/SignupEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/SignupEndpoint.ts
@@ -6,6 +6,8 @@ import { EmailVerificationCode, PasswordToken, Platform, sendEmailTemplate, User
 import { EmailTemplateType, LoginMethod, NewUser, Recipient, Replacement, SignupResponse } from '@stamhoofd/structures';
 
 import { Context } from '../../helpers/Context.js';
+import { PasswordForgotService } from '../../services/PasswordForgotService.js';
+import { VerificationCodeService } from '../../services/VerificationCodeService.js';
 
 type Params = Record<string, never>;
 type Query = undefined;
@@ -77,7 +79,7 @@ export class SignupEndpoint extends Endpoint<Params, Query, Body, ResponseBody> 
                 // We don't await this block to avoid user enumeration attack using request response time
                 (async () => {
                     // Send an e-mail to say you already have an account + follow password forgot flow
-                    const recoveryUrl = await PasswordToken.getPasswordRecoveryUrl(user, organization, request.i18n);
+                    const recoveryUrl = await PasswordForgotService.getPasswordRecoveryUrl(user, organization, request.i18n);
 
                     // Create e-mail builder
                     await sendEmailTemplate(organization, {
@@ -118,7 +120,7 @@ export class SignupEndpoint extends Endpoint<Params, Query, Body, ResponseBody> 
         const code = await EmailVerificationCode.createFor(user, user.email);
 
         if (sendCode) {
-            code.send(user, organization, request.i18n).catch(console.error);
+            VerificationCodeService.send(code, user, organization, request.i18n).catch(console.error);
         }
 
         return new Response(SignupResponse.create({

--- a/backend/app/api/src/endpoints/global/organizations/CreateOrganizationEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/organizations/CreateOrganizationEndpoint.ts
@@ -12,6 +12,7 @@ import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 import { AuditLogService } from '../../../services/AuditLogService.js';
 import { ReferralService } from '../../../services/ReferralService.js';
+import { VerificationCodeService } from '../../../services/VerificationCodeService.js';
 import { AuthenticatedStructures } from '../../../helpers/AuthenticatedStructures.js';
 import { Context } from '../../../helpers/Context.js';
 
@@ -160,7 +161,7 @@ export class CreateOrganizationEndpoint extends Endpoint<Params, Query, Body, Re
         await AuditLog.update().where('type', AuditLogType.OrganizationAdded).where('objectId', organization.id).set('userId', user.id).set('source', AuditLogSource.User).update();
 
         const code = await EmailVerificationCode.createFor(user, user.email);
-        code.send(user, organization, request.i18n).catch(console.error);
+        VerificationCodeService.send(code, user, organization, request.i18n).catch(console.error);
 
         for (const email of delayEmails) {
             Email.send({

--- a/backend/app/api/src/services/PasswordForgotService.test.ts
+++ b/backend/app/api/src/services/PasswordForgotService.test.ts
@@ -1,0 +1,99 @@
+import { I18n } from '@stamhoofd/backend-i18n';
+import { Organization, OrganizationFactory, PasswordToken, User, UserFactory } from '@stamhoofd/models';
+import { Address, OrganizationMetaData, PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { Country } from '@stamhoofd/types/Country';
+import { PasswordForgotService } from './PasswordForgotService.js';
+
+const i18n = new I18n(I18n.defaultLanguage, I18n.defaultCountry);
+
+/**
+ * An organization that is not saved in the database: enough to build an url with.
+ */
+function buildOrganization(id = 'organization-1') {
+    const organization = new Organization();
+    organization.id = id;
+    organization.name = 'Test organization';
+    organization.uri = 'test-organization';
+    organization.meta = OrganizationMetaData.create({});
+    organization.address = Address.create({
+        street: 'Demostraat',
+        number: '12',
+        city: 'Gent',
+        postalCode: '9000',
+        country: Country.Belgium,
+    });
+    return organization;
+}
+
+function buildUser(organizationId: string | null) {
+    const user = new User();
+    user.id = 'user-1';
+    user.organizationId = organizationId;
+    user.email = 'user@example.com';
+    return user;
+}
+
+function buildToken(user: User, token: string) {
+    const passwordToken = new PasswordToken();
+    passwordToken.token = token;
+    passwordToken.userId = user.id;
+    return passwordToken;
+}
+
+describe('PasswordForgotService', () => {
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'organization');
+    });
+
+    describe('getPasswordRecoveryUrl', () => {
+        test('An administrator of the organization gets a dashboard url', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const admin = await new UserFactory({
+                organization,
+                permissions: Permissions.create({ level: PermissionLevel.Full }),
+            }).create();
+
+            const url = new URL(await PasswordForgotService.getPasswordRecoveryUrl(admin, organization, i18n));
+
+            expect(url.host).toBe(STAMHOOFD.domains.dashboard);
+            expect(url.pathname).toMatch(/\/reset-password$/);
+        });
+
+        test('A user without permissions for the organization gets a registration url', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const member = await new UserFactory({ organization }).create();
+
+            const url = new URL(await PasswordForgotService.getPasswordRecoveryUrl(member, organization, i18n));
+
+            expect(url.host).not.toBe(STAMHOOFD.domains.dashboard);
+            expect(url.host.split('.')[0]).toBe(organization.uri);
+            expect(url.pathname).toMatch(/\/reset-password$/);
+        });
+
+        test('The url points to the reset-password page with a url encoded token', async () => {
+            const organization = buildOrganization();
+            const user = buildUser(organization.id);
+
+            const url = await PasswordForgotService.getPasswordRecoveryUrlForToken(buildToken(user, 'a+b/c=d&e'), organization, i18n, user);
+
+            expect(url).toMatch(/\/reset-password\?token=a%2Bb%2Fc%3Dd%26e$/);
+            expect(new URL(url).searchParams.get('token')).toBe('a+b/c=d&e');
+        });
+
+        test('Throws when the user belongs to a different organization', async () => {
+            const user = buildUser('a-different-organization');
+
+            await expect(PasswordForgotService.getPasswordRecoveryUrlForToken(buildToken(user, 'my-token'), buildOrganization(), i18n, user))
+                .rejects
+                .toThrow('Unexpected mismatch in organization id for PasswordToken');
+        });
+
+        test('Allows a user without an organization in every scope', async () => {
+            const user = buildUser(null);
+
+            await expect(PasswordForgotService.getPasswordRecoveryUrlForToken(buildToken(user, 'my-token'), buildOrganization(), i18n, user))
+                .toResolve();
+        });
+    });
+});

--- a/backend/app/api/src/services/PasswordForgotService.ts
+++ b/backend/app/api/src/services/PasswordForgotService.ts
@@ -1,0 +1,41 @@
+import type { I18n } from '@stamhoofd/backend-i18n';
+import type { Organization } from '@stamhoofd/models';
+import { PasswordToken, Platform, User } from '@stamhoofd/models';
+import { getAppHost } from '@stamhoofd/structures';
+
+/**
+ * Owns the password recovery links.
+ *
+ * Which app the link points to depends on whether the user is an administrator of the organization,
+ * and that requires the platform. Models have no request context to resolve the platform they
+ * belong to, so both the permission check and the url building live here instead of on PasswordToken.
+ */
+export class PasswordForgotService {
+    /**
+     * Create a new password token for the user and build the recovery url for it.
+     */
+    static async getPasswordRecoveryUrl(user: User, organization: Organization | null, i18n: I18n, validUntil?: Date) {
+        // Send an e-mail to say you already have an account + follow password forgot flow
+        const token = await PasswordToken.createToken(user, validUntil);
+        return await this.getPasswordRecoveryUrlForToken(token, organization, i18n, user);
+    }
+
+    /**
+     * Build the recovery url for an already created password token.
+     * Pass the user to avoid an extra query when it is already loaded.
+     */
+    static async getPasswordRecoveryUrlForToken(token: PasswordToken, organization: Organization | null, i18n: I18n, user?: User) {
+        const tokenUser = user ?? await User.getByID(token.userId);
+        if (!tokenUser) {
+            throw new Error('PasswordToken without a valid user');
+        }
+
+        if (tokenUser.organizationId !== null && ((tokenUser.organizationId ?? null) !== (organization?.id ?? null))) {
+            throw new Error('Unexpected mismatch in organization id for PasswordToken');
+        }
+
+        const hasOrganizationPermissions = organization ? tokenUser.permissions?.forOrganization(organization, await Platform.getSharedStruct())?.isEmpty === false : false;
+        const host = 'https://' + getAppHost(hasOrganizationPermissions ? 'dashboard' : 'registration', organization, hasOrganizationPermissions, i18n);
+        return host + '/reset-password?token=' + encodeURIComponent(token.token);
+    }
+}

--- a/backend/app/api/src/services/VerificationCodeService.test.ts
+++ b/backend/app/api/src/services/VerificationCodeService.test.ts
@@ -1,0 +1,71 @@
+import { I18n } from '@stamhoofd/backend-i18n';
+import { EmailMocker } from '@stamhoofd/email';
+import { EmailTemplateFactory, EmailVerificationCode, OrganizationFactory, Platform, UserFactory } from '@stamhoofd/models';
+import { EmailTemplateType } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { VerificationCodeService } from './VerificationCodeService.js';
+
+const i18n = new I18n(I18n.defaultLanguage, I18n.defaultCountry);
+
+const PLATFORM_NAME = 'The test platform';
+
+/**
+ * A template that only contains the organizationName replacement, so the name that ends up in the
+ * email can be asserted without depending on the real (translated) template contents.
+ */
+async function createVerifyEmailTemplate() {
+    await new EmailTemplateFactory({
+        type: EmailTemplateType.VerifyEmail,
+        html: '<p>{{organizationName}}</p>',
+        text: '{{organizationName}}',
+    }).create();
+}
+
+describe('VerificationCodeService', () => {
+    let originalPlatformName: string;
+
+    beforeAll(async () => {
+        const platform = await Platform.getForEditing();
+        originalPlatformName = platform.config.name;
+        platform.config.name = PLATFORM_NAME;
+        await platform.save();
+    });
+
+    afterAll(async () => {
+        const platform = await Platform.getForEditing();
+        platform.config.name = originalPlatformName;
+        await platform.save();
+    });
+
+    describe('send', () => {
+        test('Uses the name of the organization when the code is scoped to an organization', async () => {
+            TestUtils.setEnvironment('userMode', 'organization');
+            await createVerifyEmailTemplate();
+
+            const organization = await new OrganizationFactory({ name: 'Organization with a name' }).create();
+            const user = await new UserFactory({ organization }).create();
+            const code = await EmailVerificationCode.createFor(user, user.email);
+
+            await VerificationCodeService.send(code, user, organization, i18n);
+
+            const emails = await EmailMocker.transactional.getSucceededEmails();
+            expect(emails.length).toBe(1);
+            expect(emails[0].text).toContain('Organization with a name');
+            expect(emails[0].text).not.toContain(PLATFORM_NAME);
+        });
+
+        test('Falls back to the name of the platform when there is no organization', async () => {
+            TestUtils.setEnvironment('userMode', 'platform');
+            await createVerifyEmailTemplate();
+
+            const user = await new UserFactory({}).create();
+            const code = await EmailVerificationCode.createFor(user, user.email);
+
+            await VerificationCodeService.send(code, user, null, i18n);
+
+            const emails = await EmailMocker.transactional.getSucceededEmails();
+            expect(emails.length).toBe(1);
+            expect(emails[0].text).toContain(PLATFORM_NAME);
+        });
+    });
+});

--- a/backend/app/api/src/services/VerificationCodeService.ts
+++ b/backend/app/api/src/services/VerificationCodeService.ts
@@ -1,0 +1,104 @@
+import type { I18n } from '@stamhoofd/backend-i18n';
+import type { Organization } from '@stamhoofd/models';
+import { EmailVerificationCode, Platform, sendEmailTemplate, User } from '@stamhoofd/models';
+import { EmailTemplateType, getAppHost, Recipient, Replacement } from '@stamhoofd/structures';
+
+/**
+ * Owns sending the verification emails for an EmailVerificationCode.
+ *
+ * The code itself (generating, storing, verifying and rate limiting it) stays on the model: that is
+ * data access. Building the verification url and composing the email is not, and it needs the
+ * platform name as a fallback when the code is not scoped to an organization. Models cannot resolve
+ * the platform they belong to, so that logic lives here.
+ */
+export class VerificationCodeService {
+    static getEmailVerificationUrl(code: EmailVerificationCode, user: User, organization: Organization | null, i18n: I18n) {
+        const host = getAppHost('verify-email', organization, !!user.permissions, i18n);
+        return 'https://' + host + '?code=' + encodeURIComponent(code.code) + '&token=' + encodeURIComponent(code.token) + '&email=' + encodeURIComponent(code.email);
+    }
+
+    static async send(code: EmailVerificationCode, user: User, organization: Organization | null, i18n: I18n, withCode = true) {
+        const url = this.getEmailVerificationUrl(code, user, organization, i18n);
+
+        const name = organization?.name ?? (await Platform.getSharedPrivateStruct()).config.name;
+
+        const replacements: Replacement[] = [
+            Replacement.create({
+                token: 'organizationName',
+                value: name,
+            }),
+            Replacement.create({
+                token: 'confirmEmailUrl',
+                value: url,
+            }),
+        ];
+
+        if (withCode) {
+            const formattedCode = code.code.substr(0, 3) + ' ' + code.code.substr(3);
+
+            await sendEmailTemplate(organization, {
+                recipients: [
+                    Recipient.create({
+                        email: code.email,
+                        replacements: [
+                            ...replacements,
+                            Replacement.create({
+                                token: 'confirmEmailCode',
+                                value: formattedCode,
+                            }),
+                        ],
+                    }),
+                ],
+                template: {
+                    type: EmailTemplateType.VerifyEmail,
+                },
+                type: 'transactional',
+            });
+        } else {
+            await sendEmailTemplate(organization, {
+                recipients: [
+                    Recipient.create({
+                        email: code.email,
+                        replacements,
+                    }),
+                ],
+                template: {
+                    type: EmailTemplateType.VerifyEmailWithoutCode,
+                },
+                type: 'transactional',
+            });
+        }
+    }
+
+    static async resend(organization: Organization | null, token: string, i18n: I18n) {
+        const verificationCodes = await EmailVerificationCode.where({
+            token,
+            organizationId: organization
+                ? {
+                        sign: 'IN',
+                        value: [organization.id, null],
+                    }
+                : null,
+        }, { limit: 1 });
+
+        if (verificationCodes.length == 0) {
+            console.log("Can't resend code, no coded found for token", token);
+            // TODO: maybe send a note via email
+            return;
+        }
+
+        const verificationCode = verificationCodes[0];
+
+        if (verificationCode.expiresAt < new Date()) {
+            // Don't report error, could be brute forced
+            console.log("Can't resend code, token is expired", token);
+            return;
+        }
+
+        const user = await User.getByID(verificationCode.userId);
+        if (!user) {
+            return;
+        }
+        await this.send(verificationCode, user, organization, i18n);
+    }
+}

--- a/backend/shared/models/src/models/EmailVerificationCode.ts
+++ b/backend/shared/models/src/models/EmailVerificationCode.ts
@@ -1,15 +1,10 @@
 import { column } from '@simonbackx/simple-database';
 import { SimpleError } from '@simonbackx/simple-errors';
-import type { I18n } from '@stamhoofd/backend-i18n';
 import { QueryableModel } from '@stamhoofd/sql';
-import { appToUri, EmailTemplateType, getAppHost, Recipient, Replacement } from '@stamhoofd/structures';
 import basex from 'base-x';
 import crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
-import { sendEmailTemplate } from '../helpers/EmailBuilder.js';
-import { Platform } from './Platform.js';
 import type { User } from './User.js';
-import type { Organization } from './Organization.js';
 
 const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 const bs58 = basex(ALPHABET);
@@ -120,11 +115,6 @@ export class EmailVerificationCode extends QueryableModel {
         this.expiresAt = new Date(new Date().getTime() + 1000 * 60 * 60 * 12);
     }
 
-    getEmailVerificationUrl(user: User, organization: Organization | null, i18n: I18n) {
-        const host = getAppHost('verify-email', organization, !!user.permissions, i18n);
-        return 'https://' + host + '?code=' + encodeURIComponent(this.code) + '&token=' + encodeURIComponent(this.token) + '&email=' + encodeURIComponent(this.email);
-    }
-
     /**
      * Return true if this token is still valid (used for automatic polling in code view)
      */
@@ -232,92 +222,6 @@ export class EmailVerificationCode extends QueryableModel {
                 statusCode: 429,
             });
         }
-    }
-
-    async send(user: User, organization: Organization | null, i18n: I18n, withCode = true) {
-        const url = this.getEmailVerificationUrl(user, organization, i18n);
-
-        const name = organization?.name ?? (await Platform.getSharedPrivateStruct()).config.name;
-
-        const replacements: Replacement[] = [
-            Replacement.create({
-                token: 'organizationName',
-                value: name,
-            }),
-            Replacement.create({
-                token: 'confirmEmailUrl',
-                value: url,
-            }),
-        ];
-
-        if (withCode) {
-            const formattedCode = this.code.substr(0, 3) + ' ' + this.code.substr(3);
-
-            await sendEmailTemplate(organization, {
-                recipients: [
-                    Recipient.create({
-                        email: this.email,
-                        replacements: [
-                            ...replacements,
-                            Replacement.create({
-                                token: 'confirmEmailCode',
-                                value: formattedCode,
-                            }),
-                        ],
-                    }),
-                ],
-                template: {
-                    type: EmailTemplateType.VerifyEmail,
-                },
-                type: 'transactional',
-            });
-        } else {
-            await sendEmailTemplate(organization, {
-                recipients: [
-                    Recipient.create({
-                        email: this.email,
-                        replacements,
-                    }),
-                ],
-                template: {
-                    type: EmailTemplateType.VerifyEmailWithoutCode,
-                },
-                type: 'transactional',
-            });
-        }
-    }
-
-    static async resend(organization: Organization | null, token: string, i18n: I18n) {
-        const verificationCodes = await this.where({
-            token,
-            organizationId: organization
-                ? {
-                        sign: 'IN',
-                        value: [organization.id, null],
-                    }
-                : null,
-        }, { limit: 1 });
-
-        if (verificationCodes.length == 0) {
-            console.log("Can't resend code, no coded found for token", token);
-            // TODO: maybe send a note via email
-            return;
-        }
-
-        const verificationCode = verificationCodes[0];
-
-        if (verificationCode.expiresAt < new Date()) {
-            // Don't report error, could be brute forced
-            console.log("Can't resend code, token is expired", token);
-            return;
-        }
-
-        const { User } = await import('./User.js');
-        const user = await User.getByID(verificationCode.userId);
-        if (!user) {
-            return;
-        }
-        await verificationCode.send(user, organization, i18n);
     }
 
     /**

--- a/backend/shared/models/src/models/PasswordToken.ts
+++ b/backend/shared/models/src/models/PasswordToken.ts
@@ -1,15 +1,11 @@
 import type { ManyToOneRelation } from '@simonbackx/simple-database';
 import { column, Database } from '@simonbackx/simple-database';
-import type { I18n } from '@stamhoofd/backend-i18n';
 import { QueryableModel } from '@stamhoofd/sql';
 import basex from 'base-x';
 import crypto from 'crypto';
 
-import type { Organization } from './Organization.js';
 import { User } from './User.js';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { getAppHost } from '@stamhoofd/structures';
-import { Platform } from './Platform.js';
 const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 const bs58 = basex(ALPHABET);
 
@@ -120,31 +116,6 @@ export class PasswordToken extends QueryableModel {
         token.token = bs58.encode(await randomBytes(100)).toLowerCase();
         await token.save();
         return token;
-    }
-
-    static async getPasswordRecoveryUrl(user: User, organization: Organization | null, i18n: I18n, validUntil?: Date) {
-        // Send an e-mail to say you already have an account + follow password forgot flow
-        const token = await PasswordToken.createToken(user, validUntil);
-        return token.getPasswordRecoveryUrl(organization, i18n, user);
-    }
-
-    /**
-     * Build the password recovery url for this (already created) token.
-     * Pass the user to avoid an extra query when it is already loaded.
-     */
-    async getPasswordRecoveryUrl(organization: Organization | null, i18n: I18n, user?: User) {
-        const tokenUser = user ?? await User.getByID(this.userId);
-        if (!tokenUser) {
-            throw new Error('PasswordToken without a valid user');
-        }
-
-        if (tokenUser.organizationId !== null && ((tokenUser.organizationId ?? null) !== (organization?.id ?? null))) {
-            throw new Error('Unexpected mismatch in organization id for PasswordToken');
-        }
-
-        const hasOrganizationPermissions = organization ? tokenUser.permissions?.forOrganization(organization, await Platform.getSharedStruct())?.isEmpty === false : false;
-        const host = 'https://' + getAppHost(hasOrganizationPermissions ? 'dashboard' : 'registration', organization, hasOrganizationPermissions, i18n);
-        return host + '/reset-password?token=' + encodeURIComponent(this.token);
     }
 
     static async clearFor(userId: string) {

--- a/tests/playwright/src/tests/invite-admin.spec.ts
+++ b/tests/playwright/src/tests/invite-admin.spec.ts
@@ -8,6 +8,7 @@ import { expect } from '@playwright/test';
 import { I18n } from '@stamhoofd/backend-i18n';
 import type { Organization } from '@stamhoofd/models';
 import { OrganizationFactory, PasswordToken, Platform, Token, User, UserFactory } from '@stamhoofd/models';
+import { PasswordForgotService } from '@stamhoofd/backend/services/PasswordForgotService';
 import { STPackageService } from '@stamhoofd/backend/tests/helpers';
 import { PermissionLevel, PermissionRoleDetailed, Permissions, STPackageBundle, Token as TokenStruct, Version } from '@stamhoofd/structures';
 import { TestUtils } from '@stamhoofd/test-utils';
@@ -184,7 +185,7 @@ async function openInviteAndChoosePassword(browser: Browser, { userId, organizat
 
     // Find the stored PasswordToken and build the url from the invite email
     const passwordToken = await PasswordToken.select().where('userId', userId).first(true);
-    const url = await passwordToken.getPasswordRecoveryUrl(organization, i18n);
+    const url = await PasswordForgotService.getPasswordRecoveryUrlForToken(passwordToken, organization, i18n);
 
     // A new browser session with a clean local storage
     const context = await browser.newContext();

--- a/tests/playwright/src/tests/reset-password.spec.ts
+++ b/tests/playwright/src/tests/reset-password.spec.ts
@@ -8,6 +8,7 @@ import { expect } from '@playwright/test';
 import { I18n } from '@stamhoofd/backend-i18n';
 import type { Organization } from '@stamhoofd/models';
 import { OrganizationFactory, PasswordToken, User, UserFactory } from '@stamhoofd/models';
+import { PasswordForgotService } from '@stamhoofd/backend/services/PasswordForgotService';
 import { STPackageService } from '@stamhoofd/backend/tests/helpers';
 import { PermissionLevel, Permissions, STPackageBundle } from '@stamhoofd/structures';
 import { TestUtils } from '@stamhoofd/test-utils';
@@ -132,7 +133,7 @@ function defineResetScenarios(getOrganization: () => Organization) {
             const passwordToken = await PasswordToken.select().where('userId', user.id).first(true);
 
             // Navigate to the recovery url (the one that would be e-mailed to the user)
-            const url = await passwordToken.getPasswordRecoveryUrl(scope, i18n);
+            const url = await PasswordForgotService.getPasswordRecoveryUrlForToken(passwordToken, scope, i18n);
 
             await test.step('Navigate to ' + url + ' and reset password', async () => {
                 await page.goto(url);


### PR DESCRIPTION
Phase 2 of the tenants work: getting implicit platform reads out of `@stamhoofd/models`. Independent of #663.

Following your steer: **remove the business logic from models rather than wiring extra arguments into it.**

### Why not a parameter

Both methods below needed the platform. Passing one in would have kept the layering violation and merely made it explicit — the model would still own logic belonging a layer up, and every future context change (tenant, request scope) would have to be threaded through it again. Moving the logic out removes the whole class of problem.

### `PasswordForgotService`

Takes over from `PasswordToken`:
- `permissions.forOrganization(...)` — **a model computing authorization**
- picking the `dashboard` vs `registration` host, and building the `/reset-password?token=…` url

`PasswordToken` is left with token creation, lookup, expiry and `clearFor`.

### `VerificationCodeService`

Takes over `send` / `resend` / `getEmailVerificationUrl` from `EmailVerificationCode`, which read the platform name as the fallback when a code is not scoped to an organization.

`EmailVerificationCode` keeps generating, storing, verifying and rate-limiting the code — the data access. `getEmailVerificationUrl` moved with `send` rather than staying: it has exactly one caller and is url presentation, so leaving it behind would have split one cohesive operation across two layers. That part is a judgement call, not forced — say if you'd rather it stayed.

### Effect

`@stamhoofd/models` loses **125 lines** and two of its platform-resolving files. Still resolving the platform, each a separate PR: `EmailBuilder` (4 reads — `sendEmailTemplate` has 49 callers, so it needs its own design pass), `MemberPlatformMembership` (3), `Organization` (3), `Document` + `DocumentTemplate` (2), `Email` (1).

### Why this is a no-op

The logic is moved verbatim: both `throw` paths preserved, and the fire-and-forget `code.send(...).catch(console.error)` shape kept at all four call sites (awaiting them would change request latency and error handling).

Callers updated — 5 more than expected: `SignupEndpoint` (both flows), `CreateAdminEndpoint`, `ForgotPasswordEndpoint`, `PatchUserEndpoint`, `CreateTokenEndpoint`, `CreateOrganizationEndpoint`, `RetryEmailVerificationEndpoint` (via `resend`), plus the `reset-password` and `invite-admin` Playwright specs.

### Tests

Neither model had a test file. Per the rule you added: the tests were written against the **model** methods first and confirmed passing there, *then* the code moved, *then* the tests were re-pointed at the services unchanged in substance. That ordering is what makes them evidence rather than decoration.

7 tests: host selection both ways, url-encoded token, the organization-mismatch guard, the no-organization case, and the platform-name fallback both ways. **Mutation-checked** — inverting the host-selection condition fails both host tests.

### One thing to look at

`backend/app/api/package.json` gains a `./services/*` subpath export so the two Playwright specs can import `PasswordForgotService`. The alternative was extending the `tests/helpers` barrel, which CLAUDE.md forbids. It follows the existing export entries including the `@stamhoofd/source` condition, but it does widen what the api package exposes — happy to narrow it to a single named export if you prefer.

### Gates

`build:shared` · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — api **1045 passed** (+7), models 93, sql 209, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)