### PR TITLE
♻️ Renamed Settlement structure to SettlementReference

### DIFF
--- a/backend/app/api/src/crons/fake-settlements.test.ts
+++ b/backend/app/api/src/crons/fake-settlements.test.ts
@@ -1,6 +1,6 @@
 import type { Organization } from '@stamhoofd/models';
 import { OrganizationFactory, Payment, StripeAccount } from '@stamhoofd/models';
-import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, Settlement } from '@stamhoofd/structures';
+import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, SettlementReference } from '@stamhoofd/structures';
 import { TestUtils } from '@stamhoofd/test-utils';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
@@ -138,7 +138,7 @@ describe('Cron.fake-settlements', () => {
     });
 
     test('A payment that was already paid out keeps its own payout', async () => {
-        const settlement = Settlement.create({
+        const settlement = SettlementReference.create({
             id: 'stl_1',
             reference: '1234.1234.1234',
             settledAt: inWeek(1),

--- a/backend/app/api/src/crons/fake-settlements.ts
+++ b/backend/app/api/src/crons/fake-settlements.ts
@@ -7,7 +7,7 @@
 import { registerCron } from '@stamhoofd/crons';
 import { Order, Payment } from '@stamhoofd/models';
 import { SQL } from '@stamhoofd/sql';
-import { PaymentStatus, Settlement } from '@stamhoofd/structures';
+import { PaymentStatus, SettlementReference } from '@stamhoofd/structures';
 import { SETTLING_PAYMENT_PROVIDERS } from '@stamhoofd/structures/PaymentSettlement.js';
 import { Formatter } from '@stamhoofd/utility';
 import type { DateTime } from 'luxon';
@@ -100,7 +100,7 @@ async function settleWeek(payments: Payment[], weekStart: DateTime, settledAt: D
         const amount = group.reduce((total, payment) => total + payment.price, 0);
 
         for (const payment of group) {
-            payment.settlement = Settlement.create({ id, reference, settledAt, amount });
+            payment.settlement = SettlementReference.create({ id, reference, settledAt, amount });
             await payment.save();
 
             // Mark order as 'updated', or the frontend won't pull in the updates

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemBreakdownEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemBreakdownEndpoint.test.ts
@@ -2,7 +2,7 @@ import { Request } from '@simonbackx/simple-endpoints';
 import type { BalanceItem, Organization, User } from '@stamhoofd/models';
 import { BalanceItemFactory, BalanceItemPayment, OrderFactory, OrganizationFactory, Payment, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
 import type { StamhoofdFilter } from '@stamhoofd/structures';
-import { BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, Cart, CartItem, CartItemOption, CartItemPrice, Customer, Option, OptionMenu, OrderData, PaymentMethod, PaymentProvider, PaymentStatus, PermissionLevel, Permissions, Product, ProductPrice, Settlement, TranslatedString } from '@stamhoofd/structures';
+import { BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, Cart, CartItem, CartItemOption, CartItemPrice, Customer, Option, OptionMenu, OrderData, PaymentMethod, PaymentProvider, PaymentStatus, PermissionLevel, Permissions, Product, ProductPrice, SettlementReference, TranslatedString } from '@stamhoofd/structures';
 import { BreakdownRequest } from '@stamhoofd/structures/breakdown/BreakdownRequest.js';
 import type { BalanceItemBreakdown } from '@stamhoofd/structures/PaymentBreakdown.js';
 import { BreakdownAmountType, BreakdownObjectType, BreakdownPathItem, BreakdownTab } from '@stamhoofd/structures/PaymentBreakdown.js';
@@ -254,13 +254,13 @@ describe('Endpoint.GetBalanceItemBreakdownEndpoint', () => {
     });
 
     describe('Grouping by payout', () => {
-        const march = Settlement.create({ id: 'stl_march', reference: '1234567.0312.01', settledAt: new Date(2026, 2, 12), amount: 0 });
-        const april = Settlement.create({ id: 'stl_april', reference: '1234567.0409.01', settledAt: new Date(2026, 3, 9), amount: 0 });
+        const march = SettlementReference.create({ id: 'stl_march', reference: '1234567.0312.01', settledAt: new Date(2026, 2, 12), amount: 0 });
+        const april = SettlementReference.create({ id: 'stl_april', reference: '1234567.0409.01', settledAt: new Date(2026, 3, 9), amount: 0 });
 
         /**
          * Pays a part of a balance item, the way a payment provider settles it afterwards.
          */
-        const payItem = async (organization: Organization, balanceItem: BalanceItem, options: { price: number; settlement?: Settlement; status?: PaymentStatus; method?: PaymentMethod }) => {
+        const payItem = async (organization: Organization, balanceItem: BalanceItem, options: { price: number; settlement?: SettlementReference; status?: PaymentStatus; method?: PaymentMethod }) => {
             const payment = new Payment();
             payment.organizationId = organization.id;
             payment.method = options.method ?? PaymentMethod.Bancontact;

--- a/backend/app/api/src/endpoints/organization/dashboard/payments/GetPaymentBreakdownEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/payments/GetPaymentBreakdownEndpoint.test.ts
@@ -2,7 +2,7 @@ import { Request } from '@simonbackx/simple-endpoints';
 import type { BalanceItem, Organization, User } from '@stamhoofd/models';
 import { BalanceItemFactory, BalanceItemPayment, OrderFactory, OrganizationFactory, Payment, StripeAccount, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
 import type { StamhoofdFilter } from '@stamhoofd/structures';
-import { BalanceItemRelation, BalanceItemRelationType, BalanceItemType, Cart, CartItem, CartItemOption, CartItemPrice, Customer, getBalanceItemTypeIcon, getPaymentProviderName, OptionMenu, OrderData, Option, PaymentMethod, PaymentMethodHelper, PaymentProvider, PaymentStatus, PermissionLevel, Permissions, Product, ProductPrice, Settlement, StripeBusinessProfile, StripeMetaData, TransferSettings, TranslatedString } from '@stamhoofd/structures';
+import { BalanceItemRelation, BalanceItemRelationType, BalanceItemType, Cart, CartItem, CartItemOption, CartItemPrice, Customer, getBalanceItemTypeIcon, getPaymentProviderName, OptionMenu, OrderData, Option, PaymentMethod, PaymentMethodHelper, PaymentProvider, PaymentStatus, PermissionLevel, Permissions, Product, ProductPrice, SettlementReference, StripeBusinessProfile, StripeMetaData, TransferSettings, TranslatedString } from '@stamhoofd/structures';
 import { BreakdownRequest } from '@stamhoofd/structures/breakdown/BreakdownRequest.js';
 import type { PaymentBreakdown } from '@stamhoofd/structures/PaymentBreakdown.js';
 import { BreakdownGraphUnit, BreakdownObjectType, BreakdownPathItem, BreakdownTab } from '@stamhoofd/structures/PaymentBreakdown.js';
@@ -142,7 +142,7 @@ describe('Endpoint.GetPaymentBreakdownEndpoint', () => {
         iban?: string;
         transferDescription?: string;
         transferFee?: number;
-        settlement?: Settlement;
+        settlement?: SettlementReference;
         /**
          * What this payment rounded away, because a payment goes to the cent while what was charged
          * goes to four digits after the comma.
@@ -631,7 +631,7 @@ describe('Endpoint.GetPaymentBreakdownEndpoint', () => {
 
     describe('Grouping by payout', () => {
         const createSettlement = (reference: string, settledAt: Date) => {
-            return Settlement.create({ id: 'stl_' + reference, reference, settledAt, amount: 0 });
+            return SettlementReference.create({ id: 'stl_' + reference, reference, settledAt, amount: 0 });
         };
 
         test('per payout, with what is not online and what still has to be paid out apart', async () => {

--- a/backend/app/api/src/helpers/CheckSettlements.ts
+++ b/backend/app/api/src/helpers/CheckSettlements.ts
@@ -1,5 +1,5 @@
 import { MolliePayment, MollieToken, Order, Organization, PayconiqPayment, Payment, StripeAccount } from '@stamhoofd/models';
-import { Settlement } from '@stamhoofd/structures';
+import { SettlementReference } from '@stamhoofd/structures';
 import axios from 'axios';
 
 import { StripePayoutChecker } from './StripePayoutChecker.js';
@@ -203,7 +203,7 @@ async function applySettlementToPayment(settlement: MollieSettlement, mollieId: 
         const mp = mps[0];
         const payment = await Payment.getByID(mp.paymentId);
         if (payment) {
-            payment.settlement = Settlement.create({
+            payment.settlement = SettlementReference.create({
                 id: settlement.id,
                 reference: settlement.reference,
                 settledAt: new Date(settlement.settledAt),

--- a/backend/app/api/src/helpers/StripePayoutChecker.ts
+++ b/backend/app/api/src/helpers/StripePayoutChecker.ts
@@ -1,5 +1,5 @@
 import { Order, Payment, StripeCheckoutSession, StripePaymentIntent } from '@stamhoofd/models';
-import { Settlement } from '@stamhoofd/structures';
+import { SettlementReference } from '@stamhoofd/structures';
 import Stripe from 'stripe';
 import { passthroughFetch } from './passthroughFetch.js';
 
@@ -167,7 +167,7 @@ export class StripePayoutChecker {
             return;
         }
 
-        const settlement = Settlement.create({
+        const settlement = SettlementReference.create({
             id: payout.id,
             reference: payout.statement_descriptor ?? '',
             settledAt: new Date(payout.arrival_date * 1000),

--- a/backend/app/api/src/sql-filters/payment-settlement.test.ts
+++ b/backend/app/api/src/sql-filters/payment-settlement.test.ts
@@ -1,5 +1,5 @@
 import { compileToSQLFilter } from '@stamhoofd/sql';
-import { PaymentMethod, PaymentProvider, PaymentStatus, Settlement } from '@stamhoofd/structures';
+import { PaymentMethod, PaymentProvider, PaymentStatus, SettlementReference } from '@stamhoofd/structures';
 import { toBalanceItemFilter } from '@stamhoofd/structures/breakdown/breakdownFilters.js';
 import type { SettleablePayment } from '@stamhoofd/structures/PaymentSettlement.js';
 import { ACCOUNT_DEDUCTIONS_ID, FAILED_PAYMENT_ID, getPaymentSettlement, PENDING_PAYMENT_ID } from '@stamhoofd/structures/PaymentSettlement.js';
@@ -7,7 +7,7 @@ import { balanceItemFilterCompilers } from './balance-items.js';
 import { paymentFilterCompilers } from './payments.js';
 
 describe('paymentSettlementFilterCompilers', () => {
-    const settlement = Settlement.create({
+    const settlement = SettlementReference.create({
         id: 'settlement-1',
         reference: 'ST-2026-01',
         settledAt: new Date(2026, 0, 15),

--- a/backend/shared/models/src/models/Payment.ts
+++ b/backend/shared/models/src/models/Payment.ts
@@ -1,5 +1,5 @@
 import { column } from '@simonbackx/simple-database';
-import { BalanceItemDetailed, BalanceItemPaymentDetailed, BaseOrganization, PaymentCustomer, PaymentGeneral, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, Settlement, TransferSettings } from '@stamhoofd/structures';
+import { BalanceItemDetailed, BalanceItemPaymentDetailed, BaseOrganization, PaymentCustomer, PaymentGeneral, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, SettlementReference, TransferSettings } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -225,8 +225,8 @@ export class Payment extends QueryableModel {
     paidAt: Date | null = null;
 
     /// Settlement meta data
-    @column({ type: 'json', decoder: Settlement, nullable: true })
-    settlement: Settlement | null = null;
+    @column({ type: 'json', decoder: SettlementReference, nullable: true })
+    settlement: SettlementReference | null = null;
 
     @column({ type: 'string', nullable: true })
     iban: string | null = null;

--- a/shared/structures/src/PaymentSettlement.ts
+++ b/shared/structures/src/PaymentSettlement.ts
@@ -1,6 +1,6 @@
 import { Formatter } from '@stamhoofd/utility';
 import type { StamhoofdFilter } from './filters/StamhoofdFilter.js';
-import type { Settlement } from './members/Payment.js';
+import type { SettlementReference } from './members/Payment.js';
 import { OFFLINE_PAYMENT_METHODS, PaymentMethod, PaymentMethodHelper } from './PaymentMethod.js';
 import { getPaymentProviderName, PaymentProvider } from './PaymentProvider.js';
 import { PaymentStatus } from './PaymentStatus.js';
@@ -39,7 +39,7 @@ export const PENDING_PAYMENT_STATUSES = [PaymentStatus.Created, PaymentStatus.Pe
 export type SettleablePayment = {
     method: PaymentMethod;
     provider: PaymentProvider | null;
-    settlement: Settlement | null;
+    settlement: SettlementReference | null;
     status: PaymentStatus;
 };
 
@@ -198,7 +198,7 @@ export function getFailedPaymentGroup(): PaymentSettlementGroup {
     });
 }
 
-function getSettledGroup(provider: PaymentProvider | null, settlement: Settlement): PaymentSettlementGroup {
+function getSettledGroup(provider: PaymentProvider | null, settlement: SettlementReference): PaymentSettlementGroup {
     const date = Formatter.date(settlement.settledAt, true);
 
     return new PaymentSettlementGroup({

--- a/shared/structures/src/billing/STInvoicePrivate.ts
+++ b/shared/structures/src/billing/STInvoicePrivate.ts
@@ -1,7 +1,7 @@
 import { field, StringDecoder } from '@simonbackx/simple-encoding';
 import { StringCompare } from '@stamhoofd/utility';
 
-import { Settlement } from '../members/Payment.js';
+import { SettlementReference } from '../members/Payment.js';
 import { OrganizationSimple } from '../OrganizationSimple.js';
 import { STInvoice } from './STInvoice.js';
 
@@ -9,8 +9,8 @@ export class STInvoicePrivate extends STInvoice {
     @field({ decoder: OrganizationSimple, optional: true })
     organization?: OrganizationSimple;
 
-    @field({ decoder: Settlement, nullable: true })
-    settlement: Settlement | null = null;
+    @field({ decoder: SettlementReference, nullable: true })
+    settlement: SettlementReference | null = null;
 
     @field({ decoder: StringDecoder, nullable: true, version: 186 })
     reference: string | null = null;

--- a/shared/structures/src/breakdown/breakdownBuilders.test.ts
+++ b/shared/structures/src/breakdown/breakdownBuilders.test.ts
@@ -2,7 +2,7 @@ import { TestUtils } from '@stamhoofd/test-utils';
 import type { StamhoofdFilter } from '../filters/StamhoofdFilter.js';
 import { BalanceItem, BalanceItemPaymentWithPrivatePayment, BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, getBalanceItemTypeName } from '../BalanceItem.js';
 import { BalanceItemPaymentDetailed } from '../BalanceItemDetailed.js';
-import { PrivatePayment, Settlement } from '../members/Payment.js';
+import { PrivatePayment, SettlementReference } from '../members/Payment.js';
 import { PaymentGeneral } from '../members/PaymentGeneral.js';
 import { PaymentMethod, PaymentMethodHelper } from '../PaymentMethod.js';
 import { getPaymentProviderName, PaymentProvider } from '../PaymentProvider.js';
@@ -95,7 +95,7 @@ describe('Breakdown builders', () => {
         provider?: PaymentProvider | null;
         transferSettings?: TransferSettings | null;
         stripeAccountId?: string | null;
-        settlement?: Settlement | null;
+        settlement?: SettlementReference | null;
         status?: PaymentStatus;
         /**
          * What this payment rounded away, because a payment goes to the cent while what was charged
@@ -127,7 +127,7 @@ describe('Breakdown builders', () => {
      * A payout of a payment provider, e.g. everything Mollie transferred on one day.
      */
     function createSettlement({ reference, settledAt }: { reference: string; settledAt: string }) {
-        return Settlement.create({
+        return SettlementReference.create({
             id: 'stl_' + reference,
             reference,
             settledAt: new Date(settledAt),
@@ -138,7 +138,7 @@ describe('Breakdown builders', () => {
     /**
      * An online payment of one balance item, the way a balance item knows how it was paid.
      */
-    function createOnlinePaymentFor(price: number, options: { settlement?: Settlement | null; status?: PaymentStatus; provider?: PaymentProvider } = {}) {
+    function createOnlinePaymentFor(price: number, options: { settlement?: SettlementReference | null; status?: PaymentStatus; provider?: PaymentProvider } = {}) {
         return BalanceItemPaymentWithPrivatePayment.create({
             price,
             payment: PrivatePayment.create({
@@ -422,7 +422,7 @@ describe('Breakdown builders', () => {
         const march = createSettlement({ reference: '1234567.0312.01', settledAt: '2026-03-12T09:00:00.000Z' });
         const april = createSettlement({ reference: '1234567.0409.01', settledAt: '2026-04-09T09:00:00.000Z' });
 
-        function createOnlinePayment(item: BalanceItem, price: number, settlement: Settlement | null) {
+        function createOnlinePayment(item: BalanceItem, price: number, settlement: SettlementReference | null) {
             return createPayment({ items: [[item, price]], method: PaymentMethod.Bancontact, provider: PaymentProvider.Mollie, settlement });
         }
 

--- a/shared/structures/src/members/Payment.ts
+++ b/shared/structures/src/members/Payment.ts
@@ -189,7 +189,7 @@ export class Payment extends AutoEncoder {
         ];
 
         for (const replacement of data) {
-            if (replacement.value.length == 0) {
+            if (replacement.value.length === 0) {
                 continue;
             }
             str += `<tr><td><h4>${Formatter.escapeHtml(replacement.title)}</h4></td><td>${Formatter.escapeHtml(replacement.value)}</td></tr>`;
@@ -211,7 +211,7 @@ export class Payment extends AutoEncoder {
     }
 }
 
-export class Settlement extends AutoEncoder {
+export class SettlementReference extends AutoEncoder {
     @field({ decoder: StringDecoder })
     id: string;
 
@@ -236,8 +236,8 @@ export class Settlement extends AutoEncoder {
 }
 
 export class PrivatePayment extends Payment {
-    @field({ decoder: Settlement, nullable: true })
-    settlement: Settlement | null = null;
+    @field({ decoder: SettlementReference, nullable: true })
+    settlement: SettlementReference | null = null;
 
     @field({ decoder: StringDecoder, nullable: true, version: 153 })
     iban: string | null = null;

--- a/tests/playwright/src/tests/payment-breakdown.spec.ts
+++ b/tests/playwright/src/tests/payment-breakdown.spec.ts
@@ -19,7 +19,7 @@ import {
     PaymentType,
     PermissionLevel,
     Permissions,
-    Settlement,
+    SettlementReference,
     STPackageBundle,
     Token as TokenStruct,
     TransferSettings,
@@ -90,7 +90,7 @@ test.describe('Payment breakdown (organization mode) @payment-breakdown', () => 
         /**
          * The payout of the provider this payment was part of.
          */
-        settlement?: Settlement;
+        settlement?: SettlementReference;
     }): Promise<BalanceItem> {
         const registration = await new RegistrationFactory({ member, group }).create();
 
@@ -236,7 +236,7 @@ test.describe('Payment breakdown (organization mode) @payment-breakdown', () => 
         const second = await new MemberFactory({ organization, firstName: 'Jonas', lastName: 'Claes' }).create();
         const third = await new MemberFactory({ organization, firstName: 'Marie', lastName: 'Willems' }).create();
 
-        const payout = Settlement.create({
+        const payout = SettlementReference.create({
             id: 'stl_playwright',
             reference: '1234567.0312.01',
             settledAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),


### PR DESCRIPTION
The name Settlement goes to the new settlements table entity; this legacy JSON blob on PrivatePayment is a cached reference. Encoded field name stays 'settlement', so the wire format is unchanged.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788448924&installation_model_id=423362&pr_number=706&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F706&signature=8c018c1493507d13ad0730915caa5a27e4447c1e9f4a14ffd0084a759a386e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->