### PR TITLE
✨ Added WebshopUitpasNumberStruct

### DIFF
--- a/backend/shared/models/src/models/WebshopUitpasNumber.ts
+++ b/backend/shared/models/src/models/WebshopUitpasNumber.ts
@@ -62,8 +62,7 @@ export class WebshopUitpasNumber extends QueryableModel {
 
         if (uitpasEventUrl) {
             query = query.andWhere(SQL.where('productId', productId).or('uitpasEventUrl', uitpasEventUrl));
-        }
-        else {
+        } else {
             query = query.andWhere('productId', productId);
         }
 

--- a/shared/structures/src/index.ts
+++ b/shared/structures/src/index.ts
@@ -208,6 +208,7 @@ export * from './webshops/TransferSettings.js';
 export * from './webshops/Webshop.js';
 export * from './webshops/WebshopField.js';
 export * from './webshops/WebshopMetaData.js';
+export * from './webshops/WebshopUitpasNumberStruct.js';
 export * from './webshops/WebshopWithOrganization.js';
 export * from './webshops/UitpasNumberAndPrice.js';
 

--- a/shared/structures/src/webshops/WebshopUitpasNumberStruct.ts
+++ b/shared/structures/src/webshops/WebshopUitpasNumberStruct.ts
@@ -1,0 +1,79 @@
+import { AutoEncoder, DateDecoder, field, IntegerDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+
+/**
+ * One UiTPAS number used for one product in one order.
+ */
+export class WebshopUitpasNumberStruct extends AutoEncoder {
+    @field({ decoder: StringDecoder })
+    id = '';
+
+    @field({ decoder: StringDecoder })
+    uitpasNumber = '';
+
+    @field({ decoder: StringDecoder })
+    webshopId = '';
+
+    @field({ decoder: StringDecoder })
+    productId = '';
+
+    /**
+     * Resolved by the backend: products are stored inside the webshop, so clients
+     * that don't have the webshop loaded can't look this up themselves.
+     */
+    @field({ decoder: StringDecoder })
+    productName = '';
+
+    @field({ decoder: StringDecoder })
+    orderId = '';
+
+    /**
+     * Null as long as the order hasn't been marked as valid.
+     */
+    @field({ decoder: IntegerDecoder, nullable: true })
+    orderNumber: number | null = null;
+
+    @field({ decoder: DateDecoder })
+    orderCreatedAt: Date = new Date();
+
+    /**
+     * Name of the customer that placed the order.
+     */
+    @field({ decoder: StringDecoder })
+    orderName = '';
+
+    /**
+     * Set when the product is linked to an UiTPAS event and the ticket sale was registered
+     * via the UiTPAS API.
+     */
+    @field({ decoder: StringDecoder, nullable: true })
+    ticketSaleId: string | null = null;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    uitpasEventUrl: string | null = null;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    uitpasTariffId: string | null = null;
+
+    @field({ decoder: IntegerDecoder })
+    basePrice = 0;
+
+    @field({ decoder: StringDecoder })
+    basePriceLabel = '';
+
+    @field({ decoder: IntegerDecoder })
+    reducedPrice = 0;
+
+    /**
+     * The reduced price at the time the ticket sale was registered, which can differ from
+     * the reduced price when the order was placed.
+     */
+    @field({ decoder: IntegerDecoder, nullable: true })
+    reducedPriceUitpas: number | null = null;
+
+    @field({ decoder: DateDecoder, nullable: true })
+    registeredAt: Date | null = null;
+
+    get isRegistered(): boolean {
+        return this.registeredAt !== null;
+    }
+}


### PR DESCRIPTION
First PR in a stack that makes the `webshop_uitpas_numbers` rows visible in a `ModernTableView` on a webshop.

## What

A new `WebshopUitpasNumberStruct` in `@stamhoofd/structures`, plus the index export. Nothing consumes it yet — the endpoints come in the next PR.

## Notes

- **No versioning needed.** This is a brand new AutoEncoder class, so there is no older encoded data to upgrade: fields carry no `version:`/`...NextVersion`. Only new fields on *existing* classes would need that.
- **`productName`, `orderNumber`, `orderCreatedAt` and `orderName` are denormalised** into the structure. Products live inside the webshop's JSON blob, so a client that only fetches this list cannot resolve a `productId` on its own. The order fields are also needed as sort/paging keys — the table sorts on the joined `webshop_orders.createdAt`, and `getSortFilter` reads the sort values back off the returned structures.
- Prices are in the current 4-decimal representation, matching what the columns hold since migration `1763216330`.

## Stack

1. **#703 — structures (this PR)**
2. backend: sql filters/sorters + `GET /webshop/uitpas-numbers` (+ `/count`) + tests
3. frontend shared: object fetcher, filter builders, reusable table view + detail view
4. dashboard: entry point in `WebshopOverview` + Playwright test

🤖 Generated with [Claude Code](https://claude.com/claude-code)