### PR TITLE
✨ Let Caddy get certificates for tenant domains

### DIFF
--- a/backend/app/api/src/endpoints/global/caddy/CheckDomainCertEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/caddy/CheckDomainCertEndpoint.test.ts
@@ -1,0 +1,85 @@
+import { Database } from '@simonbackx/simple-database';
+import { Request } from '@simonbackx/simple-endpoints';
+import { OrganizationFactory, Platform, ROOT_TENANT_ID } from '@stamhoofd/models';
+import { Version } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+
+import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { CheckDomainCertEndpoint } from './CheckDomainCertEndpoint.js';
+
+describe('Endpoint.CheckDomainCertEndpoint', () => {
+    const endpoint = new CheckDomainCertEndpoint();
+
+    const ask = async (domain: string) => {
+        return await testServer.test(
+            endpoint,
+            Request.buildJson('GET', `/v${Version}/check-domain-cert?domain=${encodeURIComponent(domain)}`),
+        );
+    };
+
+    let registrationDomain: string;
+
+    beforeEach(async () => {
+        registrationDomain = [...new Set(Object.values(STAMHOOFD.domains.registration ?? {}))][0];
+        endpoint.registrationDomains = [registrationDomain];
+    });
+
+    afterEach(async () => {
+        await Database.delete('DELETE FROM platform WHERE id != ?', [ROOT_TENANT_ID]);
+        await Platform.clearCache();
+    });
+
+    async function createTenant(options: { uri?: string; domain?: string }) {
+        const root = await Platform.getForEditing();
+
+        const tenant = new Platform();
+        tenant.id = 'cert-tenant';
+        tenant.periodId = root.periodId;
+        tenant.uri = options.uri ?? null;
+        tenant.domain = options.domain ?? null;
+        await tenant.save();
+
+        return tenant;
+    }
+
+    test('an unknown domain is refused', async () => {
+        await expect(ask('nope.example.com')).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_domain' }),
+        );
+    });
+
+    test('an organization uri is still accepted', async () => {
+        const organization = await new OrganizationFactory({}).create();
+
+        await expect(ask(`${organization.uri}.${registrationDomain}`)).resolves.toBeDefined();
+    });
+
+    test('a tenant uri is accepted', async () => {
+        await createTenant({ uri: 'cert-tenant-uri' });
+
+        await expect(ask(`cert-tenant-uri.${registrationDomain}`)).resolves.toBeDefined();
+    });
+
+    test('an unknown uri is still refused', async () => {
+        await createTenant({ uri: 'cert-tenant-uri' });
+
+        await expect(ask(`something-else.${registrationDomain}`)).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_domain' }),
+        );
+    });
+
+    test('a tenant domain is accepted', async () => {
+        await createTenant({ domain: 'tenant.example.com' });
+
+        await expect(ask('tenant.example.com')).resolves.toBeDefined();
+    });
+
+    test('a tenant without a uri or domain matches nothing', async () => {
+        await createTenant({ uri: undefined, domain: undefined });
+
+        await expect(ask(`.${registrationDomain}`)).rejects.toThrow();
+        await expect(ask(`unclaimed.${registrationDomain}`)).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_domain' }),
+        );
+    });
+});

--- a/backend/app/api/src/endpoints/global/caddy/CheckDomainCertEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/caddy/CheckDomainCertEndpoint.ts
@@ -3,7 +3,7 @@ import { AutoEncoder, field, StringDecoder } from '@simonbackx/simple-encoding';
 import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { Organization, Webshop } from '@stamhoofd/models';
+import { Organization, Platform, Webshop } from '@stamhoofd/models';
 type Params = Record<string, never>;
 
 class Query extends AutoEncoder {
@@ -48,14 +48,20 @@ export class CheckDomainCertEndpoint extends Endpoint<Params, Query, Body, Respo
                 // Search for the URI
                 const organization = await Organization.getByURI(strippped);
 
-                if (!organization) {
-                    throw new SimpleError({
-                        code: 'unknown_domain',
-                        message: 'Not known',
-                        statusCode: 404,
-                    });
+                if (organization) {
+                    return new Response(undefined);
                 }
-                return new Response(undefined);
+
+                // A tenant serves its organizations from <tenant-uri>.<registrationDomain> too
+                if (await Platform.getByURI(strippped)) {
+                    return new Response(undefined);
+                }
+
+                throw new SimpleError({
+                    code: 'unknown_domain',
+                    message: 'Not known',
+                    statusCode: 404,
+                });
             }
         }
 
@@ -91,6 +97,11 @@ export class CheckDomainCertEndpoint extends Endpoint<Params, Query, Body, Respo
 
         const webshops = await Webshop.getByDomainOnly(request.query.domain);
         if (webshops.length > 0) {
+            return new Response(undefined);
+        }
+
+        // A tenant with its own domain
+        if (await Platform.getByDomain(request.query.domain)) {
             return new Response(undefined);
         }
 

--- a/backend/shared/models/src/models/Platform.ts
+++ b/backend/shared/models/src/models/Platform.ts
@@ -125,6 +125,26 @@ export class Platform extends QueryableModel {
         return await this.getPrivateStructForTenant(ROOT_TENANT_ID);
     }
 
+    /**
+     * Both columns are nullable. Blank input is rejected so a caller cannot ask for "the tenant with
+     * no uri" — SQL would not match NULL with '=' anyway, but an explicit reject beats relying on it.
+     */
+    static async getByURI(uri: string): Promise<Platform | undefined> {
+        if (!uri) {
+            return undefined;
+        }
+
+        return await this.select().where('uri', uri).first(false) ?? undefined;
+    }
+
+    static async getByDomain(domain: string): Promise<Platform | undefined> {
+        if (!domain) {
+            return undefined;
+        }
+
+        return await this.select().where('domain', domain).first(false) ?? undefined;
+    }
+
     static async getForEditing(tenantId: string = ROOT_TENANT_ID): Promise<Platform> {
         return QueueHandler.schedule('Platform.getModel-' + tenantId, async () => {
             // Build a new one


### PR DESCRIPTION
`CheckDomainCertEndpoint` is Caddy's `ask`. A 404 means the site is **down with a TLS error**, and Let's Encrypt rate-limits the retries — so it has to know tenant domains at least one release *before* the first tenant domain exists. That deployment ordering is the whole reason this lands now, well ahead of the routing work.

It accepts `<tenant-uri>.<registrationDomain>` and a tenant's own `domain`, alongside the existing organization lookups. Still unauthenticated and unscoped, as it must be.

Also adds the endpoint's first tests — it had none.

## Gotcha

`Platform.getByURI` / `getByDomain` reject blank input, but **not** as a security guard, which is what I first wrote. Both columns are nullable, and I assumed a blank lookup could match a tenant that hadn't set one and hand out a certificate for a domain nobody owns. It can't: SQL never matches `NULL` with `=`. The mutation test proved it — removing the guard failed nothing. The reject stays as a cheap explicit check rather than relying on that, and the comment now says so.

Mutation-checked the part that does matter: removing the two tenant lookups fails exactly the two tenant tests.