### PR TITLE
AGENTS: add a rule about code comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Backend uses a custom router (`@simonbackx/simple-endpoints`), **not Express**: 
 - For bugfixes: write a test that reproduces the bug, verify it fails before the fix and passes after.
 - Always run all linting, typechecking and tests before considering your work done.
 
+- Comments must make code faster to understand, so keep them short and only document what a reader cannot infer from the code: a non-obvious invariant, an external constraint, a gotcha. **Never comment your own reasoning** — why you chose a design, what the code used to be, what a refactor moved. That belongs in the PR description. Strip such comments when you encounter them.
+
 ## Build ordering (the #1 source of confusing errors)
 
 Packages consume each other's **built `dist/` output**, not source. After changing a shared package, consumers see stale code until you run `yarn build:shared`. Almost every "type error after editing a shared package", "test fails on module load", or "cached code keeps running" is fixed by running it first. Full reset when badly out of sync:


### PR DESCRIPTION
Adds the code-comment rule you asked for, kept to a single line in `## Rules`.

The problem it targets is agent-written comments that record *reasoning* rather than information — e.g. this one I put on `OrderService`, which you flagged:

> Sibling models already have their transitions in a service (BalanceItemService, RegistrationService, STPackageService); orders were the exception. Composing an email also needs the email templates and the platform behind them, which the lowest model layer must not resolve, so it lives here.

That is PR-description content: a reviewer needs it once, but every future reader of the file pays for it.

The rule also says to strip such comments when encountered, which I've started doing — #669 removes an 11-line class doc of exactly this kind, five test comments that only restated their assertions, and a stale `// Create e-mail builder` above a call that no longer builds one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)