### PR TITLE
Move STPackage expiry emails into STPackageService

### DIFF
--- a/backend/app/api/src/crons.ts
+++ b/backend/app/api/src/crons.ts
@@ -6,6 +6,7 @@ import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/struct
 import { checkSettlements } from './helpers/CheckSettlements.js';
 import { PaymentService } from './services/PaymentService.js';
 import { RegistrationService } from './services/RegistrationService.js';
+import { STPackageService } from './services/STPackageService.js';
 
 let lastDNSCheck: Date | null = null;
 let lastDNSId = '';
@@ -76,7 +77,7 @@ async function checkExpirationEmails() {
     console.log('[EXPIRATION EMAILS] Sending expiration emails...');
 
     for (const pack of packages) {
-        await pack.sendExpiryEmail();
+        await STPackageService.sendExpiryEmail(pack);
     }
     lastExpirationCheck = new Date();
 }

--- a/backend/app/api/src/services/STPackageService.test.ts
+++ b/backend/app/api/src/services/STPackageService.test.ts
@@ -1,0 +1,191 @@
+import { EmailMocker } from '@stamhoofd/email';
+import { EmailTemplateFactory, OrganizationFactory, STPackage, UserFactory } from '@stamhoofd/models';
+import { EmailTemplateType, PermissionLevel, Permissions, STPackageMeta, STPackageType } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { Formatter } from '@stamhoofd/utility';
+import { v4 as uuidv4 } from 'uuid';
+import { vi } from 'vitest';
+import { STPackageService } from './STPackageService.js';
+
+const DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * A global (not organization scoped) template that only contains the replacements the service fills
+ * in, so the rendered email can be asserted without depending on the real template contents.
+ */
+async function createExpirationTemplate(type: EmailTemplateType) {
+    await new EmailTemplateFactory({
+        type,
+        html: '<p>organizationName: {{organizationName}}</p>'
+            + '<p>packageName: {{packageName}}</p>'
+            + '<p>validUntil: {{validUntil}}</p>'
+            + '<p>validUntilDate: {{validUntilDate}}</p>'
+            + '<p>renewUrl: {{renewUrl}}</p>',
+    }).create();
+}
+
+async function createPackage(options: {
+    organizationId: string;
+    type: STPackageType;
+    /**
+     * Defaults to 10 days from now: inside the reminder window of every package type.
+     */
+    validUntil?: Date | null;
+    removeAt?: Date | null;
+    validAt?: Date | null;
+}) {
+    const pack = new STPackage();
+    pack.organizationId = options.organizationId;
+    pack.meta = STPackageMeta.create({
+        type: options.type,
+        startDate: new Date(Date.now() - 365 * DAY),
+    });
+    pack.validAt = options.validAt !== undefined ? options.validAt : new Date(Date.now() - 365 * DAY);
+    pack.validUntil = options.validUntil !== undefined ? options.validUntil : new Date(Date.now() + 10 * DAY);
+    pack.removeAt = options.removeAt ?? null;
+    await pack.save();
+    return pack;
+}
+
+async function createOrganizationWithAdmin() {
+    const organization = await new OrganizationFactory({}).create();
+    const admin = await new UserFactory({
+        organization,
+        firstName: 'Full',
+        lastName: 'Admin',
+        permissions: Permissions.create({ level: PermissionLevel.Full }),
+    }).create();
+    return { organization, admin };
+}
+
+describe('STPackageService', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('sendExpiryEmail', () => {
+        test('Sends the reminder to the full admins of the organization and records it on the package', async () => {
+            TestUtils.setEnvironment('environment', 'production');
+            await createExpirationTemplate(EmailTemplateType.MembersExpirationReminder);
+
+            const { organization, admin } = await createOrganizationWithAdmin();
+
+            // A user without permissions should not receive the reminder
+            const member = await new UserFactory({ organization }).create();
+
+            const validUntil = new Date(Date.now() + 10 * DAY);
+            const pack = await createPackage({ organizationId: organization.id, type: STPackageType.Members, validUntil });
+
+            await STPackageService.sendExpiryEmail(pack);
+
+            const emails = await EmailMocker.getSucceededEmails();
+            expect(emails.length).toBe(1);
+            expect(emails[0].to).toContain(admin.email);
+            expect(emails[0].to).not.toContain(member.email);
+
+            expect(emails[0].html).toContain('organizationName: ' + organization.name);
+            expect(emails[0].html).toContain('packageName: ' + pack.meta.name);
+            expect(emails[0].html).toContain('validUntil: ' + Formatter.dateTime(validUntil));
+            expect(emails[0].html).toContain('validUntilDate: ' + Formatter.date(validUntil));
+            expect(emails[0].html).toContain(`renewUrl: https://${STAMHOOFD.domains.dashboard ?? 'stamhoofd.app'}/${organization.i18n.locale}/beheerders/${organization.uri}/instellingen/functionaliteiten`);
+
+            expect(pack.lastEmailAt).not.toBeNull();
+            expect(pack.emailCount).toBe(1);
+
+            const fromDatabase = await STPackage.getByID(pack.id);
+            expect(fromDatabase!.lastEmailAt).not.toBeNull();
+            expect(fromDatabase!.emailCount).toBe(1);
+        });
+
+        test('Counts the email, but does not set lastEmailAt, for a package type without a reminder', async () => {
+            TestUtils.setEnvironment('environment', 'production');
+            const { organization } = await createOrganizationWithAdmin();
+
+            // LegacyMembers has no expiration reminder template type
+            const pack = await createPackage({ organizationId: organization.id, type: STPackageType.LegacyMembers });
+
+            await STPackageService.sendExpiryEmail(pack);
+
+            expect(await EmailMocker.getSucceededCount()).toBe(0);
+            expect(pack.lastEmailAt).toBeNull();
+            expect(pack.emailCount).toBe(1);
+
+            const fromDatabase = await STPackage.getByID(pack.id);
+            expect(fromDatabase!.lastEmailAt).toBeNull();
+            expect(fromDatabase!.emailCount).toBe(1);
+        });
+
+        test('Does not send outside production, but still records the email on the package', async () => {
+            // The production guard only covers the send itself: the bookkeeping runs in every environment
+            expect(STAMHOOFD.environment).not.toBe('production');
+            await createExpirationTemplate(EmailTemplateType.MembersExpirationReminder);
+
+            const { organization } = await createOrganizationWithAdmin();
+            const pack = await createPackage({ organizationId: organization.id, type: STPackageType.Members });
+
+            await STPackageService.sendExpiryEmail(pack);
+
+            expect(await EmailMocker.getSucceededCount()).toBe(0);
+            expect(pack.lastEmailAt).not.toBeNull();
+            expect(pack.emailCount).toBe(1);
+
+            const fromDatabase = await STPackage.getByID(pack.id);
+            expect(fromDatabase!.lastEmailAt).not.toBeNull();
+            expect(fromDatabase!.emailCount).toBe(1);
+        });
+
+        test('Logs and skips the email when the organization of the package no longer exists', async () => {
+            TestUtils.setEnvironment('environment', 'production');
+            await createExpirationTemplate(EmailTemplateType.MembersExpirationReminder);
+            const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const pack = await createPackage({ organizationId: uuidv4(), type: STPackageType.Members });
+
+            await STPackageService.sendExpiryEmail(pack);
+
+            expect(consoleError).toHaveBeenCalledWith('Could not find package organization ' + pack.id);
+            expect(await EmailMocker.getSucceededCount()).toBe(0);
+
+            // A missing organization does not stop the bookkeeping
+            expect(pack.emailCount).toBe(1);
+        });
+
+        test('Does not send or count a package that is not due', async () => {
+            TestUtils.setEnvironment('environment', 'production');
+            await createExpirationTemplate(EmailTemplateType.MembersExpirationReminder);
+
+            const { organization } = await createOrganizationWithAdmin();
+
+            const neverActivated = await createPackage({ organizationId: organization.id, type: STPackageType.Members, validAt: null });
+
+            // Expires in 100 days, which is outside the 32 day window of a members package
+            const notExpiringSoon = await createPackage({ organizationId: organization.id, type: STPackageType.Members, validUntil: new Date(Date.now() + 100 * DAY) });
+
+            await STPackageService.sendExpiryEmail(neverActivated);
+            await STPackageService.sendExpiryEmail(notExpiringSoon);
+
+            expect(await EmailMocker.getSucceededCount()).toBe(0);
+            expect(neverActivated.emailCount).toBe(0);
+            expect(neverActivated.lastEmailAt).toBeNull();
+            expect(notExpiringSoon.emailCount).toBe(0);
+            expect(notExpiringSoon.lastEmailAt).toBeNull();
+        });
+
+        test('Counts, but does not send, a package that is already removed', async () => {
+            TestUtils.setEnvironment('environment', 'production');
+            await createExpirationTemplate(EmailTemplateType.MembersExpirationReminder);
+
+            const { organization } = await createOrganizationWithAdmin();
+            const pack = await createPackage({ organizationId: organization.id, type: STPackageType.Members, removeAt: new Date(Date.now() - DAY) });
+
+            await STPackageService.sendExpiryEmail(pack);
+
+            expect(await EmailMocker.getSucceededCount()).toBe(0);
+            expect(pack.lastEmailAt).toBeNull();
+            expect(pack.emailCount).toBe(1);
+
+            const fromDatabase = await STPackage.getByID(pack.id);
+            expect(fromDatabase!.emailCount).toBe(1);
+        });
+    });
+});

--- a/backend/app/api/src/services/STPackageService.ts
+++ b/backend/app/api/src/services/STPackageService.ts
@@ -1,7 +1,7 @@
-import { BalanceItem, Organization, Platform, STPackage } from '@stamhoofd/models';
+import { BalanceItem, Organization, Platform, sendEmailTemplate, STPackage } from '@stamhoofd/models';
 import { SQL } from '@stamhoofd/sql';
 import type { Company } from '@stamhoofd/structures';
-import { BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, getPricingTypeName, STPackageStatus, STPackageType, STPackageTypeHelper, STPricingType, TranslatedString } from '@stamhoofd/structures';
+import { BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, EmailTemplateType, getPricingTypeName, Recipient, Replacement, STPackageStatus, STPackageType, STPackageTypeHelper, STPricingType, TranslatedString } from '@stamhoofd/structures';
 import { Formatter, STMath } from '@stamhoofd/utility';
 import { VATService } from './VATService.js';
 
@@ -261,6 +261,122 @@ export class STPackageService {
             await pack.save();
         }
         await this.updateOrganizationPackages(organizationId);
+    }
+
+    /**
+     * Send the expiration reminder of a package if one is due, and record on the package that it was
+     * sent (also when nothing was sent, so a package is only ever considered once).
+     *
+     * Composing the reminder needs the administrators of the organization, and those are filtered
+     * with the platform. Models have no request context to resolve the platform they belong to, so
+     * this lives here instead of on STPackage.
+     */
+    static async sendExpiryEmail(pack: STPackage) {
+        if (pack.validAt === null) {
+            // never activated
+            return;
+        }
+
+        if (pack.removeAt && pack.removeAt <= new Date()) {
+            pack.emailCount += 1;
+            await pack.save();
+            return;
+        }
+
+        let allowDays = 0;
+        let type: EmailTemplateType | null = null;
+
+        if (pack.meta.type === STPackageType.Members) {
+            type = EmailTemplateType.MembersExpirationReminder;
+            allowDays = 32;
+        } else if (pack.meta.type === STPackageType.Webshops) {
+            type = EmailTemplateType.WebshopsExpirationReminder;
+            allowDays = 32;
+        } else if (pack.meta.type === STPackageType.SingleWebshop) {
+            type = EmailTemplateType.SingleWebshopExpirationReminder;
+            allowDays = 7;
+        } else if (pack.meta.type === STPackageType.TrialMembers) {
+            type = EmailTemplateType.TrialMembersExpirationReminder;
+            allowDays = 3;
+        } else if (pack.meta.type === STPackageType.TrialWebshops) {
+            type = EmailTemplateType.TrialWebshopsExpirationReminder;
+            allowDays = 3;
+        }
+
+        const allowFrom = new Date(Date.now() + 1000 * 60 * 60 * 24 * allowDays);
+        if (type && (pack.validUntil === null || pack.validUntil < new Date() || pack.validUntil > allowFrom)) {
+            console.log('Skip sending expiration email for ' + pack.id);
+            return;
+        }
+
+        if (type) {
+            console.log('Sending expiration email for ' + pack.id, type);
+            if (STAMHOOFD.environment === 'production') {
+                await this.sendEmailTemplate(pack, {
+                    type,
+                });
+            }
+            pack.lastEmailAt = new Date();
+        } else {
+            console.log('Skip sending expiration email for ' + pack.id + ' (no type)');
+        }
+
+        pack.emailCount += 1;
+        await pack.save();
+    }
+
+    /**
+     * Send an email template about a package to the full administrators of its organization.
+     */
+    static async sendEmailTemplate(pack: STPackage, data: {
+        type: EmailTemplateType;
+    }) {
+        const organization = await Organization.getByID(pack.organizationId);
+
+        if (!organization) {
+            console.error('Could not find package organization ' + pack.id);
+            return;
+        }
+
+        const admins = await organization.getFullAdmins();
+
+        const recipients = admins.map(admin =>
+            Recipient.create({
+                firstName: admin.firstName,
+                lastName: admin.lastName,
+                email: admin.email,
+                replacements: [
+                    Replacement.create({
+                        token: 'organizationName',
+                        value: organization.name,
+                    }),
+                    Replacement.create({
+                        token: 'packageName',
+                        value: pack.meta.name ?? '',
+                    }),
+                    Replacement.create({
+                        token: 'validUntil',
+                        value: pack.validUntil ? Formatter.dateTime(pack.validUntil) : 'nooit',
+                    }),
+                    Replacement.create({
+                        token: 'validUntilDate',
+                        value: pack.validUntil ? Formatter.date(pack.validUntil) : 'nooit',
+                    }),
+                    Replacement.create({
+                        token: 'renewUrl',
+                        value: `https://${(STAMHOOFD.domains.dashboard ?? 'stamhoofd.app')}/${organization.i18n.locale}/beheerders/${organization.uri}/instellingen/functionaliteiten`,
+                    }),
+                ],
+            }),
+        );
+
+        // Create e-mail builder
+        await sendEmailTemplate(null, {
+            template: {
+                type: data.type,
+            },
+            recipients,
+        });
     }
 
     static async markBalanceRestored(organizationId: string) {

--- a/backend/shared/models/src/models/STPackage.ts
+++ b/backend/shared/models/src/models/STPackage.ts
@@ -1,12 +1,9 @@
 import { column } from '@simonbackx/simple-database';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { EmailTemplateType, Recipient, Replacement, STPackageMeta, STPackageStatus, STPackageStatusServiceFee, STPackageType, STPricingType } from '@stamhoofd/structures';
-import { Formatter } from '@stamhoofd/utility';
+import { STPackageMeta, STPackageStatus, STPackageStatusServiceFee, STPackageType, STPricingType } from '@stamhoofd/structures';
 import { v4 as uuidv4 } from 'uuid';
 
 import { QueryableModel } from '@stamhoofd/sql';
-import { sendEmailTemplate } from '../helpers/EmailBuilder.js';
-import { Organization } from './Organization.js';
 
 export class STPackage extends QueryableModel {
     static table = 'stamhoofd_packages';
@@ -194,112 +191,6 @@ export class STPackage extends QueryableModel {
                         : (this.validUntil ?? this.removeAt),
                 },
                 )],
-        });
-    }
-
-    async sendExpiryEmail() {
-        if (this.validAt === null) {
-            // never activated
-            return;
-        }
-
-        if (this.removeAt && this.removeAt <= new Date()) {
-            this.emailCount += 1;
-            await this.save();
-            return;
-        }
-
-        let allowDays = 0;
-        let type: EmailTemplateType | null = null;
-
-        if (this.meta.type === STPackageType.Members) {
-            type = EmailTemplateType.MembersExpirationReminder;
-            allowDays = 32;
-        } else if (this.meta.type === STPackageType.Webshops) {
-            type = EmailTemplateType.WebshopsExpirationReminder;
-            allowDays = 32;
-        } else if (this.meta.type === STPackageType.SingleWebshop) {
-            type = EmailTemplateType.SingleWebshopExpirationReminder;
-            allowDays = 7;
-        } else if (this.meta.type === STPackageType.TrialMembers) {
-            type = EmailTemplateType.TrialMembersExpirationReminder;
-            allowDays = 3;
-        } else if (this.meta.type === STPackageType.TrialWebshops) {
-            type = EmailTemplateType.TrialWebshopsExpirationReminder;
-            allowDays = 3;
-        }
-
-        const allowFrom = new Date(Date.now() + 1000 * 60 * 60 * 24 * allowDays);
-        if (type && (this.validUntil === null || this.validUntil < new Date() || this.validUntil > allowFrom)) {
-            console.log('Skip sending expiration email for ' + this.id);
-            return;
-        }
-
-        if (type) {
-            console.log('Sending expiration email for ' + this.id, type);
-            if (STAMHOOFD.environment === 'production') {
-                await this.sendEmailTemplate({
-                    type,
-                });
-            }
-            this.lastEmailAt = new Date();
-        } else {
-            console.log('Skip sending expiration email for ' + this.id + ' (no type)');
-        }
-
-        this.emailCount += 1;
-        await this.save();
-    }
-
-    async sendEmailTemplate(data: {
-        type: EmailTemplateType;
-        replyTo?: string;
-    }) {
-        const organization = await Organization.getByID(this.organizationId);
-
-        if (!organization) {
-            console.error('Could not find package organization ' + this.id);
-            return;
-        }
-
-        const admins = await organization.getFullAdmins();
-
-        const recipients = admins.map(admin =>
-            Recipient.create({
-                firstName: admin.firstName,
-                lastName: admin.lastName,
-                email: admin.email,
-                replacements: [
-                    Replacement.create({
-                        token: 'organizationName',
-                        value: organization.name,
-                    }),
-                    Replacement.create({
-                        token: 'packageName',
-                        value: this.meta.name ?? '',
-                    }),
-                    Replacement.create({
-                        token: 'validUntil',
-                        value: this.validUntil ? Formatter.dateTime(this.validUntil) : 'nooit',
-                    }),
-                    Replacement.create({
-                        token: 'validUntilDate',
-                        value: this.validUntil ? Formatter.date(this.validUntil) : 'nooit',
-                    }),
-                    Replacement.create({
-                        token: 'renewUrl',
-                        value: `https://${(STAMHOOFD.domains.dashboard ?? 'stamhoofd.app')}/${organization.i18n.locale}/beheerders/${organization.uri}/instellingen/functionaliteiten`,
-                    }),
-                ],
-            }),
-        );
-
-        // Create e-mail builder
-        await sendEmailTemplate(null, {
-            template: {
-                type: data.type,
-            },
-            recipients,
         });
     }
 }


### PR DESCRIPTION
Phase 2, **step 1 of 5** taking the email subsystem out of `@stamhoofd/models`. Independent of #666.

`EmailBuilder.ts` (818 lines) can't move to the api app while four models still import it: `Email`, `Order`, `Organization`, `STPackage`. Each has its own `sendEmailTemplate` wrapper. This removes the first.

`sendExpiryEmail` and `sendEmailTemplate` move to **`STPackageService`**, which already owns the package lifecycle (`markValid`, `didRenew`, `deactivatePackage`, `chargePackage`). `STPackage` is left as pure data access and sheds 6 imports. One caller: `crons.ts:79`.

### The part that needed care

This decides **how often customers get billing email**, and the bookkeeping is asymmetric:

- `lastEmailAt` is set **only** in the branch that resolves a template type
- `emailCount += 1` and `save()` run in **both** branches
- the `STAMHOOFD.environment === 'production'` guard wraps **only the send** — so outside production a package still records an email it never sent

All preserved, and now pinned by tests rather than left to inference. Test 3 asserts exactly that: non-production → zero emails, but `lastEmailAt` non-null and `emailCount === 1`, both in memory and re-read from the database.

### One deliberate deviation from a byte-for-byte move

The old wrapper accepted `replyTo?: string`. It was never read, never passed by its single caller, and **could not have been forwarded anyway** — the helper's parameter type is `Omit<EmailBuilderOptions, 'subject' | 'html' | 'from' | 'replyTo'>`. Dropped rather than carried over. Flagging it since everything else is verbatim.

### Tests

`STPackage` had **no test file**. 6 tests, written against the model method first and passing there before anything moved:

1. full send — asserts one email to the full admin (not to a permission-less user) with `organizationName`, `packageName`, `validUntil`, `validUntilDate` and the complete `renewUrl` including `organization.i18n.locale` and uri
2. the no-type (`LegacyMembers`) branch — no email, `lastEmailAt` stays null, `emailCount === 1`, persisted
3. the production guard
4. missing organization — logs, returns, bookkeeping still runs
5. not-due packages — never activated, and expiring in 100 days
6. already removed (`removeAt` in the past)

**Mutation-checked**: moving `emailCount += 1` inside the type branch fails test 2 (`expected +0 to be 1`).

### Left alone, but worth a look

**A latent bug in the counter.** When a type *does* resolve but `validUntil` falls outside the window, the method returns **without** touching `emailCount`. When *no* type resolves, it **increments**. Since the cron selects only `emailCount: 0` packages, a `LegacyMembers` package is consumed by the counter after a single no-op pass and is never reconsidered — while an in-window package gets re-evaluated hourly. Preserved as-is.

Also: `lastEmailAt` is set even when the organization is missing, so the package looks emailed when nothing was sent. And `pack.meta.name ?? ''` is dead (`meta.name` is a non-nullable getter). Both preserved verbatim.

### Gates

`build:shared` · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — api **1060 passed** (+6), no failures.

`grep EmailBuilder backend/shared/models/src/models/` now lists only `Email.ts`, `Order.ts`, `Organization.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)