### PR TITLE
Require email confirmation before 2FA enrollment of inactive admins

### DIFF
--- a/backend/app/api/src/endpoints/auth/CreateTokenEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/CreateTokenEndpoint.ts
@@ -150,7 +150,7 @@ export class CreateTokenEndpoint extends Endpoint<Params, Query, Body, ResponseB
                 // Second factor / forced enrollment: block the session until the user
                 // completes (or first sets up) a second factor. Shared with every other
                 // grant that mints a session from a single primary credential.
-                await TwoFactorHelper.assertSecondFactorOrThrow(user, organization, request.request.getVersion());
+                await TwoFactorHelper.assertSecondFactorOrThrow(user, organization, request.request.getVersion(), { loginMethod: 'password', i18n: request.i18n });
 
                 const token = await Token.createToken(user, new Date());
 
@@ -311,7 +311,10 @@ export class CreateTokenEndpoint extends Endpoint<Params, Query, Body, ResponseB
                 // Forced enrollment (the user has no factor yet) additionally returns a
                 // temporary session token: this flow is also used to choose a first
                 // password (invites), which the client can only do with a session.
-                await TwoFactorHelper.assertSecondFactorOrThrow(passwordToken.user, organization, request.request.getVersion(), { allowTemporarySession: true });
+                //
+                // The link was emailed to the account, so this is also how a long-inactive
+                // admin confirms their email address and gets to enroll after all.
+                await TwoFactorHelper.assertSecondFactorOrThrow(passwordToken.user, organization, request.request.getVersion(), { loginMethod: 'email', i18n: request.i18n, allowTemporarySession: true });
 
                 // Important to create a new token before adjusting the old token
                 const token = await Token.createToken(passwordToken.user, new Date());

--- a/backend/app/api/src/endpoints/auth/ForgotPasswordEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/auth/ForgotPasswordEndpoint.test.ts
@@ -1,0 +1,45 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import { EmailMocker } from '@stamhoofd/email';
+import { EmailTemplateFactory, OrganizationFactory, PasswordToken, UserFactory } from '@stamhoofd/models';
+import { EmailTemplateType } from '@stamhoofd/structures';
+
+import { testServer } from '../../../tests/helpers/TestServer.js';
+import { ForgotPasswordEndpoint } from './ForgotPasswordEndpoint.js';
+
+const endpoint = new ForgotPasswordEndpoint();
+
+describe('Endpoint.ForgotPassword', () => {
+    beforeEach(async () => {
+        await new EmailTemplateFactory({ type: EmailTemplateType.ForgotPassword }).create();
+        await new EmailTemplateFactory({ type: EmailTemplateType.ForgotPasswordButNoAccount }).create();
+    });
+
+    function request(host: string, email: string) {
+        return Request.buildJson('POST', '/forgot-password', host, { email });
+    }
+
+    test('the recovery link is emailed to the stored address, not the one that was typed', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({ organization, password: 'test-password-1234' }).create();
+
+        await testServer.test(endpoint, request(organization.getApiHost(), user.email.toUpperCase()));
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        expect(emails).toHaveLength(1);
+        expect(emails[0].to).toContain(user.email);
+
+        const [passwordToken] = await PasswordToken.select().where('userId', user.id).fetch();
+        expect(passwordToken).toBeDefined();
+        expect(emails[0].html).toContain(encodeURIComponent(passwordToken.token));
+    });
+
+    test('an unknown address still gets an email, so it does not leak who has an account', async () => {
+        const organization = await new OrganizationFactory({}).create();
+
+        await testServer.test(endpoint, request(organization.getApiHost(), 'nobody@example.com'));
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        expect(emails).toHaveLength(1);
+        expect(emails[0].to).toContain('nobody@example.com');
+    });
+});

--- a/backend/app/api/src/endpoints/auth/ForgotPasswordEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/ForgotPasswordEndpoint.ts
@@ -3,7 +3,7 @@ import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
 import { Platform, User } from '@stamhoofd/models';
 import { sendEmailTemplate } from '../../helpers/EmailBuilder.js';
-import { EmailTemplateType, ForgotPasswordRequest, LoginMethod, Recipient, Replacement } from '@stamhoofd/structures';
+import { EmailTemplateType, ForgotPasswordRequest, LoginMethod, Recipient } from '@stamhoofd/structures';
 
 import { SimpleError } from '@simonbackx/simple-errors';
 import { Context } from '../../helpers/Context.js';
@@ -74,28 +74,7 @@ export class ForgotPasswordEndpoint extends Endpoint<Params, Query, Body, Respon
             return new Response(undefined);
         }
 
-        const recoveryUrl = await PasswordForgotService.getPasswordRecoveryUrl(user, organization, request.i18n);
-
-        // Create e-mail builder
-        await sendEmailTemplate(organization, {
-            recipients: [
-                Recipient.create({
-                    firstName: user.firstName,
-                    lastName: user.lastName,
-                    email: request.body.email,
-                    replacements: [
-                        Replacement.create({
-                            token: 'resetUrl',
-                            value: recoveryUrl,
-                        }),
-                    ],
-                }),
-            ],
-            template: {
-                type: EmailTemplateType.ForgotPassword,
-            },
-            type: 'transactional',
-        });
+        await PasswordForgotService.sendPasswordRecoveryEmail(user, organization, request.i18n);
 
         return new Response(undefined);
     }

--- a/backend/app/api/src/endpoints/auth/MFA.test.ts
+++ b/backend/app/api/src/endpoints/auth/MFA.test.ts
@@ -1,15 +1,17 @@
 import { Endpoint, Request } from '@simonbackx/simple-endpoints';
 import { isSimpleError, isSimpleErrors, SimpleError } from '@simonbackx/simple-errors';
-import { AuditLog, EmailVerificationCode, MFARecoveryCode, MFATOTP, MFAToken, Organization, PasswordToken, Platform, Token, User, UserFactory, OrganizationFactory, WebauthnChallenge, WebauthnCredential } from '@stamhoofd/models';
-import { AuditLogReplacementType, AuditLogType, MFAMethodType, PermissionLevel, Permissions, Token as TokenStruct } from '@stamhoofd/structures';
+import { EmailMocker } from '@stamhoofd/email';
+import { AuditLog, EmailTemplateFactory, EmailVerificationCode, MFARecoveryCode, MFATOTP, MFAToken, Organization, PasswordToken, Platform, Token, User, UserFactory, OrganizationFactory, WebauthnChallenge, WebauthnCredential } from '@stamhoofd/models';
+import { AuditLogReplacementType, AuditLogType, EmailTemplateType, MFAMethodType, PermissionLevel, Permissions, Token as TokenStruct } from '@stamhoofd/structures';
 import { authenticator } from 'otplib';
 import crypto from 'crypto';
 
 import { MFATestHelper } from '../../../tests/helpers/MFATestHelper.js';
 import { testServer } from '../../../tests/helpers/TestServer.js';
 import { RECOVERY_CODE_ALPHABET, RecoveryCodeHelper } from '../../helpers/RecoveryCodeHelper.js';
-import { TwoFactorHelper } from '../../helpers/TwoFactorHelper.js';
+import { INACTIVE_ADMIN_ENROLLMENT_DAYS, TwoFactorHelper } from '../../helpers/TwoFactorHelper.js';
 import { WebauthnHelper } from '../../helpers/WebauthnHelper.js';
+import { PasswordForgotService } from '../../services/PasswordForgotService.js';
 import { ConfirmTOTPEndpoint } from './ConfirmTOTPEndpoint.js';
 import { CreateTokenEndpoint } from './CreateTokenEndpoint.js';
 import { DeletePasskeyEndpoint } from './DeletePasskeyEndpoint.js';
@@ -508,6 +510,188 @@ describe('MFA', () => {
             // authenticateFresh() only accepts Bearer, so the MFASetup scheme is refused.
             expect(err.statusCode).toBeGreaterThanOrEqual(400);
             expect(['not_supported_authentication', 'not_authenticated'].includes(err.code)).toBe(true);
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Forced enrollment of accounts that were not used for a long time
+    // -----------------------------------------------------------------------
+    describe('inactive admins confirm their email before enrolling', () => {
+        const day = 24 * 60 * 60 * 1000;
+
+        beforeEach(async () => {
+            // Without a template no email is built at all, and the assertions below would
+            // pass on a version that never sends one.
+            await new EmailTemplateFactory({ type: EmailTemplateType.ForgotPassword }).create();
+        });
+
+        async function inactiveAdmin({ inactiveDays = INACTIVE_ADMIN_ENROLLMENT_DAYS + 1, requireTwoFactor = true }: { inactiveDays?: number; requireTwoFactor?: boolean } = {}) {
+            const organization = await new OrganizationFactory({}).create();
+            organization.privateMeta.requireTwoFactor = requireTwoFactor;
+            await organization.save();
+
+            const user = await new UserFactory({ organization, password, permissions: Permissions.create({ level: PermissionLevel.Full }) }).create();
+            user.lastActiveAt = new Date(Date.now() - inactiveDays * day);
+            await user.save();
+            return { organization, user };
+        }
+
+        async function passwordTokensFor(user: User): Promise<PasswordToken[]> {
+            return await PasswordToken.select().where('userId', user.id).fetch();
+        }
+
+        async function recoveryEmailsFor(user: User) {
+            return (await EmailMocker.transactional.getSucceededEmails()).filter(e => e.to.includes(user.email));
+        }
+
+        test('a long inactive admin is locked out and gets a password recovery link', async () => {
+            const { organization, user } = await inactiveAdmin();
+
+            const err = await captureError(testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password)));
+            expect(err.code).toBe('require_email_confirmation');
+            expect(err.statusCode).toBe(403);
+
+            const [passwordToken] = await passwordTokensFor(user);
+            expect(passwordToken).toBeDefined();
+
+            // The link in the email is the one that gets them back in.
+            const emails = await recoveryEmailsFor(user);
+            expect(emails).toHaveLength(1);
+            expect(emails[0].html).toContain(encodeURIComponent(passwordToken.token));
+
+            // No setup token was handed out: the enrollment may not start from the password alone.
+            expect(await MFAToken.select().where('userId', user.id).fetch()).toHaveLength(0);
+            expect((await User.getByID(user.id))!.lastActiveAt!.getTime()).toBeLessThan(Date.now() - INACTIVE_ADMIN_ENROLLMENT_DAYS * day);
+        });
+
+        test('an admin who signed in recently is only forced to enroll', async () => {
+            const { organization, user } = await inactiveAdmin({ inactiveDays: INACTIVE_ADMIN_ENROLLMENT_DAYS - 1 });
+
+            const err = await captureError(testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password)));
+            expect(err.code).toBe('require_mfa_setup');
+            expect(await passwordTokensFor(user)).toHaveLength(0);
+            expect(await recoveryEmailsFor(user)).toHaveLength(0);
+        });
+
+        test('a long inactive platform admin is locked out too', async () => {
+            await setPlatformRequiresTwoFactor(true);
+            const user = await new UserFactory({ password, globalPermissions: Permissions.create({ level: PermissionLevel.Full }) }).create();
+            user.lastActiveAt = new Date(Date.now() - (INACTIVE_ADMIN_ENROLLMENT_DAYS + 1) * day);
+            await user.save();
+
+            const err = await captureError(testServer.test(tokenEndpoint, passwordLogin(null, user.email, password)));
+            expect(err.code).toBe('require_email_confirmation');
+        });
+
+        test('an inactive admin who already enrolled is challenged as usual', async () => {
+            const { organization, user } = await inactiveAdmin();
+            const { secret } = await addConfirmedTOTP(user);
+
+            const challenge = await requireMfa(organization, user.email, password);
+            const response = await testServer.test(tokenEndpoint, mfaGrant(organization, { mfa_token: challenge.token, method: 'TOTP', code: authenticator.generate(secret) }));
+            expect(response.body).toBeInstanceOf(TokenStruct);
+            expect(await passwordTokensFor(user)).toHaveLength(0);
+        });
+
+        test('an inactive user without permissions logs in normally', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            organization.privateMeta.requireTwoFactor = true;
+            await organization.save();
+
+            const user = await new UserFactory({ organization, password }).create();
+            user.lastActiveAt = new Date(Date.now() - 400 * day);
+            await user.save();
+
+            const response = await testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password));
+            expect(response.body).toBeInstanceOf(TokenStruct);
+        });
+
+        test('an inactive admin is not blocked when 2FA is not required', async () => {
+            const { organization, user } = await inactiveAdmin({ requireTwoFactor: false });
+
+            const response = await testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password));
+            expect(response.body).toBeInstanceOf(TokenStruct);
+        });
+
+        test('an admin who never signed in is judged on the creation date', async () => {
+            const { organization, user } = await inactiveAdmin();
+            user.lastActiveAt = null;
+            await user.save();
+
+            const fresh = await captureError(testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password)));
+            expect(fresh.code).toBe('require_mfa_setup');
+
+            user.createdAt = new Date(Date.now() - (INACTIVE_ADMIN_ENROLLMENT_DAYS + 1) * day);
+            await user.save();
+
+            const stale = await captureError(testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password)));
+            expect(stale.code).toBe('require_email_confirmation');
+        });
+
+        test('the emailed link confirms the email address and unlocks the enrollment', async () => {
+            const { organization, user } = await inactiveAdmin();
+            await captureError(testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password)));
+
+            const [passwordToken] = await passwordTokensFor(user);
+            expect(passwordToken).toBeDefined();
+
+            const err = await captureError(testServer.test(tokenEndpoint, Request.buildJson('POST', '/oauth/token', organization.getApiHost(), { grant_type: 'password_token', token: passwordToken.token })));
+            expect(err.code).toBe('require_mfa_setup');
+            expect((err.meta as { setupToken: string }).setupToken).toBeTruthy();
+        });
+
+        test('an email verification code also unlocks the enrollment', async () => {
+            const { organization, user } = await inactiveAdmin();
+
+            const code = await EmailVerificationCode.createFor(user, user.email);
+            const err = await captureError(testServer.test(new VerifyEmailEndpoint(), Request.buildJson('POST', '/verify-email', organization.getApiHost(), { token: code.token, code: code.code })));
+            expect(err.code).toBe('require_mfa_setup');
+        });
+
+        test('repeated logins stop sending new recovery links', async () => {
+            const { organization, user } = await inactiveAdmin();
+
+            for (let i = 0; i < 6; i++) {
+                const err = await captureError(testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password)));
+                expect(err.code).toBe('require_email_confirmation');
+            }
+
+            expect(await passwordTokensFor(user)).toHaveLength(3);
+            expect(await recoveryEmailsFor(user)).toHaveLength(3);
+        });
+
+        test('a failing email does not turn the lockout into a server error', async () => {
+            const { organization, user } = await inactiveAdmin();
+            const send = vi.spyOn(PasswordForgotService, 'sendPasswordRecoveryEmail').mockRejectedValue(new Error('Mail server down'));
+
+            try {
+                const err = await captureError(testServer.test(tokenEndpoint, passwordLogin(organization, user.email, password)));
+                expect(err.code).toBe('require_email_confirmation');
+                expect(send).toHaveBeenCalledOnce();
+            }
+            finally {
+                send.mockRestore();
+            }
+        });
+
+        test('the limit is only crossed after a full 45 days', async () => {
+            const { user } = await inactiveAdmin();
+
+            // A minute on either side of the limit, so the datetime column losing
+            // milliseconds cannot decide the outcome.
+            user.lastActiveAt = new Date(Date.now() - INACTIVE_ADMIN_ENROLLMENT_DAYS * day + 60 * 1000);
+            expect(TwoFactorHelper.isInactiveForEnrollment(user)).toBe(false);
+
+            user.lastActiveAt = new Date(Date.now() - INACTIVE_ADMIN_ENROLLMENT_DAYS * day - 60 * 1000);
+            expect(TwoFactorHelper.isInactiveForEnrollment(user)).toBe(true);
+        });
+
+        test('an SSO login of an inactive admin is not blocked', async () => {
+            // The identity provider authenticated the user, so there is nothing to confirm.
+            const { organization, user } = await inactiveAdmin();
+
+            const requirement = await TwoFactorHelper.getSecondFactorRequirement(user, organization, { loginMethod: 'sso' });
+            expect(requirement.type).toBe('setup');
         });
     });
 

--- a/backend/app/api/src/endpoints/auth/VerifyEmailEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/VerifyEmailEndpoint.ts
@@ -116,7 +116,7 @@ export class VerifyEmailEndpoint extends Endpoint<Params, Query, Body, ResponseB
         // the request already comes from a session of that same user (changing your email
         // address while signed in): the second factor was checked when it was created.
         if (authenticatedUser?.id !== user.id) {
-            await TwoFactorHelper.assertSecondFactorOrThrow(user, organization, request.request.getVersion());
+            await TwoFactorHelper.assertSecondFactorOrThrow(user, organization, request.request.getVersion(), { loginMethod: 'email', i18n: request.i18n });
         }
 
         const token = await Token.createToken(user);

--- a/backend/app/api/src/helpers/TwoFactorHelper.ts
+++ b/backend/app/api/src/helpers/TwoFactorHelper.ts
@@ -1,4 +1,5 @@
 import { SimpleError } from '@simonbackx/simple-errors';
+import type { I18n } from '@stamhoofd/backend-i18n/I18n';
 import type { User } from '@stamhoofd/models';
 import { MFARecoveryCode, MFATOTP, MFAToken, Organization, Platform, RateLimiter, Token, WebauthnCredential } from '@stamhoofd/models';
 import type { User as UserStruct } from '@stamhoofd/structures';
@@ -6,6 +7,7 @@ import { MFAChallengeResponse, MFAEnrollmentResult, MFAMethodType, MFASetupRespo
 
 import type { PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/server';
 
+import { PasswordForgotService } from '../services/PasswordForgotService.js';
 import { RecoveryCodeHelper } from './RecoveryCodeHelper.js';
 import { WebauthnHelper } from './WebauthnHelper.js';
 import { Formatter, Sorter } from '@stamhoofd/utility';
@@ -30,13 +32,42 @@ export const mfaVerificationRateLimiter = new RateLimiter({
 });
 
 /**
+ * An admin who has to enroll a second factor, but never did, first has to prove they still
+ * read the email address on the account when they were inactive for this long. A dormant
+ * account is the one most likely to have a leaked or reused password, and enrolling a
+ * factor with only that password would hand the account to whoever holds it — protected by
+ * the very second factor the organization asked for.
+ */
+export const INACTIVE_ADMIN_ENROLLMENT_DAYS = 45;
+
+/**
+ * The confirmation email is triggered by a login attempt, so cap how often one account can
+ * send it: whoever knows the password could otherwise flood the mailbox. Like every rate
+ * limiter here this counts per process and in a window shared by all keys, so it thins out
+ * a flood rather than enforcing an exact number of emails.
+ */
+const enrollmentConfirmationRateLimiter = new RateLimiter({
+    limits: [
+        {
+            limit: 3,
+            duration: 60 * 60 * 1000,
+        },
+        {
+            limit: 10,
+            duration: 24 * 60 * 60 * 1000,
+        },
+    ],
+});
+
+/**
  * What still has to happen before a session may be issued for a user whose primary
  * credential was just accepted.
  */
 export type SecondFactorRequirement
     = | { type: 'none' }
         | { type: 'challenge'; challenge: MFAChallengeResponse }
-        | { type: 'setup'; setupToken: MFAToken };
+        | { type: 'setup'; setupToken: MFAToken }
+        | { type: 'confirm-email' };
 
 export class TwoFactorHelper {
     /**
@@ -88,20 +119,34 @@ export class TwoFactorHelper {
     }
 
     /**
+     * Whether the account was unused for long enough that its password alone is no longer
+     * enough to start a forced enrollment. Accounts that never signed in fall back to their
+     * creation date, so an admin who was just invited is not locked out right away.
+     */
+    static isInactiveForEnrollment(user: User): boolean {
+        const lastActiveAt = user.lastActiveAt ?? user.createdAt;
+        return lastActiveAt.getTime() < Date.now() - INACTIVE_ADMIN_ENROLLMENT_DAYS * 24 * 60 * 60 * 1000;
+    }
+
+    /**
      * What still has to happen before a session may be handed out, after a primary
      * credential was accepted.
      *
      * `loginMethod` describes the credential that was just verified:
-     *  - 'password': a password, password token or email verification code. All of these
-     *    are single credentials owned by the user, so a required second factor must be
-     *    set up here if the user does not have one yet.
+     *  - 'password': the account password. A single credential that says nothing about
+     *    whether the user still reads the email address on the account, so a required
+     *    second factor must be set up here if the user does not have one yet — and a
+     *    long-inactive admin has to confirm their email address before they may.
+     *  - 'email': a password token or email verification code. Also a single credential,
+     *    but one that only reaches someone who reads the account's email, so it is the way
+     *    out of that email confirmation.
      *  - 'sso': an external identity provider already authenticated the user, and is
      *    trusted to apply its own second factor. An enrolled factor is still verified
      *    (the user asked us to protect their account), but we do not force enrollment —
      *    unless the account ALSO has a password, because then the password remains a way
      *    in that bypasses whatever the provider enforces.
      */
-    static async getSecondFactorRequirement(user: User, organization: Organization | null, { loginMethod }: { loginMethod: 'password' | 'sso' }): Promise<SecondFactorRequirement> {
+    static async getSecondFactorRequirement(user: User, organization: Organization | null, { loginMethod }: { loginMethod: 'password' | 'email' | 'sso' }): Promise<SecondFactorRequirement> {
         if (await TwoFactorHelper.userHasFactors(user.id)) {
             return { type: 'challenge', challenge: await TwoFactorHelper.createLoginChallenge(user) };
         }
@@ -111,6 +156,9 @@ export class TwoFactorHelper {
         }
 
         if (await TwoFactorHelper.isTwoFactorRequired(user, organization)) {
+            if (loginMethod === 'password' && TwoFactorHelper.isInactiveForEnrollment(user)) {
+                return { type: 'confirm-email' };
+            }
             return { type: 'setup', setupToken: await MFAToken.createFor(user.id, 'setup') };
         }
 
@@ -118,10 +166,33 @@ export class TwoFactorHelper {
     }
 
     /**
+     * Send the password recovery link a long-inactive admin needs to get back to enrolling
+     * their second factor. Never throws: the login is blocked either way, and turning a
+     * mail failure into a 500 would only hide why the user cannot sign in.
+     */
+    static async sendEnrollmentConfirmationEmail(user: User, organization: Organization | null, i18n: I18n): Promise<void> {
+        try {
+            enrollmentConfirmationRateLimiter.track(user.id);
+        }
+        catch {
+            // Sent often enough already.
+            return;
+        }
+
+        try {
+            await PasswordForgotService.sendPasswordRecoveryEmail(user, organization, i18n);
+        }
+        catch (e) {
+            console.error('Could not send the two-factor enrollment confirmation email', e);
+        }
+    }
+
+    /**
      * Enforce the second-factor / forced-enrollment step after a successful primary
      * authentication (password login, password-reset token, email verification). Throws a
-     * `require_mfa` or `require_mfa_setup` error when the user must still complete a second
-     * factor before a session may be issued; returns normally when the login may proceed.
+     * `require_mfa`, `require_mfa_setup` or `require_email_confirmation` error when the user
+     * must still do something before a session may be issued; returns normally when the
+     * login may proceed. The last one also emails the user the link they need to get past it.
      *
      * This MUST be called from every path that mints a full session from a single primary
      * credential, otherwise that path becomes an MFA bypass. The SSO callback is a redirect
@@ -132,8 +203,19 @@ export class TwoFactorHelper {
      * whoever holds the link could enroll one and get a session anyway, and the client
      * needs a session to let the user choose a password before enrolling.
      */
-    static async assertSecondFactorOrThrow(user: User, organization: Organization | null, version: number, { allowTemporarySession = false }: { allowTemporarySession?: boolean } = {}): Promise<void> {
-        const requirement = await TwoFactorHelper.getSecondFactorRequirement(user, organization, { loginMethod: 'password' });
+    static async assertSecondFactorOrThrow(user: User, organization: Organization | null, version: number, { loginMethod, i18n, allowTemporarySession = false }: { loginMethod: 'password' | 'email'; i18n: I18n; allowTemporarySession?: boolean }): Promise<void> {
+        const requirement = await TwoFactorHelper.getSecondFactorRequirement(user, organization, { loginMethod });
+
+        if (requirement.type === 'confirm-email') {
+            await TwoFactorHelper.sendEnrollmentConfirmationEmail(user, organization, i18n);
+
+            throw new SimpleError({
+                code: 'require_email_confirmation',
+                message: 'Email confirmation required before two-factor authentication setup',
+                human: $t('Je account is beheerder en moet beveiligd worden met tweestapsverificatie, maar je logde al meer dan {days} dagen niet meer in. Bevestig eerst je e-mailadres: we stuurden je een e-mail met een link waarmee je opnieuw toegang krijgt en tweestapsverificatie kan instellen. Kreeg je geen e-mail? Dan kan je ook een nieuwe link aanvragen via wachtwoord vergeten.', { days: INACTIVE_ADMIN_ENROLLMENT_DAYS.toString() }),
+                statusCode: 403,
+            });
+        }
 
         if (requirement.type === 'challenge') {
             throw new SimpleError({

--- a/backend/app/api/src/services/PasswordForgotService.ts
+++ b/backend/app/api/src/services/PasswordForgotService.ts
@@ -1,7 +1,9 @@
 import type { I18n } from '@stamhoofd/backend-i18n';
 import type { Organization } from '@stamhoofd/models';
 import { PasswordToken, Platform, User } from '@stamhoofd/models';
-import { getAppHost } from '@stamhoofd/structures';
+import { EmailTemplateType, getAppHost, Recipient, Replacement } from '@stamhoofd/structures';
+
+import { sendEmailTemplate } from '../helpers/EmailBuilder.js';
 
 /**
  * Builds the password recovery links. Which app the link points to depends on whether the user is an
@@ -15,6 +17,34 @@ export class PasswordForgotService {
         // Send an e-mail to say you already have an account + follow password forgot flow
         const token = await PasswordToken.createToken(user, validUntil);
         return await this.getPasswordRecoveryUrlForToken(token, organization, i18n, user);
+    }
+
+    /**
+     * Create a new password token and email the recovery link to the user. Always sent to the
+     * stored address, never to whatever the request asked for.
+     */
+    static async sendPasswordRecoveryEmail(user: User, organization: Organization | null, i18n: I18n) {
+        const recoveryUrl = await this.getPasswordRecoveryUrl(user, organization, i18n);
+
+        await sendEmailTemplate(organization, {
+            recipients: [
+                Recipient.create({
+                    firstName: user.firstName,
+                    lastName: user.lastName,
+                    email: user.email,
+                    replacements: [
+                        Replacement.create({
+                            token: 'resetUrl',
+                            value: recoveryUrl,
+                        }),
+                    ],
+                }),
+            ],
+            template: {
+                type: EmailTemplateType.ForgotPassword,
+            },
+            type: 'transactional',
+        });
     }
 
     /**

--- a/backend/app/api/src/services/SSOService.ts
+++ b/backend/app/api/src/services/SSOService.ts
@@ -707,7 +707,7 @@ export class SSOServiceWithSession {
                     // enrollment endpoints check this themselves.
                     redirectUri.searchParams.set('oid_mfa_passkeys', user.canUsePasskeys() ? '1' : '0');
                     redirectUri.searchParams.set('s', session.spaState);
-                } else {
+                } else if (requirement.type === 'none') {
                     const token = await Token.createExpiredToken(user);
 
                     if (!token) {
@@ -722,6 +722,19 @@ export class SSOServiceWithSession {
                     const st = new TokenStruct(token);
                     redirectUri.searchParams.set('oid_rt', st.refreshToken);
                     redirectUri.searchParams.set('s', session.spaState);
+                } else if (requirement.type === 'confirm-email') {
+                    // Only password logins reach this: an SSO login is not the credential
+                    // that has to be confirmed. Fail closed rather than fall through to a
+                    // session, which would make this redirect an enrollment bypass.
+                    throw new SimpleError({
+                        code: 'error',
+                        message: 'Email confirmation is not supported for SSO logins',
+                        statusCode: 500,
+                    });
+                } else {
+                    // Compile error when a requirement is added without handling it here.
+                    const unsupported: never = requirement;
+                    throw new Error('Unsupported second factor requirement: ' + JSON.stringify(unsupported));
                 }
             } else if (this.session.reauthenticateAccessToken) {
                 // The provider confirmed the identity of the user that is already signed in,


### PR DESCRIPTION
Admins subject to a `requireTwoFactor` policy who never enrolled a second factor can no longer start that enrollment from a password login if the account has been inactive for **more than 45 days**. The login is blocked with a new `require_email_confirmation` error (403) and a password recovery link is emailed to them. Following that link (the `password_token` grant) proves mailbox access and unlocks the normal forced-enrollment flow.

Why: a dormant admin account is the one most likely to have a leaked or reused password. Letting it enroll a factor with only that password hands the account to whoever holds it, protected by the very second factor the organization asked for.

No new setting — it applies automatically wherever `requireTwoFactor` is already on. No `@stamhoofd/structures` change, so no versioning impact.

### Notes

- The gate lives in `getSecondFactorRequirement`, so every session-minting path inherits it. SSO and email-verification logins are exempt: neither is the credential that needs confirming.
- The SSO redirect now requires an explicit `none` before handing out a session, with a `never` guard on the remaining branch — a future requirement becomes a compile error instead of a silent bypass.
- `lastActiveAt` falls back to `createdAt` so a freshly invited admin is not locked out immediately. Legacy accounts were backfilled from `tokens` by seed `1785417302`.
- Sending is rate limited (3/hour, 10/day per user) and can never throw: a mail failure must not replace the 403 with a 500.
- Reuses the existing `ForgotPassword` email template. Its copy says *"Je gaf aan dat je jouw wachtwoord bent vergeten"*, which does not quite fit this trigger — a dedicated template would need a new `EmailTemplateType` plus a default-template migration.
- `PasswordForgotService.sendPasswordRecoveryEmail` now owns the email composition, shared with `ForgotPasswordEndpoint`. That endpoint now mails the stored address instead of the user-supplied casing.
- The frontend shows the error message in the login error box (`LoginHelper` rethrows unknown codes); there is no dedicated view.