### PR TITLE
Move Order email and payment lifecycle into OrderService

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
@@ -10,6 +10,7 @@ import { AuditLogSource, BalanceItemRelation, BalanceItemRelationType, BalanceIt
 import { Context } from '../../../../helpers/Context.js';
 import { ServiceFeeHelper } from '../../../../helpers/ServiceFeeHelper.js';
 import { AuditLogService } from '../../../../services/AuditLogService.js';
+import { OrderService } from '../../../../services/OrderService.js';
 import { PaymentService } from '../../../../services/PaymentService.js';
 import { shouldReserveUitpasNumbers, UitpasService } from '../../../../services/uitpas/UitpasService.js';
 
@@ -151,7 +152,7 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
                         order.data.paymentMethod = PaymentMethod.Unknown;
 
                         // Mark this order as paid
-                        await order.markPaid(null, organization, webshop);
+                        await OrderService.markPaid(order, null, organization, webshop);
                         await order.save();
                     } else {
                         const payment = new Payment();
@@ -217,12 +218,12 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
                         await balanceItemPayment.save();
 
                         if (payment.method === PaymentMethod.Transfer) {
-                            await order.markValid(payment, []);
+                            await OrderService.markValid(order, payment, []);
                             await payment.save();
                             await order.save();
                         } else if (payment.method === PaymentMethod.PointOfSale) {
                             // Not really paid, but needed to create the tickets if needed
-                            await order.markPaid(payment, organization, webshop);
+                            await OrderService.markPaid(order, payment, organization, webshop);
                             await payment.save();
                             await order.save();
                         } else {

--- a/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
@@ -16,6 +16,7 @@ import { ServiceFeeHelper } from '../../../helpers/ServiceFeeHelper.js';
 import { StripeHelper } from '../../../helpers/StripeHelper.js';
 import { AuditLogService } from '../../../services/AuditLogService.js';
 import { MollieService } from '../../../services/MollieService.js';
+import { OrderService } from '../../../services/OrderService.js';
 import { PaymentService } from '../../../services/PaymentService.js';
 import { UitpasService } from '../../../services/uitpas/UitpasService.js';
 import { WebshopAuthHelper } from './WebshopAuthHelper.js';
@@ -171,7 +172,7 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                 order.data.paymentMethod = PaymentMethod.Unknown;
 
                 // Mark this order as paid
-                await order.markPaid(null, organization, webshop);
+                await OrderService.markPaid(order, null, organization, webshop);
                 await order.save();
             } else {
                 const payment = new Payment();
@@ -242,7 +243,7 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                 const description = webshop.meta.name + ' - ' + organization.name;
 
                 if (payment.method === PaymentMethod.Transfer) {
-                    await order.markValid(payment, []);
+                    await OrderService.markValid(order, payment, []);
 
                     if (order.number) {
                         balanceItem.description = order.generateBalanceDescription(webshop);
@@ -253,7 +254,7 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                     await payment.save();
                 } else if (payment.method === PaymentMethod.PointOfSale) {
                     // Not really paid, but needed to create the tickets if needed
-                    await order.markPaid(payment, organization, webshop);
+                    await OrderService.markPaid(order, payment, organization, webshop);
 
                     if (order.number) {
                         balanceItem.description = order.generateBalanceDescription(webshop);

--- a/backend/app/api/src/services/BalanceItemService.ts
+++ b/backend/app/api/src/services/BalanceItemService.ts
@@ -7,6 +7,7 @@ import { Formatter } from '@stamhoofd/utility';
 import { GroupedThrottledQueue } from '../helpers/GroupedThrottledQueue.js';
 import { ThrottledQueue } from '../helpers/ThrottledQueue.js';
 import { AuditLogService } from './AuditLogService.js';
+import { OrderService } from './OrderService.js';
 import { PaymentReallocationService } from './PaymentReallocationService.js';
 import { RegistrationService } from './RegistrationService.js';
 import { STPackageService } from './STPackageService.js';
@@ -235,7 +236,7 @@ export class BalanceItemService {
             const order = await Order.getByID(balanceItem.orderId);
             if (order) {
                 shouldMarkUpdated = false;
-                await order.markPaid(payment, organization);
+                await OrderService.markPaid(order, payment, organization);
 
                 // Save number in balance description
                 if (order.number !== null) {

--- a/backend/app/api/src/services/OrderService.test.ts
+++ b/backend/app/api/src/services/OrderService.test.ts
@@ -1,0 +1,308 @@
+import { I18n } from '@stamhoofd/backend-i18n';
+import { EmailMocker } from '@stamhoofd/email';
+import type { Organization } from '@stamhoofd/models';
+import { EmailTemplateFactory, Order, OrganizationFactory, Payment, Webshop, WebshopCounter, WebshopFactory } from '@stamhoofd/models';
+import { Cart, CartItem, Customer, EmailContent, EmailTemplateType, OrderData, OrderStatus, PaymentMethod, PaymentStatus, Product, ProductPrice, ProductType, WebshopMetaData, WebshopStatus, WebshopTicketType } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { Country } from '@stamhoofd/types/Country';
+import { Language } from '@stamhoofd/types/Language';
+import { OrderService } from './OrderService.js';
+
+/**
+ * The order emails are rendered in the language the customer ordered in. The status name below is
+ * rendered through $t inside the order recipient replacements, and is hardcoded on purpose so we
+ * don't verify $t with the same $t machinery we're testing.
+ * (translations of OrderStatus.Created in shared/locales/dist/locales/digit/{nl,fr}-BE.json)
+ */
+const orderStatusName = {
+    [Language.Dutch]: 'Nieuw',
+    [Language.French]: 'Nouveau',
+};
+
+function createCustomer() {
+    return Customer.create({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+    });
+}
+
+async function createOrder(webshop: Webshop, options: { consumerLanguage?: Language; valid?: boolean; cart?: Cart; paymentMethod?: PaymentMethod } = {}) {
+    const order = new Order();
+    order.organizationId = webshop.organizationId;
+    order.webshopId = webshop.id;
+    order.status = OrderStatus.Created;
+    order.consumerLanguage = options.consumerLanguage ?? Language.Dutch;
+    order.data = OrderData.create({
+        paymentMethod: options.paymentMethod ?? PaymentMethod.Transfer,
+        customer: createCustomer(),
+        cart: options.cart ?? Cart.create({}),
+    });
+
+    if (options.valid ?? true) {
+        order.validAt = new Date();
+        order.number = await WebshopCounter.getNextNumber(webshop);
+    }
+
+    await order.save();
+    return order;
+}
+
+function loadRelations(order: Order, webshop: Webshop, organization: Organization) {
+    return order.setRelation(Order.webshop, webshop.setRelation(Webshop.organization, organization));
+}
+
+async function createTransferPayment(organization: Organization) {
+    const payment = new Payment();
+    payment.organizationId = organization.id;
+    payment.method = PaymentMethod.Transfer;
+    payment.status = PaymentStatus.Succeeded;
+    payment.price = 1000;
+    payment.paidAt = new Date();
+    await payment.save();
+    return payment;
+}
+
+describe('OrderService', () => {
+    describe('sendEmailTemplate', () => {
+        test('renders the email in the language the customer ordered in, not the ambient language', async () => {
+            // Make French a valid locale so its real translations (loaded from disk) are actually used.
+            TestUtils.setEnvironment('locales', { [Country.Belgium]: [Language.Dutch, Language.French] });
+
+            const organization = await new OrganizationFactory({}).create();
+            const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.OrderConfirmationOnline,
+                subject: 'Bevestiging',
+                html: '<p>{{orderStatus}}</p>',
+                text: '{{orderStatus}}',
+            }).create();
+
+            const order = await createOrder(webshop, { consumerLanguage: Language.French });
+            const loadedOrder = loadRelations(order, webshop, organization);
+
+            // The ambient language is Dutch while the customer ordered in French
+            await I18n.runWithLocale(new I18n(Language.Dutch, Country.Belgium), async () => {
+                await OrderService.sendEmailTemplate(loadedOrder, {
+                    type: EmailTemplateType.OrderConfirmationOnline,
+                });
+            });
+
+            const emails = await EmailMocker.transactional.getSucceededEmails();
+            expect(emails).toHaveLength(1);
+            expect(emails[0].html).toContain(orderStatusName[Language.French]);
+            expect(emails[0].html).not.toContain(orderStatusName[Language.Dutch]);
+        });
+
+        test('does not send anything for an archived webshop', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const webshop = await new WebshopFactory({
+                organizationId: organization.id,
+                meta: WebshopMetaData.patch({ status: WebshopStatus.Archived }),
+            }).create();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.OrderConfirmationOnline,
+                subject: 'Bevestiging',
+                html: '<p>Bevestiging</p>',
+                text: 'Bevestiging',
+            }).create();
+
+            const order = await createOrder(webshop);
+            const loadedOrder = loadRelations(order, webshop, organization);
+
+            await OrderService.sendEmailTemplate(loadedOrder, {
+                type: EmailTemplateType.OrderConfirmationOnline,
+            });
+
+            expect(await EmailMocker.transactional.getSucceededEmails()).toHaveLength(0);
+        });
+    });
+
+    describe('markValid', () => {
+        test('sends the notification email without the customer name and in the webshop language', async () => {
+            TestUtils.setEnvironment('locales', { [Country.Belgium]: [Language.Dutch, Language.French] });
+
+            const organization = await new OrganizationFactory({}).create();
+            const webshop = await new WebshopFactory({
+                organizationId: organization.id,
+                meta: WebshopMetaData.patch({ defaultLanguage: Language.French }),
+            }).create();
+            webshop.privateMeta.notificationEmails = ['admin@example.com'];
+            await webshop.save();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.OrderConfirmationOnline,
+                subject: 'Bevestiging',
+                html: '<p>Bevestiging</p>',
+                text: 'Bevestiging',
+            }).create();
+
+            // Default (Dutch) content + a French translation, so we can tell which language was selected
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.OrderNotification,
+                subject: 'Nederlandse melding',
+                html: '<p>NL [{{firstName}}][{{lastName}}] {{orderUrl}}</p>',
+                text: 'Nederlandse melding',
+                language: Language.Dutch,
+                translations: new Map([
+                    [Language.French, EmailContent.create({
+                        subject: 'Franse melding',
+                        html: '<p>FR [{{firstName}}][{{lastName}}] {{orderUrl}}</p>',
+                        text: 'Franse melding',
+                    })],
+                ]),
+            }).create();
+
+            // The customer ordered in Dutch, the webshop default language is French
+            const order = await createOrder(webshop, { consumerLanguage: Language.Dutch, valid: false });
+            const loadedOrder = loadRelations(order, webshop, organization);
+
+            await OrderService.markValid(loadedOrder, null, []);
+
+            const emails = await EmailMocker.transactional.getSucceededEmails();
+            expect(emails).toHaveLength(2);
+
+            const customerEmail = emails.find(e => e.to.includes('john@example.com'));
+            const notification = emails.find(e => e.to.includes('admin@example.com'));
+            expect(customerEmail).toBeDefined();
+            expect(notification).toBeDefined();
+
+            // The customer name is cleared, so the notification is not addressed to the customer
+            expect(notification!.to).toBe('admin@example.com');
+
+            // The firstName/lastName replacements are dropped, so the customer name doesn't leak
+            expect(notification!.html).toContain('[][]');
+            expect(notification!.html).not.toContain('John');
+            expect(notification!.html).not.toContain('Doe');
+
+            // The language falls back to the webshop default (French), not the customer's (Dutch)
+            expect(notification!.subject).toBe('Franse melding');
+            expect(notification!.html).toContain('FR ');
+
+            // The orderUrl of the notification points at the dashboard, not at the webshop order page
+            expect(notification!.html).toContain('/webshops/');
+
+            // The customer still receives their own confirmation
+            expect(customerEmail!.subject).toBe('Bevestiging');
+        });
+    });
+
+    describe('markPaid', () => {
+        test('sends the tickets email when tickets were created', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const productPrice = ProductPrice.create({ name: 'Standaard', price: 0 });
+            const ticketProduct = Product.create({
+                name: 'Ticket',
+                type: ProductType.Ticket,
+                prices: [productPrice],
+            });
+
+            const webshop = await new WebshopFactory({
+                organizationId: organization.id,
+                meta: WebshopMetaData.patch({ ticketType: WebshopTicketType.Tickets }),
+                products: [ticketProduct],
+            }).create();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.TicketsReceivedTransfer,
+                subject: 'Tickets ontvangen',
+                html: '<p>Tickets ontvangen</p>',
+                text: 'Tickets ontvangen',
+            }).create();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.OrderReceivedTransfer,
+                subject: 'Betaling ontvangen',
+                html: '<p>Betaling ontvangen</p>',
+                text: 'Betaling ontvangen',
+            }).create();
+
+            const order = await createOrder(webshop, {
+                cart: Cart.create({
+                    items: [CartItem.create({ product: ticketProduct, productPrice, amount: 1 })],
+                }),
+            });
+
+            const payment = await createTransferPayment(organization);
+            await OrderService.markPaid(order, payment, organization, webshop);
+
+            const emails = await EmailMocker.transactional.getSucceededEmails();
+            expect(emails).toHaveLength(1);
+            expect(emails[0].subject).toBe('Tickets ontvangen');
+        });
+
+        test('sends the paid email for a transfer payment when no tickets were created', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.TicketsReceivedTransfer,
+                subject: 'Tickets ontvangen',
+                html: '<p>Tickets ontvangen</p>',
+                text: 'Tickets ontvangen',
+            }).create();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.OrderReceivedTransfer,
+                subject: 'Betaling ontvangen',
+                html: '<p>Betaling ontvangen</p>',
+                text: 'Betaling ontvangen',
+            }).create();
+
+            const order = await createOrder(webshop);
+            const payment = await createTransferPayment(organization);
+
+            await OrderService.markPaid(order, payment, organization, webshop);
+
+            const emails = await EmailMocker.transactional.getSucceededEmails();
+            expect(emails).toHaveLength(1);
+            expect(emails[0].subject).toBe('Betaling ontvangen');
+        });
+
+        test('does not send the paid email for a non-transfer payment when no tickets were created', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const webshop = await new WebshopFactory({ organizationId: organization.id }).create();
+
+            await new EmailTemplateFactory({
+                organization,
+                webshopId: webshop.id,
+                type: EmailTemplateType.OrderReceivedTransfer,
+                subject: 'Betaling ontvangen',
+                html: '<p>Betaling ontvangen</p>',
+                text: 'Betaling ontvangen',
+            }).create();
+
+            const order = await createOrder(webshop, { paymentMethod: PaymentMethod.PointOfSale });
+
+            const payment = new Payment();
+            payment.organizationId = organization.id;
+            payment.method = PaymentMethod.PointOfSale;
+            payment.status = PaymentStatus.Succeeded;
+            payment.price = 1000;
+            payment.paidAt = new Date();
+            await payment.save();
+
+            await OrderService.markPaid(order, payment, organization, webshop);
+
+            expect(await EmailMocker.transactional.getSucceededEmails()).toHaveLength(0);
+        });
+    });
+});

--- a/backend/app/api/src/services/OrderService.ts
+++ b/backend/app/api/src/services/OrderService.ts
@@ -1,0 +1,221 @@
+import { I18n } from '@stamhoofd/backend-i18n';
+import type { Organization, Payment, Ticket } from '@stamhoofd/models';
+import { Order, sendEmailTemplate, Webshop, WebshopCounter } from '@stamhoofd/models';
+import { EmailTemplateType, OrderStatus, PaymentMethod, Recipient, Replacement, WebshopPreview, WebshopStatus, WebshopTicketType } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+
+/**
+ * An order with its webshop, and the organization of that webshop, loaded.
+ *
+ * The order emails need both, so they are required by the signature instead of being fetched (or
+ * assumed) here: the caller already has them in almost every case.
+ */
+export type OrderWithWebshop = Order & { webshop: Webshop & { organization: Organization } };
+
+/**
+ * Owns the lifecycle transitions of an order (valid / paid) and the customer emails they send.
+ *
+ * Sibling models already have their transitions in a service (BalanceItemService, RegistrationService,
+ * STPackageService); orders were the exception. Composing an email also needs the email templates and
+ * the platform behind them, which the lowest model layer must not resolve, so it lives here.
+ */
+export class OrderService {
+    /**
+     * Only call this once! Make sure you use the queues correctly
+     */
+    static async markPaid(order: Order, payment: Payment | null, organization: Organization, knownWebshop?: Webshop) {
+        if (!order.id) {
+            await order.save();
+        }
+        console.log('Marking order ' + order.id + ' as paid');
+
+        const webshop = (knownWebshop ?? (await Webshop.getByID(order.webshopId)))?.setRelation(Webshop.organization, organization);
+        if (!webshop) {
+            console.error('Missing webshop for order ' + order.id);
+            return;
+        }
+
+        if (order.status === OrderStatus.Deleted) {
+            await order.undoPaymentFailed(payment, organization);
+        }
+
+        const loadedOrder = order.setRelation(Order.webshop, webshop);
+        const { tickets, didCreateTickets } = await loadedOrder.updateTickets({ hasPaidPayment: true });
+
+        // Needs to happen before validation, because we can include the tickets in the validation that way
+        if (order.validAt === null) {
+            await this.markValid(loadedOrder, payment, tickets);
+        } else {
+            order.markUpdated();
+            await order.save();
+
+            if (!order.data.shouldSendPaymentUpdates) {
+                console.log('Skip sending paid email for order ' + order.id);
+                return;
+            }
+            if (order.data.customer.email.length > 0) {
+                if (didCreateTickets) {
+                    await this.sendTickets(loadedOrder);
+                } else {
+                    if (payment && payment.method === PaymentMethod.Transfer) {
+                        await this.sendPaidMail(loadedOrder);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * WARNING: this should always run inside a queue so it only runs once for the same order
+     * Include any tickets that are generated and should be included in the e-mail
+     */
+    static async markValid(order: OrderWithWebshop, payment: Payment | null, tickets: Ticket[]) {
+        const webshop = order.webshop;
+        const organization = webshop.organization;
+
+        console.log('Marking as valid: order ' + order.id);
+        const wasValid = order.validAt !== null;
+
+        if (wasValid) {
+            console.warn('Warning: already validated an order');
+            return;
+        }
+        order.validAt = new Date(); // will get flattened AFTER calculations
+        order.validAt.setMilliseconds(0);
+        order.number = await WebshopCounter.getNextNumber(webshop);
+
+        if (payment && !Order.payment.isLoaded(order)) {
+            order.setRelation(Order.payment, payment);
+        }
+
+        // Now we have a number, update the payment
+        if (payment && payment.method === PaymentMethod.Transfer) {
+            // Only now we can update the transfer description, since we need the order number as a reference
+            payment.transferSettings = order.getTransferSettings({ shouldThrowIfNoIban: true });
+            payment.generateDescription(organization, order.number.toString(), order.getTransferReplacements());
+            await payment.save();
+        }
+
+        await order.save();
+
+        if (order.data.customer.email.length > 0) {
+            if (tickets.length > 0) {
+                // Also send a copy
+                if (payment && payment.method === PaymentMethod.PointOfSale) {
+                    await this.sendEmailTemplate(order, {
+                        type: EmailTemplateType.TicketsConfirmationPOS,
+                    });
+                } else {
+                    await this.sendEmailTemplate(order, {
+                        type: EmailTemplateType.TicketsConfirmation,
+                    });
+                }
+            } else {
+                if (webshop.meta.ticketType === WebshopTicketType.None) {
+                    if (payment && payment.method === PaymentMethod.Transfer) {
+                        // Also send a copy
+                        await this.sendEmailTemplate(order, {
+                            type: EmailTemplateType.OrderConfirmationTransfer,
+                        });
+                    } else if (payment && payment.method === PaymentMethod.PointOfSale) {
+                        await this.sendEmailTemplate(order, {
+                            type: EmailTemplateType.OrderConfirmationPOS,
+                        });
+                    } else {
+                        // Also send a copy
+                        await this.sendEmailTemplate(order, {
+                            type: EmailTemplateType.OrderConfirmationOnline,
+                        });
+                    }
+                } else {
+                    if (payment && payment.method === PaymentMethod.Transfer) {
+                        await this.sendEmailTemplate(order, {
+                            type: EmailTemplateType.TicketsConfirmationTransfer,
+                        });
+                    } else {
+                        console.error('Unexpected missing tickets for order where tickets are expected');
+                    }
+                }
+            }
+        }
+
+        if (webshop.privateMeta.notificationEmails) {
+            const i18n = organization.i18n;
+
+            const webshopDashboardUrl = 'https://' + (STAMHOOFD.domains.dashboard ?? 'stamhoofd.app') + '/' + i18n.locale + '/webshops/' + Formatter.slug(webshop.meta.name) + '/orders';
+
+            // Send an email to all these notification emails
+            for (const email of webshop.privateMeta.notificationEmails) {
+                await this.sendEmailTemplate(order, {
+                    type: EmailTemplateType.OrderNotification,
+                    to: Recipient.create({
+                        email,
+                        replacements: [
+                            Replacement.create({
+                                token: 'orderUrl',
+                                value: webshopDashboardUrl,
+                            }),
+                        ],
+                    }),
+                });
+            }
+        }
+    }
+
+    static async sendPaidMail(order: OrderWithWebshop) {
+        // For a tickets webshop, where the order was marked as paid / non-paid, we should still send the tickets email
+        // - because the normal email is not editable
+        const hasTickets = order.webshop.meta.hasTickets;
+
+        await this.sendEmailTemplate(order, {
+            type: hasTickets ? EmailTemplateType.TicketsReceivedTransfer : EmailTemplateType.OrderReceivedTransfer,
+        });
+    }
+
+    static async sendTickets(order: OrderWithWebshop) {
+        await this.sendEmailTemplate(order, {
+            type: EmailTemplateType.TicketsReceivedTransfer,
+        });
+    }
+
+    static async sendEmailTemplate(order: OrderWithWebshop, data: {
+        type: EmailTemplateType;
+        to?: Recipient;
+    }) {
+        // Never send an email for archived webshops
+        if (order.webshop.meta.status === WebshopStatus.Archived) {
+            return;
+        }
+
+        // Render all $t's (recipient replacements, order tables, template...) in the language
+        // the customer used while placing the order, instead of the current request language.
+        const i18n = new I18n(order.consumerLanguage, order.webshop.organization.address.country);
+
+        await I18n.runWithLocale(i18n, async () => {
+            let recipient = (await order.getStructure()).getRecipient(
+                order.webshop.organization.getBaseStructure(),
+                WebshopPreview.create(order.webshop),
+            );
+
+            if (data.to) {
+                // Clear first and last name
+                recipient.firstName = null;
+                recipient.lastName = null;
+                recipient.language = order.webshop.meta.defaultLanguage;
+                recipient.replacements = recipient.replacements.filter(r => !['firstName', 'lastName'].includes(r.token));
+                data.to.merge(recipient);
+                recipient = data.to;
+            }
+
+            // Create e-mail builder
+            await sendEmailTemplate(order.webshop.organization, {
+                recipients: [recipient],
+                template: {
+                    type: data.type,
+                    webshop: order.webshop,
+                },
+                type: 'transactional',
+            });
+        });
+    }
+}

--- a/backend/shared/models/src/models/Order.ts
+++ b/backend/shared/models/src/models/Order.ts
@@ -1,17 +1,14 @@
 import type { ManyToOneRelation } from '@simonbackx/simple-database';
 import { column } from '@simonbackx/simple-database';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { I18n } from '@stamhoofd/backend-i18n/I18n';
 import { QueueHandler } from '@stamhoofd/queues';
 import { Language } from '@stamhoofd/types/Language';
 import { QueryableModel, SQL } from '@stamhoofd/sql';
 import type { TransferSettings, WebshopTimeSlot } from '@stamhoofd/structures';
-import { BalanceItemPaymentWithPayment, BalanceItemPaymentWithPrivatePayment, BalanceItemWithPayments, BalanceItemWithPrivatePayments, EmailTemplateType, OrderData, OrderStatus, Order as OrderStruct, PaymentMethod, PaymentStatus, Payment as PaymentStruct, PrivateOrder, PrivatePayment, ProductType, Recipient, Replacement, WebshopPreview, WebshopStatus, WebshopTicketType } from '@stamhoofd/structures';
+import { BalanceItemPaymentWithPayment, BalanceItemPaymentWithPrivatePayment, BalanceItemWithPayments, BalanceItemWithPrivatePayments, OrderData, OrderStatus, Order as OrderStruct, PaymentMethod, PaymentStatus, Payment as PaymentStruct, PrivateOrder, PrivatePayment, ProductType, WebshopTicketType } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 
-import { sendEmailTemplate } from '../helpers/EmailBuilder.js';
-import { WebshopCounter } from '../helpers/WebshopCounter.js';
 import { BalanceItem } from './BalanceItem.js';
 import { BalanceItemPayment } from './BalanceItemPayment.js';
 import type { Organization } from './Organization.js';
@@ -736,66 +733,6 @@ export class Order extends QueryableModel {
         await this.setRelation(Order.webshop, webshop).updateTickets();
     }
 
-    /**
-     * Only call this once! Make sure you use the queues correctly
-     */
-    async markPaid(this: Order, payment: Payment | null, organization: Organization, knownWebshop?: Webshop) {
-        if (!this.id) {
-            await this.save();
-        }
-        console.log('Marking order ' + this.id + ' as paid');
-
-        const webshop = (knownWebshop ?? (await Webshop.getByID(this.webshopId)))?.setRelation(Webshop.organization, organization);
-        if (!webshop) {
-            console.error('Missing webshop for order ' + this.id);
-            return;
-        }
-
-        if (this.status === OrderStatus.Deleted) {
-            await this.undoPaymentFailed(payment, organization);
-        }
-
-        const { tickets, didCreateTickets } = await this.setRelation(Order.webshop, webshop).updateTickets({ hasPaidPayment: true });
-
-        // Needs to happen before validation, because we can include the tickets in the validation that way
-        if (this.validAt === null) {
-            await this.setRelation(Order.webshop, webshop).markValid(payment, tickets);
-        } else {
-            this.markUpdated();
-            await this.save();
-
-            if (!this.data.shouldSendPaymentUpdates) {
-                console.log('Skip sending paid email for order ' + this.id);
-                return;
-            }
-            if (this.data.customer.email.length > 0) {
-                if (didCreateTickets) {
-                    await this.setRelation(Order.webshop, webshop).sendTickets();
-                } else {
-                    if (payment && payment.method === PaymentMethod.Transfer) {
-                        await this.setRelation(Order.webshop, webshop).sendPaidMail();
-                    }
-                }
-            }
-        }
-    }
-
-    async sendPaidMail(this: Order & { webshop: Webshop & { organization: Organization } }) {
-        // For a tickets webshop, where the order was marked as paid / non-paid, we should still send the tickets email
-        // - because the normal email is not editable
-        const hasTickets = this.webshop.meta.hasTickets;
-
-        await this.sendEmailTemplate({
-            type: hasTickets ? EmailTemplateType.TicketsReceivedTransfer : EmailTemplateType.OrderReceivedTransfer,
-        });
-    }
-
-    async sendTickets(this: Order & { webshop: Webshop & { organization: Organization } }) {
-        await this.sendEmailTemplate({
-            type: EmailTemplateType.TicketsReceivedTransfer,
-        });
-    }
-
     getStructureWithoutPayment() {
         return OrderStruct.create({
             id: this.id,
@@ -901,47 +838,6 @@ export class Order extends QueryableModel {
         return (await Order.getStructures([this]))[0];
     }
 
-    async sendEmailTemplate(this: Order & { webshop: Webshop & { organization: Organization } }, data: {
-        type: EmailTemplateType;
-        to?: Recipient;
-    }) {
-        // Never send an email for archived webshops
-        if (this.webshop.meta.status === WebshopStatus.Archived) {
-            return;
-        }
-
-        // Render all $t's (recipient replacements, order tables, template...) in the language
-        // the customer used while placing the order, instead of the current request language.
-        const i18n = new I18n(this.consumerLanguage, this.webshop.organization.address.country);
-
-        await I18n.runWithLocale(i18n, async () => {
-            let recipient = (await this.getStructure()).getRecipient(
-                this.webshop.organization.getBaseStructure(),
-                WebshopPreview.create(this.webshop),
-            );
-
-            if (data.to) {
-                // Clear first and last name
-                recipient.firstName = null;
-                recipient.lastName = null;
-                recipient.language = this.webshop.meta.defaultLanguage;
-                recipient.replacements = recipient.replacements.filter(r => !['firstName', 'lastName'].includes(r.token));
-                data.to.merge(recipient);
-                recipient = data.to;
-            }
-
-            // Create e-mail builder
-            await sendEmailTemplate(this.webshop.organization, {
-                recipients: [recipient],
-                template: {
-                    type: data.type,
-                    webshop: this.webshop,
-                },
-                type: 'transactional',
-            });
-        });
-    }
-
     /**
      * Get the transfer settings for this order
      * @param this
@@ -960,104 +856,5 @@ export class Order extends QueryableModel {
         }
 
         return transferSettings;
-    }
-
-    /**
-     * WARNING: this should always run inside a queue so it only runs once for the same orde
-     * Include any tickets that are generated and should be included in the e-mail
-     */
-    async markValid(this: Order & { webshop: Webshop & { organization: Organization } }, payment: Payment | null, tickets: Ticket[]) {
-        const webshop = this.webshop;
-        const organization = webshop.organization;
-
-        console.log('Marking as valid: order ' + this.id);
-        const wasValid = this.validAt !== null;
-
-        if (wasValid) {
-            console.warn('Warning: already validated an order');
-            return;
-        }
-        this.validAt = new Date(); // will get flattened AFTER calculations
-        this.validAt.setMilliseconds(0);
-        this.number = await WebshopCounter.getNextNumber(this.webshop);
-
-        if (payment && !Order.payment.isLoaded(this)) {
-            this.setRelation(Order.payment, payment);
-        }
-
-        // Now we have a number, update the payment
-        if (payment && payment.method === PaymentMethod.Transfer) {
-            // Only now we can update the transfer description, since we need the order number as a reference
-            payment.transferSettings = this.getTransferSettings({ shouldThrowIfNoIban: true });
-            payment.generateDescription(organization, this.number.toString(), this.getTransferReplacements());
-            await payment.save();
-        }
-
-        await this.save();
-
-        if (this.data.customer.email.length > 0) {
-            if (tickets.length > 0) {
-                // Also send a copy
-                if (payment && payment.method === PaymentMethod.PointOfSale) {
-                    await this.sendEmailTemplate({
-                        type: EmailTemplateType.TicketsConfirmationPOS,
-                    });
-                } else {
-                    await this.sendEmailTemplate({
-                        type: EmailTemplateType.TicketsConfirmation,
-                    });
-                }
-            } else {
-                if (this.webshop.meta.ticketType === WebshopTicketType.None) {
-                    if (payment && payment.method === PaymentMethod.Transfer) {
-                        // Also send a copy
-                        await this.sendEmailTemplate({
-                            type: EmailTemplateType.OrderConfirmationTransfer,
-                        });
-                    } else if (payment && payment.method === PaymentMethod.PointOfSale) {
-                        await this.sendEmailTemplate({
-                            type: EmailTemplateType.OrderConfirmationPOS,
-                        });
-                    } else {
-                        // Also send a copy
-                        await this.sendEmailTemplate({
-                            type: EmailTemplateType.OrderConfirmationOnline,
-                        });
-                    }
-                } else {
-                    if (payment && payment.method === PaymentMethod.Transfer) {
-                        await this.sendEmailTemplate({
-                            type: EmailTemplateType.TicketsConfirmationTransfer,
-                        });
-                    } else {
-                        console.error('Unexpected missing tickets for order where tickets are expected');
-                    }
-                }
-            }
-        }
-
-        if (this.webshop.privateMeta.notificationEmails) {
-            const webshop = this.webshop;
-            const organization = webshop.organization;
-            const i18n = organization.i18n;
-
-            const webshopDashboardUrl = 'https://' + (STAMHOOFD.domains.dashboard ?? 'stamhoofd.app') + '/' + i18n.locale + '/webshops/' + Formatter.slug(webshop.meta.name) + '/orders';
-
-            // Send an email to all these notification emails
-            for (const email of this.webshop.privateMeta.notificationEmails) {
-                await this.sendEmailTemplate({
-                    type: EmailTemplateType.OrderNotification,
-                    to: Recipient.create({
-                        email,
-                        replacements: [
-                            Replacement.create({
-                                token: 'orderUrl',
-                                value: webshopDashboardUrl,
-                            }),
-                        ],
-                    }),
-                });
-            }
-        }
     }
 }


### PR DESCRIPTION
Phase 2, **step 3 of 5** taking the email subsystem out of `@stamhoofd/models`. Independent of #666 and #667.

`Order.ts` no longer imports `EmailBuilder`. **−205 lines** from the model.

### Why a service, and why this name

Every sibling model's lifecycle transitions **already** live in a service — `BalanceItemService.markPaid`, `BalanceItemPaymentService.markPaid`, `RegistrationService.markValid`, `STPackageService.markValid`. `Order` was the last one still holding its own. `OrderService` completes an existing pattern rather than inventing one.

### Scope chosen by transitive closure, not intuition

Starting from the one method that imports `EmailBuilder`:

```
sendEmailTemplate
  ← sendPaidMail, sendTickets, markValid
    ← markPaid
```

So exactly those **five** move. `paymentChanged` and `undoPaid` were checked and **do not** reach the email cluster (they are `markUpdated` / `save` / `updateTickets`), so they stay on the model and their `BalanceItemService` call sites are untouched. Everything that is data access — `getStructure`, `updateTickets`, `getTransferSettings`, `undoPaymentFailed`, … — stays too.

### The typed-`this` guarantee is preserved, not assumed

These methods used `this: Order & { webshop: Webshop & { organization: Organization } }` to require a loaded relation. Rather than dropping that at the service boundary, `OrderService` exports:

```ts
export type OrderWithWebshop = Order & { webshop: Webshop & { organization: Organization } };
```

and takes it wherever the old `this` demanded it — so a caller that hasn't loaded the relation still fails to compile. `markPaid` keeps a bare `Order` (matching its old `this`), because `BalanceItemService` passes a plain `getByID` result; it resolves the webshop itself and narrows from there.

One structural change inside `markPaid`: four repeated `this.setRelation(Order.webshop, webshop)` calls hoisted into one `const loadedOrder`. Equivalent — `setRelation` mutates and returns the same object.

### Why this is a no-op

The customer-visible parts are preserved exactly:

- the **archived-webshop early return** (no mail for archived shops)
- the `I18n.runWithLocale` wrapper built from `consumerLanguage` + the organization's country — **this is what makes the customer receive mail in the language they ordered in** rather than the current request language
- the `data.to` override branch: names cleared, language set to the webshop default, `firstName`/`lastName` replacements filtered, then merged
- `type: 'transactional'`, the `template: { type, webshop }` shape, and every `save()` position

### Tests

Written against the **model** methods first and passing there before anything moved.

6 tests. The highest-value one is the consumer-language assertion: a French order rendered under an explicit **Dutch** ambient locale must still produce `Nouveau`, not `Nieuw`. **Mutation-checked** — swapping the constructed `i18n` for the ambient one fails exactly that test (`expected '<p>Nieuw</p>' to contain 'Nouveau'`).

Also covered: the archived-webshop return; the `data.to` branch driven through its real caller (`markValid` + `privateMeta.notificationEmails`), asserting the name is cleared, no `John`/`Doe` leak, the webshop-default language wins for the notification while the customer's own mail stays Dutch; and `markPaid` picking tickets vs paid-mail vs nothing across three cases.

### Playwright

No spec references any moved symbol — `webshop-orders.spec.ts` and `email-translations-orders.spec.ts` drive the HTTP endpoints, whose behaviour is unchanged. I ran both specs locally anyway, since this is the order/ticket email path.

### Gates

`build:shared` · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — api **1066 passed** (+6), no failures.

`grep EmailBuilder backend/shared/models/src/models/` now lists only `Email.ts` and `Organization.ts` (plus `STPackage.ts`, removed by #667 on its own branch).

### Noticed for the next step

`Organization.ts:497` imports `EmailBuilder` **lazily** (`await import(...)`), presumably to break a require cycle — so a static-import grep under-reports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)