### PR TITLE
Fix getFinanceAdminRecipients skipping financial directors

### DIFF
--- a/backend/shared/models/src/models/Organization.test.ts
+++ b/backend/shared/models/src/models/Organization.test.ts
@@ -1,6 +1,8 @@
 import { Database } from '@simonbackx/simple-database';
+import { AccessRight, PermissionLevel, PermissionRoleDetailed, Permissions } from '@stamhoofd/structures';
 import { EventFactory } from '../factories/EventFactory.js';
 import { OrganizationFactory } from '../factories/OrganizationFactory.js';
+import { UserFactory } from '../factories/UserFactory.js';
 import { Organization } from './Organization.js';
 import { TestUtils } from '@stamhoofd/test-utils';
 
@@ -115,5 +117,49 @@ describe('Organization.updateFutureEventsForOrganizations', () => {
         await expect(Organization.updateFutureEventsForOrganizations([])).resolves.toBeUndefined();
 
         expect(await getHasFutureEvents(organization)).toBe(true);
+    });
+});
+
+describe('Organization admin recipients', () => {
+    async function createOrganizationWithAdmins() {
+        const financeRole = PermissionRoleDetailed.create({
+            name: 'financial director',
+            accessRights: [AccessRight.OrganizationFinanceDirector],
+        });
+
+        const organization = await new OrganizationFactory({ roles: [financeRole] }).create();
+
+        const fullAdmin = await new UserFactory({
+            organization,
+            email: 'full-admin@example.com',
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+
+        const financeAdmin = await new UserFactory({
+            organization,
+            email: 'finance-admin@example.com',
+            permissions: Permissions.create({
+                level: PermissionLevel.None,
+                roles: [financeRole],
+            }),
+        }).create();
+
+        return { organization, fullAdmin, financeAdmin };
+    }
+
+    test('The finance admin recipients include a financial director without full access', async () => {
+        const { organization, fullAdmin, financeAdmin } = await createOrganizationWithAdmins();
+
+        const emails = (await organization.getFinanceAdminRecipients()).map(r => r.email);
+
+        expect(emails).toIncludeSameMembers([fullAdmin.email, financeAdmin.email]);
+    });
+
+    test('The regular admin recipients only include full admins', async () => {
+        const { organization, fullAdmin } = await createOrganizationWithAdmins();
+
+        const emails = (await organization.getAdminRecipients()).map(r => r.email);
+
+        expect(emails).toIncludeSameMembers([fullAdmin.email]);
     });
 });

--- a/backend/shared/models/src/models/Organization.ts
+++ b/backend/shared/models/src/models/Organization.ts
@@ -927,7 +927,7 @@ export class Organization extends QueryableModel {
      * These email addresess are private
      */
     async getFinanceAdminRecipients(): Promise<Recipient[]> {
-        const filtered = await this.getFullAdmins();
+        const filtered = await this.getFinanceAdmins();
         return this.adminsToRecipients(filtered);
     }
 


### PR DESCRIPTION
Bugfix, split out of the models refactor as you asked.

### The bug

```ts
async getAdminRecipients(): Promise<Recipient[]> {
    const filtered = await this.getFullAdmins();      // correct
    return this.adminsToRecipients(filtered);
}

async getFinanceAdminRecipients(): Promise<Recipient[]> {
    const filtered = await this.getFullAdmins();      // ← should be getFinanceAdmins()
    return this.adminsToRecipients(filtered);
}
```

The two methods were byte-identical. `getFinanceAdmins` exists precisely to widen the set to `hasFullAccess() || hasAccessRight(OrganizationFinanceDirector)`.

**Effect:** `PaymentService.ts:240,277` — chargeback and failed-payment emails — reached only full-access admins. A user whose role grants `OrganizationFinanceDirector` but not full access never received them.

Not a regression: introduced already-wrong on 2026-05-28 in `e584a0193` ("Added chargeback and failed payment emails"), almost certainly copy-pasted from the method directly above it. `getFinanceAdmins` had no other live caller as a result, which is what made it look like dead code when I first grepped it.

### Tests

Two, in `Organization.test.ts`:

- financial directors **are** included in `getFinanceAdminRecipients`
- financial directors are still **excluded** from `getAdminRecipients` — so the fix doesn't over-widen the wrong method

Verified the first fails before the change:

```
FAIL  src/models/Organization.test.ts > Organization admin recipients > The finance admin recipients include a financial director without full access
Tests  1 failed | 9 passed (10)
```

and passes after (10/10).

### Note on who starts receiving mail

This changes behaviour by design: users holding only `OrganizationFinanceDirector` will now start receiving chargeback and failed-payment notifications. That is what the method name and `getFinanceAdmins` both imply was intended — flagging it explicitly since it is customer-visible.

### Gates

`build:shared` · `yarn typecheck` (22 projects) · `yarn lint` (40 projects) · `yarn stam test unit` — api 1080, models 10/10, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)