### PR TITLE
✨ Fake settlements write the new settlement rows

### DIFF
--- a/backend/app/api/src/crons/fake-settlements.test.ts
+++ b/backend/app/api/src/crons/fake-settlements.test.ts
@@ -1,6 +1,10 @@
 import type { Organization } from '@stamhoofd/models';
-import { OrganizationFactory, Payment, StripeAccount } from '@stamhoofd/models';
+import { OrganizationFactory, Payment, Platform, StripeAccount } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
 import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, SettlementReference } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
 import { TestUtils } from '@stamhoofd/test-utils';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
@@ -8,10 +12,20 @@ import { createFakeSettlements } from './fake-settlements.js';
 
 describe('Cron.fake-settlements', () => {
     let organization: Organization;
+    let membershipOrganization: Organization;
+
+    beforeAll(async () => {
+        membershipOrganization = await new OrganizationFactory({}).create();
+    });
 
     beforeEach(async () => {
         TestUtils.setEnvironment('environment', 'development');
         organization = await new OrganizationFactory({}).create();
+
+        // The platform's own accounts belong to the membership organization
+        const platform = await Platform.getForEditing();
+        platform.membershipOrganizationId = membershipOrganization.id;
+        await platform.save();
     });
 
     /**
@@ -22,7 +36,7 @@ describe('Cron.fake-settlements', () => {
         return Formatter.luxon(new Date()).startOf('week').minus({ weeks: weeksAgo }).plus({ days: 2, hours: 12 }).toJSDate();
     };
 
-    const createPayment = async ({ price = 50_0000, paidAt = inWeek(2), provider = PaymentProvider.Mollie as PaymentProvider | null, status = PaymentStatus.Succeeded, method = PaymentMethod.Bancontact, type = PaymentType.Payment, organizationId = undefined as string | undefined, stripeAccountId = null as string | null }: {
+    const createPayment = async ({ price = 50_0000, paidAt = inWeek(2), provider = PaymentProvider.Mollie as PaymentProvider | null, status = PaymentStatus.Succeeded, method = PaymentMethod.Bancontact, type = PaymentType.Payment, organizationId = undefined as string | undefined, stripeAccountId = null as string | null, serviceFeePayout = 0, transferFee = 0 }: {
         price?: number;
         paidAt?: Date | null;
         provider?: PaymentProvider | null;
@@ -31,6 +45,8 @@ describe('Cron.fake-settlements', () => {
         type?: PaymentType;
         organizationId?: string;
         stripeAccountId?: string | null;
+        serviceFeePayout?: number;
+        transferFee?: number;
     } = {}) => {
         const payment = new Payment();
         payment.organizationId = organizationId ?? organization.id;
@@ -41,6 +57,8 @@ describe('Cron.fake-settlements', () => {
         payment.price = price;
         payment.paidAt = paidAt;
         payment.stripeAccountId = stripeAccountId;
+        payment.serviceFeePayout = serviceFeePayout;
+        payment.transferFee = transferFee;
         await payment.save();
         return payment;
     };
@@ -69,8 +87,9 @@ describe('Cron.fake-settlements', () => {
         expect(settlement).toMatchObject({
             settledAt: Formatter.luxon(inWeek(2)).startOf('week').plus({ weeks: 1, days: 2 }).toJSDate(),
 
-            // Refunds are taken out of the payout, just like the provider does
-            amount: 65_0000,
+            // Refunds are taken out of the payout, just like the provider does, and so are the
+            // fake Mollie costs: 3 payments x 0.30 + 21% VAT
+            amount: 65_0000 - 90_00 - 18_90,
         });
 
         // All payments of the week point to the same payout
@@ -113,8 +132,10 @@ describe('Cron.fake-settlements', () => {
             await getSettlement(otherStripe),
         ];
 
-        // Same week, but four accounts: four payouts, each holding only its own money
-        expect(settlements.map(s => s!.amount)).toEqual([50_0000, 30_0000, 20_0000, 15_0000]);
+        // Same week, but four accounts: four payouts, each holding only its own money. The Mollie
+        // payouts are reduced by the fake cost of one payment (0.30 + 21% VAT); the Stripe payments
+        // carry no fees here
+        expect(settlements.map(s => s!.amount)).toEqual([50_0000 - 36_30, 30_0000 - 36_30, 20_0000, 15_0000]);
         expect(new Set(settlements.map(s => s!.id)).size).toBe(4);
         expect(new Set(settlements.map(s => s!.reference)).size).toBe(4);
     });
@@ -161,5 +182,96 @@ describe('Cron.fake-settlements', () => {
         await createFakeSettlements();
 
         expect(await getSettlement(payment)).toBeNull();
+    });
+
+    describe('Settlement rows', () => {
+        const getSettlementRow = async (payment: Payment) => {
+            const reference = await getSettlement(payment);
+            return await Settlement.select().where('externalId', reference!.id).first(true);
+        };
+
+        test('A Mollie payout stores payment lines and cost rows, and reconciles to zero', async () => {
+            const first = await createPayment({ price: 50_0000 });
+            const second = await createPayment({ price: -10_0000, type: PaymentType.Refund });
+
+            await createFakeSettlements();
+
+            const settlement = await getSettlementRow(first);
+            expect(settlement.provider).toBe(PaymentProvider.Mollie);
+            expect(settlement.organizationId).toBe(organization.id);
+            expect(settlement.amount).toBe(40_0000 - 60_00 - 12_60);
+            expect(settlement.unexplainedAmount).toBe(0);
+            expect(settlement.syncedAt).not.toBeNull();
+
+            const lines = await PaymentSettlement.select().where('settlementId', settlement.id).fetch();
+            expect(lines.map(l => [l.paymentId, l.amount]).sort()).toEqual([
+                [first.id, 50_0000],
+                [second.id, -10_0000],
+            ].sort());
+
+            const settledMonth = settlement.settledAt.getFullYear() + '-' + (settlement.settledAt.getMonth() + 1).toString().padStart(2, '0');
+            const charges = await SettlementCharge.select().where('settlementId', settlement.id).fetch();
+            expect(charges.map(c => ({ type: c.type, amount: c.amount, providerInvoiceId: c.providerInvoiceId })).sort((a, b) => a.amount - b.amount)).toEqual([
+                { type: SettlementChargeType.ProviderTransactionFee, amount: -60_00, providerInvoiceId: 'fake-invoice-mollie-' + settledMonth },
+                { type: SettlementChargeType.Tax, amount: -12_60, providerInvoiceId: 'fake-invoice-mollie-' + settledMonth },
+            ]);
+        });
+
+        test('A Stripe application fee is mirrored on the payout and a monthly platform payout', async () => {
+            const stripeAccount = await createStripeAccount(organization);
+            const payment = await createPayment({
+                price: 20_0000,
+                provider: PaymentProvider.Stripe,
+                stripeAccountId: stripeAccount.id,
+                serviceFeePayout: 2_0000,
+                transferFee: 50_00,
+            });
+
+            await createFakeSettlements();
+
+            const settlement = await getSettlementRow(payment);
+            expect(settlement.amount).toBe(20_0000 - 2_0000 - 50_00);
+            expect(settlement.unexplainedAmount).toBe(0);
+            expect(settlement.stripeAccountId).toBe(stripeAccount.id);
+
+            const applicationFeeId = 'fake-fee-' + payment.id;
+            const feeRows = await SettlementCharge.select().where('applicationFeeId', applicationFeeId).fetch();
+
+            const byType = new Map(feeRows.map(row => [row.type, row]));
+            expect(byType.get(SettlementChargeType.ApplicationFeeService)).toMatchObject({
+                amount: -2_0000, settlementId: settlement.id, paymentId: payment.id, stripeAccountId: stripeAccount.id,
+            });
+            expect(byType.get(SettlementChargeType.ApplicationFeeTransfer)).toMatchObject({
+                amount: -50_00, settlementId: settlement.id,
+            });
+
+            // The platform side receives the same fee: per applicationFeeId both sides of one kind
+            // sum to zero
+            const received = byType.get(SettlementChargeType.ReceivedApplicationFeeService)!;
+            expect(received.amount).toBe(2_0000);
+            expect(byType.get(SettlementChargeType.ReceivedApplicationFeeTransfer)!.amount).toBe(50_00);
+
+            const platformSettlement = await Settlement.getByID(received.settlementId!);
+            expect(platformSettlement!.stripeAccountId).toBeNull();
+            expect(platformSettlement!.organizationId).toBe(membershipOrganization.id);
+            expect(platformSettlement!.externalId).toContain('fake-settlement-Stripe-platform-');
+
+            // The monthly platform settlement is shared: unsettled payments of other tests in the
+            // same database land in it too, so only the identity is asserted, not the exact amount
+            expect(platformSettlement!.amount).toBeGreaterThanOrEqual(2_5000);
+            expect(platformSettlement!.unexplainedAmount).toBe(0);
+        });
+
+        test('Payments without fees write no charge rows', async () => {
+            const stripeAccount = await createStripeAccount(organization);
+            const payment = await createPayment({ price: 20_0000, provider: PaymentProvider.Stripe, stripeAccountId: stripeAccount.id });
+
+            await createFakeSettlements();
+
+            const settlement = await getSettlementRow(payment);
+            expect(settlement.amount).toBe(20_0000);
+            expect(settlement.unexplainedAmount).toBe(0);
+            expect(await SettlementCharge.select().where('settlementId', settlement.id).count()).toBe(0);
+        });
     });
 });

--- a/backend/app/api/src/crons/fake-settlements.ts
+++ b/backend/app/api/src/crons/fake-settlements.ts
@@ -5,12 +5,17 @@
  */
 
 import { registerCron } from '@stamhoofd/crons';
-import { Order, Payment } from '@stamhoofd/models';
+import { Order, Payment, Platform } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
 import { SQL } from '@stamhoofd/sql';
-import { PaymentStatus, SettlementReference } from '@stamhoofd/structures';
+import { PaymentProvider, PaymentStatus, SettlementReference } from '@stamhoofd/structures';
 import { SETTLING_PAYMENT_PROVIDERS } from '@stamhoofd/structures/PaymentSettlement.js';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
 import { Formatter } from '@stamhoofd/utility';
 import type { DateTime } from 'luxon';
+import { SettlementService } from '../services/SettlementService.js';
 
 registerCron('fake-settlements', createFakeSettlements);
 
@@ -25,6 +30,12 @@ const PAYOUT_DELAY_DAYS = 2;
  */
 const BATCH_SIZE = 1000;
 
+/**
+ * Fake Mollie transaction fee per settled payment, excluding VAT.
+ */
+const MOLLIE_FEE_PER_PAYMENT = 30_00;
+const MOLLIE_FEE_VAT_PERCENTAGE = 21;
+
 export async function createFakeSettlements() {
     if (STAMHOOFD.environment !== 'development') {
         return;
@@ -32,9 +43,21 @@ export async function createFakeSettlements() {
 
     const now = new Date();
 
+    // The platform's own accounts belong to the membership organization; without one, their
+    // payouts can't be attributed and are skipped
+    const platformOrganizationId = (await Platform.getShared()).membershipOrganizationId;
+
+    // Payments that couldn't be attributed to an organization are scanned past instead of
+    // reselected forever, so they can't stall the payout of later weeks
+    let scanAfter: Date | null = null;
+
     // Pay out week per week, oldest first, until we reach a week that isn't paid out yet
     for (;;) {
-        const oldest = await selectUnsettledPayments().orderBy('paidAt', 'ASC').first(false);
+        let oldestQuery = selectUnsettledPayments();
+        if (scanAfter) {
+            oldestQuery = oldestQuery.where('paidAt', '>', scanAfter);
+        }
+        const oldest = await oldestQuery.orderBy('paidAt', 'ASC').first(false);
         if (!oldest?.paidAt) {
             break;
         }
@@ -51,8 +74,17 @@ export async function createFakeSettlements() {
 
         // Nothing is left before this week, so this selects exactly the payments of this week. What
         // doesn't fit in one batch is picked up by the next round, in the same payout
-        const payments = await selectUnsettledPayments().where('paidAt', '<', weekEnd.toJSDate()).limit(BATCH_SIZE).fetch();
-        await settleWeek(payments, weekStart, settledAt);
+        let batchQuery = selectUnsettledPayments().where('paidAt', '<', weekEnd.toJSDate());
+        if (scanAfter) {
+            batchQuery = batchQuery.where('paidAt', '>', scanAfter);
+        }
+        const payments = await batchQuery.limit(BATCH_SIZE).fetch();
+        const settledCount = await settleWeek(payments, weekStart, settledAt, platformOrganizationId);
+
+        if (settledCount === 0) {
+            // Everything in this batch was skipped: continue behind it
+            scanAfter = new Date(Math.max(...payments.map(p => p.paidAt!.getTime())));
+        }
     }
 }
 
@@ -76,7 +108,39 @@ function getPayoutAccount(payment: Payment): string {
     return payment.provider + '-' + (payment.stripeAccountId ?? payment.organizationId ?? 'platform');
 }
 
-async function settleWeek(payments: Payment[], weekStart: DateTime, settledAt: Date) {
+function getStripeFakeFees(payment: Payment) {
+    return { serviceFee: payment.serviceFeePayout, transferFee: payment.transferFee };
+}
+
+/**
+ * Upsert a settlement while accumulating the amount: a week larger than one batch settles in
+ * multiple rounds, all in the same payout.
+ */
+async function upsertFakeSettlement(data: { provider: PaymentProvider; externalId: string; stripeAccountId: string | null; organizationId: string; reference: string; settledAt: Date; addedAmount: number }) {
+    const existing = await Settlement.select()
+        .where('provider', data.provider)
+        .where('externalId', data.externalId)
+        .first(false);
+
+    return await SettlementService.upsertSettlement({
+        provider: data.provider,
+        externalId: data.externalId,
+        stripeAccountId: data.stripeAccountId,
+        organizationId: data.organizationId,
+        reference: data.reference,
+        amount: (existing?.amount ?? 0) + data.addedAmount,
+        settledAt: data.settledAt,
+    });
+}
+
+async function finishFakeSync(settlement: Settlement) {
+    const lineCount = await PaymentSettlement.select().where('settlementId', settlement.id).count();
+    const chargeCount = await SettlementCharge.select().where('settlementId', settlement.id).count();
+    await SettlementService.finishSync(settlement, { transactionCount: lineCount + chargeCount });
+}
+
+async function settleWeek(payments: Payment[], weekStart: DateTime, settledAt: Date, platformOrganizationId: string | null): Promise<number> {
+    let settledCount = 0;
     const groups = new Map<string, Payment[]>();
 
     for (const payment of payments) {
@@ -97,10 +161,50 @@ async function settleWeek(payments: Payment[], weekStart: DateTime, settledAt: D
 
         // Every account gets its own payout, so the reference has to tell them apart
         const reference = 'DEV ' + week + ' (' + account.slice(-8) + ')';
-        const amount = group.reduce((total, payment) => total + payment.price, 0);
+        const provider = group[0].provider!;
+
+        // Payments without an organization arrived on the platform's own account
+        const organizationId = group[0].organizationId ?? platformOrganizationId;
+        if (!organizationId) {
+            console.log('Skipped fake settlement ' + reference + ': no platform membership organization configured');
+            continue;
+        }
+
+        // Fees are deducted from the payout, so the identity
+        // amount = sum of payment lines + sum of charges closes
+        let fees = 0;
+        if (provider === PaymentProvider.Stripe) {
+            fees = group.reduce((total, payment) => {
+                const { serviceFee, transferFee } = getStripeFakeFees(payment);
+                return total + serviceFee + transferFee;
+            }, 0);
+        } else if (provider === PaymentProvider.Mollie) {
+            const net = MOLLIE_FEE_PER_PAYMENT * group.length;
+            fees = net + Math.round(net * MOLLIE_FEE_VAT_PERCENTAGE / 100);
+        }
+
+        const grossAmount = group.reduce((total, payment) => total + payment.price, 0);
+        const amount = grossAmount - fees;
+
+        const settlement = await upsertFakeSettlement({
+            provider,
+            externalId: id,
+            stripeAccountId: group[0].stripeAccountId,
+            organizationId,
+            reference,
+            settledAt,
+            addedAmount: amount,
+        });
 
         for (const payment of group) {
-            payment.settlement = SettlementReference.create({ id, reference, settledAt, amount });
+            await SettlementService.upsertPaymentLine(settlement, {
+                paymentId: payment.id,
+                amount: payment.price,
+                externalId: 'fake-txn-' + payment.id,
+                occurredAt: payment.paidAt!,
+            });
+
+            payment.settlement = SettlementReference.create({ id, reference, settledAt, amount: settlement.amount });
             await payment.save();
 
             // Mark order as 'updated', or the frontend won't pull in the updates
@@ -112,6 +216,139 @@ async function settleWeek(payments: Payment[], weekStart: DateTime, settledAt: D
             }
         }
 
-        console.log('Created settlement ' + reference + ' of ' + Formatter.price(amount) + ' for ' + group.length + ' payments');
+        if (provider === PaymentProvider.Stripe) {
+            await createStripeFeeRows(settlement, group, settledAt, platformOrganizationId);
+        } else if (provider === PaymentProvider.Mollie) {
+            await createMollieCostRows(settlement, group, settledAt);
+        }
+
+        await finishFakeSync(settlement);
+        settledCount += group.length;
+
+        console.log('Created settlement ' + reference + ' of ' + Formatter.price(settlement.amount) + ' for ' + group.length + ' payments');
     }
+
+    return settledCount;
+}
+
+/**
+ * The application fee of a Stripe payment is mirrored, like Stripe mirrors it: two negative
+ * deduction rows on the organization payout, and two positive Received rows on a fake monthly
+ * platform payout.
+ */
+async function createStripeFeeRows(settlement: Settlement, group: Payment[], settledAt: Date, platformOrganizationId: string | null) {
+    const month = SettlementService.getPeriodKey(settledAt);
+    let addedFees = 0;
+    const feeRows: { payment: Payment; applicationFeeId: string; serviceFee: number; transferFee: number }[] = [];
+
+    for (const payment of group) {
+        const { serviceFee, transferFee } = getStripeFakeFees(payment);
+        if (serviceFee === 0 && transferFee === 0) {
+            continue;
+        }
+
+        const applicationFeeId = 'fake-fee-' + payment.id;
+        feeRows.push({ payment, applicationFeeId, serviceFee, transferFee });
+        addedFees += serviceFee + transferFee;
+
+        for (const [type, feeAmount] of [
+            [SettlementChargeType.ApplicationFeeService, serviceFee],
+            [SettlementChargeType.ApplicationFeeTransfer, transferFee],
+        ] as const) {
+            if (feeAmount === 0) {
+                continue;
+            }
+            await SettlementService.upsertCharge({
+                type,
+                externalId: applicationFeeId + ':' + type,
+                amount: -feeAmount,
+                settlementId: settlement.id,
+                applicationFeeId,
+                paymentId: payment.id,
+                organizationId: payment.organizationId,
+                stripeAccountId: payment.stripeAccountId,
+                occurredAt: payment.paidAt!,
+            });
+        }
+    }
+
+    if (feeRows.length === 0) {
+        return;
+    }
+
+    if (!platformOrganizationId) {
+        console.log('Skipped the fake platform fee payout: no platform membership organization configured');
+        return;
+    }
+
+    // One fake platform payout per month receives all fees of that month
+    const platformSettlement = await upsertFakeSettlement({
+        provider: PaymentProvider.Stripe,
+        externalId: 'fake-settlement-Stripe-platform-' + month,
+        stripeAccountId: null,
+        organizationId: platformOrganizationId,
+        reference: 'DEV STRIPE FEES ' + month,
+        settledAt,
+        addedAmount: addedFees,
+    });
+
+    for (const { payment, applicationFeeId, serviceFee, transferFee } of feeRows) {
+        for (const [type, feeAmount] of [
+            [SettlementChargeType.ReceivedApplicationFeeService, serviceFee],
+            [SettlementChargeType.ReceivedApplicationFeeTransfer, transferFee],
+        ] as const) {
+            if (feeAmount === 0) {
+                continue;
+            }
+            await SettlementService.upsertCharge({
+                type,
+                externalId: applicationFeeId + ':' + type,
+                amount: feeAmount,
+                settlementId: platformSettlement.id,
+                applicationFeeId,
+                paymentId: payment.id,
+                organizationId: payment.organizationId,
+                stripeAccountId: payment.stripeAccountId,
+                occurredAt: payment.paidAt!,
+            });
+        }
+    }
+
+    await finishFakeSync(platformSettlement);
+}
+
+/**
+ * Mollie deducts its own costs from the settlement: one fake transaction fee line plus its VAT, so
+ * the settlement reconciles to 0 like a real one.
+ */
+async function createMollieCostRows(settlement: Settlement, group: Payment[], settledAt: Date) {
+    const externalId = settlement.externalId + ':cost:0';
+    const existing = await SettlementCharge.select().where('externalId', externalId).first(false);
+
+    const addedNet = MOLLIE_FEE_PER_PAYMENT * group.length;
+    const net = (existing ? -existing.amount : 0) + addedNet;
+    const vat = Math.round(net * MOLLIE_FEE_VAT_PERCENTAGE / 100);
+    const providerInvoiceId = 'fake-invoice-mollie-' + SettlementService.getPeriodKey(settledAt);
+
+    await SettlementService.upsertCharge({
+        type: SettlementChargeType.ProviderTransactionFee,
+        externalId,
+        amount: -net,
+        settlementId: settlement.id,
+        organizationId: settlement.organizationId,
+        providerInvoiceId,
+        description: 'DEV Mollie transactiekosten',
+        occurredAt: settledAt,
+    });
+
+    await SettlementService.upsertCharge({
+        type: SettlementChargeType.Tax,
+        externalId: externalId + ':tax',
+        amount: -vat,
+        settlementId: settlement.id,
+        organizationId: settlement.organizationId,
+        providerInvoiceId,
+        description: 'DEV BTW op Mollie transactiekosten',
+        occurredAt: settledAt,
+    });
 }


### PR DESCRIPTION
Dev-only cron now also fills settlements, payment_settlements and settlement_charges: payment lines per payment, mirrored Stripe fee rows with a monthly fake platform payout, and Mollie cost+VAT rows, so every fake settlement reconciles to zero.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454323&installation_model_id=423362&pr_number=710&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F710&signature=be5475a22ba16c61d62781796edeb33c3215e7f6080d41a41aec0bbeff4d9a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Known limitation (deliberate): the amount accumulation across batches is not crash-safe — a crash between the settlement upsert and the payment saves double-counts once. Dev-only cron; it surfaces as unexplainedAmount != 0.
