### PR TITLE
✨ Answer GET /tenant as well as GET /platform

### DIFF
--- a/backend/app/api/src/endpoints/global/platform/GetPlatformEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/platform/GetPlatformEndpoint.test.ts
@@ -9,8 +9,8 @@ import { GetPlatformEndpoint } from './GetPlatformEndpoint.js';
 describe('Endpoint.GetPlatformEndpoint', () => {
     const endpoint = new GetPlatformEndpoint();
 
-    const getPlatform = async (token?: Token) => {
-        const request = Request.buildJson('GET', `/v${Version}/platform`);
+    const getPlatform = async (token?: Token, path = 'platform') => {
+        const request = Request.buildJson('GET', `/v${Version}/${path}`);
         if (token) {
             request.headers.authorization = 'Bearer ' + token.accessToken;
         }
@@ -64,5 +64,26 @@ describe('Endpoint.GetPlatformEndpoint', () => {
         token.accessToken = 'invalid-token';
         await token.save();
         await expect(getPlatform(token)).rejects.toThrow('The access token is invalid');
+    });
+
+    describe('/tenant', () => {
+        test('it answers on the canonical path too', async () => {
+            const viaTenant = await getPlatform(undefined, 'tenant');
+            const viaPlatform = await getPlatform(undefined, 'platform');
+
+            expect(viaTenant.body.privateConfig).toBeNull();
+            expect(viaTenant.body.encode({ version: Version })).toEqual(viaPlatform.body.encode({ version: Version }));
+        });
+
+        test('it applies the same authorization', async () => {
+            const user = await new UserFactory({
+                globalPermissions: Permissions.create({ level: PermissionLevel.Full }),
+            }).create();
+            const token = await Token.createToken(user);
+
+            const response = await getPlatform(token, 'tenant');
+
+            expect(response.body.privateConfig).not.toBeNull();
+        });
     });
 });

--- a/backend/app/api/src/endpoints/global/platform/GetPlatformEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/platform/GetPlatformEndpoint.test.ts
@@ -2,17 +2,16 @@ import { Request } from '@simonbackx/simple-endpoints';
 import type { Token } from '@stamhoofd/models';
 import { UserFactory } from '@stamhoofd/models';
 import { PermissionLevel, Permissions, Version } from '@stamhoofd/structures';
-import { SessionService } from '../../../services/SessionService.js';
-
 import { TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { SessionService } from '../../../services/SessionService.js';
 import { GetPlatformEndpoint } from './GetPlatformEndpoint.js';
 
 describe('Endpoint.GetPlatformEndpoint', () => {
     const endpoint = new GetPlatformEndpoint();
 
-    const getPlatform = async (token?: Token) => {
-        const request = Request.buildJson('GET', `/v${Version}/platform`);
+    const getPlatform = async (token?: Token, path = 'platform') => {
+        const request = Request.buildJson('GET', `/v${Version}/${path}`);
         if (token) {
             request.headers.authorization = 'Bearer ' + token.accessToken;
         }
@@ -66,5 +65,26 @@ describe('Endpoint.GetPlatformEndpoint', () => {
         token.accessToken = 'invalid-token';
         await token.save();
         await expect(getPlatform(token)).rejects.toThrow('The access token is invalid');
+    });
+
+    describe('/tenant', () => {
+        test('it answers on the canonical path too', async () => {
+            const viaTenant = await getPlatform(undefined, 'tenant');
+            const viaPlatform = await getPlatform(undefined, 'platform');
+
+            expect(viaTenant.body.privateConfig).toBeNull();
+            expect(viaTenant.body.encode({ version: Version })).toEqual(viaPlatform.body.encode({ version: Version }));
+        });
+
+        test('it applies the same authorization', async () => {
+            const user = await new UserFactory({
+                globalPermissions: Permissions.create({ level: PermissionLevel.Full }),
+            }).create();
+            const token = await SessionService.createSession(user);
+
+            const response = await getPlatform(token, 'tenant');
+
+            expect(response.body.privateConfig).not.toBeNull();
+        });
     });
 });

--- a/backend/app/api/src/endpoints/global/platform/GetPlatformEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/platform/GetPlatformEndpoint.ts
@@ -1,9 +1,9 @@
 import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
-import { Platform } from '@stamhoofd/models';
 import type { Platform as PlatformStruct } from '@stamhoofd/structures';
 
 import { Context } from '../../../helpers/Context.js';
+import { TenantContext } from '../../../helpers/TenantContext.js';
 
 type Params = Record<string, never>;
 type Query = undefined;
@@ -16,10 +16,14 @@ export class GetPlatformEndpoint extends Endpoint<Params, Query, Body, ResponseB
             return [false];
         }
 
-        const params = Endpoint.parseParameters(request.url, '/platform', {});
+        // /tenant is the canonical name. /platform stays forever: cached web apps and installed
+        // mobile apps keep asking for it.
+        for (const path of ['/tenant', '/platform']) {
+            const params = Endpoint.parseParameters(request.url, path, {});
 
-        if (params) {
-            return [true, params as Params];
+            if (params) {
+                return [true, params as Params];
+            }
         }
         return [false];
     }
@@ -29,13 +33,13 @@ export class GetPlatformEndpoint extends Endpoint<Params, Query, Body, ResponseB
         await Context.optionalAuthenticate({ allowWithoutAccount: false });
 
         if (Context.optionalAuth?.hasSomePlatformAccess()) {
-            const platform = await Platform.getSharedPrivateStruct();
+            const platform = await TenantContext.current.getPrivateStruct();
             if (!platform.privateConfig) {
                 throw new Error('Private config not found');
             }
             return new Response(platform);
         }
-        const platform = await Platform.getSharedStruct();
+        const platform = await TenantContext.current.getStruct();
         return new Response(platform);
     }
 }


### PR DESCRIPTION
Same endpoint, same authorization, same response body — `/tenant` is just the canonical name. `/platform` stays forever: cached web apps and installed mobile apps keep asking for it.

It also resolves through `TenantContext` instead of `Platform.getShared*`. Safe here because an endpoint always runs inside `TenantScopeMiddleware`, so a scope is guaranteed — unlike the ~100 other `getShared*` call sites, which I'm deliberately not sweeping.

One endpoint matching two paths rather than a second class, so the two can't drift apart in authorization.

Mutation-checked: removing `/tenant` from the match list fails both new tests.