### PR TITLE
♻️ Make the platform caches per tenant

### DIFF
--- a/backend/shared/models/src/models/Platform.test.ts
+++ b/backend/shared/models/src/models/Platform.test.ts
@@ -2,6 +2,7 @@ import { PlatformConfig, PlatformMembershipType } from '@stamhoofd/structures';
 import { Platform } from './Platform.js';
 import { Database } from '@simonbackx/simple-database';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+import { QueueHandler } from '@stamhoofd/queues';
 
 describe('Model.Platform', () => {
     describe('Shared caches', () => {
@@ -239,6 +240,27 @@ describe('Model.Platform', () => {
             expect(await Platform.getStructForTenant('1')).toBe(rootBefore);
             expect(await Platform.getStructForTenant('second-tenant')).not.toBe(otherBefore);
         });
+
+        test('one tenant loading its cache does not queue behind another', async () => {
+            await createSecondTenant();
+            await Platform.clearCacheForTenantWithoutRefresh('second-tenant');
+
+            let release!: () => void;
+            const held = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+
+            // Occupy the key a process-wide cache would have used. If the per-tenant load shares it,
+            // this never resolves and the test times out.
+            const blocker = QueueHandler.schedule('Platform.loadCaches', async () => {
+                await held;
+            });
+
+            await Platform.getStructForTenant('second-tenant');
+
+            release();
+            await blocker;
+        }, 5000);
 
         test('an unknown tenant is not created on the fly', async () => {
             await expect(Platform.getForEditing('does-not-exist')).rejects.toThrow(

--- a/backend/shared/models/src/models/Platform.test.ts
+++ b/backend/shared/models/src/models/Platform.test.ts
@@ -1,7 +1,7 @@
 import { PlatformConfig, PlatformMembershipType } from '@stamhoofd/structures';
 import { Platform } from './Platform.js';
 import { Database } from '@simonbackx/simple-database';
-import { TestUtils } from '@stamhoofd/test-utils';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 
 describe('Model.Platform', () => {
     describe('Shared caches', () => {
@@ -178,6 +178,72 @@ describe('Model.Platform', () => {
             const reloaded = await Platform.getByID('clash-c');
             expect(reloaded!.parentTenantId).toBe(existing.id);
             expect(reloaded!.feesTenantId).toBe(existing.id);
+        });
+    });
+
+    describe('Per-tenant caches', () => {
+        async function createSecondTenant() {
+            const root = await Platform.getForEditing();
+
+            const other = new Platform();
+            other.id = 'second-tenant';
+            other.periodId = root.periodId;
+            other.config = PlatformConfig.create({
+                membershipTypes: [PlatformMembershipType.create({ id: 't2', name: 'Second tenant type' })],
+            });
+            await other.save();
+
+            return { root, other };
+        }
+
+        afterEach(async () => {
+            await Platform.clearCacheForTenantWithoutRefresh('second-tenant');
+            await Database.delete('DELETE FROM platform WHERE id != ?', ['1']);
+            await Platform.clearCache();
+        });
+
+        test('each tenant caches its own struct', async () => {
+            const { root } = await createSecondTenant();
+
+            root.config.membershipTypes = [PlatformMembershipType.create({ id: 't1', name: 'Root type' })];
+            await root.save();
+
+            const rootStruct = await Platform.getStructForTenant('1');
+            const otherStruct = await Platform.getStructForTenant('second-tenant');
+
+            expect(rootStruct.config.membershipTypes.map(m => m.name)).toEqual(['Root type']);
+            expect(otherStruct.config.membershipTypes.map(m => m.name)).toEqual(['Second tenant type']);
+        });
+
+        test('saving one tenant does not discard another tenant cache', async () => {
+            const { root } = await createSecondTenant();
+
+            const otherBefore = await Platform.getStructForTenant('second-tenant');
+
+            root.config.membershipTypes = [PlatformMembershipType.create({ id: 't1', name: 'Changed' })];
+            await root.save();
+
+            // Same object identity: the second tenant's cache was never rebuilt
+            expect(await Platform.getStructForTenant('second-tenant')).toBe(otherBefore);
+            expect((await Platform.getStructForTenant('1')).config.membershipTypes[0].name).toBe('Changed');
+        });
+
+        test('clearing one tenant cache leaves the other in place', async () => {
+            await createSecondTenant();
+
+            const rootBefore = await Platform.getStructForTenant('1');
+            const otherBefore = await Platform.getStructForTenant('second-tenant');
+
+            await Platform.clearCacheForTenant('second-tenant');
+
+            expect(await Platform.getStructForTenant('1')).toBe(rootBefore);
+            expect(await Platform.getStructForTenant('second-tenant')).not.toBe(otherBefore);
+        });
+
+        test('an unknown tenant is not created on the fly', async () => {
+            await expect(Platform.getForEditing('does-not-exist')).rejects.toThrow(
+                STExpect.simpleError({ code: 'tenant_not_found' }),
+            );
         });
     });
 });

--- a/backend/shared/models/src/models/Platform.ts
+++ b/backend/shared/models/src/models/Platform.ts
@@ -8,6 +8,14 @@ import { deepFreeze } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 import { RegistrationPeriod } from './RegistrationPeriod.js';
 
+export const ROOT_TENANT_ID = '1';
+
+type TenantCache = {
+    model: Readonly<Platform>;
+    struct: PlatformStruct;
+    privateStruct: PlatformStruct & { privateConfig: PlatformPrivateConfig };
+};
+
 export class Platform extends QueryableModel {
     static table = 'platform';
 
@@ -81,20 +89,20 @@ export class Platform extends QueryableModel {
         });
     }
 
-    private static shared: Platform | null = null;
-    private static sharedPrivateStruct: PlatformStruct & { privateConfig: PlatformPrivateConfig } | null = null;
-    private static sharedStruct: PlatformStruct | null = null;
+    private static caches: Map<string, TenantCache> = new Map();
 
-    static async getSharedStruct(): Promise<PlatformStruct> {
-        if (!this.sharedStruct) {
-            await this.loadCaches();
-        }
+    static async getStructForTenant(tenantId: string): Promise<PlatformStruct> {
+        const struct = (await this.getCache(tenantId)).struct;
 
-        if (!this.sharedStruct || !!this.sharedStruct.privateConfig) {
+        if (struct.privateConfig) {
             throw new Error('[Platform] Failed to load platform shared struct');
         }
 
-        return this.sharedStruct;
+        return struct;
+    }
+
+    static async getSharedStruct(): Promise<PlatformStruct> {
+        return await this.getStructForTenant(ROOT_TENANT_ID);
     }
 
     async setPreviousPeriodId() {
@@ -103,29 +111,40 @@ export class Platform extends QueryableModel {
         this.nextPeriodId = period?.nextPeriodId ?? null;
     }
 
-    static async getSharedPrivateStruct(): Promise<PlatformStruct & { privateConfig: PlatformPrivateConfig }> {
-        if (!this.sharedPrivateStruct) {
-            await this.loadCaches();
-        }
+    static async getPrivateStructForTenant(tenantId: string): Promise<PlatformStruct & { privateConfig: PlatformPrivateConfig }> {
+        const privateStruct = (await this.getCache(tenantId)).privateStruct;
 
-        if (!this.sharedPrivateStruct || !this.sharedPrivateStruct.privateConfig) {
+        if (!privateStruct.privateConfig) {
             throw new Error('[Platform] Failed to load platform shared private struct');
         }
 
-        return this.sharedPrivateStruct;
+        return privateStruct;
     }
 
-    static async getForEditing(): Promise<Platform> {
-        return QueueHandler.schedule('Platform.getModel', async () => {
+    static async getSharedPrivateStruct(): Promise<PlatformStruct & { privateConfig: PlatformPrivateConfig }> {
+        return await this.getPrivateStructForTenant(ROOT_TENANT_ID);
+    }
+
+    static async getForEditing(tenantId: string = ROOT_TENANT_ID): Promise<Platform> {
+        return QueueHandler.schedule('Platform.getModel-' + tenantId, async () => {
             // Build a new one
-            let model = await this.getByID('1');
+            let model = await this.getByID(tenantId);
 
             if (!model) {
+                if (tenantId !== ROOT_TENANT_ID) {
+                    // Only the root tenant bootstraps itself. Any other tenant is created explicitly.
+                    throw new SimpleError({
+                        code: 'tenant_not_found',
+                        message: 'Tenant ' + tenantId + ' not found',
+                        statusCode: 404,
+                    });
+                }
+
                 console.info('[Platform] Creating new platform');
 
                 // Create a new platform
                 model = new Platform();
-                model.id = '1';
+                model.id = tenantId;
                 model.feesTenantId = model.id;
                 model.uri = STAMHOOFD.platformName;
                 model.domain = STAMHOOFD.domains.dashboard ?? null;
@@ -145,35 +164,44 @@ export class Platform extends QueryableModel {
         });
     }
 
+    static async getForTenant(tenantId: string): Promise<Readonly<Platform> & { save: never }> {
+        return (await this.getCache(tenantId)).model as any;
+    }
+
     static async getShared(): Promise<Readonly<Platform> & { save: never }> {
-        if (this.shared) {
+        return await this.getForTenant(ROOT_TENANT_ID);
+    }
+
+    private static async getCache(tenantId: string): Promise<TenantCache> {
+        const cached = this.caches.get(tenantId);
+        if (cached) {
             // Skip queue if possible (performance optimization)
-            return this.shared as any;
+            return cached;
         }
 
-        return QueueHandler.schedule('Platform.getShared', async () => {
-            if (this.shared) {
-                return this.shared;
-            }
+        await this.loadCachesForTenant(tenantId);
 
-            // Build a new one
-            const model = await this.getForEditing();
-            deepFreeze(model);
-            this.shared = model;
-            return model as any;
+        const loaded = this.caches.get(tenantId);
+        if (!loaded) {
+            throw new Error('[Platform] Failed to load caches for tenant ' + tenantId);
+        }
+        return loaded;
+    }
+
+    static async loadCachesForTenant(tenantId: string): Promise<void> {
+        // Keyed per tenant: a global key would stall every tenant behind one tenant's reload.
+        await QueueHandler.schedule('Platform.loadCaches-' + tenantId, async () => {
+            if (this.caches.has(tenantId)) {
+                // Already loaded (possible if multiple calls were made)
+                return;
+            }
+            const model = await this.getForEditing(tenantId);
+            await this.setCachesFromModel(model);
         });
     }
 
     static async loadCaches(): Promise<void> {
-        await QueueHandler.schedule('Platform.loadCaches', async () => {
-            if (this.sharedPrivateStruct && this.sharedStruct) {
-                // Already loaded (possible if multiple calls to loadCaches were made)
-                return;
-            }
-            // Build a new one
-            const model = await this.getForEditing();
-            await this.setCachesFromModel(model);
-        });
+        await this.loadCachesForTenant(ROOT_TENANT_ID);
     }
 
     private static async setCachesFromModel(model: Platform) {
@@ -185,31 +213,46 @@ export class Platform extends QueryableModel {
         });
 
         // We clone to avoid the chance of updating the platform model
-        this.sharedPrivateStruct = struct.clone() as PlatformStruct & { privateConfig: PlatformPrivateConfig };
+        const privateStruct = struct.clone() as PlatformStruct & { privateConfig: PlatformPrivateConfig };
 
         const clone = struct.clone();
         clone.privateConfig = null;
 
-        // Audit logs render uuids from a bare id, so they cannot receive a platform through their
-        // call chain. Bind the resolver to the struct we are about to cache, so it is refreshed
-        // together with the caches. Uses the public struct on purpose: resolving privateConfig
-        // roles would change the names that get persisted in audit logs.
-        AuditLogReplacementDependencies.uuidToName = uuid => uuidToName(uuid, clone);
+        if (model.id === ROOT_TENANT_ID) {
+            // Audit logs render uuids from a bare id, so they cannot receive a platform through their
+            // call chain. Bind the resolver to the struct we are about to cache, so it is refreshed
+            // together with the caches. Uses the public struct on purpose: resolving privateConfig
+            // roles would change the names that get persisted in audit logs.
+            // Still process-wide: it becomes tenant-aware once a request carries its tenant.
+            AuditLogReplacementDependencies.uuidToName = uuid => uuidToName(uuid, clone);
+        }
 
-        this.sharedStruct = clone;
+        deepFreeze(model);
+
+        this.caches.set(model.id, {
+            model,
+            struct: clone,
+            privateStruct,
+        });
+    }
+
+    static async clearCacheForTenant(tenantId: string) {
+        await this.clearCacheForTenantWithoutRefresh(tenantId);
+        await this.loadCachesForTenant(tenantId);
+    }
+
+    static async clearCacheForTenantWithoutRefresh(tenantId: string) {
+        await QueueHandler.schedule('Platform.loadCaches-' + tenantId, async () => {
+            this.caches.delete(tenantId);
+        });
     }
 
     static async clearCache() {
-        await this.clearCacheWithoutRefresh();
-        await this.loadCaches();
+        await this.clearCacheForTenant(ROOT_TENANT_ID);
     }
 
     static async clearCacheWithoutRefresh() {
-        await QueueHandler.schedule('Platform.loadCaches', async () => {
-            this.sharedStruct = null;
-            this.sharedPrivateStruct = null;
-        });
-        this.shared = null;
+        await this.clearCacheForTenantWithoutRefresh(ROOT_TENANT_ID);
     }
 
     async save() {
@@ -220,8 +263,8 @@ export class Platform extends QueryableModel {
         const s = await super.save();
 
         if (update) {
-            // Force update cache immediately
-            await Platform.clearCache();
+            // Only this tenant's cache: another tenant's is unaffected by this save.
+            await Platform.clearCacheForTenant(this.id);
         }
 
         return s;


### PR DESCRIPTION
The three process-wide cache fields in `Platform` become a `Map` keyed by tenant id. `getSharedStruct()` and friends now resolve the root tenant explicitly, so nothing changes while one tenant exists.

Also: the `QueueHandler` key is namespaced per tenant (a global key would stall every tenant behind one tenant's reload), and saving a tenant only discards its own cache.

Doing this before `TenantContext` because the dependency runs that way — a context that can hold any tenant needs a cache it can key by tenant.

## Gotchas

`getForEditing` takes a tenant id but still only bootstraps a missing row for the **root** tenant; any other id throws `tenant_not_found`. Auto-creating would turn a typo'd tenant id into a silently empty tenant.

The audit-log uuid resolver (`AuditLogReplacementDependencies.uuidToName`) stays bound to the root tenant's struct, and is now explicitly guarded on it. It is process-wide and cannot be made correct per tenant until a request carries its tenant — that moves with `TenantContext`.

My first four tests all passed with a single global queue key, so the namespacing was completely untested while looking covered. The extra test occupies the key a process-wide cache would have used and shows the per-tenant load still completes; it times out if the keys are shared again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787984718&installation_model_id=423362&pr_number=682&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F682&signature=af61d8765caa042434321adc9ac644a14fbf94323d7e9b715317b45c52b8a0ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->