### PR TITLE
♻️ Extracted resolveStripePaymentId + StripeMocker payouts

### DIFF
--- a/backend/app/api/src/helpers/StripePayoutChecker.ts
+++ b/backend/app/api/src/helpers/StripePayoutChecker.ts
@@ -1,11 +1,14 @@
-import { Order, Payment, StripeCheckoutSession, StripePaymentIntent } from '@stamhoofd/models';
+import { Order, Payment } from '@stamhoofd/models';
 import { SettlementReference } from '@stamhoofd/structures';
 import Stripe from 'stripe';
 import { passthroughFetch } from './passthroughFetch.js';
+import type { StripePaymentIdCache } from './resolveStripePaymentId.js';
+import { resolveStripePaymentId } from './resolveStripePaymentId.js';
 
 export class StripePayoutChecker {
     private stripe: Stripe;
     private stripePlatform: Stripe;
+    private paymentIdCache: StripePaymentIdCache = new Map();
 
     constructor({ secretKey, stripeAccount }: { secretKey: string; stripeAccount?: string }) {
         this.stripe = new Stripe(
@@ -89,60 +92,10 @@ export class StripePayoutChecker {
             return;
         }
 
-        let paymentId = balanceItem.source.metadata.payment;
-
-        if (!paymentId) {
-            // Search in the metadata of the application fee, originating transaction
-            if (typeof balanceItem.source.application_fee !== 'string' && balanceItem.source.application_fee) {
-                const applicationFee = balanceItem.source.application_fee;
-
-                if (applicationFee.originating_transaction !== 'string' && applicationFee.originating_transaction) {
-                    const originatingTransaction = applicationFee.originating_transaction as Stripe.Charge;
-                    paymentId = originatingTransaction.metadata.payment;
-
-                    if (!paymentId) {
-                        // Historical bug where we didn't save payment in metadata
-                        // Try to look it up by payment intent id
-
-                        if (originatingTransaction.payment_intent) {
-                            const paymentIntentId = typeof originatingTransaction.payment_intent === 'string' ? originatingTransaction.payment_intent : originatingTransaction.payment_intent.id;
-                            const stripePayments = await StripePaymentIntent.where({
-                                stripeIntentId: paymentIntentId,
-                            }, { limit: 1 });
-
-                            if (stripePayments.length === 1) {
-                                paymentId = stripePayments[0].paymentId;
-                                console.log('Found missing payment metadata for payment intent ', originatingTransaction.payment_intent, paymentId);
-                            } else {
-                                // Probably a card payment
-                                // Search for the checkout session
-                                const checkoutSession = await this.stripePlatform.checkout.sessions.list({
-                                    payment_intent: paymentIntentId,
-                                });
-                                if (checkoutSession.data.length === 1) {
-                                    const session = checkoutSession.data[0];
-                                    console.log('Found checkout session for payment intent ', paymentIntentId, session);
-
-                                    // Search
-                                    const stripeCheckoutSessions = await StripeCheckoutSession.where({
-                                        stripeSessionId: session.id,
-                                    }, { limit: 1 });
-
-                                    if (stripeCheckoutSessions.length === 1) {
-                                        paymentId = stripeCheckoutSessions[0].paymentId;
-                                        console.log('Found missing payment metadata for payment intent ', originatingTransaction.payment_intent, paymentId);
-                                    } else {
-                                        console.log('No payment found for checkout session ' + session.id);
-                                    }
-                                } else {
-                                    console.log('No Stripe Checkout Sessions found for payment intent ' + paymentIntentId);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        const paymentId = await resolveStripePaymentId(balanceItem.source, {
+            stripePlatform: this.stripePlatform,
+            cache: this.paymentIdCache,
+        });
 
         if (!paymentId) {
             console.log(balanceItem);

--- a/backend/app/api/src/helpers/resolveStripePaymentId.test.ts
+++ b/backend/app/api/src/helpers/resolveStripePaymentId.test.ts
@@ -1,0 +1,113 @@
+import { StripeCheckoutSession, StripePaymentIntent } from '@stamhoofd/models';
+import Stripe from 'stripe';
+import { v4 as uuidv4 } from 'uuid';
+
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import { passthroughFetch } from './passthroughFetch.js';
+import { resolveStripePaymentId } from './resolveStripePaymentId.js';
+
+describe('resolveStripePaymentId', () => {
+    const stripeMocker = new StripeMocker();
+    let stripePlatform: Stripe;
+
+    beforeAll(() => {
+        stripeMocker.start();
+        stripePlatform = new Stripe(STAMHOOFD.STRIPE_SECRET_KEY!, {
+            apiVersion: '2024-06-20',
+            typescript: true,
+            maxNetworkRetries: 0,
+            timeout: 10000,
+            httpClient: Stripe.createFetchHttpClient(passthroughFetch),
+        });
+    });
+
+    afterAll(() => {
+        stripeMocker.stop();
+    });
+
+    beforeEach(() => {
+        stripeMocker.clear();
+    });
+
+    const asCharge = (data: Record<string, unknown>): Stripe.Charge => {
+        return { id: stripeMocker.createId('ch'), object: 'charge', metadata: {}, ...data } as unknown as Stripe.Charge;
+    };
+
+    test('the payment metadata on the charge wins', async () => {
+        const paymentId = uuidv4();
+        const charge = asCharge({ metadata: { payment: paymentId } });
+
+        expect(await resolveStripePaymentId(charge, { stripePlatform })).toBe(paymentId);
+    });
+
+    test('falls back to the metadata of the application fee originating transaction', async () => {
+        const paymentId = uuidv4();
+        const originating = asCharge({ metadata: { payment: paymentId } });
+        const charge = asCharge({
+            application_fee: stripeMocker.createApplicationFee({
+                amount: 250,
+                account: 'acct_1',
+                originatingTransaction: originating,
+            }),
+        });
+
+        expect(await resolveStripePaymentId(charge, { stripePlatform })).toBe(paymentId);
+    });
+
+    test('falls back to a stored StripePaymentIntent', async () => {
+        const paymentId = uuidv4();
+        const intentId = stripeMocker.createId('pi');
+
+        const intent = new StripePaymentIntent();
+        intent.paymentId = paymentId;
+        intent.stripeIntentId = intentId;
+        await intent.save();
+
+        const charge = asCharge({ payment_intent: intentId });
+
+        expect(await resolveStripePaymentId(charge, { stripePlatform })).toBe(paymentId);
+    });
+
+    test('falls back to the checkout session of the payment intent', async () => {
+        const paymentId = uuidv4();
+        const intentId = stripeMocker.createId('pi');
+        const mockedSession = stripeMocker.createCheckoutSession({ paymentIntent: intentId });
+
+        const session = new StripeCheckoutSession();
+        session.paymentId = paymentId;
+        session.stripeSessionId = mockedSession.id;
+        await session.save();
+
+        const charge = asCharge({ payment_intent: intentId });
+
+        expect(await resolveStripePaymentId(charge, { stripePlatform })).toBe(paymentId);
+    });
+
+    test('returns null when nothing matches', async () => {
+        const charge = asCharge({ payment_intent: stripeMocker.createId('pi') });
+
+        expect(await resolveStripePaymentId(charge, { stripePlatform })).toBe(null);
+    });
+
+    test('a resolution warms the cache for the charge and its originating transaction', async () => {
+        const paymentId = uuidv4();
+        const originating = asCharge({ metadata: { payment: paymentId } });
+        const charge = asCharge({
+            application_fee: stripeMocker.createApplicationFee({
+                amount: 250,
+                account: 'acct_1',
+                originatingTransaction: originating,
+            }),
+        });
+
+        const cache = new Map<string, string>();
+        expect(await resolveStripePaymentId(charge, { stripePlatform, cache })).toBe(paymentId);
+        expect(cache.get(charge.id)).toBe(paymentId);
+        expect(cache.get(originating.id)).toBe(paymentId);
+
+        // The platform walk warmed the cache with the originating charge id: the connected-side
+        // charge without any metadata still resolves without network or database lookups
+        const bare = asCharge({ id: originating.id, metadata: {} });
+        expect(await resolveStripePaymentId(bare, { stripePlatform, cache })).toBe(paymentId);
+    });
+});

--- a/backend/app/api/src/helpers/resolveStripePaymentId.ts
+++ b/backend/app/api/src/helpers/resolveStripePaymentId.ts
@@ -1,0 +1,93 @@
+import { StripeCheckoutSession, StripePaymentIntent } from '@stamhoofd/models';
+import type Stripe from 'stripe';
+
+/**
+ * Maps Stripe charge ids to local payment ids. Shared across one sync run: the platform payout walk
+ * resolves most charges cheaply and the connected walk then rarely needs the expensive
+ * checkout-session fallback.
+ */
+export type StripePaymentIdCache = Map<string, string>;
+
+/**
+ * Find the local payment behind a Stripe charge, the same ladder StripePayoutChecker has been using
+ * in production: charge metadata → application fee's originating transaction metadata →
+ * StripePaymentIntent → StripeCheckoutSession. Returns null when nothing matches: the caller
+ * decides whether that is an error.
+ *
+ * The `stripePlatform` client must not be account-scoped: checkout sessions live on the platform
+ * account.
+ */
+export async function resolveStripePaymentId(charge: Stripe.Charge, { stripePlatform, cache }: { stripePlatform: Stripe; cache?: StripePaymentIdCache }): Promise<string | null> {
+    // A destination charge shows up twice: as the platform charge (the application fee's
+    // originating transaction) and as the charge on the connected account. Both point to the same
+    // payment, so both are usable candidates and both warm the cache.
+    const candidates: Stripe.Charge[] = [charge];
+
+    if (charge.application_fee && typeof charge.application_fee !== 'string') {
+        const originatingTransaction = charge.application_fee.originating_transaction;
+        if (originatingTransaction && typeof originatingTransaction !== 'string') {
+            candidates.push(originatingTransaction as Stripe.Charge);
+        }
+    }
+
+    const remember = (paymentId: string) => {
+        for (const candidate of candidates) {
+            cache?.set(candidate.id, paymentId);
+        }
+        return paymentId;
+    };
+
+    for (const candidate of candidates) {
+        const cached = cache?.get(candidate.id);
+        if (cached) {
+            return remember(cached);
+        }
+    }
+
+    for (const candidate of candidates) {
+        const paymentId = candidate.metadata?.payment;
+        if (paymentId) {
+            return remember(paymentId);
+        }
+    }
+
+    // Historical bug where we didn't save payment in metadata: try to look it up by payment intent
+    for (const candidate of candidates) {
+        if (!candidate.payment_intent) {
+            continue;
+        }
+        const paymentIntentId = typeof candidate.payment_intent === 'string' ? candidate.payment_intent : candidate.payment_intent.id;
+
+        const stripePayments = await StripePaymentIntent.where({
+            stripeIntentId: paymentIntentId,
+        }, { limit: 1 });
+
+        if (stripePayments.length === 1) {
+            console.log('Found missing payment metadata for payment intent', paymentIntentId, stripePayments[0].paymentId);
+            return remember(stripePayments[0].paymentId);
+        }
+
+        // Probably a card payment: search for the checkout session
+        const checkoutSessions = await stripePlatform.checkout.sessions.list({
+            payment_intent: paymentIntentId,
+        });
+
+        if (checkoutSessions.data.length !== 1) {
+            console.log('No Stripe Checkout Sessions found for payment intent ' + paymentIntentId);
+            continue;
+        }
+
+        const stripeCheckoutSessions = await StripeCheckoutSession.where({
+            stripeSessionId: checkoutSessions.data[0].id,
+        }, { limit: 1 });
+
+        if (stripeCheckoutSessions.length === 1) {
+            console.log('Found missing payment metadata for payment intent', paymentIntentId, stripeCheckoutSessions[0].paymentId);
+            return remember(stripeCheckoutSessions[0].paymentId);
+        }
+
+        console.log('No payment found for checkout session ' + checkoutSessions.data[0].id);
+    }
+
+    return null;
+}

--- a/backend/app/api/tests/helpers/StripeMocker.ts
+++ b/backend/app/api/tests/helpers/StripeMocker.ts
@@ -10,14 +10,27 @@ import { testServer } from './TestServer.js';
 import { resetNock } from './resetNock.js';
 
 export type PaymentIntent = { id: string; return_url?: string };
+
+/**
+ * Loose Stripe API object: the mocker serves back exactly what a test built, so only the id is
+ * mandatory.
+ */
+export type StripeObject = { id: string } & Record<string, any>;
+
 export class StripeMocker {
     paymentIntents: PaymentIntent[] = [];
-    charges: { id: string }[] = [];
+    charges: StripeObject[] = [];
+    payouts: StripeObject[] = [];
+    balanceTransactions: StripeObject[] = [];
+    checkoutSessions: StripeObject[] = [];
     #forceFailure = false;
 
     reset() {
         this.paymentIntents = [];
         this.charges = [];
+        this.payouts = [];
+        this.balanceTransactions = [];
+        this.checkoutSessions = [];
         this.#forceFailure = false;
     }
 
@@ -30,25 +43,15 @@ export class StripeMocker {
             throw new Error('Invalid STRIPE_SECRET_KEY. Even in test mode it should start with sk_test_');
         }
 
+        const mocker = this;
         nock('https://api.stripe.com')
             .persist()
             .get(/v1\/.*/)
-            .reply((uri, body) => {
-                const [match, resource, id] = uri.match(/\/?v1\/(\w+)(?:\/(\w+)){0,2}/) || [null];
-
-                if (!match) {
-                    return [500];
-                }
-
-                if (resource === 'payment_intents') {
-                    return this.#getPaymentIntent(id);
-                }
-
-                if (resource === 'charges') {
-                    return this.#getCharge(id);
-                }
-
-                return [500];
+            // A regular function: nock exposes the intercepted request (and its Stripe-Account
+            // header) on `this`
+            .reply(function (uri) {
+                const stripeAccount = (this.req.headers['stripe-account'] as string | undefined) ?? null;
+                return mocker.#handleGet(uri, stripeAccount);
             });
 
         nock('https://api.stripe.com')
@@ -84,10 +87,175 @@ export class StripeMocker {
     clear() {
         this.paymentIntents = [];
         this.charges = [];
+        this.payouts = [];
+        this.balanceTransactions = [];
+        this.checkoutSessions = [];
     }
 
     createId(prefix: string) {
         return prefix + '_' + uuidv4().replaceAll('-', '');
+    }
+
+    #handleGet(uri: string, stripeAccount: string | null) {
+        const [match, resource, id] = uri.match(/\/?v1\/(\w+)(?:\/(\w+)){0,2}/) || [null];
+
+        if (!match) {
+            return [500];
+        }
+
+        const query = this.decodeBody(uri.split('?')[1] ?? '') as Record<string, any>;
+
+        if (resource === 'payment_intents') {
+            return this.#getPaymentIntent(id);
+        }
+
+        if (resource === 'charges') {
+            return this.#getCharge(id);
+        }
+
+        if (resource === 'payouts') {
+            return this.#listPayouts(id, query, stripeAccount);
+        }
+
+        if (resource === 'balance_transactions') {
+            return this.#listBalanceTransactions(query, stripeAccount);
+        }
+
+        if (resource === 'checkout' && id === 'sessions') {
+            return this.#listCheckoutSessions(query);
+        }
+
+        return [500];
+    }
+
+    #list(data: StripeObject[], url: string) {
+        return [200, { object: 'list', data, has_more: false, url }];
+    }
+
+    #listPayouts(id: string | undefined, query: Record<string, any>, stripeAccount: string | null) {
+        let data = this.payouts.filter(p => (p.stripeAccount ?? null) === stripeAccount);
+
+        if (id) {
+            const payout = data.find(p => p.id === id);
+            return payout ? [200, payout] : [404];
+        }
+
+        if (query.status) {
+            data = data.filter(p => p.status === query.status);
+        }
+        if (query.arrival_date?.gte !== undefined) {
+            data = data.filter(p => p.arrival_date >= query.arrival_date.gte);
+        }
+        if (query.arrival_date?.lte !== undefined) {
+            data = data.filter(p => p.arrival_date <= query.arrival_date.lte);
+        }
+        return this.#list(data, '/v1/payouts');
+    }
+
+    #listBalanceTransactions(query: Record<string, any>, stripeAccount: string | null) {
+        let data = this.balanceTransactions.filter(t => (t.stripeAccount ?? null) === stripeAccount);
+
+        if (query.payout) {
+            data = data.filter(t => t.payout === query.payout);
+        }
+        if (query.type) {
+            data = data.filter(t => t.type === query.type);
+        }
+        if (query.created?.gte !== undefined) {
+            data = data.filter(t => t.created >= query.created.gte);
+        }
+        if (query.created?.lte !== undefined) {
+            data = data.filter(t => t.created <= query.created.lte);
+        }
+        return this.#list(data, '/v1/balance_transactions');
+    }
+
+    #listCheckoutSessions(query: Record<string, any>) {
+        let data = this.checkoutSessions;
+
+        if (query.payment_intent) {
+            data = data.filter(s => s.payment_intent === query.payment_intent);
+        }
+        return this.#list(data, '/v1/checkout/sessions');
+    }
+
+    /**
+     * Amounts are in Stripe cents, like the real API.
+     */
+    createPayout(data: { amount: number; arrivalDate: Date; status?: string; statementDescriptor?: string; stripeAccount?: string | null } & Record<string, any>): StripeObject {
+        const { arrivalDate, statementDescriptor, stripeAccount, ...rest } = data;
+        const payout: StripeObject = {
+            id: this.createId('po'),
+            object: 'payout',
+            status: 'paid',
+            currency: 'eur',
+            arrival_date: Math.floor(arrivalDate.getTime() / 1000),
+            statement_descriptor: statementDescriptor ?? 'STAMHOOFD',
+            stripeAccount: stripeAccount ?? null,
+            ...rest,
+        };
+        this.payouts.push(payout);
+        return payout;
+    }
+
+    /**
+     * The `payout` field links the transaction to a payout, `stripeAccount` scopes it to a
+     * connected account (null = platform account). Sources are served exactly as passed, so tests
+     * control the expansions.
+     */
+    createBalanceTransaction(data: { type: string; amount: number; created: Date; payout?: string | null; stripeAccount?: string | null; fee?: number; source?: unknown } & Record<string, any>): StripeObject {
+        const { created, payout, stripeAccount, ...rest } = data;
+        const transaction: StripeObject = {
+            id: this.createId('txn'),
+            object: 'balance_transaction',
+            fee: 0,
+            fee_details: [],
+            created: Math.floor(created.getTime() / 1000),
+            payout: payout ?? null,
+            stripeAccount: stripeAccount ?? null,
+            ...rest,
+        };
+        this.balanceTransactions.push(transaction);
+        return transaction;
+    }
+
+    /**
+     * An expanded ApplicationFee object, used as the source of application_fee transactions and as
+     * charge.application_fee expansions.
+     */
+    createApplicationFee(data: { amount: number; account: string; originatingTransaction?: StripeObject | null; charge?: StripeObject | null } & Record<string, any>): StripeObject {
+        const { account, originatingTransaction, charge, ...rest } = data;
+        return {
+            id: this.createId('fee'),
+            object: 'application_fee',
+            account,
+            originating_transaction: originatingTransaction ?? null,
+            charge: charge ?? null,
+            ...rest,
+        };
+    }
+
+    createChargeObject(data: Record<string, any> = {}): StripeObject {
+        const charge: StripeObject = {
+            id: this.createId('ch'),
+            object: 'charge',
+            metadata: {},
+            ...data,
+        };
+        this.charges.push(charge);
+        return charge;
+    }
+
+    createCheckoutSession(data: { paymentIntent: string } & Record<string, any>): StripeObject {
+        const { paymentIntent, ...rest } = data;
+        const session: StripeObject = {
+            id: this.createId('cs'),
+            object: 'checkout.session',
+            payment_intent: paymentIntent,
+            ...rest,
+        };
+        this.checkoutSessions.push(session);
+        return session;
     }
 
     #getPaymentIntent(id: string) {


### PR DESCRIPTION
The charge→payment ladder (metadata → application fee originating transaction → StripePaymentIntent → StripeCheckoutSession) moves out of StripePayoutChecker into a shared helper with a per-run cache, so the payout syncs can reuse it. StripeMocker now serves payouts, balance transactions and checkout sessions from its persistent interceptor, scoped by the Stripe-Account header.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454327&installation_model_id=423362&pr_number=711&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F711&signature=95c0f2c5b9d6a0a8334229d7dd2114fbdf87b7f42d29f0487ddfc0a563f98d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->