### PR TITLE
Strip reasoning comments from the extracted services

### DIFF
--- a/backend/app/api/src/services/DocumentRenderService.ts
+++ b/backend/app/api/src/services/DocumentRenderService.ts
@@ -7,15 +7,7 @@ import { DocumentStatus, Version } from '@stamhoofd/structures';
 import { Sorter } from '@stamhoofd/utility';
 
 /**
- * Owns rendering documents and document templates into HTML/XML.
- *
- * Turning a row into a handlebars context and rendering that context is not data access: the context
- * mixes in the platform (for the fallback logo and, for an XML export, the document numbering), and
- * models have no request context to resolve the platform they belong to. So both context building and
- * the render calls live here instead of on Document/DocumentTemplate.
- *
- * Document and DocumentTemplate keep the rows themselves, including DocumentTemplate.buildAll which
- * is a document lifecycle operation and has its own callers.
+ * Renders documents and document templates into HTML/XML.
  */
 export class DocumentRenderService {
     /**

--- a/backend/app/api/src/services/EmailPreviewService.test.ts
+++ b/backend/app/api/src/services/EmailPreviewService.test.ts
@@ -253,8 +253,6 @@ describe('EmailPreviewService', () => {
         });
 
         test('the allLanguages option is not read: the example recipients only depend on the languages of the email', async () => {
-            // Documents the current behaviour. Moving this code has to be a strict no-op, so the
-            // option is kept as it is even though it is not used.
             TestUtils.setEnvironment('locales', { BE: [Language.Dutch, Language.French] });
 
             const email = await createSentEmail({

--- a/backend/app/api/src/services/EmailPreviewService.ts
+++ b/backend/app/api/src/services/EmailPreviewService.ts
@@ -8,15 +8,8 @@ import { ExampleReplacements } from '@stamhoofd/structures/email/exampleReplacem
 import type { Language } from '@stamhoofd/types/Language';
 
 /**
- * Owns building the read-only structures of an email: the preview an administrator sees while
- * composing or browsing emails, and the version of a sent email a user sees in the member portal.
- *
- * Both fill (and strip) the recipient replacements for display instead of for sending, and filling
- * replacements needs the platform. Models have no request context to resolve the platform they
- * belong to, so this display logic lives here instead of on the Email model.
- *
- * The Email model keeps the send pipeline (queueForSending, resumeSending, buildRecipients) and the
- * data it needs (getLanguages, getFromAddress, getCombinedHtml), which is used from here as well.
+ * Builds the read-only structures of an email: the preview an administrator sees while composing or
+ * browsing emails, and the version of a sent email a user sees in the member portal.
  */
 export class EmailPreviewService {
     /**

--- a/backend/app/api/src/services/OrderService.ts
+++ b/backend/app/api/src/services/OrderService.ts
@@ -6,18 +6,11 @@ import { Formatter } from '@stamhoofd/utility';
 
 /**
  * An order with its webshop, and the organization of that webshop, loaded.
- *
- * The order emails need both, so they are required by the signature instead of being fetched (or
- * assumed) here: the caller already has them in almost every case.
  */
 export type OrderWithWebshop = Order & { webshop: Webshop & { organization: Organization } };
 
 /**
- * Owns the lifecycle transitions of an order (valid / paid) and the customer emails they send.
- *
- * Sibling models already have their transitions in a service (BalanceItemService, RegistrationService,
- * STPackageService); orders were the exception. Composing an email also needs the email templates and
- * the platform behind them, which the lowest model layer must not resolve, so it lives here.
+ * The lifecycle transitions of an order (valid / paid) and the customer emails they send.
  */
 export class OrderService {
     /**

--- a/backend/app/api/src/services/PasswordForgotService.ts
+++ b/backend/app/api/src/services/PasswordForgotService.ts
@@ -4,11 +4,8 @@ import { PasswordToken, Platform, User } from '@stamhoofd/models';
 import { getAppHost } from '@stamhoofd/structures';
 
 /**
- * Owns the password recovery links.
- *
- * Which app the link points to depends on whether the user is an administrator of the organization,
- * and that requires the platform. Models have no request context to resolve the platform they
- * belong to, so both the permission check and the url building live here instead of on PasswordToken.
+ * Builds the password recovery links. Which app the link points to depends on whether the user is an
+ * administrator of the organization.
  */
 export class PasswordForgotService {
     /**

--- a/backend/app/api/src/services/STPackageService.ts
+++ b/backend/app/api/src/services/STPackageService.ts
@@ -266,10 +266,6 @@ export class STPackageService {
     /**
      * Send the expiration reminder of a package if one is due, and record on the package that it was
      * sent (also when nothing was sent, so a package is only ever considered once).
-     *
-     * Composing the reminder needs the administrators of the organization, and those are filtered
-     * with the platform. Models have no request context to resolve the platform they belong to, so
-     * this lives here instead of on STPackage.
      */
     static async sendExpiryEmail(pack: STPackage) {
         if (pack.validAt === null) {

--- a/backend/app/api/src/services/VerificationCodeService.ts
+++ b/backend/app/api/src/services/VerificationCodeService.ts
@@ -4,12 +4,8 @@ import { EmailVerificationCode, Platform, sendEmailTemplate, User } from '@stamh
 import { EmailTemplateType, getAppHost, Recipient, Replacement } from '@stamhoofd/structures';
 
 /**
- * Owns sending the verification emails for an EmailVerificationCode.
- *
- * The code itself (generating, storing, verifying and rate limiting it) stays on the model: that is
- * data access. Building the verification url and composing the email is not, and it needs the
- * platform name as a fallback when the code is not scoped to an organization. Models cannot resolve
- * the platform they belong to, so that logic lives here.
+ * Sends the verification emails for an EmailVerificationCode. The code itself is generated, stored
+ * and verified on the model.
  */
 export class VerificationCodeService {
     static getEmailVerificationUrl(code: EmailVerificationCode, user: User, organization: Organization | null, i18n: I18n) {


### PR DESCRIPTION
Applies the rule from #672 to the services extracted over the last few PRs.

Each of these carried a doc comment explaining *why the service exists* and *what moved out of which model* — refactor rationale that belonged in the PR description, not in the file. Removed, and replaced with a short line saying what the class does where the name doesn't already say it.

−43 comment lines, +8. No logic changes.

| File | Was |
|---|---|
| `OrderService` | the 5-line one you quoted, plus a 4-line note on `OrganizationEmailService`'s type |
| `EmailPreviewService` | 10 lines |
| `DocumentRenderService` | 10 lines |
| `VerificationCodeService` | 7 lines |
| `PasswordForgotService` | 6 lines |
| `STPackageService` | 3 lines on `sendExpiryEmail` |
| `EmailPreviewService.test.ts` | a comment explaining that a behaviour was preserved because the refactor had to be a no-op |

**Kept** the comments that carry information you can't get from the code — why a fixture needs exactly four entries, why a token has to appear in the email html for a leak to be observable, why a translated string is hardcoded rather than fetched through `$t`, and the pre-existing `// yay! Do not Save until after doing AWS changes`.

### Note on the gates

`yarn stam test unit` reports one failure, `shared/cli > route-reservation > skips ranges with a port that is already bound`. It is **not** from this change — it fails identically with these changes stashed, and reproduces in isolation. It binds a real port, and I've been running e2e suites on this machine all session. Typecheck (22 projects) and lint (40 projects) are clean; the api suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)