### PR TITLE
✨ Put every request in a tenant scope

### DIFF
--- a/backend/app/api/src/boot.ts
+++ b/backend/app/api/src/boot.ts
@@ -18,6 +18,7 @@ import { resumeEmails } from './helpers/EmailResumer.js';
 import { GlobalHelper } from './helpers/GlobalHelper.js';
 import { SetupStepUpdater } from './helpers/SetupStepUpdater.js';
 import { ContextMiddleware } from './middleware/ContextMiddleware.js';
+import { TenantScopeMiddleware } from './middleware/TenantScopeMiddleware.js';
 import { AuditLogService } from './services/AuditLogService.js';
 import { BalanceItemService } from './services/BalanceItemService.js';
 import { BootChecksService } from './services/BootChecksService.js';
@@ -136,6 +137,10 @@ export const boot = async (options: { killProcess: boolean }) => {
 
     // Contexts
     routerServer.addRequestMiddleware(ContextMiddleware);
+
+    // After ContextMiddleware on purpose: the last registered wrapRun is the outermost, and the
+    // tenant has to be in scope before the context that reads it.
+    routerServer.addRequestMiddleware(TenantScopeMiddleware);
 
     // Add version headers and minimum version
     const versionMiddleware = new VersionMiddleware({

--- a/backend/app/api/src/middleware/TenantScopeMiddleware.test.ts
+++ b/backend/app/api/src/middleware/TenantScopeMiddleware.test.ts
@@ -1,0 +1,41 @@
+import type { DecodedRequest } from '@simonbackx/simple-endpoints';
+import { Endpoint, Request, Response } from '@simonbackx/simple-endpoints';
+import { ROOT_TENANT_ID } from '@stamhoofd/models';
+import { testServer } from '../../tests/helpers/TestServer.js';
+import { TenantContext } from '../helpers/TenantContext.js';
+
+type Params = Record<string, never>;
+
+/**
+ * Reports the tenant scope it was reached in, so a request can assert what the middleware set up.
+ */
+class TenantProbeEndpoint extends Endpoint<Params, undefined, undefined, string> {
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'GET' || request.url !== '/tenant-probe') {
+            return [false];
+        }
+        return [true, {}];
+    }
+
+    async handle(_request: DecodedRequest<Params, undefined, undefined>) {
+        return new Response(TenantContext.optional?.tenantId ?? 'no-tenant');
+    }
+}
+
+describe('TenantScopeMiddleware', () => {
+    test('a request runs in a tenant scope', async () => {
+        const endpoint = new TenantProbeEndpoint();
+
+        const response = await testServer.test(endpoint, Request.buildJson('GET', '/tenant-probe', 'localhost'));
+
+        expect(response.body).toBe(ROOT_TENANT_ID);
+    });
+
+    test('the scope does not outlive the request', async () => {
+        const endpoint = new TenantProbeEndpoint();
+
+        await testServer.test(endpoint, Request.buildJson('GET', '/tenant-probe', 'localhost'));
+
+        expect(TenantContext.optional).toBeNull();
+    });
+});

--- a/backend/app/api/src/middleware/TenantScopeMiddleware.ts
+++ b/backend/app/api/src/middleware/TenantScopeMiddleware.ts
@@ -1,0 +1,24 @@
+import type { Request, RequestMiddleware } from '@simonbackx/simple-endpoints';
+import { ROOT_TENANT_ID } from '@stamhoofd/models';
+
+import { TenantContext } from '../helpers/TenantContext.js';
+
+/**
+ * Puts every request in a tenant scope.
+ *
+ * Every request resolves to the deployment's root tenant for now. Resolving it from the host is a
+ * later step; this exists so the scope is already there when it starts to matter.
+ *
+ * Register this *after* ContextMiddleware: wrapRun wrappers are applied in registration order, so
+ * the last one registered is the outermost. The tenant has to be in scope before the context that
+ * reads it.
+ */
+export const TenantScopeMiddleware: RequestMiddleware = {
+    wrapRun<T>(run: () => Promise<T>, _request: Request) {
+        return TenantContext.run(ROOT_TENANT_ID, run);
+    },
+
+    handleRequest() {
+        // Noop
+    },
+};

--- a/backend/app/api/tests/helpers/TestServer.ts
+++ b/backend/app/api/tests/helpers/TestServer.ts
@@ -3,12 +3,16 @@ import { VersionMiddleware } from '@stamhoofd/backend-middleware';
 import { Version } from '@stamhoofd/structures';
 
 import { ContextMiddleware } from '../../src/middleware/ContextMiddleware.js';
+import { TenantScopeMiddleware } from '../../src/middleware/TenantScopeMiddleware.js';
 import { FileSignService } from '../../src/services/FileSignService.js';
 
 export const testServer = new TestServer();
 
 // Contexts
 testServer.addRequestMiddleware(ContextMiddleware);
+
+// Registration order mirrors boot.ts
+testServer.addRequestMiddleware(TenantScopeMiddleware);
 testServer.addResponseMiddleware(FileSignService);
 testServer.addRequestMiddleware(FileSignService);
 


### PR DESCRIPTION
Stacked on #683. `TenantScopeMiddleware` enters `TenantContext` for each request — the root tenant for now; resolving it from the host comes with the tenant routing work.

## Gotcha

It is registered **after** `ContextMiddleware`, which looks backwards. `RouterServer` wraps each `wrapRun` around the previous one, so the *last* registered middleware is the *outermost* — and the tenant has to be in scope before the context that will read it.

Nothing reads the tenant during a request yet, so that ordering is not observable in a test. The test asserts the weaker property that actually holds today: an endpoint sees a tenant scope, and the scope does not outlive the request. Mutation-checked by unregistering the middleware.

`tests/helpers/TestServer.ts` gets the same registration so endpoint tests match production.