### PR TITLE
✨ Add a nullable tenantId to the four core tables

### DIFF
--- a/backend/shared/models/src/migrations/1785433585-organizations-tenant-id.sql
+++ b/backend/shared/models/src/migrations/1785433585-organizations-tenant-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `organizations` ADD COLUMN `tenantId` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL;

--- a/backend/shared/models/src/migrations/1785433586-users-tenant-id.sql
+++ b/backend/shared/models/src/migrations/1785433586-users-tenant-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD COLUMN `tenantId` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL;

--- a/backend/shared/models/src/migrations/1785433587-registration-periods-tenant-id.sql
+++ b/backend/shared/models/src/migrations/1785433587-registration-periods-tenant-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `registration_periods` ADD COLUMN `tenantId` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL;

--- a/backend/shared/models/src/migrations/1785433588-members-tenant-id.sql
+++ b/backend/shared/models/src/migrations/1785433588-members-tenant-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `members` ADD COLUMN `tenantId` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL;

--- a/backend/shared/models/src/migrations/1785433589-organizations-tenant-id-index.sql
+++ b/backend/shared/models/src/migrations/1785433589-organizations-tenant-id-index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `organizations` ADD KEY `tenantId` (`tenantId`);

--- a/backend/shared/models/src/migrations/1785433590-users-tenant-id-index.sql
+++ b/backend/shared/models/src/migrations/1785433590-users-tenant-id-index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD KEY `tenantId` (`tenantId`);

--- a/backend/shared/models/src/migrations/1785433591-registration-periods-tenant-id-index.sql
+++ b/backend/shared/models/src/migrations/1785433591-registration-periods-tenant-id-index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `registration_periods` ADD KEY `tenantId` (`tenantId`);

--- a/backend/shared/models/src/migrations/1785433592-members-tenant-id-index.sql
+++ b/backend/shared/models/src/migrations/1785433592-members-tenant-id-index.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `members` ADD KEY `tenantId` (`tenantId`);

--- a/backend/shared/models/src/models/Member.ts
+++ b/backend/shared/models/src/models/Member.ts
@@ -46,6 +46,12 @@ export class Member extends QueryableModel {
     })
     id!: string;
 
+    /**
+     * The tenant this row belongs to. Nullable until every row is backfilled.
+     */
+    @column({ type: 'string', nullable: true })
+    tenantId: string | null = null;
+
     @column({ type: 'string', nullable: true })
     organizationId: string | null = null;
 

--- a/backend/shared/models/src/models/Organization.ts
+++ b/backend/shared/models/src/models/Organization.ts
@@ -31,6 +31,12 @@ export class Organization extends QueryableModel {
     })
     id!: string;
 
+    /**
+     * The tenant this row belongs to. Nullable until every row is backfilled.
+     */
+    @column({ type: 'string', nullable: true })
+    tenantId: string | null = null;
+
     @column({ type: 'string' })
     name: string;
 

--- a/backend/shared/models/src/models/RegistrationPeriod.ts
+++ b/backend/shared/models/src/models/RegistrationPeriod.ts
@@ -15,6 +15,12 @@ export class RegistrationPeriod extends QueryableModel {
     })
     id!: string;
 
+    /**
+     * The tenant this row belongs to. Nullable until every row is backfilled.
+     */
+    @column({ type: 'string', nullable: true })
+    tenantId: string | null = null;
+
     @column({ type: 'string', nullable: true })
     customName: string | null = null;
 

--- a/backend/shared/models/src/models/User.ts
+++ b/backend/shared/models/src/models/User.ts
@@ -22,6 +22,12 @@ export class User extends QueryableModel {
     })
     id!: string;
 
+    /**
+     * The tenant this row belongs to. Nullable until every row is backfilled.
+     */
+    @column({ type: 'string', nullable: true })
+    tenantId: string | null = null;
+
     @column({ type: 'string', nullable: true })
     organizationId: string | null;
 

--- a/backend/shared/models/src/models/tenantId.test.ts
+++ b/backend/shared/models/src/models/tenantId.test.ts
@@ -1,0 +1,42 @@
+import { MemberFactory, OrganizationFactory, RegistrationPeriodFactory, UserFactory } from '../factories/index.js';
+import { Member } from './Member.js';
+import { Organization } from './Organization.js';
+import { RegistrationPeriod } from './RegistrationPeriod.js';
+import { User } from './User.js';
+
+describe('tenantId', () => {
+    test('it is null on rows created before the backfill', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({ organization }).create();
+        const member = await new MemberFactory({ organization }).create();
+        const period = await new RegistrationPeriodFactory({}).create();
+
+        expect(organization.tenantId).toBeNull();
+        expect(user.tenantId).toBeNull();
+        expect(member.tenantId).toBeNull();
+        expect(period.tenantId).toBeNull();
+    });
+
+    test('it round-trips through the database', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        organization.tenantId = 'some-tenant';
+        await organization.save();
+
+        expect((await Organization.getByID(organization.id))!.tenantId).toBe('some-tenant');
+
+        const user = await new UserFactory({ organization }).create();
+        user.tenantId = 'some-tenant';
+        await user.save();
+        expect((await User.getByID(user.id))!.tenantId).toBe('some-tenant');
+
+        const member = await new MemberFactory({ organization }).create();
+        member.tenantId = 'some-tenant';
+        await member.save();
+        expect((await Member.getByID(member.id))!.tenantId).toBe('some-tenant');
+
+        const period = await new RegistrationPeriodFactory({}).create();
+        period.tenantId = 'some-tenant';
+        await period.save();
+        expect((await RegistrationPeriod.getByID(period.id))!.tenantId).toBe('some-tenant');
+    });
+});


### PR DESCRIPTION
The expand step of phase 5a: a nullable `tenantId` plus an index on `organizations`, `users`, `registration_periods` and `members`.

**Additive only — nothing writes or reads it.** The dual-write, the backfill and the `NOT NULL` are separate PRs, per the expand/contract rule.

One `ALTER` per migration file, as agreed on #680, so a partial failure stays retryable.

Verified against a rebuilt database (`--clear`), not just a warm one, plus a test that the column round-trips and is null on existing rows.

No foreign key to `platform(id)` yet: the column is all-NULL until the backfill, and the constraint is more useful added with the `NOT NULL` once the values are known good.