### PR TITLE
✨ Stripe fee sync stores the Received application fee rows

### DIFF
--- a/backend/app/api/src/helpers/StripeFeeSync.test.ts
+++ b/backend/app/api/src/helpers/StripeFeeSync.test.ts
@@ -1,0 +1,163 @@
+import type { Organization, StripeAccount } from '@stamhoofd/models';
+import { OrganizationFactory, Payment } from '@stamhoofd/models';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import { StripeFeeSync } from './StripeFeeSync.js';
+
+describe('StripeFeeSync', () => {
+    const stripeMocker = new StripeMocker();
+    let organization: Organization;
+    let stripeAccount: StripeAccount;
+
+    const start = new Date(2026, 0, 1);
+    const end = new Date(2026, 1, 1);
+    const created = new Date(2026, 0, 15);
+
+    beforeAll(async () => {
+        stripeMocker.start();
+        organization = await new OrganizationFactory({}).create();
+        stripeAccount = await stripeMocker.createStripeAccount(organization.id);
+    });
+
+    afterAll(() => {
+        stripeMocker.stop();
+    });
+
+    beforeEach(() => {
+        stripeMocker.clear();
+    });
+
+    const createSync = () => new StripeFeeSync({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+
+    const createPayment = async () => {
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.stripeAccountId = stripeAccount.id;
+        payment.method = PaymentMethod.Bancontact;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = 25_00_00;
+        payment.paidAt = created;
+        await payment.save();
+        return payment;
+    };
+
+    /**
+     * One application_fee balance transaction of `feeCents`, of which `serviceFeeCents` is the
+     * service part (stored in the originating charge metadata, like the payment flow does).
+     */
+    const mockFeeTransaction = ({ payment, feeCents = 250, serviceFeeCents = 30 as number | string | null, account = undefined as string | undefined }: { payment: Payment | null; feeCents?: number; serviceFeeCents?: number | string | null; account?: string }) => {
+        const metadata: Record<string, string> = {};
+        if (payment) {
+            metadata.payment = payment.id;
+        }
+        if (serviceFeeCents !== null) {
+            metadata.serviceFee = serviceFeeCents.toString();
+        }
+
+        const charge = stripeMocker.createChargeObject({ metadata });
+        const fee = stripeMocker.createApplicationFee({
+            amount: feeCents,
+            account: account ?? stripeAccount.accountId,
+            originatingTransaction: charge,
+        });
+
+        const transaction = stripeMocker.createBalanceTransaction({
+            type: 'application_fee',
+            amount: feeCents,
+            created,
+            source: fee,
+        });
+
+        return { charge, fee, transaction };
+    };
+
+    test('one fee becomes two Received rows with the metadata split', async () => {
+        const payment = await createPayment();
+        const { fee } = mockFeeTransaction({ payment, feeCents: 250, serviceFeeCents: 30 });
+
+        await createSync().syncFees({ start, end });
+
+        const rows = await SettlementCharge.select().where('applicationFeeId', fee.id).fetch();
+        const byType = new Map(rows.map(r => [r.type, r]));
+
+        expect(rows).toHaveLength(2);
+        expect(byType.get(SettlementChargeType.ReceivedApplicationFeeService)).toMatchObject({
+            externalId: fee.id + ':' + SettlementChargeType.ReceivedApplicationFeeService,
+            amount: 30_00,
+            settlementId: null,
+            paymentId: payment.id,
+            organizationId: organization.id,
+            stripeAccountId: stripeAccount.id,
+            occurredAt: created,
+        });
+        expect(byType.get(SettlementChargeType.ReceivedApplicationFeeTransfer)).toMatchObject({
+            amount: 2_20_00,
+            paymentId: payment.id,
+        });
+    });
+
+    test('re-running stores identical rows', async () => {
+        const payment = await createPayment();
+        const { fee } = mockFeeTransaction({ payment });
+
+        const sync = createSync();
+        await sync.syncFees({ start, end });
+        const before = (await SettlementCharge.select().where('applicationFeeId', fee.id).fetch()).map(r => r.id).sort();
+
+        await sync.syncFees({ start, end });
+        const after = (await SettlementCharge.select().where('applicationFeeId', fee.id).fetch()).map(r => r.id).sort();
+
+        expect(after).toEqual(before);
+    });
+
+    test('missing serviceFee metadata stores nothing for that fee, but not at the cost of the others', async () => {
+        const payment = await createPayment();
+        const broken = mockFeeTransaction({ payment, serviceFeeCents: null });
+        const good = mockFeeTransaction({ payment, feeCents: 300, serviceFeeCents: 50 });
+
+        await expect(createSync().syncFees({ start, end })).rejects.toThrow(/Fee sync failed for 1 transaction/);
+
+        expect(await SettlementCharge.select().where('applicationFeeId', broken.fee.id).count()).toBe(0);
+        expect(await SettlementCharge.select().where('applicationFeeId', good.fee.id).count()).toBe(2);
+    });
+
+    test('an unresolvable payment throws instead of storing a guessed row', async () => {
+        const { fee } = mockFeeTransaction({ payment: null });
+
+        await expect(createSync().syncFees({ start, end })).rejects.toThrow(/Fee sync failed/);
+        expect(await SettlementCharge.select().where('applicationFeeId', fee.id).count()).toBe(0);
+    });
+
+    test('an unknown Stripe account throws', async () => {
+        const payment = await createPayment();
+        mockFeeTransaction({ payment, account: 'acct_unknown' });
+
+        await expect(createSync().syncFees({ start, end })).rejects.toThrow(/No Stripe account found/);
+    });
+
+    test('a zero service fee only writes the transfer row', async () => {
+        const payment = await createPayment();
+        const { fee } = mockFeeTransaction({ payment, feeCents: 100, serviceFeeCents: 0 });
+
+        await createSync().syncFees({ start, end });
+
+        const rows = await SettlementCharge.select().where('applicationFeeId', fee.id).fetch();
+        expect(rows).toHaveLength(1);
+        expect(rows[0].type).toBe(SettlementChargeType.ReceivedApplicationFeeTransfer);
+        expect(rows[0].amount).toBe(1_00_00);
+    });
+
+    test('transactions outside the window are left alone', async () => {
+        const payment = await createPayment();
+        const { fee, transaction } = mockFeeTransaction({ payment });
+        transaction.created = Math.floor(new Date(2026, 2, 15).getTime() / 1000);
+
+        await createSync().syncFees({ start, end });
+
+        expect(await SettlementCharge.select().where('applicationFeeId', fee.id).count()).toBe(0);
+    });
+});

--- a/backend/app/api/src/helpers/StripeFeeSync.ts
+++ b/backend/app/api/src/helpers/StripeFeeSync.ts
@@ -1,0 +1,141 @@
+import { SimpleError } from '@simonbackx/simple-errors';
+import { StripeAccount } from '@stamhoofd/models';
+import type { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import Stripe from 'stripe';
+
+import { SettlementService } from '../services/SettlementService.js';
+import { passthroughFetch } from './passthroughFetch.js';
+import type { StripePaymentIdCache } from './resolveStripePaymentId.js';
+import { resolveStripePaymentId } from './resolveStripePaymentId.js';
+import { ApplicationFeeDetails } from './StripeInvoicer.js';
+
+/**
+ * Stores the platform side of every application fee: the two Received rows that the monthly
+ * invoicing will be built on. The settlement link is left alone here — our payout usually arrives
+ * later, and the platform payout sync fills it in.
+ */
+export class StripeFeeSync {
+    private stripe: Stripe;
+
+    /**
+     * Shared with the payout syncs of the same run, so most charges resolve without extra lookups.
+     */
+    readonly cache: StripePaymentIdCache;
+
+    constructor({ secretKey, cache }: { secretKey: string; cache?: StripePaymentIdCache }) {
+        this.cache = cache ?? new Map();
+        this.stripe = new Stripe(secretKey, {
+            apiVersion: '2024-06-20',
+            typescript: true,
+            maxNetworkRetries: 1,
+            timeout: 10000,
+            httpClient: STAMHOOFD.environment === 'test'
+                ? Stripe.createFetchHttpClient(passthroughFetch)
+                : undefined,
+        });
+    }
+
+    /**
+     * Walks all application_fee balance transactions in the window. A broken fee doesn't block
+     * storing the others, but the walk still fails loudly at the end: a month is only invoiced
+     * after a run without errors.
+     */
+    async syncFees({ start, end }: { start: Date; end: Date }) {
+        const errors: unknown[] = [];
+
+        for await (const transaction of this.stripe.balanceTransactions.list({
+            type: 'application_fee',
+            created: {
+                gte: Math.floor(start.getTime() / 1000),
+                lte: Math.floor(end.getTime() / 1000),
+            },
+            expand: ['data.source', 'data.source.originating_transaction'],
+            limit: 100,
+        })) {
+            try {
+                await this.syncFeeTransaction(transaction);
+            } catch (e) {
+                console.error('Failed to sync application fee transaction ' + transaction.id, e);
+                errors.push(e);
+            }
+        }
+
+        if (errors.length > 0) {
+            throw new SimpleError({
+                code: 'stripe_fee_sync_failed',
+                message: 'Fee sync failed for ' + errors.length + ' transaction(s): ' + errors.map(e => e instanceof Error ? e.message : String(e)).join('; '),
+            });
+        }
+    }
+
+    /**
+     * Upserts the Received rows of one application_fee balance transaction. Throws instead of
+     * writing a guessed row: missing serviceFee metadata, an unknown Stripe account or an
+     * unresolvable payment all mean someone has to look at it first.
+     *
+     * The platform payout sync passes `settlementId` to link the rows to the payout containing
+     * them.
+     */
+    async syncFeeTransaction(transaction: Stripe.BalanceTransaction, options: { settlementId?: string } = {}): Promise<SettlementCharge[]> {
+        const fee = transaction.source as Stripe.ApplicationFee;
+        const accountId = typeof fee.account === 'string' ? fee.account : fee.account.id;
+
+        const stripeAccount = await StripeAccount.select().where('accountId', accountId).first(false);
+        if (!stripeAccount) {
+            throw new SimpleError({
+                code: 'stripe_account_not_found',
+                message: 'No Stripe account found for ' + accountId,
+            });
+        }
+
+        const originatingTransaction = fee.originating_transaction;
+        if (!originatingTransaction || typeof originatingTransaction === 'string') {
+            throw new SimpleError({
+                code: 'missing_originating_transaction',
+                message: 'Application fee ' + fee.id + ' has no expanded originating transaction',
+            });
+        }
+
+        const details = ApplicationFeeDetails.fromStripe(transaction);
+
+        const paymentId = await resolveStripePaymentId(originatingTransaction as Stripe.Charge, {
+            stripePlatform: this.stripe,
+            cache: this.cache,
+        });
+
+        if (!paymentId) {
+            throw new SimpleError({
+                code: 'payment_not_found',
+                message: 'No payment found for application fee ' + fee.id,
+            });
+        }
+
+        const occurredAt = new Date(transaction.created * 1000);
+
+        const rows: SettlementCharge[] = [];
+
+        for (const [type, amount] of [
+            [SettlementChargeType.ReceivedApplicationFeeService, details.serviceFee],
+            [SettlementChargeType.ReceivedApplicationFeeTransfer, details.transferFee],
+        ] as const) {
+            if (amount === 0) {
+                continue;
+            }
+
+            rows.push(await SettlementService.upsertCharge({
+                type,
+                externalId: fee.id + ':' + type,
+                amount,
+                ...(options.settlementId !== undefined ? { settlementId: options.settlementId } : {}),
+                applicationFeeId: fee.id,
+                paymentId,
+                organizationId: stripeAccount.organizationId,
+                stripeAccountId: stripeAccount.id,
+                occurredAt,
+            }));
+        }
+
+        return rows;
+    }
+}


### PR DESCRIPTION
Walks application_fee balance transactions per window and upserts the two Received rows per fee (the future invoicing source), settlement link left for the payout sync. Fails loudly per fee: missing serviceFee metadata, unknown account or unresolvable payment throws instead of storing a guessed row.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454331&installation_model_id=423362&pr_number=712&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F712&signature=ccc7b940e00c8b98d296c21ff20f6eaedcb04bfeeff7dff2f0896b618a965a79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->