### PR TITLE
✨ Add the tenant identity to the platform structure

### DIFF
--- a/backend/shared/models/src/models/Platform.test.ts
+++ b/backend/shared/models/src/models/Platform.test.ts
@@ -1,4 +1,4 @@
-import { PlatformConfig, PlatformMembershipType } from '@stamhoofd/structures';
+import { PermissionRoleDetailed, PlatformConfig, PlatformMembershipType, PlatformPrivateConfig } from '@stamhoofd/structures';
 import { Platform } from './Platform.js';
 import { Database } from '@simonbackx/simple-database';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
@@ -126,6 +126,68 @@ describe('Model.Platform', () => {
             const editable = await Platform.getSharedStruct();
             expect(editable).toBeDefined();
             expect(await Platform.getByID('1')).toBeDefined();
+        });
+    });
+
+    describe('Parent tenant', () => {
+        afterEach(async () => {
+            await Database.delete('DELETE FROM platform WHERE id != ?', ['1']);
+            await Platform.clearCache();
+        });
+
+        async function createChildOfRoot() {
+            const root = await Platform.getForEditing();
+            root.privateConfig = PlatformPrivateConfig.create({
+                roles: [PermissionRoleDetailed.create({ name: 'root role' })],
+            });
+            root.config = PlatformConfig.create({
+                membershipTypes: [PlatformMembershipType.create({ id: 'r', name: 'Root type' })],
+            });
+            await root.save();
+
+            const child = new Platform();
+            child.id = 'child-tenant';
+            child.periodId = root.periodId;
+            child.parentTenantId = root.id;
+            await child.save();
+
+            return { root, child };
+        }
+
+        test('a child tenant struct carries its parent', async () => {
+            const { root } = await createChildOfRoot();
+
+            const struct = await Platform.getStructForTenant('child-tenant');
+
+            expect(struct.parentTenant?.id).toBe(root.id);
+            expect(struct.parentTenant?.config.membershipTypes.map(m => m.name)).toEqual(['Root type']);
+        });
+
+        test('the parent never carries its private config', async () => {
+            await createChildOfRoot();
+
+            // Both variants: a child tenant administrator has no rights on the parent either way
+            expect((await Platform.getStructForTenant('child-tenant')).parentTenant?.privateConfig).toBeNull();
+            expect((await Platform.getPrivateStructForTenant('child-tenant')).parentTenant?.privateConfig).toBeNull();
+        });
+
+        test('the parent is only one level deep', async () => {
+            const { root } = await createChildOfRoot();
+
+            const grandchild = new Platform();
+            grandchild.id = 'grandchild-tenant';
+            grandchild.periodId = root.periodId;
+            grandchild.parentTenantId = 'child-tenant';
+            await grandchild.save();
+
+            const struct = await Platform.getStructForTenant('grandchild-tenant');
+
+            expect(struct.parentTenant?.id).toBe('child-tenant');
+            expect(struct.parentTenant?.parentTenant).toBeNull();
+        });
+
+        test('the root tenant has no parent', async () => {
+            expect((await Platform.getStructForTenant('1')).parentTenant).toBeNull();
         });
     });
 

--- a/backend/shared/models/src/models/Platform.ts
+++ b/backend/shared/models/src/models/Platform.ts
@@ -230,6 +230,7 @@ export class Platform extends QueryableModel {
         const struct = PlatformStruct.create({
             ...model,
             period: period?.getStructure() ?? undefined,
+            parentTenant: await this.getParentStruct(model),
         });
 
         // We clone to avoid the chance of updating the platform model
@@ -253,6 +254,34 @@ export class Platform extends QueryableModel {
             model,
             struct: clone,
             privateStruct,
+        });
+    }
+
+    /**
+     * The immediate parent, without its own parent and without its private config.
+     *
+     * Reads the parent row directly instead of going through its cache: that keeps this one query
+     * deep, so a parentTenantId cycle cannot recurse, and it cannot hand a child tenant the parent's
+     * privateConfig.
+     */
+    private static async getParentStruct(model: Platform): Promise<PlatformStruct | null> {
+        if (!model.parentTenantId) {
+            return null;
+        }
+
+        const parent = await this.getByID(model.parentTenantId);
+        if (!parent) {
+            console.error('[Platform] Tenant ' + model.id + ' has an unknown parentTenantId', model.parentTenantId);
+            return null;
+        }
+
+        const parentPeriod = await RegistrationPeriod.getByID(parent.periodId);
+
+        return PlatformStruct.create({
+            ...parent,
+            period: parentPeriod?.getStructure() ?? undefined,
+            parentTenant: null,
+            privateConfig: null,
         });
     }
 

--- a/backend/shared/models/src/models/Platform.ts
+++ b/backend/shared/models/src/models/Platform.ts
@@ -210,6 +210,7 @@ export class Platform extends QueryableModel {
         const struct = PlatformStruct.create({
             ...model,
             period: period?.getStructure() ?? undefined,
+            parentTenant: await this.getParentStruct(model),
         });
 
         // We clone to avoid the chance of updating the platform model
@@ -233,6 +234,34 @@ export class Platform extends QueryableModel {
             model,
             struct: clone,
             privateStruct,
+        });
+    }
+
+    /**
+     * The immediate parent, without its own parent and without its private config.
+     *
+     * Reads the parent row directly instead of going through its cache: that keeps this one query
+     * deep, so a parentTenantId cycle cannot recurse, and it cannot hand a child tenant the parent's
+     * privateConfig.
+     */
+    private static async getParentStruct(model: Platform): Promise<PlatformStruct | null> {
+        if (!model.parentTenantId) {
+            return null;
+        }
+
+        const parent = await this.getByID(model.parentTenantId);
+        if (!parent) {
+            console.error('[Platform] Tenant ' + model.id + ' has an unknown parentTenantId', model.parentTenantId);
+            return null;
+        }
+
+        const parentPeriod = await RegistrationPeriod.getByID(parent.periodId);
+
+        return PlatformStruct.create({
+            ...parent,
+            period: parentPeriod?.getStructure() ?? undefined,
+            parentTenant: null,
+            privateConfig: null,
         });
     }
 

--- a/shared/structures/src/Platform.test.ts
+++ b/shared/structures/src/Platform.test.ts
@@ -74,7 +74,6 @@ describe('Platform tenant identity', () => {
     test('the identity survives an encode and decode', () => {
         const platform = Platform.create({
             id: 'tenant-a',
-            parentTenantId: 'tenant-root',
             feesTenantId: 'tenant-root',
             uri: 'tenant-a',
             domain: 'a.example.com',
@@ -83,40 +82,27 @@ describe('Platform tenant identity', () => {
         const decoded = roundtrip(platform);
 
         expect(decoded.id).toBe('tenant-a');
-        expect(decoded.parentTenantId).toBe('tenant-root');
         expect(decoded.feesTenantId).toBe('tenant-root');
         expect(decoded.uri).toBe('tenant-a');
         expect(decoded.domain).toBe('a.example.com');
     });
 
+    test('the parent tenant survives an encode and decode', () => {
+        const platform = Platform.create({
+            id: 'tenant-a',
+            parentTenant: Platform.create({ id: 'tenant-root', uri: 'root' }),
+        });
+
+        const decoded = roundtrip(platform);
+
+        expect(decoded.parentTenant?.id).toBe('tenant-root');
+        expect(decoded.parentTenant?.uri).toBe('root');
+    });
+
     test('a root tenant has no parent and charges its own fees', () => {
         const decoded = roundtrip(Platform.create({ id: '1', feesTenantId: '1' }));
 
-        expect(decoded.parentTenantId).toBeNull();
+        expect(decoded.parentTenant).toBeNull();
         expect(decoded.feesTenantId).toBe('1');
-    });
-
-    test('data stored before tenants existed still decodes', () => {
-        // A client on an older version never sent these fields
-        const decoded = Platform.decode(new ObjectData({
-            config: {},
-            privateConfig: null,
-            period: Platform.create({}).period.encode({ version: Version - 1 }),
-        }, { version: Version - 1 }));
-
-        expect(decoded.id).toBe('');
-        expect(decoded.parentTenantId).toBeNull();
-        expect(decoded.feesTenantId).toBeNull();
-        expect(decoded.uri).toBeNull();
-        expect(decoded.domain).toBeNull();
-    });
-
-    test('an older client is not sent the tenant identity', () => {
-        const platform = Platform.create({ id: 'tenant-a', uri: 'tenant-a' });
-
-        const encoded = platform.encode({ version: Version - 1 }) as Record<string, unknown>;
-
-        expect(encoded.id).toBeUndefined();
-        expect(encoded.uri).toBeUndefined();
     });
 });

--- a/shared/structures/src/Platform.test.ts
+++ b/shared/structures/src/Platform.test.ts
@@ -66,6 +66,11 @@ describe('PlatformMembershipTypeConfig', () => {
 });
 
 describe('Platform tenant identity', () => {
+    // A fixed version from before these fields existed. Not Version - 1: these fields land at
+    // NextVersion, so once Version is bumped on release, Version - 1 would be a version that *does*
+    // have them and the backwards compatibility assertions below would silently stop testing anything.
+    const versionBeforeTenants = 400;
+
     function roundtrip(platform: Platform, version: number = Version): Platform {
         const encoded = JSON.parse(JSON.stringify(platform.encode({ version })));
         return Platform.decode(new ObjectData(encoded, { version }));
@@ -74,7 +79,6 @@ describe('Platform tenant identity', () => {
     test('the identity survives an encode and decode', () => {
         const platform = Platform.create({
             id: 'tenant-a',
-            parentTenantId: 'tenant-root',
             feesTenantId: 'tenant-root',
             uri: 'tenant-a',
             domain: 'a.example.com',
@@ -83,40 +87,55 @@ describe('Platform tenant identity', () => {
         const decoded = roundtrip(platform);
 
         expect(decoded.id).toBe('tenant-a');
-        expect(decoded.parentTenantId).toBe('tenant-root');
         expect(decoded.feesTenantId).toBe('tenant-root');
         expect(decoded.uri).toBe('tenant-a');
         expect(decoded.domain).toBe('a.example.com');
     });
 
+    test('the parent tenant survives an encode and decode', () => {
+        const platform = Platform.create({
+            id: 'tenant-a',
+            parentTenant: Platform.create({ id: 'tenant-root', uri: 'root' }),
+        });
+
+        const decoded = roundtrip(platform);
+
+        expect(decoded.parentTenant?.id).toBe('tenant-root');
+        expect(decoded.parentTenant?.uri).toBe('root');
+    });
+
     test('a root tenant has no parent and charges its own fees', () => {
         const decoded = roundtrip(Platform.create({ id: '1', feesTenantId: '1' }));
 
-        expect(decoded.parentTenantId).toBeNull();
+        expect(decoded.parentTenant).toBeNull();
         expect(decoded.feesTenantId).toBe('1');
     });
 
     test('data stored before tenants existed still decodes', () => {
-        // A client on an older version never sent these fields
         const decoded = Platform.decode(new ObjectData({
             config: {},
             privateConfig: null,
-            period: Platform.create({}).period.encode({ version: Version - 1 }),
-        }, { version: Version - 1 }));
+            period: Platform.create({}).period.encode({ version: versionBeforeTenants }),
+        }, { version: versionBeforeTenants }));
 
         expect(decoded.id).toBe('');
-        expect(decoded.parentTenantId).toBeNull();
+        expect(decoded.parentTenant).toBeNull();
         expect(decoded.feesTenantId).toBeNull();
         expect(decoded.uri).toBeNull();
         expect(decoded.domain).toBeNull();
     });
 
     test('an older client is not sent the tenant identity', () => {
-        const platform = Platform.create({ id: 'tenant-a', uri: 'tenant-a' });
+        const platform = Platform.create({
+            id: 'tenant-a',
+            uri: 'tenant-a',
+            parentTenant: Platform.create({ id: 'tenant-root' }),
+        });
 
-        const encoded = platform.encode({ version: Version - 1 }) as Record<string, unknown>;
+        const encoded = platform.encode({ version: versionBeforeTenants }) as Record<string, unknown>;
 
         expect(encoded.id).toBeUndefined();
         expect(encoded.uri).toBeUndefined();
+        expect(encoded.parentTenant).toBeUndefined();
     });
 });

--- a/shared/structures/src/Platform.test.ts
+++ b/shared/structures/src/Platform.test.ts
@@ -1,5 +1,7 @@
+import { ObjectData } from '@simonbackx/simple-encoding';
 import { Formatter } from '@stamhoofd/utility';
-import { PlatformMembershipTypeBehaviour, PlatformMembershipTypeConfig } from './Platform.js';
+import { Platform, PlatformMembershipTypeBehaviour, PlatformMembershipTypeConfig } from './Platform.js';
+import { Version } from './Version.js';
 
 describe('PlatformMembershipTypeConfig', () => {
     describe('getMaximumEndDate', () => {
@@ -60,5 +62,61 @@ describe('PlatformMembershipTypeConfig', () => {
             expect(maximumEndDateBrussels.minute).toBe(59);
             expect(maximumEndDateBrussels.second).toBe(59);
         });
+    });
+});
+
+describe('Platform tenant identity', () => {
+    function roundtrip(platform: Platform, version: number = Version): Platform {
+        const encoded = JSON.parse(JSON.stringify(platform.encode({ version })));
+        return Platform.decode(new ObjectData(encoded, { version }));
+    }
+
+    test('the identity survives an encode and decode', () => {
+        const platform = Platform.create({
+            id: 'tenant-a',
+            parentTenantId: 'tenant-root',
+            feesTenantId: 'tenant-root',
+            uri: 'tenant-a',
+            domain: 'a.example.com',
+        });
+
+        const decoded = roundtrip(platform);
+
+        expect(decoded.id).toBe('tenant-a');
+        expect(decoded.parentTenantId).toBe('tenant-root');
+        expect(decoded.feesTenantId).toBe('tenant-root');
+        expect(decoded.uri).toBe('tenant-a');
+        expect(decoded.domain).toBe('a.example.com');
+    });
+
+    test('a root tenant has no parent and charges its own fees', () => {
+        const decoded = roundtrip(Platform.create({ id: '1', feesTenantId: '1' }));
+
+        expect(decoded.parentTenantId).toBeNull();
+        expect(decoded.feesTenantId).toBe('1');
+    });
+
+    test('data stored before tenants existed still decodes', () => {
+        // A client on an older version never sent these fields
+        const decoded = Platform.decode(new ObjectData({
+            config: {},
+            privateConfig: null,
+            period: Platform.create({}).period.encode({ version: Version - 1 }),
+        }, { version: Version - 1 }));
+
+        expect(decoded.id).toBe('');
+        expect(decoded.parentTenantId).toBeNull();
+        expect(decoded.feesTenantId).toBeNull();
+        expect(decoded.uri).toBeNull();
+        expect(decoded.domain).toBeNull();
+    });
+
+    test('an older client is not sent the tenant identity', () => {
+        const platform = Platform.create({ id: 'tenant-a', uri: 'tenant-a' });
+
+        const encoded = platform.encode({ version: Version - 1 }) as Record<string, unknown>;
+
+        expect(encoded.id).toBeUndefined();
+        expect(encoded.uri).toBeUndefined();
     });
 });

--- a/shared/structures/src/Platform.ts
+++ b/shared/structures/src/Platform.ts
@@ -564,9 +564,13 @@ export class Platform extends AutoEncoder {
 
     /**
      * The tenant this tenant belongs to. Null for a root tenant.
+     *
+     * Only the immediate parent, and only its public data: its own parentTenant and privateConfig are
+     * always null. Nesting the whole chain would put every ancestor's config on every response, and a
+     * child tenant's administrators have no rights on the parent.
      */
-    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
-    parentTenantId: string | null = null;
+    @field({ decoder: Platform, nullable: true, ...NextVersion })
+    parentTenant: Platform | null = null;
 
     /**
      * The tenant that charges this one for packages, transfer fees, service fees and invoices.

--- a/shared/structures/src/Platform.ts
+++ b/shared/structures/src/Platform.ts
@@ -549,6 +549,33 @@ export class PlatformConfig extends AutoEncoder {
 }
 
 export class Platform extends AutoEncoder {
+    /**
+     * Empty when it was decoded from data stored before tenants existed.
+     */
+    @field({ decoder: StringDecoder, ...NextVersion })
+    id: string = '';
+
+    /**
+     * The tenant this tenant belongs to. Null for a root tenant.
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    parentTenantId: string | null = null;
+
+    /**
+     * The tenant that charges this one for packages, transfer fees, service fees and invoices.
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    feesTenantId: string | null = null;
+
+    /**
+     * Globally unique, shares its namespace with Organization.uri.
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    uri: string | null = null;
+
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    domain: string | null = null;
+
     @field({ decoder: PlatformConfig })
     config: PlatformConfig = PlatformConfig.create({});
 

--- a/shared/structures/src/Platform.ts
+++ b/shared/structures/src/Platform.ts
@@ -557,9 +557,13 @@ export class Platform extends AutoEncoder {
 
     /**
      * The tenant this tenant belongs to. Null for a root tenant.
+     *
+     * Only the immediate parent, and only its public data: its own parentTenant and privateConfig are
+     * always null. Nesting the whole chain would put every ancestor's config on every response, and a
+     * child tenant's administrators have no rights on the parent.
      */
-    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
-    parentTenantId: string | null = null;
+    @field({ decoder: Platform, nullable: true, ...NextVersion })
+    parentTenant: Platform | null = null;
 
     /**
      * The tenant that charges this one for packages, transfer fees, service fees and invoices.

--- a/shared/structures/src/Platform.ts
+++ b/shared/structures/src/Platform.ts
@@ -556,6 +556,33 @@ export class PlatformConfig extends AutoEncoder {
 }
 
 export class Platform extends AutoEncoder {
+    /**
+     * Empty when it was decoded from data stored before tenants existed.
+     */
+    @field({ decoder: StringDecoder, ...NextVersion })
+    id: string = '';
+
+    /**
+     * The tenant this tenant belongs to. Null for a root tenant.
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    parentTenantId: string | null = null;
+
+    /**
+     * The tenant that charges this one for packages, transfer fees, service fees and invoices.
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    feesTenantId: string | null = null;
+
+    /**
+     * Globally unique, shares its namespace with Organization.uri.
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    uri: string | null = null;
+
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    domain: string | null = null;
+
     @field({ decoder: PlatformConfig })
     config: PlatformConfig = PlatformConfig.create({});
 


### PR DESCRIPTION
Phase 4, and independent of the open #683→#688 stack. Puts `id`, `parentTenantId`, `feesTenantId`, `uri` and `domain` on the `Platform` structure at `...NextVersion`, matching the columns added in #680. Nothing reads them yet — this is so the frontend can resolve a tenant from its host later without a second wire change.

Read the versioning guide first, per the project rule. No `Version.ts` edit, no field removed or renamed.

## Gotchas

**`id` defaults to `''`, not a fresh uuid.** The frontend caches the platform in a `VersionBox`, so data stored before these fields existed decodes at its stored version with the defaults applied — and a `uuidv4()` default would invent a *different* tenant id on every decode of a stale cache. Empty is honest and easy to guard on.

**These do not become writable over the API.** `PatchPlatformEnpoint` applies every field explicitly (`if (request.body.membershipOrganizationId !== undefined)` and friends) rather than applying the patch wholesale, so adding fields to the structure does not expose them. Worth stating because if it *had* applied patches wholesale, adding `domain` here would have let a platform admin take over another tenant's host.

**No `flags` object yet.** The plan bundles it here to avoid a second wire change, but that reasoning does not hold: `flags` would be an AutoEncoder, and adding fields *inside* it later is exactly as cheap as adding it now. No flag has a consumer until the ancestor-trust and `userMode` work, so it lands with the first one that does.

## Gates

Ran the frontend component suite too, since a structures change ripples both ways: structures 300, models 66, api 1175, components 256. Mutation-checked the version gate — dropping `...NextVersion` from `id` fails the "older client is not sent the tenant identity" test.