### PR TITLE
✨ Add tenant lookups by domain and uri

### DIFF
--- a/backend/app/api/src/endpoints/global/platform/GetTenantFromDomainEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/platform/GetTenantFromDomainEndpoint.test.ts
@@ -1,0 +1,114 @@
+import { Database } from '@simonbackx/simple-database';
+import { Request } from '@simonbackx/simple-endpoints';
+import { Platform, ROOT_TENANT_ID, Token, UserFactory } from '@stamhoofd/models';
+import { PermissionLevel, Permissions, PlatformPrivateConfig, Version } from '@stamhoofd/structures';
+import { STExpect } from '@stamhoofd/test-utils';
+
+import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { GetTenantFromDomainEndpoint } from './GetTenantFromDomainEndpoint.js';
+import { GetTenantFromUriEndpoint } from './GetTenantFromUriEndpoint.js';
+
+describe('Endpoint.GetTenantFrom*', () => {
+    const domainEndpoint = new GetTenantFromDomainEndpoint();
+    const uriEndpoint = new GetTenantFromUriEndpoint();
+
+    let registrationDomain: string;
+
+    beforeEach(() => {
+        registrationDomain = [...new Set(Object.values(STAMHOOFD.domains.registration ?? {}))][0];
+        domainEndpoint.registrationDomains = [registrationDomain];
+    });
+
+    afterEach(async () => {
+        await Database.delete('DELETE FROM platform WHERE id != ?', [ROOT_TENANT_ID]);
+        await Platform.clearCache();
+    });
+
+    async function createTenant(options: { uri?: string; domain?: string }) {
+        const root = await Platform.getForEditing();
+
+        const tenant = new Platform();
+        tenant.id = 'lookup-tenant';
+        tenant.periodId = root.periodId;
+        tenant.uri = options.uri ?? null;
+        tenant.domain = options.domain ?? null;
+        tenant.privateConfig = PlatformPrivateConfig.create({});
+        await tenant.save();
+
+        return tenant;
+    }
+
+    const byDomain = async (domain: string, token?: Token) => {
+        const request = Request.buildJson('GET', `/v${Version}/tenant-from-domain?domain=${encodeURIComponent(domain)}`);
+        if (token) {
+            request.headers.authorization = 'Bearer ' + token.accessToken;
+        }
+        return await testServer.test(domainEndpoint, request);
+    };
+
+    const byUri = async (uri: string) => {
+        return await testServer.test(
+            uriEndpoint,
+            Request.buildJson('GET', `/v${Version}/tenant-from-uri?uri=${encodeURIComponent(uri)}`),
+        );
+    };
+
+    test('it resolves a tenant by its own domain', async () => {
+        await createTenant({ domain: 'lookup.example.com' });
+
+        const response = await byDomain('lookup.example.com');
+
+        expect(response.body).toBe(await Platform.getStructForTenant('lookup-tenant'));
+    });
+
+    test('it resolves a tenant served from the registration domain', async () => {
+        await createTenant({ uri: 'lookup-uri' });
+
+        const response = await byDomain(`lookup-uri.${registrationDomain}`);
+
+        expect(response.body).toBe(await Platform.getStructForTenant('lookup-tenant'));
+    });
+
+    test('an unknown host is a 404', async () => {
+        await expect(byDomain('nobody.example.com')).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_domain' }),
+        );
+    });
+
+    test('a deeper subdomain is not resolved', async () => {
+        await createTenant({ uri: 'lookup-uri' });
+
+        await expect(byDomain(`deeper.lookup-uri.${registrationDomain}`)).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_domain' }),
+        );
+    });
+
+    test('it never answers with the private config', async () => {
+        await createTenant({ domain: 'lookup.example.com' });
+
+        // Even for a platform administrator: this endpoint is unauthenticated, so it must not become
+        // a second way to read privateConfig
+        const user = await new UserFactory({
+            globalPermissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await Token.createToken(user);
+
+        expect((await byDomain('lookup.example.com')).body.privateConfig).toBeNull();
+        expect((await byDomain('lookup.example.com', token)).body.privateConfig).toBeNull();
+    });
+
+    test('it resolves a tenant by uri', async () => {
+        await createTenant({ uri: 'lookup-uri' });
+
+        const response = await byUri('lookup-uri');
+
+        expect(response.body).toBe(await Platform.getStructForTenant('lookup-tenant'));
+        expect(response.body.privateConfig).toBeNull();
+    });
+
+    test('an unknown uri is a 404', async () => {
+        await expect(byUri('nobody')).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_uri' }),
+        );
+    });
+});

--- a/backend/app/api/src/endpoints/global/platform/GetTenantFromDomainEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/platform/GetTenantFromDomainEndpoint.test.ts
@@ -1,0 +1,116 @@
+import { Database } from '@simonbackx/simple-database';
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Token } from '@stamhoofd/models';
+import { Platform, ROOT_TENANT_ID, UserFactory } from '@stamhoofd/models';
+import { PermissionLevel, Permissions, PlatformPrivateConfig, Version } from '@stamhoofd/structures';
+import { STExpect } from '@stamhoofd/test-utils';
+
+import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { SessionService } from '../../../services/SessionService.js';
+import { GetTenantFromDomainEndpoint } from './GetTenantFromDomainEndpoint.js';
+import { GetTenantFromUriEndpoint } from './GetTenantFromUriEndpoint.js';
+
+describe('Endpoint.GetTenantFrom*', () => {
+    const domainEndpoint = new GetTenantFromDomainEndpoint();
+    const uriEndpoint = new GetTenantFromUriEndpoint();
+
+    let registrationDomain: string;
+
+    beforeEach(() => {
+        registrationDomain = [...new Set(Object.values(STAMHOOFD.domains.registration ?? {}))][0];
+        domainEndpoint.registrationDomains = [registrationDomain];
+    });
+
+    afterEach(async () => {
+        await Database.delete('DELETE FROM platform WHERE id != ?', [ROOT_TENANT_ID]);
+        await Platform.clearCache();
+    });
+
+    async function createTenant(options: { uri?: string; domain?: string }) {
+        const root = await Platform.getForEditing();
+
+        const tenant = new Platform();
+        tenant.id = 'lookup-tenant';
+        tenant.periodId = root.periodId;
+        tenant.uri = options.uri ?? null;
+        tenant.domain = options.domain ?? null;
+        tenant.privateConfig = PlatformPrivateConfig.create({});
+        await tenant.save();
+
+        return tenant;
+    }
+
+    const byDomain = async (domain: string, token?: Token) => {
+        const request = Request.buildJson('GET', `/v${Version}/tenant-from-domain?domain=${encodeURIComponent(domain)}`);
+        if (token) {
+            request.headers.authorization = 'Bearer ' + token.accessToken;
+        }
+        return await testServer.test(domainEndpoint, request);
+    };
+
+    const byUri = async (uri: string) => {
+        return await testServer.test(
+            uriEndpoint,
+            Request.buildJson('GET', `/v${Version}/tenant-from-uri?uri=${encodeURIComponent(uri)}`),
+        );
+    };
+
+    test('it resolves a tenant by its own domain', async () => {
+        await createTenant({ domain: 'lookup.example.com' });
+
+        const response = await byDomain('lookup.example.com');
+
+        expect(response.body).toBe(await Platform.getStructForTenant('lookup-tenant'));
+    });
+
+    test('it resolves a tenant served from the registration domain', async () => {
+        await createTenant({ uri: 'lookup-uri' });
+
+        const response = await byDomain(`lookup-uri.${registrationDomain}`);
+
+        expect(response.body).toBe(await Platform.getStructForTenant('lookup-tenant'));
+    });
+
+    test('an unknown host is a 404', async () => {
+        await expect(byDomain('nobody.example.com')).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_domain' }),
+        );
+    });
+
+    test('a deeper subdomain is not resolved', async () => {
+        await createTenant({ uri: 'lookup-uri' });
+
+        await expect(byDomain(`deeper.lookup-uri.${registrationDomain}`)).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_domain' }),
+        );
+    });
+
+    test('it never answers with the private config', async () => {
+        await createTenant({ domain: 'lookup.example.com' });
+
+        // Even for a platform administrator: this endpoint is unauthenticated, so it must not become
+        // a second way to read privateConfig
+        const user = await new UserFactory({
+            globalPermissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        const token = await SessionService.createSession(user);
+
+        expect((await byDomain('lookup.example.com')).body.privateConfig).toBeNull();
+        expect((await byDomain('lookup.example.com', token)).body.privateConfig).toBeNull();
+    });
+
+    test('it resolves a tenant by uri', async () => {
+        await createTenant({ uri: 'lookup-uri' });
+
+        const response = await byUri('lookup-uri');
+
+        expect(response.body).toBe(await Platform.getStructForTenant('lookup-tenant'));
+        expect(response.body.privateConfig).toBeNull();
+    });
+
+    test('an unknown uri is a 404', async () => {
+        await expect(byUri('nobody')).rejects.toThrow(
+            STExpect.simpleError({ code: 'unknown_uri' }),
+        );
+    });
+});

--- a/backend/app/api/src/endpoints/global/platform/GetTenantFromDomainEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/platform/GetTenantFromDomainEndpoint.ts
@@ -1,0 +1,79 @@
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { AutoEncoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { SimpleError } from '@simonbackx/simple-errors';
+import { Platform } from '@stamhoofd/models';
+import type { Platform as PlatformStruct } from '@stamhoofd/structures';
+
+type Params = Record<string, never>;
+
+class Query extends AutoEncoder {
+    @field({ decoder: StringDecoder })
+    domain: string;
+}
+
+type Body = undefined;
+type ResponseBody = PlatformStruct;
+
+/**
+ * Resolves the tenant a host belongs to.
+ *
+ * Unauthenticated on purpose: the frontend calls this before it has a session, to know which tenant
+ * it is rendering. It therefore answers with the public structure only, never privateConfig.
+ */
+export class GetTenantFromDomainEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    queryDecoder = Query as Decoder<Query>;
+
+    registrationDomains = [...new Set(Object.values(STAMHOOFD.domains.registration ?? {}))];
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'GET') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/tenant-from-domain', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        const tenant = await this.findTenant(request.query.domain);
+
+        if (!tenant) {
+            throw new SimpleError({
+                code: 'unknown_domain',
+                message: 'Not known',
+                statusCode: 404,
+            });
+        }
+
+        return new Response(await Platform.getStructForTenant(tenant.id));
+    }
+
+    private async findTenant(host: string): Promise<Platform | undefined> {
+        const byDomain = await Platform.getByDomain(host);
+        if (byDomain) {
+            return byDomain;
+        }
+
+        // A tenant without its own domain is served from <tenant-uri>.<registrationDomain>
+        for (const domain of this.registrationDomains) {
+            if (!host.endsWith('.' + domain)) {
+                continue;
+            }
+
+            const uri = host.substring(0, host.length - ('.' + domain).length);
+            if (uri.includes('.')) {
+                return undefined;
+            }
+
+            return await Platform.getByURI(uri);
+        }
+
+        return undefined;
+    }
+}

--- a/backend/app/api/src/endpoints/global/platform/GetTenantFromUriEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/platform/GetTenantFromUriEndpoint.ts
@@ -1,0 +1,53 @@
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { AutoEncoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { SimpleError } from '@simonbackx/simple-errors';
+import { Platform } from '@stamhoofd/models';
+import type { Platform as PlatformStruct } from '@stamhoofd/structures';
+
+type Params = Record<string, never>;
+
+class Query extends AutoEncoder {
+    @field({ decoder: StringDecoder })
+    uri: string;
+}
+
+type Body = undefined;
+type ResponseBody = PlatformStruct;
+
+/**
+ * Resolves a tenant by its uri, for switching between tenants.
+ *
+ * Unauthenticated on purpose, like the domain lookup, so it answers with the public structure only.
+ */
+export class GetTenantFromUriEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    queryDecoder = Query as Decoder<Query>;
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'GET') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/tenant-from-uri', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        const tenant = await Platform.getByURI(request.query.uri);
+
+        if (!tenant) {
+            throw new SimpleError({
+                code: 'unknown_uri',
+                message: 'Not known',
+                statusCode: 404,
+            });
+        }
+
+        return new Response(await Platform.getStructForTenant(tenant.id));
+    }
+}


### PR DESCRIPTION
Stacked on #691, which adds the `Platform.getByDomain` / `getByURI` lookups these use.

`GET /tenant-from-domain` and `GET /tenant-from-uri`, both **unauthenticated** — the frontend has to know which tenant it is rendering before it has a session, so this is its first network call.

The domain lookup also accepts `<tenant-uri>.<registrationDomain>`, so it resolves exactly the hosts #691 hands out certificates for.

## Gotcha

Because they are unauthenticated they answer with the **public** structure only, and there is a test asserting `privateConfig` is null *even when a platform administrator's token is attached*. Without that, these would quietly become a second way to read `privateConfig` that skips the authorization `GET /platform` does.

The tests assert the resolved tenant by object identity against the per-tenant cache rather than by reading `id` off the structure — `id` lands in #689, and I did not want a test-only reason to chain these two independent PRs together.