### PR TITLE
✨ SettlementService: upserts, sweep, finishSync, legacy dual-write

### DIFF
--- a/backend/app/api/src/services/SettlementService.test.ts
+++ b/backend/app/api/src/services/SettlementService.test.ts
@@ -1,0 +1,316 @@
+import type { Organization } from '@stamhoofd/models';
+import { OrganizationFactory, Payment, StripeAccount } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { PaymentMethod, PaymentProvider, PaymentStatus, SettlementReference } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { v4 as uuidv4 } from 'uuid';
+import { ReportedRows, SettlementService } from './SettlementService.js';
+
+describe('SettlementService', () => {
+    let organization: Organization;
+
+    beforeAll(async () => {
+        organization = await new OrganizationFactory({}).create();
+    });
+
+    async function createPayment(price = 50_00_00) {
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.method = PaymentMethod.Bancontact;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = price;
+        payment.paidAt = new Date();
+        await payment.save();
+        return payment;
+    }
+
+    function settlementData(overrides: Partial<Parameters<typeof SettlementService.upsertSettlement>[0]> = {}) {
+        return {
+            provider: PaymentProvider.Stripe,
+            externalId: 'po_' + uuidv4(),
+            organizationId: organization.id,
+            amount: 370_00_00,
+            reference: 'STRIPE PAYOUT',
+            settledAt: new Date(2026, 0, 15),
+            ...overrides,
+        };
+    }
+
+    describe('upsertSettlement', () => {
+        test('re-running updates the same row instead of duplicating', async () => {
+            const data = settlementData();
+            const created = await SettlementService.upsertSettlement(data);
+
+            const updated = await SettlementService.upsertSettlement({ ...data, amount: 400_00_00 });
+
+            expect(updated.id).toBe(created.id);
+            expect(updated.amount).toBe(400_00_00);
+            expect(await Settlement.select().where('externalId', data.externalId).count()).toBe(1);
+        });
+
+        test('the same externalId of a different provider is a different settlement', async () => {
+            const externalId = 'shared_' + uuidv4();
+            const stripe = await SettlementService.upsertSettlement(settlementData({ externalId }));
+            const mollie = await SettlementService.upsertSettlement(settlementData({ externalId, provider: PaymentProvider.Mollie }));
+
+            expect(mollie.id).not.toBe(stripe.id);
+        });
+
+        test('undefined optional fields keep their stored value', async () => {
+            const data = settlementData({ stripeAccountId: null });
+            const created = await SettlementService.upsertSettlement(data);
+            expect(created.organizationId).toBe(organization.id);
+
+            const updated = await SettlementService.upsertSettlement({
+                provider: data.provider,
+                externalId: data.externalId,
+                organizationId: organization.id,
+                amount: data.amount,
+                settledAt: data.settledAt,
+            });
+            expect(updated.stripeAccountId).toBe(null);
+            expect(updated.reference).toBe('STRIPE PAYOUT');
+        });
+    });
+
+    describe('upsertPaymentLine', () => {
+        test('idempotent per (settlement, externalId), but the same transaction can sit in another settlement', async () => {
+            const payment = await createPayment();
+            const s1 = await SettlementService.upsertSettlement(settlementData());
+            const s2 = await SettlementService.upsertSettlement(settlementData());
+
+            const line = await SettlementService.upsertPaymentLine(s1, {
+                paymentId: payment.id,
+                amount: 50_00_00,
+                externalId: 'txn_1',
+                occurredAt: new Date(2026, 0, 14),
+            });
+            const again = await SettlementService.upsertPaymentLine(s1, {
+                paymentId: payment.id,
+                amount: 51_00_00,
+                externalId: 'txn_1',
+                occurredAt: new Date(2026, 0, 14),
+            });
+            const other = await SettlementService.upsertPaymentLine(s2, {
+                paymentId: payment.id,
+                amount: -20_00_00,
+                externalId: 'txn_1',
+                occurredAt: new Date(2026, 0, 20),
+            });
+
+            expect(again.id).toBe(line.id);
+            expect(again.amount).toBe(51_00_00);
+            expect(other.id).not.toBe(line.id);
+            expect(await PaymentSettlement.select().where('paymentId', payment.id).count()).toBe(2);
+        });
+    });
+
+    describe('upsertCharge', () => {
+        test('idempotent by externalId, and undefined fields keep their stored value', async () => {
+            const settlement = await SettlementService.upsertSettlement(settlementData());
+            const externalId = 'fee_' + uuidv4() + ':ReceivedApplicationFeeService';
+
+            const created = await SettlementService.upsertCharge({
+                type: SettlementChargeType.ReceivedApplicationFeeService,
+                externalId,
+                amount: 1_00_00,
+                settlementId: settlement.id,
+                applicationFeeId: 'fee_123',
+                occurredAt: new Date(2026, 0, 14),
+            });
+
+            // The fee sync doesn't know the settlement: it may not unlink the row
+            const updated = await SettlementService.upsertCharge({
+                type: SettlementChargeType.ReceivedApplicationFeeService,
+                externalId,
+                amount: 1_10_00,
+                occurredAt: new Date(2026, 0, 14),
+            });
+
+            expect(updated.id).toBe(created.id);
+            expect(updated.amount).toBe(1_10_00);
+            expect(updated.settlementId).toBe(settlement.id);
+            expect(updated.applicationFeeId).toBe('fee_123');
+
+            // An explicit null does clear the link
+            const cleared = await SettlementService.upsertCharge({
+                type: SettlementChargeType.ReceivedApplicationFeeService,
+                externalId,
+                amount: 1_10_00,
+                settlementId: null,
+                occurredAt: new Date(2026, 0, 14),
+            });
+            expect(cleared.settlementId).toBe(null);
+        });
+    });
+
+    describe('sweepSettlement', () => {
+        test('deletes payout-only rows, but only unlinks the Received fee rows', async () => {
+            const payment = await createPayment();
+            const settlement = await SettlementService.upsertSettlement(settlementData());
+
+            const keptLine = await SettlementService.upsertPaymentLine(settlement, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_kept', occurredAt: new Date(2026, 0, 14),
+            });
+            const movedLine = await SettlementService.upsertPaymentLine(settlement, {
+                paymentId: payment.id, amount: 10_00_00, externalId: 'txn_moved', occurredAt: new Date(2026, 0, 14),
+            });
+            const received = await SettlementService.upsertCharge({
+                type: SettlementChargeType.ReceivedApplicationFeeService,
+                externalId: 'fee_' + uuidv4() + ':ReceivedApplicationFeeService',
+                amount: 1_00_00,
+                settlementId: settlement.id,
+                occurredAt: new Date(2026, 0, 14),
+            });
+            const providerFee = await SettlementService.upsertCharge({
+                type: SettlementChargeType.ProviderTransactionFee,
+                externalId: 'txn_moved:fee:0',
+                amount: -30_00,
+                settlementId: settlement.id,
+                occurredAt: new Date(2026, 0, 14),
+            });
+            const keptFee = await SettlementService.upsertCharge({
+                type: SettlementChargeType.ProviderTransactionFee,
+                externalId: 'txn_kept:fee:0',
+                amount: -25_00,
+                settlementId: settlement.id,
+                occurredAt: new Date(2026, 0, 14),
+            });
+
+            const reported = new ReportedRows();
+            reported.paymentLine(keptLine);
+            reported.charge(keptFee);
+            await SettlementService.sweepSettlement(settlement, reported);
+
+            expect(await PaymentSettlement.getByID(keptLine.id)).toBeDefined();
+            expect(await PaymentSettlement.getByID(movedLine.id)).toBeUndefined();
+            expect(await SettlementCharge.getByID(providerFee.id)).toBeUndefined();
+            expect((await SettlementCharge.getByID(keptFee.id))?.settlementId).toBe(settlement.id);
+
+            const unlinked = await SettlementCharge.getByID(received.id);
+            expect(unlinked).toBeDefined();
+            expect(unlinked!.settlementId).toBe(null);
+        });
+    });
+
+    describe('finishSync and markSyncFailed', () => {
+        test('finishSync caches the reconciliation delta and resets the failure count', async () => {
+            const payment = await createPayment();
+            const settlement = await SettlementService.upsertSettlement(settlementData({ amount: 48_70_00 }));
+            await SettlementService.markSyncFailed(settlement);
+            expect(settlement.syncFailureCount).toBe(1);
+            expect(settlement.syncedAt).toBe(null);
+
+            await SettlementService.upsertPaymentLine(settlement, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_1', occurredAt: new Date(2026, 0, 14),
+            });
+            await SettlementService.upsertCharge({
+                type: SettlementChargeType.ApplicationFeeService,
+                externalId: 'fee_' + uuidv4() + ':ApplicationFeeService',
+                amount: -1_00_00,
+                settlementId: settlement.id,
+                occurredAt: new Date(2026, 0, 14),
+            });
+
+            await SettlementService.finishSync(settlement, { transactionCount: 2 });
+
+            // 48.70 - (50.00 - 1.00) = -0.30 unexplained
+            expect(settlement.unexplainedAmount).toBe(-30_00);
+            expect(settlement.transactionCount).toBe(2);
+            expect(settlement.syncedAt).not.toBe(null);
+            expect(settlement.syncFailureCount).toBe(0);
+        });
+    });
+
+    describe('updateLegacySettlementReference', () => {
+        test('the largest line wins and re-syncs never flip-flop the column', async () => {
+            const payment = await createPayment();
+            const original = await SettlementService.upsertSettlement(settlementData({ settledAt: new Date(2026, 0, 15) }));
+            const refundPayout = await SettlementService.upsertSettlement(settlementData({ settledAt: new Date(2026, 0, 22) }));
+
+            await SettlementService.upsertPaymentLine(original, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_pay', occurredAt: new Date(2026, 0, 14),
+            });
+            await SettlementService.upsertPaymentLine(refundPayout, {
+                paymentId: payment.id, amount: -20_00_00, externalId: 'txn_refund', occurredAt: new Date(2026, 0, 21),
+            });
+
+            await SettlementService.updateLegacySettlementReference(payment);
+            expect(payment.settlement?.id).toBe(original.externalId);
+            expect(payment.settlement?.amount).toBe(original.amount);
+
+            await SettlementService.updateLegacySettlementReference(payment);
+            expect(payment.settlement?.id).toBe(original.externalId);
+        });
+
+        test('keeps the deprecated fee field when the primary settlement is unchanged', async () => {
+            const payment = await createPayment();
+            const settlement = await SettlementService.upsertSettlement(settlementData());
+            await SettlementService.upsertPaymentLine(settlement, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_pay', occurredAt: new Date(2026, 0, 14),
+            });
+
+            // Written earlier by StripePayoutChecker
+            payment.settlement = SettlementReference.create({
+                id: settlement.externalId,
+                reference: 'OLD',
+                settledAt: new Date(2026, 0, 15),
+                amount: 370_00_00,
+                fee: 1_23_00,
+            });
+            await payment.save();
+
+            await SettlementService.updateLegacySettlementReference(payment);
+            expect(payment.settlement?.fee).toBe(1_23_00);
+
+            // A different primary settlement can't invent a fee
+            const bigger = await SettlementService.upsertSettlement(settlementData());
+            await SettlementService.upsertPaymentLine(bigger, {
+                paymentId: payment.id, amount: 60_00_00, externalId: 'txn_bigger', occurredAt: new Date(2026, 0, 20),
+            });
+            await SettlementService.updateLegacySettlementReference(payment);
+            expect(payment.settlement?.id).toBe(bigger.externalId);
+            expect(payment.settlement?.fee).toBe(0);
+        });
+
+        test('the payout of the payment\'s own account beats an equal platform payout line', async () => {
+            const stripeAccount = new StripeAccount();
+            stripeAccount.organizationId = organization.id;
+            stripeAccount.accountId = 'acct_' + uuidv4();
+            await stripeAccount.save();
+
+            const payment = await createPayment();
+            payment.stripeAccountId = stripeAccount.id;
+            await payment.save();
+
+            // A destination charge: gross in our platform payout (settles first) and gross in the
+            // organization payout
+            const platformPayout = await SettlementService.upsertSettlement(settlementData({ stripeAccountId: null, settledAt: new Date(2026, 0, 10) }));
+            const organizationPayout = await SettlementService.upsertSettlement(settlementData({ stripeAccountId: stripeAccount.id, settledAt: new Date(2026, 0, 15) }));
+
+            await SettlementService.upsertPaymentLine(platformPayout, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_platform', occurredAt: new Date(2026, 0, 9),
+            });
+            await SettlementService.upsertPaymentLine(organizationPayout, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_organization', occurredAt: new Date(2026, 0, 9),
+            });
+
+            await SettlementService.updateLegacySettlementReference(payment);
+            expect(payment.settlement?.id).toBe(organizationPayout.externalId);
+        });
+
+        test('a payment without settlement rows is left untouched', async () => {
+            const payment = await createPayment();
+            payment.settlement = SettlementReference.create({
+                id: 'legacy', reference: 'LEGACY', settledAt: new Date(2026, 0, 15), amount: 370_00_00,
+            });
+            await payment.save();
+
+            await SettlementService.updateLegacySettlementReference(payment);
+            expect(payment.settlement?.id).toBe('legacy');
+        });
+    });
+});

--- a/backend/app/api/src/services/SettlementService.ts
+++ b/backend/app/api/src/services/SettlementService.ts
@@ -1,0 +1,352 @@
+import { SimpleError } from '@simonbackx/simple-errors';
+import type { Payment } from '@stamhoofd/models';
+import { Order, Platform } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { QueueHandler } from '@stamhoofd/queues';
+import { SQL } from '@stamhoofd/sql';
+import type { PaymentProvider } from '@stamhoofd/structures';
+import { SettlementReference } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import type { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementStatus.js';
+
+export type SettlementData = {
+    provider: PaymentProvider;
+    externalId: string;
+    stripeAccountId?: string | null;
+    organizationId: string;
+    reference?: string;
+    amount: number;
+    currency?: string;
+    status?: SettlementStatus;
+    settledAt: Date;
+};
+
+export type PaymentLineData = {
+    paymentId: string;
+    amount: number;
+    externalId: string;
+    occurredAt: Date;
+};
+
+export type ChargeData = {
+    type: SettlementChargeType;
+    externalId: string;
+    amount: number;
+    settlementId?: string | null;
+    applicationFeeId?: string | null;
+    paymentId?: string | null;
+    organizationId?: string | null;
+    stripeAccountId?: string | null;
+    providerInvoiceId?: string | null;
+    description?: string;
+    occurredAt: Date;
+};
+
+/**
+ * The Received rows are the invoicing source: the sweep never deletes them and upserts never clear
+ * their balanceItemId.
+ */
+const RECEIVED_FEE_TYPES: SettlementChargeType[] = [
+    SettlementChargeType.ReceivedApplicationFeeService,
+    SettlementChargeType.ReceivedApplicationFeeTransfer,
+];
+
+/**
+ * Collects which rows the provider still reports in a settlement while a sync walks it. A stored
+ * row of the settlement that is not in here after the walk has moved or disappeared at the
+ * provider, and gets swept.
+ */
+export class ReportedRows {
+    readonly paymentLineExternalIds = new Set<string>();
+    readonly chargeExternalIds = new Set<string>();
+
+    paymentLine(line: PaymentSettlement) {
+        this.paymentLineExternalIds.add(line.externalId);
+    }
+
+    charge(charge: SettlementCharge) {
+        this.chargeExternalIds.add(charge.externalId);
+    }
+
+    charges(charges: SettlementCharge[]) {
+        for (const charge of charges) {
+            this.charge(charge);
+        }
+    }
+}
+
+/**
+ * All writes to the settlements tables go through this service. Every write is an upsert on the
+ * deterministic unique key of its table, so re-running a sync can never duplicate rows.
+ */
+export class SettlementService {
+    /**
+     * Serializes syncs of the same settlement, so cron and manual backfill can't race. In-process
+     * only: across multiple API instances the tables' unique keys are the real guard, so a
+     * concurrent sync surfaces as a duplicate-key error and is retryable.
+     */
+    static lock<T>(provider: PaymentProvider, externalId: string, handler: () => Promise<T>): Promise<T> {
+        return QueueHandler.schedule('settlement-sync-' + provider + '-' + externalId, handler);
+    }
+
+    /**
+     * Month bucket of a charge, in server-local time: the same boundaries as
+     * StripeInvoicer.getMonthUnixStartEnd, which drive the monthly invoice grouping.
+     */
+    static getPeriodStart(date: Date): Date {
+        return new Date(date.getFullYear(), date.getMonth(), 1);
+    }
+
+    /**
+     * The same month bucket as getPeriodStart, as a 'YYYY-MM' key.
+     */
+    static getPeriodKey(date: Date): string {
+        return date.getFullYear() + '-' + (date.getMonth() + 1).toString().padStart(2, '0');
+    }
+
+    /**
+     * Every settlement belongs to an organization. The platform's own provider accounts (the
+     * platform Stripe account, the platform Mollie token) belong to the platform membership
+     * organization: without one configured, platform payouts cannot be stored.
+     */
+    static async getPlatformOrganizationId(): Promise<string> {
+        const membershipOrganizationId = (await Platform.getShared()).membershipOrganizationId;
+        if (!membershipOrganizationId) {
+            throw new SimpleError({
+                code: 'missing_membership_organization',
+                message: 'Platform has no membership organization configured, so platform payouts cannot be attributed to an organization',
+            });
+        }
+        return membershipOrganizationId;
+    }
+
+    /**
+     * Upsert on (provider, externalId). Never touches syncedAt/syncFailureCount: those belong to
+     * finishSync/markSyncFailed.
+     */
+    static async upsertSettlement(data: SettlementData): Promise<Settlement> {
+        const settlement = await Settlement.select()
+            .where('provider', data.provider)
+            .where('externalId', data.externalId)
+            .first(false) ?? new Settlement();
+
+        settlement.provider = data.provider;
+        settlement.externalId = data.externalId;
+        settlement.organizationId = data.organizationId;
+        settlement.amount = data.amount;
+        settlement.settledAt = data.settledAt;
+
+        if (data.stripeAccountId !== undefined) {
+            settlement.stripeAccountId = data.stripeAccountId;
+        }
+        if (data.reference !== undefined) {
+            settlement.reference = data.reference;
+        }
+        if (data.currency !== undefined) {
+            settlement.currency = data.currency;
+        }
+        if (data.status !== undefined) {
+            settlement.status = data.status;
+        }
+
+        await settlement.save();
+        return settlement;
+    }
+
+    /**
+     * Upsert on (settlementId, externalId): one payment can be part of multiple settlements, but a
+     * provider transaction appears in a settlement only once.
+     */
+    static async upsertPaymentLine(settlement: Settlement, data: PaymentLineData): Promise<PaymentSettlement> {
+        const line = await PaymentSettlement.select()
+            .where('settlementId', settlement.id)
+            .where('externalId', data.externalId)
+            .first(false) ?? new PaymentSettlement();
+
+        line.settlementId = settlement.id;
+        line.externalId = data.externalId;
+        line.paymentId = data.paymentId;
+        line.amount = data.amount;
+        line.occurredAt = data.occurredAt;
+
+        await line.save();
+        return line;
+    }
+
+    /**
+     * Upsert on the globally unique externalId. Fields that are undefined keep their stored value,
+     * so the fee sync (which doesn't know the settlement yet) can't unlink a charge the payout sync
+     * linked earlier. balanceItemId is deliberately not settable here: it is only stamped when
+     * invoicing.
+     */
+    static async upsertCharge(data: ChargeData): Promise<SettlementCharge> {
+        const charge = await SettlementCharge.select()
+            .where('externalId', data.externalId)
+            .first(false) ?? new SettlementCharge();
+
+        charge.type = data.type;
+        charge.externalId = data.externalId;
+        charge.amount = data.amount;
+        charge.occurredAt = data.occurredAt;
+
+        if (data.settlementId !== undefined) {
+            charge.settlementId = data.settlementId;
+        }
+        if (data.applicationFeeId !== undefined) {
+            charge.applicationFeeId = data.applicationFeeId;
+        }
+        if (data.paymentId !== undefined) {
+            charge.paymentId = data.paymentId;
+        }
+        if (data.organizationId !== undefined) {
+            charge.organizationId = data.organizationId;
+        }
+        if (data.stripeAccountId !== undefined) {
+            charge.stripeAccountId = data.stripeAccountId;
+        }
+        if (data.providerInvoiceId !== undefined) {
+            charge.providerInvoiceId = data.providerInvoiceId;
+        }
+        if (data.description !== undefined) {
+            charge.description = data.description;
+        }
+        await charge.save();
+        return charge;
+    }
+
+    /**
+     * After a complete walk of a settlement: remove rows the provider no longer reports in this
+     * settlement (a transaction can move to another payout). Rows that only exist because of the
+     * payout are deleted; the Received fee rows are only unlinked, because they are the invoicing
+     * source and may already carry a balanceItemId.
+     */
+    static async sweepSettlement(settlement: Settlement, reported: ReportedRows) {
+        const lines = await PaymentSettlement.select()
+            .where('settlementId', settlement.id)
+            .fetch();
+
+        for (const line of lines) {
+            if (!reported.paymentLineExternalIds.has(line.externalId)) {
+                await line.delete();
+            }
+        }
+
+        const charges = await SettlementCharge.select()
+            .where('settlementId', settlement.id)
+            .fetch();
+
+        for (const charge of charges) {
+            if (reported.chargeExternalIds.has(charge.externalId)) {
+                continue;
+            }
+
+            if (RECEIVED_FEE_TYPES.includes(charge.type)) {
+                charge.settlementId = null;
+                await charge.save();
+            } else {
+                await charge.delete();
+            }
+        }
+    }
+
+    /**
+     * Marks a complete, error-free sync: caches the reconciliation delta and sets syncedAt.
+     * `unexplainedAmount` should be 0 — a non-zero value is a real question to answer.
+     */
+    static async finishSync(settlement: Settlement, { transactionCount }: { transactionCount: number }): Promise<Settlement> {
+        const paymentSum = await PaymentSettlement.select()
+            .where('settlementId', settlement.id)
+            .sum(SQL.column('amount')) ?? 0;
+
+        const chargeSum = await SettlementCharge.select()
+            .where('settlementId', settlement.id)
+            .sum(SQL.column('amount')) ?? 0;
+
+        settlement.unexplainedAmount = settlement.amount - paymentSum - chargeSum;
+        settlement.transactionCount = transactionCount;
+        settlement.syncFailureCount = 0;
+
+        const syncedAt = new Date();
+        syncedAt.setMilliseconds(0);
+        settlement.syncedAt = syncedAt;
+
+        await settlement.save();
+        return settlement;
+    }
+
+    /**
+     * A failed sync leaves syncedAt NULL: that is the whole error queue.
+     */
+    static async markSyncFailed(settlement: Settlement): Promise<Settlement> {
+        settlement.syncedAt = null;
+        settlement.syncFailureCount += 1;
+        await settlement.save();
+        return settlement;
+    }
+
+    /**
+     * Dual-write of the legacy payments.settlement JSON blob from the new rows. The blob holds one
+     * settlement, so the primary is picked deterministically: largest |amount| line, earliest
+     * settledAt as tiebreaker — re-syncs never flip-flop the column.
+     */
+    static async updateLegacySettlementReference(payment: Payment): Promise<void> {
+        const lines = await PaymentSettlement.select()
+            .where('paymentId', payment.id)
+            .fetch();
+
+        if (lines.length === 0) {
+            return;
+        }
+
+        const settlements = await Settlement.select()
+            .where('id', lines.map(l => l.settlementId))
+            .fetch();
+        const settlementsById = new Map(settlements.map(s => [s.id, s]));
+
+        // A destination charge sits in two payouts (gross in the organization payout, gross in our
+        // platform payout): only the payout of the payment's own account may become the blob, or
+        // the organization would see our platform payout. No scoped lines (e.g. the own-account
+        // payout isn't synced yet) means the blob stays untouched.
+        const candidates = lines.filter(line => settlementsById.get(line.settlementId)!.stripeAccountId === payment.stripeAccountId);
+        if (candidates.length === 0) {
+            return;
+        }
+
+        const primary = candidates.sort((a, b) => {
+            if (Math.abs(a.amount) !== Math.abs(b.amount)) {
+                return Math.abs(b.amount) - Math.abs(a.amount);
+            }
+            const settledA = settlementsById.get(a.settlementId)!.settledAt.getTime();
+            const settledB = settlementsById.get(b.settlementId)!.settledAt.getTime();
+            if (settledA !== settledB) {
+                return settledA - settledB;
+            }
+            return a.externalId.localeCompare(b.externalId);
+        })[0];
+
+        const settlement = settlementsById.get(primary.settlementId)!;
+
+        payment.settlement = SettlementReference.create({
+            id: settlement.externalId,
+            reference: settlement.reference,
+            settledAt: settlement.settledAt,
+            amount: settlement.amount,
+            // The deprecated fee field is still written by StripePayoutChecker; keep it when the
+            // primary settlement doesn't change
+            fee: payment.settlement?.id === settlement.externalId ? payment.settlement.fee : 0,
+        });
+        const saved = await payment.save();
+
+        if (saved) {
+            // Mark order as 'updated', or the frontend won't pull in the updates
+            const order = await Order.getForPayment(null, payment.id);
+            if (order) {
+                order.updatedAt = new Date();
+                order.forceSaveProperty('updatedAt');
+                await order.save();
+            }
+        }
+    }
+}


### PR DESCRIPTION
All writes are upserts on the tables' unique keys, so re-running a sync can never duplicate rows. No callers yet.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788448931&installation_model_id=423362&pr_number=708&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F708&signature=26a6cf33288d982e412812fe3bd1eba87598d7fefffe12f43bd4f04496979306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->