### PR TITLE
🔒 Don't merge an account that has a second factor

### DIFF
--- a/backend/app/api/src/endpoints/auth/MFA.security.test.ts
+++ b/backend/app/api/src/endpoints/auth/MFA.security.test.ts
@@ -1,7 +1,7 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import { isSimpleError, isSimpleErrors, SimpleError } from '@simonbackx/simple-errors';
 import { EmailVerificationCode, MFARecoveryCode, MFATOTP, MFAToken, Organization, OrganizationFactory, PasswordToken, Token, User, UserFactory, WebauthnCredential } from '@stamhoofd/models';
-import { PermissionLevel, Permissions, Token as TokenStruct } from '@stamhoofd/structures';
+import { NewUser, PermissionLevel, Permissions, Token as TokenStruct } from '@stamhoofd/structures';
 import { TestUtils } from '@stamhoofd/test-utils';
 import crypto from 'crypto';
 import { authenticator } from 'otplib';
@@ -16,6 +16,7 @@ import { DeletePasskeyEndpoint } from './DeletePasskeyEndpoint.js';
 import { DeleteTOTPEndpoint } from './DeleteTOTPEndpoint.js';
 import { GetMFAChallengeEndpoint } from './GetMFAChallengeEndpoint.js';
 import { GetMFAStatusEndpoint } from './GetMFAStatusEndpoint.js';
+import { PatchUserEndpoint } from './PatchUserEndpoint.js';
 import { RegisterPasskeyOptionsEndpoint } from './RegisterPasskeyOptionsEndpoint.js';
 import { SetupTOTPEndpoint } from './SetupTOTPEndpoint.js';
 import { VerifyEmailEndpoint } from './VerifyEmailEndpoint.js';
@@ -505,6 +506,80 @@ describe('MFA security', () => {
             const code = await EmailVerificationCode.createFor(user, user.email);
             const err = await captureError(testServer.test(new VerifyEmailEndpoint(), bearer(Request.buildJson('POST', '/verify-email', organization.getApiHost(), { token: code.token, code: code.code }), expired)));
             expect(err.code).toBe('require_mfa');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // Absorbing someone else's account by taking over their email address
+    // -----------------------------------------------------------------------
+    describe('merging accounts', () => {
+        /**
+         * Verifying an email address that already belongs to another account merges that
+         * account into yours. Reading the victim's mailbox is a single primary credential,
+         * exactly the one a second factor exists to back up, so it must not be enough to
+         * pull an account that has a second factor (and its permissions) into an account
+         * that does not.
+         */
+        async function requestEmailChange(user: User, token: Token, newEmail: string, organization: Organization): Promise<EmailVerificationCode> {
+            const request = Request.patch({
+                path: '/user/' + user.id,
+                host: organization.getApiHost(),
+                headers: { authorization: 'Bearer ' + token.accessToken },
+                body: NewUser.patch({ id: user.id, email: newEmail }),
+            });
+
+            const err = await captureError(testServer.test(new PatchUserEndpoint(), request));
+            expect(err.code).toBe('verify_email');
+
+            const verificationToken = (err.meta as { token: string }).token;
+            const code = await EmailVerificationCode.select().where('token', verificationToken).first(true);
+            expect(code.email).toBe(newEmail);
+            return code;
+        }
+
+        test('taking over the email address of an account with a second factor is refused', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const victim = await new UserFactory({ organization, password, permissions: Permissions.create({ level: PermissionLevel.Full }) }).create();
+            const victimTotp = await addConfirmedTOTP(victim);
+
+            const attacker = await new UserFactory({ organization, password }).create();
+            const attackerToken = await freshToken(attacker);
+
+            const code = await requestEmailChange(attacker, attackerToken, victim.email, organization);
+
+            const err = await captureError(testServer.test(new VerifyEmailEndpoint(), bearer(Request.buildJson('POST', '/verify-email', organization.getApiHost(), { token: code.token, code: code.code }), attackerToken)));
+            expect(err.code).toBe('email_in_use');
+
+            // The victim still owns their account, their permissions and their factor.
+            const storedVictim = await User.getByID(victim.id);
+            expect(storedVictim).toBeDefined();
+            expect(storedVictim!.email).toBe(victim.email);
+            expect(await MFATOTP.getByID(victimTotp.id)).toBeDefined();
+
+            const storedAttacker = await User.getByID(attacker.id);
+            expect(storedAttacker!.email).toBe(attacker.email);
+            expect(storedAttacker!.permissions).toBeNull();
+        });
+
+        test('an account without a second factor can still be merged', async () => {
+            // Merging is a real feature for people who signed up twice. Without a factor,
+            // whoever reads the mailbox could take that account over with a password reset
+            // anyway, so nothing is bypassed here.
+            const organization = await new OrganizationFactory({}).create();
+            const other = await new UserFactory({ organization, password, permissions: Permissions.create({ level: PermissionLevel.Full }) }).create();
+
+            const user = await new UserFactory({ organization, password }).create();
+            const token = await freshToken(user);
+
+            const code = await requestEmailChange(user, token, other.email, organization);
+
+            const response = await testServer.test(new VerifyEmailEndpoint(), bearer(Request.buildJson('POST', '/verify-email', organization.getApiHost(), { token: code.token, code: code.code }), token));
+            expect(response.body).toBeInstanceOf(TokenStruct);
+
+            expect(await User.getByID(other.id)).toBeUndefined();
+            const stored = await User.getByID(user.id);
+            expect(stored!.email).toBe(other.email);
+            expect(stored!.permissions).not.toBeNull();
         });
     });
 

--- a/backend/app/api/src/endpoints/auth/VerifyEmailEndpoint.ts
+++ b/backend/app/api/src/endpoints/auth/VerifyEmailEndpoint.ts
@@ -82,6 +82,20 @@ export class VerifyEmailEndpoint extends Endpoint<Params, Query, Body, ResponseB
             const other = await User.getForAuthentication(user.organizationId, code.email, { allowWithoutAccount: true });
 
             if (other) {
+                // Merging absorbs the other account (its permissions included) and then
+                // deletes it, second factor and all. Reading the mailbox is exactly the
+                // single credential a second factor exists to back up, so an account that
+                // has one may not be taken over this way: nothing in this request proves
+                // the caller can pass it.
+                if (await TwoFactorHelper.userHasFactors(other.id)) {
+                    throw new SimpleError({
+                        code: 'email_in_use',
+                        message: 'This e-mail is already in use by an account with two-factor authentication',
+                        human: $t('Er bestaat al een account met dit e-mailadres dat beveiligd is met tweestapsverificatie. Log in op het bestaande account in plaats van je e-mailadres te wijzigen.'),
+                        statusCode: 400,
+                    });
+                }
+
                 // Delete the other user, but merge data
                 await user.merge(other);
                 if (user.organizationId) {


### PR DESCRIPTION
`/verify-email` merged any account that already owned the verified address into the account doing the verification. `User.merge()` copies the other account's permissions over and then deletes its row — and `mfa_totp`, `webauthn_credentials` and the recovery codes all cascade on `users`, so the absorbed account's second factor disappeared with it.

That turned read access to an admin's mailbox into their permissions on an attacker-controlled account with no second factor:

1. sign up a plain account A, sign in;
2. `PATCH /user/{A}` with the admin's email — allowed for your own account, no privilege needed;
3. `POST /verify-email` with the mailed code → A absorbs the admin, their factors are deleted.

The final second-factor check didn't catch it either: the "already signed in as this user" shortcut compares against A, the account that just absorbed the admin.

Mailbox access is exactly the single credential a second factor exists to back up — `assertSecondFactorOrThrow(..., { loginMethod: 'email' })` already guards the password-reset and email-verification grants for that reason. This merge went around it.

## Fix

Refuse the merge when the other account has an enrolled factor. Accounts without one still merge (the "I signed up twice" flow): whoever reads that mailbox could take them over with a password reset anyway, so nothing is bypassed there. `merge()` has no other callers.

The check sits at verification time rather than on the email change, so it takes the mailed code to reach it — it can't be used to probe which addresses have 2FA.

## Tests

New `merging accounts` block in `MFA.security.test.ts`, driving the real `PATCH /user` → `/verify-email` sequence. The takeover test fails on the unpatched code (the request succeeds) and passes after; the second test pins that an ordinary merge still works.

Full api suite, lint and typecheck are green.

## Left alone

The signed-in shortcut still skips the second-factor check after a merge. With this fix the absorbed account has no factors, so the only residue is that permissions merged in from an admin who was required to enroll but never did won't force enrollment in that session. The same attacker gets the same access through a password reset by enrolling a factor of their own, so it isn't a new boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788421350&installation_model_id=423362&pr_number=701&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F701&signature=f253e5cc49715be9d20d91d2ab84463da461ee6fa743f1242045947721b49e66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->