### PR TITLE
✨ Stripe platform payout sync

### DIFF
--- a/backend/app/api/src/helpers/StripePayoutSync.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutSync.test.ts
@@ -1,0 +1,413 @@
+import type { Organization, StripeAccount } from '@stamhoofd/models';
+import { OrganizationFactory, Payment, Platform } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import type { StripeObject } from '../../tests/helpers/StripeMocker.js';
+import { StripePayoutSync } from './StripePayoutSync.js';
+
+describe('StripePayoutSync', () => {
+    const stripeMocker = new StripeMocker();
+    let organization: Organization;
+    let stripeAccount: StripeAccount;
+
+    const start = new Date(2026, 0, 1);
+    const created = new Date(2026, 0, 15);
+    const arrivalDate = new Date(2026, 0, 20);
+
+    let membershipOrganization: Organization;
+
+    beforeAll(async () => {
+        stripeMocker.start();
+        organization = await new OrganizationFactory({}).create();
+        stripeAccount = await stripeMocker.createStripeAccount(organization.id);
+
+        // Platform payouts belong to the membership organization
+        membershipOrganization = await new OrganizationFactory({}).create();
+        const platform = await Platform.getForEditing();
+        platform.membershipOrganizationId = membershipOrganization.id;
+        await platform.save();
+    });
+
+    afterAll(() => {
+        stripeMocker.stop();
+    });
+
+    beforeEach(() => {
+        stripeMocker.clear();
+    });
+
+    const createSync = () => new StripePayoutSync({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+
+    const createPayment = async ({ price = 100_00_00, type = PaymentType.Payment, reversingPaymentId = null as string | null } = {}) => {
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.stripeAccountId = stripeAccount.id;
+        payment.method = PaymentMethod.Bancontact;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.type = type;
+        payment.price = price;
+        payment.reversingPaymentId = reversingPaymentId;
+        payment.paidAt = created;
+        await payment.save();
+        return payment;
+    };
+
+    const getSettlement = async (payout: StripeObject) => {
+        return await Settlement.select().where('externalId', payout.id).first(true);
+    };
+
+    test('a full destination-charge payout reconciles to zero', async () => {
+        const payment = await createPayment({ price: 100_00_00 });
+        const payout = stripeMocker.createPayout({ amount: 225, arrivalDate });
+
+        const chargeTxn = stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 10000,
+            fee: 25,
+            fee_details: [{ type: 'stripe_fee', amount: 25, description: 'Stripe processing fees' }],
+            created,
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: payment.id } }),
+        });
+
+        stripeMocker.createBalanceTransaction({
+            type: 'transfer',
+            amount: -10000,
+            created,
+            payout: payout.id,
+            source: { object: 'transfer', id: stripeMocker.createId('tr'), destination: stripeAccount.accountId },
+        });
+
+        stripeMocker.createBalanceTransaction({
+            type: 'application_fee',
+            amount: 250,
+            created,
+            payout: payout.id,
+            source: stripeMocker.createApplicationFee({
+                amount: 250,
+                account: stripeAccount.accountId,
+                originatingTransaction: stripeMocker.createChargeObject({ metadata: { payment: payment.id, serviceFee: '30' } }),
+            }),
+        });
+
+        stripeMocker.createBalanceTransaction({
+            type: 'payout',
+            amount: -225,
+            created,
+            payout: payout.id,
+            source: null,
+        });
+
+        const result = await createSync().syncPayouts({ start });
+        expect(result).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const settlement = await getSettlement(payout);
+        expect(settlement).toMatchObject({
+            provider: PaymentProvider.Stripe,
+            stripeAccountId: null,
+            organizationId: membershipOrganization.id,
+            amount: 2_25_00,
+            unexplainedAmount: 0,
+            transactionCount: 4,
+        });
+        expect(settlement.syncedAt).not.toBeNull();
+
+        const lines = await PaymentSettlement.select().where('settlementId', settlement.id).fetch();
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toMatchObject({ paymentId: payment.id, amount: 100_00_00, externalId: chargeTxn.id });
+
+        const charges = await SettlementCharge.select().where('settlementId', settlement.id).fetch();
+        const byType = (type: SettlementChargeType) => charges.filter(c => c.type === type);
+        expect(byType(SettlementChargeType.ProviderTransactionFee)[0]).toMatchObject({
+            amount: -25_00,
+            paymentId: payment.id,
+            providerInvoiceId: 'stripe-2026-01',
+        });
+        expect(byType(SettlementChargeType.Transfer)[0]).toMatchObject({ amount: -100_00_00 });
+        expect(byType(SettlementChargeType.ReceivedApplicationFeeService)[0]).toMatchObject({ amount: 30_00, stripeAccountId: stripeAccount.id });
+        expect(byType(SettlementChargeType.ReceivedApplicationFeeTransfer)[0]).toMatchObject({ amount: 2_20_00 });
+
+        // The legacy blob only ever shows the payout of the payment's own account: after just the
+        // platform walk it stays untouched (the connected walk writes it)
+        const updated = await Payment.getByID(payment.id);
+        expect(updated!.settlement).toBeNull();
+    });
+
+    test('a refund is stored on the reversing payment', async () => {
+        const original = await createPayment({ price: 100_00_00 });
+        const refund = await createPayment({ price: -20_00_00, type: PaymentType.Refund, reversingPaymentId: original.id });
+
+        const payout = stripeMocker.createPayout({ amount: 8000, arrivalDate });
+        stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 10000,
+            created,
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: original.id } }),
+        });
+        stripeMocker.createBalanceTransaction({
+            type: 'refund',
+            amount: -2000,
+            created,
+            payout: payout.id,
+            source: {
+                object: 'refund',
+                id: stripeMocker.createId('re'),
+                charge: stripeMocker.createChargeObject({ metadata: { payment: original.id } }),
+            },
+        });
+        stripeMocker.createBalanceTransaction({ type: 'payout', amount: -8000, created, payout: payout.id, source: null });
+
+        const result = await createSync().syncPayouts({ start });
+        expect(result).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const settlement = await getSettlement(payout);
+        expect(settlement.unexplainedAmount).toBe(0);
+
+        const lines = await PaymentSettlement.select().where('settlementId', settlement.id).fetch();
+        expect(lines.map(l => [l.paymentId, l.amount]).sort()).toEqual([
+            [original.id, 100_00_00],
+            [refund.id, -20_00_00],
+        ].sort());
+    });
+
+    test('a refund without reversing payment fails the payout', async () => {
+        const original = await createPayment({ price: 100_00_00 });
+
+        const payout = stripeMocker.createPayout({ amount: -2000, arrivalDate });
+        stripeMocker.createBalanceTransaction({
+            type: 'refund',
+            amount: -2000,
+            created,
+            payout: payout.id,
+            source: {
+                object: 'refund',
+                id: stripeMocker.createId('re'),
+                charge: stripeMocker.createChargeObject({ metadata: { payment: original.id } }),
+            },
+        });
+
+        const result = await createSync().syncPayouts({ start });
+        expect(result).toEqual({ synced: 0, skipped: 0, failed: 1 });
+
+        const settlement = await getSettlement(payout);
+        expect(settlement.syncedAt).toBeNull();
+        expect(settlement.syncFailureCount).toBe(1);
+        expect(await PaymentSettlement.select().where('settlementId', settlement.id).count()).toBe(0);
+    });
+
+    test('two identical refunds pair deterministically with the two chargebacks', async () => {
+        const original = await createPayment({ price: 100_00_00 });
+        const first = await createPayment({ price: -20_00_00, type: PaymentType.Refund, reversingPaymentId: original.id });
+        const second = await createPayment({ price: -20_00_00, type: PaymentType.Refund, reversingPaymentId: original.id });
+
+        const payout = stripeMocker.createPayout({ amount: -4000, arrivalDate });
+        for (const _ of [first, second]) {
+            stripeMocker.createBalanceTransaction({
+                type: 'refund',
+                amount: -2000,
+                created,
+                payout: payout.id,
+                source: {
+                    object: 'refund',
+                    id: stripeMocker.createId('re'),
+                    charge: stripeMocker.createChargeObject({ metadata: { payment: original.id } }),
+                },
+            });
+        }
+
+        const sync = createSync();
+        expect(await sync.syncPayouts({ start })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const settlement = await getSettlement(payout);
+        const lines = await PaymentSettlement.select().where('settlementId', settlement.id).fetch();
+        expect(lines.map(l => l.paymentId).sort()).toEqual([first.id, second.id].sort());
+
+        // Re-running keeps the same pairing
+        const pairing = new Map(lines.map(l => [l.externalId, l.paymentId]));
+        expect(await sync.syncPayouts({ start, force: true })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+        const after = await PaymentSettlement.select().where('settlementId', settlement.id).fetch();
+        for (const line of after) {
+            expect(line.paymentId).toBe(pairing.get(line.externalId));
+        }
+    });
+
+    test('an unknown fee detail type fails the payout', async () => {
+        const payment = await createPayment();
+        const payout = stripeMocker.createPayout({ amount: 9975, arrivalDate });
+        stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 10000,
+            fee: 25,
+            fee_details: [{ type: 'weird_fee', amount: 25 }],
+            created,
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: payment.id } }),
+        });
+
+        const result = await createSync().syncPayouts({ start });
+        expect(result).toEqual({ synced: 0, skipped: 0, failed: 1 });
+        expect((await getSettlement(payout)).syncedAt).toBeNull();
+    });
+
+    test('an unknown transaction type fails the payout instead of inventing a row', async () => {
+        const payout = stripeMocker.createPayout({ amount: 1000, arrivalDate });
+        stripeMocker.createBalanceTransaction({
+            type: 'connect_collection_transfer',
+            amount: 1000,
+            created,
+            payout: payout.id,
+            source: null,
+        });
+
+        const result = await createSync().syncPayouts({ start });
+        expect(result).toEqual({ synced: 0, skipped: 0, failed: 1 });
+
+        const settlement = await getSettlement(payout);
+        expect(settlement.syncedAt).toBeNull();
+    });
+
+    test('fee refunds, account fees, reserves and disputes become their own rows', async () => {
+        const payment = await createPayment();
+
+        const payout = stripeMocker.createPayout({ amount: -3600, arrivalDate });
+        const feeRefund = stripeMocker.createBalanceTransaction({
+            type: 'application_fee_refund',
+            amount: -100,
+            created,
+            payout: payout.id,
+            source: { object: 'fee_refund', id: stripeMocker.createId('fr'), fee: 'fee_original' },
+        });
+        stripeMocker.createBalanceTransaction({
+            type: 'stripe_fee',
+            amount: -500,
+            description: 'Billing - Usage Fee',
+            created,
+            payout: payout.id,
+            source: null,
+        });
+        stripeMocker.createBalanceTransaction({
+            type: 'reserve_transaction',
+            amount: -1000,
+            created,
+            payout: payout.id,
+            source: null,
+        });
+        stripeMocker.createBalanceTransaction({
+            type: 'adjustment',
+            amount: -2000,
+            created,
+            payout: payout.id,
+            source: { object: 'dispute', id: stripeMocker.createId('dp'), charge: stripeMocker.createChargeObject({ metadata: { payment: payment.id } }) },
+        });
+
+        const result = await createSync().syncPayouts({ start });
+        expect(result).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const settlement = await getSettlement(payout);
+        expect(settlement.unexplainedAmount).toBe(0);
+
+        const charges = await SettlementCharge.select().where('settlementId', settlement.id).fetch();
+        const byType = new Map(charges.map(c => [c.type, c]));
+
+        expect(byType.get(SettlementChargeType.ApplicationFeeRefund)).toMatchObject({
+            externalId: (feeRefund.source as StripeObject).id,
+            amount: -1_00_00,
+            applicationFeeId: 'fee_original',
+        });
+        expect(byType.get(SettlementChargeType.ProviderAccountFee)).toMatchObject({
+            amount: -5_00_00,
+            description: 'Billing - Usage Fee',
+            providerInvoiceId: 'stripe-2026-01',
+        });
+        expect(byType.get(SettlementChargeType.Reserve)).toMatchObject({ amount: -10_00_00 });
+        expect(byType.get(SettlementChargeType.Adjustment)).toMatchObject({ amount: -20_00_00, paymentId: payment.id });
+    });
+
+    test('re-running skips synced payouts and stays idempotent under force', async () => {
+        const payment = await createPayment();
+        const payout = stripeMocker.createPayout({ amount: 10000, arrivalDate });
+        stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 10000,
+            created,
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: payment.id } }),
+        });
+
+        const sync = createSync();
+        expect(await sync.syncPayouts({ start })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const settlement = await getSettlement(payout);
+        const rowIds = (await PaymentSettlement.select().where('settlementId', settlement.id).fetch()).map(r => r.id);
+
+        expect(await sync.syncPayouts({ start })).toEqual({ synced: 0, skipped: 1, failed: 0 });
+        expect(await createSync().syncPayouts({ start, force: true })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const after = (await PaymentSettlement.select().where('settlementId', settlement.id).fetch()).map(r => r.id);
+        expect(after).toEqual(rowIds);
+    });
+
+    test('a transaction that moved to another payout is swept, but Received rows only unlink', async () => {
+        const payment = await createPayment();
+        const otherPayment = await createPayment({ price: 50_00_00 });
+        const payout = stripeMocker.createPayout({ amount: 15250, arrivalDate });
+
+        stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 10000,
+            created,
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: payment.id } }),
+        });
+        const movedCharge = stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 5000,
+            created,
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: otherPayment.id } }),
+        });
+        const movedFee = stripeMocker.createBalanceTransaction({
+            type: 'application_fee',
+            amount: 250,
+            created,
+            payout: payout.id,
+            source: stripeMocker.createApplicationFee({
+                amount: 250,
+                account: stripeAccount.accountId,
+                originatingTransaction: stripeMocker.createChargeObject({ metadata: { payment: payment.id, serviceFee: '30' } }),
+            }),
+        });
+
+        const sync = createSync();
+        expect(await sync.syncPayouts({ start })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const settlement = await getSettlement(payout);
+        expect(await PaymentSettlement.select().where('settlementId', settlement.id).count()).toBe(2);
+
+        // Stripe moved the second charge and the fee to a later payout
+        movedCharge.payout = stripeMocker.createId('po');
+        movedFee.payout = stripeMocker.createId('po');
+        payout.amount = 10000;
+
+        expect(await sync.syncPayouts({ start, force: true })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+
+        const lines = await PaymentSettlement.select().where('settlementId', settlement.id).fetch();
+        expect(lines).toHaveLength(1);
+        expect(lines[0].paymentId).toBe(payment.id);
+
+        const received = await SettlementCharge.select().where('applicationFeeId', ((movedFee.source as StripeObject)).id).fetch();
+        expect(received).toHaveLength(2);
+        for (const row of received) {
+            expect(row.settlementId).toBeNull();
+        }
+
+        expect((await getSettlement(payout)).unexplainedAmount).toBe(0);
+    });
+});

--- a/backend/app/api/src/helpers/StripePayoutSync.ts
+++ b/backend/app/api/src/helpers/StripePayoutSync.ts
@@ -1,0 +1,507 @@
+import { SimpleError } from '@simonbackx/simple-errors';
+import { Email } from '@stamhoofd/email';
+import type { StripeAccount } from '@stamhoofd/models';
+import { Payment } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import type { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { PaymentProvider } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementStatus.js';
+import Stripe from 'stripe';
+
+import { ReportedRows, SettlementService } from '../services/SettlementService.js';
+import { passthroughFetch } from './passthroughFetch.js';
+import type { StripePaymentIdCache } from './resolveStripePaymentId.js';
+import { resolveStripePaymentId } from './resolveStripePaymentId.js';
+import { StripeFeeSync } from './StripeFeeSync.js';
+
+/**
+ * Walks paid payouts and stores every balance transaction in them: payments become
+ * payment_settlements rows, everything else becomes settlement_charges rows. One walker for both
+ * scopes: `stripeAccount === null` walks our own platform account, otherwise the connected
+ * account's payouts.
+ *
+ * Fail loudly: a transaction that can't be attributed or an unknown transaction type fails the
+ * whole payout. The settlement stays unsynced (`syncedAt IS NULL`) and is retried later.
+ */
+export class StripePayoutSync {
+    private stripe: Stripe;
+    private stripePlatform: Stripe;
+    private stripeAccount: StripeAccount | null;
+    private feeSync: StripeFeeSync;
+    readonly cache: StripePaymentIdCache;
+
+    /**
+     * Explicitly fetched charges (when an expansion came back as an id), per run.
+     */
+    private fetchedCharges = new Map<string, Stripe.Charge>();
+
+    constructor({ secretKey, stripeAccount, cache }: { secretKey: string; stripeAccount?: StripeAccount | null; cache?: StripePaymentIdCache }) {
+        this.stripeAccount = stripeAccount ?? null;
+        this.cache = cache ?? new Map();
+        this.feeSync = new StripeFeeSync({ secretKey, cache: this.cache });
+
+        const options: Stripe.StripeConfig = {
+            apiVersion: '2024-06-20',
+            typescript: true,
+            maxNetworkRetries: 1,
+            timeout: 10000,
+            httpClient: STAMHOOFD.environment === 'test'
+                ? Stripe.createFetchHttpClient(passthroughFetch)
+                : undefined,
+        };
+
+        this.stripe = new Stripe(secretKey, { ...options, stripeAccount: this.stripeAccount?.accountId });
+        this.stripePlatform = new Stripe(secretKey, options);
+    }
+
+    /**
+     * Sync all paid payouts that arrived in the window. A failing payout is marked, emailed and
+     * skipped so the other payouts still sync; the summary tells the caller how bad it was.
+     */
+    async syncPayouts({ start, end, force = false }: { start: Date; end?: Date; force?: boolean }): Promise<{ synced: number; skipped: number; failed: number }> {
+        const result = { synced: 0, skipped: 0, failed: 0 };
+
+        // Fail once up front when no organization can own these payouts, instead of once per payout
+        // inside the per-payout error boundary
+        await this.#getOrganizationId();
+
+        for await (const payout of this.stripe.payouts.list({
+            status: 'paid',
+            arrival_date: {
+                gte: Math.floor(start.getTime() / 1000),
+                ...(end ? { lte: Math.floor(end.getTime() / 1000) } : {}),
+            },
+            limit: 100,
+        })) {
+            try {
+                const { skipped } = await this.syncPayout(payout, { force });
+                if (skipped) {
+                    result.skipped += 1;
+                } else {
+                    result.synced += 1;
+                }
+            } catch (e) {
+                console.error('Failed to sync Stripe payout ' + payout.id, e);
+                result.failed += 1;
+
+                Email.sendWebmaster({
+                    subject: 'Synchroniseren Stripe uitbetaling ' + payout.id + ' mislukt',
+                    html: 'Synchroniseren van Stripe uitbetaling ' + payout.id + (this.stripeAccount ? (' van account ' + this.stripeAccount.accountId) : '') + ' is mislukt. <br><br> ' + (e as Error).toString(),
+                });
+            }
+        }
+
+        return result;
+    }
+
+    #organizationId: string | null = null;
+
+    /**
+     * The organization that owns the walked account: the connected account's organization, or the
+     * platform membership organization for our own platform account (resolved once per instance).
+     */
+    async #getOrganizationId(): Promise<string> {
+        this.#organizationId ??= this.stripeAccount?.organizationId ?? await SettlementService.getPlatformOrganizationId();
+        return this.#organizationId;
+    }
+
+    async syncPayout(payout: Stripe.Payout, { force = false }: { force?: boolean } = {}): Promise<{ settlement: Settlement; skipped: boolean }> {
+        return await SettlementService.lock(PaymentProvider.Stripe, payout.id, async () => {
+            const settlement = await SettlementService.upsertSettlement({
+                provider: PaymentProvider.Stripe,
+                externalId: payout.id,
+                stripeAccountId: this.stripeAccount?.id ?? null,
+                organizationId: await this.#getOrganizationId(),
+                reference: payout.statement_descriptor ?? '',
+                amount: payout.amount * 100,
+                currency: payout.currency?.toUpperCase() ?? 'EUR',
+                status: getSettlementStatus(payout.status),
+                settledAt: new Date(payout.arrival_date * 1000),
+            });
+
+            if (settlement.syncedAt && !force) {
+                return { settlement, skipped: true };
+            }
+
+            try {
+                await this.#walkPayout(payout, settlement);
+            } catch (e) {
+                await SettlementService.markSyncFailed(settlement);
+                throw e;
+            }
+
+            return { settlement, skipped: false };
+        });
+    }
+
+    async #walkPayout(payout: Stripe.Payout, settlement: Settlement) {
+        const reported = new ReportedRows();
+        let transactionCount = 0;
+
+        for await (const transaction of this.stripe.balanceTransactions.list({
+            payout: payout.id,
+            limit: 100,
+            expand: this.stripeAccount
+                ? ['data.source', 'data.source.application_fee', 'data.source.application_fee.originating_transaction', 'data.source.charge']
+                : ['data.source', 'data.source.originating_transaction', 'data.source.charge'],
+        })) {
+            transactionCount += 1;
+            await this.#handleTransaction(transaction, settlement, reported);
+        }
+
+        await SettlementService.sweepSettlement(settlement, reported);
+        await SettlementService.finishSync(settlement, { transactionCount });
+    }
+
+    async #handleTransaction(transaction: Stripe.BalanceTransaction, settlement: Settlement, reported: ReportedRows) {
+        const occurredAt = new Date(transaction.created * 1000);
+
+        // A plain string switch: the pinned SDK's type union misses some real-world types
+        // (e.g. network_cost)
+        switch (transaction.type as string) {
+            case 'charge':
+            case 'payment': {
+                const payment = await this.#resolvePayment(transaction);
+                reported.paymentLine(await SettlementService.upsertPaymentLine(settlement, {
+                    paymentId: payment.id,
+                    amount: transaction.amount * 100,
+                    externalId: transaction.id,
+                    occurredAt,
+                }));
+                await this.#storeProviderFeeDetails(transaction, settlement, reported, { paymentId: payment.id });
+                await SettlementService.updateLegacySettlementReference(payment);
+                return;
+            }
+
+            case 'refund':
+            case 'payment_refund':
+            case 'payment_failure_refund':
+            case 'refund_failure': {
+                // The failure types are SEPA debit failures after settling: locally a Chargeback
+                // payment, linked the same way as a refund
+                const payment = await this.#resolveReversingPayment(transaction);
+                reported.paymentLine(await SettlementService.upsertPaymentLine(settlement, {
+                    paymentId: payment.id,
+                    amount: transaction.amount * 100,
+                    externalId: transaction.id,
+                    occurredAt,
+                }));
+                await this.#storeProviderFeeDetails(transaction, settlement, reported, { paymentId: payment.id });
+                await SettlementService.updateLegacySettlementReference(payment);
+                return;
+            }
+
+            case 'application_fee': {
+                // The fee's two Received rows, now linked to the payout that contains them
+                reported.charges(await this.feeSync.syncFeeTransaction(transaction, { settlementId: settlement.id }));
+                await this.#storeProviderFeeDetails(transaction, settlement, reported, { paymentId: null });
+                return;
+            }
+
+            case 'application_fee_refund': {
+                const source = transaction.source as Stripe.FeeRefund;
+                const applicationFeeId = typeof source.fee === 'string' ? source.fee : source.fee.id;
+
+                const charge = await SettlementService.upsertCharge({
+                    type: SettlementChargeType.ApplicationFeeRefund,
+                    externalId: source.id,
+                    amount: transaction.amount * 100,
+                    settlementId: settlement.id,
+                    applicationFeeId,
+                    description: transaction.description ?? '',
+                    occurredAt,
+                });
+                reported.charge(charge);
+                await this.#storeProviderFeeDetails(transaction, settlement, reported, { paymentId: null });
+                return;
+            }
+
+            case 'transfer':
+            case 'transfer_cancel':
+            case 'transfer_failure':
+            case 'transfer_refund': {
+                const charge = await SettlementService.upsertCharge({
+                    type: transaction.type === 'transfer' ? SettlementChargeType.Transfer : SettlementChargeType.TransferReversal,
+                    externalId: transaction.id,
+                    amount: transaction.amount * 100,
+                    settlementId: settlement.id,
+                    description: transaction.description ?? '',
+                    occurredAt,
+                });
+                reported.charge(charge);
+                await this.#storeProviderFeeDetails(transaction, settlement, reported, { paymentId: null });
+                return;
+            }
+
+            case 'stripe_fee':
+            case 'network_cost': {
+                const charge = await SettlementService.upsertCharge({
+                    type: SettlementChargeType.ProviderAccountFee,
+                    externalId: transaction.id,
+                    amount: transaction.amount * 100,
+                    settlementId: settlement.id,
+                    organizationId: settlement.organizationId,
+                    providerInvoiceId: getStripeInvoiceId(occurredAt),
+                    description: transaction.description ?? '',
+                    occurredAt,
+                });
+                reported.charge(charge);
+                return;
+            }
+
+            case 'reserve_transaction': {
+                const charge = await SettlementService.upsertCharge({
+                    type: SettlementChargeType.Reserve,
+                    externalId: transaction.id,
+                    amount: transaction.amount * 100,
+                    settlementId: settlement.id,
+                    description: transaction.description ?? '',
+                    occurredAt,
+                });
+                reported.charge(charge);
+                return;
+            }
+
+            case 'adjustment': {
+                const paymentId = await this.#tryResolveAdjustmentPayment(transaction);
+                const charge = await SettlementService.upsertCharge({
+                    type: SettlementChargeType.Adjustment,
+                    externalId: transaction.id,
+                    amount: transaction.amount * 100,
+                    settlementId: settlement.id,
+                    // Unresolvable stays undefined: a re-sync may not clear an earlier stored link
+                    ...(paymentId ? { paymentId } : {}),
+                    description: transaction.description ?? '',
+                    occurredAt,
+                });
+                reported.charge(charge);
+                await this.#storeProviderFeeDetails(transaction, settlement, reported, { paymentId });
+                return;
+            }
+
+            case 'payout':
+                // The payout transaction is the payout itself
+                return;
+
+            default:
+                throw new SimpleError({
+                    code: 'unknown_balance_transaction_type',
+                    message: 'Unknown balance transaction type ' + transaction.type + ' for transaction ' + transaction.id,
+                });
+        }
+    }
+
+    /**
+     * The provider's own fees, deducted inside the transaction. The amounts always come from the
+     * balance transaction itself.
+     */
+    async #storeProviderFeeDetails(transaction: Stripe.BalanceTransaction, settlement: Settlement, reported: ReportedRows, { paymentId }: { paymentId: string | null }) {
+        const occurredAt = new Date(transaction.created * 1000);
+
+        for (const [index, detail] of (transaction.fee_details ?? []).entries()) {
+            if (detail.amount === 0) {
+                continue;
+            }
+
+            const charge = await SettlementService.upsertCharge({
+                type: getFeeDetailType(detail, transaction),
+                externalId: transaction.id + ':fee:' + index,
+                amount: -detail.amount * 100,
+                settlementId: settlement.id,
+                paymentId,
+                organizationId: settlement.organizationId,
+                stripeAccountId: this.stripeAccount?.id ?? null,
+                providerInvoiceId: detail.type === 'application_fee' ? null : getStripeInvoiceId(occurredAt),
+                description: detail.description ?? '',
+                occurredAt,
+            });
+            reported.charge(charge);
+        }
+    }
+
+    async #resolvePayment(transaction: Stripe.BalanceTransaction): Promise<Payment> {
+        const source = transaction.source;
+        if (!source || typeof source === 'string' || source.object !== 'charge') {
+            throw new SimpleError({
+                code: 'missing_charge',
+                message: 'Balance transaction ' + transaction.id + ' has no expanded charge source',
+            });
+        }
+
+        const paymentId = await resolveStripePaymentId(source, {
+            stripePlatform: this.stripePlatform,
+            cache: this.cache,
+        });
+
+        if (!paymentId) {
+            throw new SimpleError({
+                code: 'payment_not_found',
+                message: 'No payment found for charge ' + source.id + ' in transaction ' + transaction.id,
+            });
+        }
+
+        const payment = await Payment.getByID(paymentId);
+        if (!payment) {
+            throw new SimpleError({
+                code: 'payment_not_found',
+                message: 'Payment ' + paymentId + ' referenced by charge ' + source.id + ' does not exist',
+            });
+        }
+
+        return payment;
+    }
+
+    /**
+     * Stripe's refund transaction points at the original charge; locally the refund is its own
+     * Payment linked through reversingPaymentId, matched on amount. No match means someone refunded
+     * outside Stamhoofd: fix the data, don't paper over it.
+     */
+    async #resolveReversingPayment(transaction: Stripe.BalanceTransaction): Promise<Payment> {
+        const source = transaction.source;
+        if (!source || typeof source === 'string' || source.object !== 'refund') {
+            throw new SimpleError({
+                code: 'missing_refund',
+                message: 'Balance transaction ' + transaction.id + ' has no expanded refund source',
+            });
+        }
+
+        if (!source.charge) {
+            throw new SimpleError({
+                code: 'missing_refund_charge',
+                message: 'Refund ' + source.id + ' in transaction ' + transaction.id + ' has no charge',
+            });
+        }
+
+        const charge = await this.#getCharge(source.charge, transaction);
+        const originalPaymentId = await resolveStripePaymentId(charge, {
+            stripePlatform: this.stripePlatform,
+            cache: this.cache,
+        });
+
+        if (!originalPaymentId) {
+            throw new SimpleError({
+                code: 'payment_not_found',
+                message: 'No payment found for refunded charge ' + charge.id + ' in transaction ' + transaction.id,
+            });
+        }
+
+        let candidates = await Payment.select()
+            .where('reversingPaymentId', originalPaymentId)
+            .where('price', transaction.amount * 100)
+            .fetch();
+
+        if (candidates.length > 1) {
+            // Two refunds of the same amount are interchangeable (same original payment, same
+            // price): drop the ones already matched to a different provider transaction, then pair
+            // deterministically so re-syncs keep the same pairing
+            const lines = await PaymentSettlement.select()
+                .where('paymentId', candidates.map(c => c.id))
+                .fetch();
+            const claimed = new Set(lines.filter(l => l.externalId !== transaction.id).map(l => l.paymentId));
+            candidates = candidates
+                .filter(c => !claimed.has(c.id))
+                .sort((a, b) => (a.createdAt.getTime() - b.createdAt.getTime()) || a.id.localeCompare(b.id))
+                .slice(0, 1);
+        }
+
+        if (candidates.length !== 1) {
+            throw new SimpleError({
+                code: 'reversing_payment_not_found',
+                message: 'Found ' + candidates.length + ' reversing payments for payment ' + originalPaymentId + ' with amount ' + (transaction.amount * 100) + ' (transaction ' + transaction.id + ')',
+            });
+        }
+
+        return candidates[0];
+    }
+
+    async #tryResolveAdjustmentPayment(transaction: Stripe.BalanceTransaction): Promise<string | null> {
+        const source = transaction.source;
+        if (!source || typeof source === 'string') {
+            return null;
+        }
+
+        const charge = (source as { charge?: string | Stripe.Charge }).charge;
+        if (!charge) {
+            return null;
+        }
+
+        try {
+            return await resolveStripePaymentId(await this.#getCharge(charge, transaction), {
+                stripePlatform: this.stripePlatform,
+                cache: this.cache,
+            });
+        } catch (e) {
+            // A charge that no longer exists is "not resolvable"; transient errors must still fail
+            // the payout
+            if (e instanceof SimpleError && e.code === 'charge_not_found') {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Stripe caps `expand` at 4 paths, so a nested object can still come back as an id: fetch it
+     * explicitly then (cached per run).
+     */
+    async #getCharge(charge: string | Stripe.Charge, transaction: Stripe.BalanceTransaction): Promise<Stripe.Charge> {
+        if (typeof charge !== 'string') {
+            return charge;
+        }
+
+        const cached = this.fetchedCharges.get(charge);
+        if (cached) {
+            return cached;
+        }
+
+        try {
+            const fetched = await this.stripe.charges.retrieve(charge);
+            this.fetchedCharges.set(charge, fetched);
+            return fetched;
+        } catch (e) {
+            if ((e as { statusCode?: number }).statusCode === 404) {
+                throw new SimpleError({
+                    code: 'charge_not_found',
+                    message: 'Charge ' + charge + ' of transaction ' + transaction.id + ' does not exist',
+                });
+            }
+            throw e;
+        }
+    }
+}
+
+function getSettlementStatus(status: string): SettlementStatus {
+    switch (status) {
+        case 'paid': return SettlementStatus.Paid;
+        case 'pending':
+        case 'in_transit': return SettlementStatus.Pending;
+        case 'failed': return SettlementStatus.Failed;
+        case 'canceled': return SettlementStatus.Canceled;
+        default:
+            throw new SimpleError({
+                code: 'unknown_payout_status',
+                message: 'Unknown payout status ' + status,
+            });
+    }
+}
+
+/**
+ * Stripe has no invoice id in the API, so the derived monthly id groups fee rows per invoice
+ * document.
+ */
+function getStripeInvoiceId(occurredAt: Date): string {
+    return 'stripe-' + occurredAt.getFullYear() + '-' + (occurredAt.getMonth() + 1).toString().padStart(2, '0');
+}
+
+function getFeeDetailType(detail: Stripe.BalanceTransaction.FeeDetail, transaction: Stripe.BalanceTransaction): SettlementChargeType {
+    switch (detail.type) {
+        case 'stripe_fee': return SettlementChargeType.ProviderTransactionFee;
+        case 'tax': return SettlementChargeType.Tax;
+        default:
+            throw new SimpleError({
+                code: 'unknown_fee_detail_type',
+                message: 'Unknown fee detail type ' + detail.type + ' on transaction ' + transaction.id,
+            });
+    }
+}


### PR DESCRIPTION
Walks paid payouts on our platform account and stores every balance transaction: payment lines via the id ladder, refunds via reversingPaymentId matched on amount, Received fee rows linked per payout, fee refunds/transfers/account fees/reserves/adjustments as typed charge rows. Unknown transaction types fail the payout (syncedAt stays NULL) instead of writing invented rows. Also dual-writes the legacy payments.settlement JSON.

Platform payouts and their fee rows belong to the platform membership organization (the platform Stripe account is its account); the sync fails up front when none is configured.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
