### PR TITLE
✨ Add TenantContext

### DIFF
--- a/backend/app/api/src/helpers/TenantContext.test.ts
+++ b/backend/app/api/src/helpers/TenantContext.test.ts
@@ -1,0 +1,96 @@
+import { Database } from '@simonbackx/simple-database';
+import { Platform, ROOT_TENANT_ID } from '@stamhoofd/models';
+import { PlatformConfig, PlatformMembershipType } from '@stamhoofd/structures';
+import { STExpect } from '@stamhoofd/test-utils';
+import { TenantContext } from './TenantContext.js';
+
+describe('TenantContext', () => {
+    test('there is no tenant outside a scope', () => {
+        expect(TenantContext.optional).toBeNull();
+        expect(() => TenantContext.current).toThrow(
+            STExpect.simpleError({ code: 'no_tenant_context' }),
+        );
+    });
+
+    test('currentOrRoot falls back to the root tenant', () => {
+        expect(TenantContext.currentOrRoot.tenantId).toBe(ROOT_TENANT_ID);
+    });
+
+    test('run enters a scope and leaves it again', async () => {
+        await TenantContext.run('tenant-a', async () => {
+            expect(TenantContext.current.tenantId).toBe('tenant-a');
+            expect(TenantContext.currentOrRoot.tenantId).toBe('tenant-a');
+        });
+
+        expect(TenantContext.optional).toBeNull();
+    });
+
+    test('a nested scope wins and the outer one is restored', async () => {
+        await TenantContext.run('tenant-a', async () => {
+            await TenantContext.run('tenant-b', async () => {
+                expect(TenantContext.current.tenantId).toBe('tenant-b');
+            });
+
+            expect(TenantContext.current.tenantId).toBe('tenant-a');
+        });
+    });
+
+    test('concurrent scopes do not leak into each other', async () => {
+        const seen: string[] = [];
+
+        const observe = async (tenantId: string, delay: number) => {
+            return await TenantContext.run(tenantId, async () => {
+                await new Promise(resolve => setTimeout(resolve, delay));
+                seen.push(`${tenantId}:${TenantContext.current.tenantId}`);
+                return TenantContext.current.tenantId;
+            });
+        };
+
+        // a enters first but resumes first too, so a save/restore of one mutable "current" would
+        // hand a whichever tenant entered after it
+        const [a, b] = await Promise.all([observe('tenant-a', 5), observe('tenant-b', 30)]);
+
+        expect(a).toBe('tenant-a');
+        expect(b).toBe('tenant-b');
+        expect(seen).toEqual(['tenant-a:tenant-a', 'tenant-b:tenant-b']);
+    });
+
+    describe('resolving the tenant', () => {
+        afterEach(async () => {
+            await Platform.clearCacheForTenantWithoutRefresh('context-tenant');
+            await Database.delete('DELETE FROM platform WHERE id != ?', [ROOT_TENANT_ID]);
+            await Platform.clearCache();
+        });
+
+        test('the scope resolves its own struct', async () => {
+            const root = await Platform.getForEditing();
+
+            const other = new Platform();
+            other.id = 'context-tenant';
+            other.periodId = root.periodId;
+            other.config = PlatformConfig.create({
+                membershipTypes: [PlatformMembershipType.create({ id: 'ct', name: 'Context tenant type' })],
+            });
+            await other.save();
+
+            await TenantContext.run('context-tenant', async () => {
+                const struct = await TenantContext.current.getStruct();
+                expect(struct.config.membershipTypes.map(m => m.name)).toEqual(['Context tenant type']);
+                expect(struct.privateConfig).toBeNull();
+
+                const privateStruct = await TenantContext.current.getPrivateStruct();
+                expect(privateStruct.privateConfig).not.toBeNull();
+
+                expect((await TenantContext.current.getTenant()).id).toBe('context-tenant');
+            });
+        });
+
+        test('an unknown tenant does not resolve', async () => {
+            await TenantContext.run('no-such-tenant', async () => {
+                await expect(TenantContext.current.getStruct()).rejects.toThrow(
+                    STExpect.simpleError({ code: 'tenant_not_found' }),
+                );
+            });
+        });
+    });
+});

--- a/backend/app/api/src/helpers/TenantContext.ts
+++ b/backend/app/api/src/helpers/TenantContext.ts
@@ -1,0 +1,67 @@
+import { SimpleError } from '@simonbackx/simple-errors';
+import { Platform, ROOT_TENANT_ID } from '@stamhoofd/models';
+import type { PlatformPrivateConfig, Platform as PlatformStruct } from '@stamhoofd/structures';
+import { AsyncLocalStorage } from 'async_hooks';
+
+export class TenantContextInstance {
+    readonly tenantId: string;
+
+    constructor(tenantId: string) {
+        this.tenantId = tenantId;
+    }
+
+    async getTenant(): Promise<Readonly<Platform>> {
+        return await Platform.getForTenant(this.tenantId);
+    }
+
+    async getStruct(): Promise<PlatformStruct> {
+        return await Platform.getStructForTenant(this.tenantId);
+    }
+
+    async getPrivateStruct(): Promise<PlatformStruct & { privateConfig: PlatformPrivateConfig }> {
+        return await Platform.getPrivateStructForTenant(this.tenantId);
+    }
+}
+
+/**
+ * The tenant the current work belongs to.
+ *
+ * Separate from Context on purpose: crons, migrations and queued jobs run for a fixed tenant with no
+ * request, no authentication and no user, so a request-scoped context cannot carry them.
+ */
+export class TenantContext {
+    private static asyncLocalStorage = new AsyncLocalStorage<TenantContextInstance>();
+
+    static get optional(): TenantContextInstance | null {
+        return this.asyncLocalStorage.getStore() ?? null;
+    }
+
+    static get current(): TenantContextInstance {
+        const c = this.optional;
+
+        if (!c) {
+            throw new SimpleError({
+                code: 'no_tenant_context',
+                message: 'No tenant context found',
+                statusCode: 500,
+            });
+        }
+
+        return c;
+    }
+
+    /**
+     * The current tenant, or the root tenant when nothing has entered a scope yet.
+     *
+     * Only for call sites that have not been given a tenant yet. Anything that already runs for a
+     * known tenant should use current, so a missing scope fails loudly instead of quietly reading
+     * the root tenant.
+     */
+    static get currentOrRoot(): TenantContextInstance {
+        return this.optional ?? new TenantContextInstance(ROOT_TENANT_ID);
+    }
+
+    static async run<T>(tenantId: string, handler: () => Promise<T>): Promise<T> {
+        return await this.asyncLocalStorage.run(new TenantContextInstance(tenantId), handler);
+    }
+}


### PR DESCRIPTION
Stacked on #682.

An `AsyncLocalStorage` holding the tenant the current work belongs to: `current`, `optional`, `currentOrRoot`, `run`. **Nothing uses it yet** — the request and cron entry points are the next PRs.

It is separate from `Context` because crons, migrations and queued jobs run for a fixed tenant with no request, authentication or user, so a request-scoped context cannot carry them.

## Gotchas

**No `runFor(tenantId, reason, fn)` yet.** The plan has it, but entering *another* tenant's scope is only needed for the billing crossings, and the audit log for a crossing belongs in the service that owns them, not in the primitive. Adding it now would be an audit-logging API with zero callers.

`currentOrRoot` exists so the ~107 existing `Platform.getShared*` call sites can be converted incrementally without each one having to be inside a scope first. It is deliberately a *separate* accessor from `current` rather than a fallback inside it — once a call site is supposed to have a tenant, a missing scope should throw rather than quietly read the root tenant.

My first version of the concurrency test passed against a deliberately wrong implementation (one mutable `current` with save/restore instead of `AsyncLocalStorage`). The interleaving mattered: I had the second scope finish first, which is exactly the case where save/restore happens to put back the right value. It now has the *first* scope resume first, where a mutable global hands it the wrong tenant — and that version does fail against the mutation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787985550&installation_model_id=423362&pr_number=683&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F683&signature=8ccba96330289647eb0068ff0326c1479bd04a958c61ec1ba9f0d92f5a991624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->