### PR TITLE
✨ Stripe connected payout sync

### DIFF
--- a/backend/app/api/src/helpers/StripeInvoicer.ts
+++ b/backend/app/api/src/helpers/StripeInvoicer.ts
@@ -28,7 +28,7 @@ export class ApplicationFeeDetails {
         return this.transferFee + this.serviceFee;
     }
 
-    static fromStripe(transaction: Stripe.BalanceTransaction) {
+    static fromStripe(transaction: Pick<Stripe.BalanceTransaction, 'source' | 'amount' | 'created'>) {
         const source = transaction.source as Stripe.ApplicationFee;
         const metadata = (source.originating_transaction as Stripe.Charge).metadata;
 

--- a/backend/app/api/src/helpers/StripePayoutSync.test.ts
+++ b/backend/app/api/src/helpers/StripePayoutSync.test.ts
@@ -410,4 +410,148 @@ describe('StripePayoutSync', () => {
 
         expect((await getSettlement(payout)).unexplainedAmount).toBe(0);
     });
+
+    describe('Connected accounts', () => {
+        test('an organization payout writes the mirrored deduction rows, summing to zero against the Received rows', async () => {
+            const payment = await createPayment();
+            const fee = stripeMocker.createApplicationFee({
+                amount: 250,
+                account: stripeAccount.accountId,
+                originatingTransaction: stripeMocker.createChargeObject({ metadata: { payment: payment.id, serviceFee: '30' } }),
+            });
+
+            // Our platform payout receives the fee
+            const platformPayout = stripeMocker.createPayout({ amount: 250, arrivalDate });
+            stripeMocker.createBalanceTransaction({
+                type: 'application_fee',
+                amount: 250,
+                created,
+                payout: platformPayout.id,
+                source: fee,
+            });
+            stripeMocker.createBalanceTransaction({ type: 'payout', amount: -250, created, payout: platformPayout.id, source: null });
+
+            // The organization payout holds the payment, the fee sits inside its fee_details
+            const payout = stripeMocker.createPayout({ amount: 9725, arrivalDate, stripeAccount: stripeAccount.accountId });
+            stripeMocker.createBalanceTransaction({
+                type: 'payment',
+                amount: 10000,
+                fee: 275,
+                fee_details: [
+                    { type: 'stripe_fee', amount: 25, description: 'Stripe processing fees' },
+                    { type: 'application_fee', amount: 250, description: 'Application fee' },
+                ],
+                created,
+                payout: payout.id,
+                stripeAccount: stripeAccount.accountId,
+                source: stripeMocker.createChargeObject({ metadata: { payment: payment.id }, application_fee: fee }),
+            });
+            stripeMocker.createBalanceTransaction({ type: 'payout', amount: -9725, created, payout: payout.id, stripeAccount: stripeAccount.accountId, source: null });
+
+            const cache = new Map<string, string>();
+            expect(await new StripePayoutSync({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY!, cache }).syncPayouts({ start })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+            expect(await StripePayoutSync.syncConnectedPayouts({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY!, start, cache })).toMatchObject({ synced: 1, failed: 0 });
+
+            const settlement = await getSettlement(payout);
+            expect(settlement).toMatchObject({
+                stripeAccountId: stripeAccount.id,
+                organizationId: organization.id,
+                amount: 97_25_00,
+                unexplainedAmount: 0,
+            });
+
+            const rows = await SettlementCharge.select().where('applicationFeeId', fee.id).fetch();
+            const byType = new Map(rows.map(r => [r.type, r]));
+
+            expect(byType.get(SettlementChargeType.ApplicationFeeService)).toMatchObject({
+                amount: -30_00,
+                settlementId: settlement.id,
+                paymentId: payment.id,
+                stripeAccountId: stripeAccount.id,
+            });
+            expect(byType.get(SettlementChargeType.ApplicationFeeTransfer)).toMatchObject({ amount: -2_20_00, settlementId: settlement.id });
+
+            // Both sides of the same fee cancel out per kind
+            expect(byType.get(SettlementChargeType.ReceivedApplicationFeeService)!.amount + byType.get(SettlementChargeType.ApplicationFeeService)!.amount).toBe(0);
+            expect(byType.get(SettlementChargeType.ReceivedApplicationFeeTransfer)!.amount + byType.get(SettlementChargeType.ApplicationFeeTransfer)!.amount).toBe(0);
+
+            // The legacy blob is dual-written with the payment's own payout, never our platform one
+            const updated = await Payment.getByID(payment.id);
+            expect(updated!.settlement?.id).toBe(payout.id);
+        });
+
+        test('spoofed charge metadata pointing at another account\'s payment fails the payout', async () => {
+            const otherOrganization = await new OrganizationFactory({}).create();
+            const otherAccount = await stripeMocker.createStripeAccount(otherOrganization.id);
+            const foreignPayment = new Payment();
+            foreignPayment.organizationId = otherOrganization.id;
+            foreignPayment.stripeAccountId = otherAccount.id;
+            foreignPayment.method = PaymentMethod.Bancontact;
+            foreignPayment.provider = PaymentProvider.Stripe;
+            foreignPayment.status = PaymentStatus.Succeeded;
+            foreignPayment.price = 100_00_00;
+            foreignPayment.paidAt = created;
+            await foreignPayment.save();
+
+            const payout = stripeMocker.createPayout({ amount: 10000, arrivalDate, stripeAccount: stripeAccount.accountId });
+            stripeMocker.createBalanceTransaction({
+                type: 'payment',
+                amount: 10000,
+                created,
+                payout: payout.id,
+                stripeAccount: stripeAccount.accountId,
+                source: stripeMocker.createChargeObject({ metadata: { payment: foreignPayment.id } }),
+            });
+
+            const result = await new StripePayoutSync({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY!, stripeAccount }).syncPayouts({ start });
+            expect(result).toEqual({ synced: 0, skipped: 0, failed: 1 });
+            expect((await getSettlement(payout)).syncedAt).toBeNull();
+            expect(await PaymentSettlement.select().where('paymentId', foreignPayment.id).count()).toBe(0);
+        });
+
+        test('an application fee detail on the platform account fails the payout', async () => {
+            const payment = await createPayment();
+            const payout = stripeMocker.createPayout({ amount: 9750, arrivalDate });
+            stripeMocker.createBalanceTransaction({
+                type: 'charge',
+                amount: 10000,
+                fee: 250,
+                fee_details: [{ type: 'application_fee', amount: 250 }],
+                created,
+                payout: payout.id,
+                source: stripeMocker.createChargeObject({ metadata: { payment: payment.id } }),
+            });
+
+            const result = await createSync().syncPayouts({ start });
+            expect(result).toEqual({ synced: 0, skipped: 0, failed: 1 });
+            expect((await getSettlement(payout)).syncedAt).toBeNull();
+        });
+
+        test('a negative application fee detail fails the payout', async () => {
+            const payment = await createPayment();
+            const fee = stripeMocker.createApplicationFee({
+                amount: 250,
+                account: stripeAccount.accountId,
+                originatingTransaction: stripeMocker.createChargeObject({ metadata: { payment: payment.id, serviceFee: '30' } }),
+            });
+
+            const payout = stripeMocker.createPayout({ amount: 10250, arrivalDate, stripeAccount: stripeAccount.accountId });
+            stripeMocker.createBalanceTransaction({
+                type: 'payment',
+                amount: 10000,
+                fee: -250,
+                fee_details: [{ type: 'application_fee', amount: -250 }],
+                created,
+                payout: payout.id,
+                stripeAccount: stripeAccount.accountId,
+                source: stripeMocker.createChargeObject({ metadata: { payment: payment.id }, application_fee: fee }),
+            });
+
+            const result = await StripePayoutSync.syncConnectedPayouts({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY!, start });
+            expect(result.failed).toBe(1);
+
+            const settlement = await getSettlement(payout);
+            expect(settlement.syncedAt).toBeNull();
+        });
+    });
 });

--- a/backend/app/api/src/helpers/StripePayoutSync.ts
+++ b/backend/app/api/src/helpers/StripePayoutSync.ts
@@ -1,7 +1,6 @@
 import { SimpleError } from '@simonbackx/simple-errors';
 import { Email } from '@stamhoofd/email';
-import type { StripeAccount } from '@stamhoofd/models';
-import { Payment } from '@stamhoofd/models';
+import { Payment, StripeAccount } from '@stamhoofd/models';
 import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
 import type { Settlement } from '@stamhoofd/models/models/Settlement.js';
 import { PaymentProvider } from '@stamhoofd/structures';
@@ -14,6 +13,7 @@ import { passthroughFetch } from './passthroughFetch.js';
 import type { StripePaymentIdCache } from './resolveStripePaymentId.js';
 import { resolveStripePaymentId } from './resolveStripePaymentId.js';
 import { StripeFeeSync } from './StripeFeeSync.js';
+import { ApplicationFeeDetails } from './StripeInvoicer.js';
 
 /**
  * Walks paid payouts and stores every balance transaction in them: payments become
@@ -53,6 +53,37 @@ export class StripePayoutSync {
 
         this.stripe = new Stripe(secretKey, { ...options, stripeAccount: this.stripeAccount?.accountId });
         this.stripePlatform = new Stripe(secretKey, options);
+    }
+
+    /**
+     * Walks the payouts of every active connected account, after the platform walk warmed the
+     * shared payment id cache.
+     */
+    static async syncConnectedPayouts({ secretKey, start, end, force, cache }: { secretKey: string; start: Date; end?: Date; force?: boolean; cache?: StripePaymentIdCache }): Promise<{ synced: number; skipped: number; failed: number }> {
+        const sharedCache = cache ?? new Map<string, string>();
+        const totals = { synced: 0, skipped: 0, failed: 0 };
+
+        const accounts = await StripeAccount.select().where('status', 'active').fetch();
+
+        for (const account of accounts) {
+            try {
+                const sync = new StripePayoutSync({ secretKey, stripeAccount: account, cache: sharedCache });
+                const result = await sync.syncPayouts({ start, end, force });
+                totals.synced += result.synced;
+                totals.skipped += result.skipped;
+                totals.failed += result.failed;
+            } catch (e) {
+                console.error('Failed to sync payouts of Stripe account ' + account.accountId, e);
+                totals.failed += 1;
+
+                Email.sendWebmaster({
+                    subject: 'Synchroniseren Stripe uitbetalingen van account ' + account.accountId + ' mislukt',
+                    html: 'Synchroniseren van de Stripe uitbetalingen van account ' + account.accountId + ' is mislukt. <br><br> ' + (e as Error).toString(),
+                });
+            }
+        }
+
+        return totals;
     }
 
     /**
@@ -304,6 +335,11 @@ export class StripePayoutSync {
                 continue;
             }
 
+            if (detail.type === 'application_fee') {
+                await this.#storeApplicationFeeDeduction(transaction, detail, settlement, reported, { paymentId });
+                continue;
+            }
+
             const charge = await SettlementService.upsertCharge({
                 type: getFeeDetailType(detail, transaction),
                 externalId: transaction.id + ':fee:' + index,
@@ -312,8 +348,80 @@ export class StripePayoutSync {
                 paymentId,
                 organizationId: settlement.organizationId,
                 stripeAccountId: this.stripeAccount?.id ?? null,
-                providerInvoiceId: detail.type === 'application_fee' ? null : getStripeInvoiceId(occurredAt),
+                providerInvoiceId: getStripeInvoiceId(occurredAt),
                 description: detail.description ?? '',
+                occurredAt,
+            });
+            reported.charge(charge);
+        }
+    }
+
+    /**
+     * On the connected account the application fee is not a separate transaction: it sits inside
+     * the payment's fee_details, and the fee id comes from the charge's application_fee. The two
+     * negative deduction rows mirror the Received rows of the platform payout, so per
+     * applicationFeeId both sides of one kind sum to zero.
+     */
+    async #storeApplicationFeeDeduction(transaction: Stripe.BalanceTransaction, detail: Stripe.BalanceTransaction.FeeDetail, settlement: Settlement, reported: ReportedRows, { paymentId }: { paymentId: string | null }) {
+        if (!this.stripeAccount) {
+            throw new SimpleError({
+                code: 'unexpected_application_fee_detail',
+                message: 'Transaction ' + transaction.id + ' on the platform account has an application_fee fee detail',
+            });
+        }
+
+        if (detail.amount < 0) {
+            // A refunded fee inside an organization payout walk: give it its own mirrored type
+            // first instead of writing wrong rows
+            throw new SimpleError({
+                code: 'negative_application_fee_detail',
+                message: 'Transaction ' + transaction.id + ' has a negative application_fee fee detail',
+            });
+        }
+
+        const source = transaction.source;
+        if (!source || typeof source === 'string' || source.object !== 'charge') {
+            throw new SimpleError({
+                code: 'missing_charge',
+                message: 'Transaction ' + transaction.id + ' with an application fee has no expanded charge source',
+            });
+        }
+
+        const applicationFee = source.application_fee;
+        if (!applicationFee || typeof applicationFee === 'string') {
+            throw new SimpleError({
+                code: 'missing_application_fee',
+                message: 'Charge ' + source.id + ' of transaction ' + transaction.id + ' has no expanded application fee',
+            });
+        }
+
+        // Reuse the platform-side split verbatim, so both sides of the fee (and its serviceFee
+        // metadata errors) can never diverge
+        const details = ApplicationFeeDetails.fromStripe({
+            source: applicationFee,
+            amount: detail.amount,
+            created: transaction.created,
+        });
+
+        const occurredAt = new Date(transaction.created * 1000);
+
+        for (const [type, amount] of [
+            [SettlementChargeType.ApplicationFeeService, details.serviceFee],
+            [SettlementChargeType.ApplicationFeeTransfer, details.transferFee],
+        ] as const) {
+            if (amount === 0) {
+                continue;
+            }
+
+            const charge = await SettlementService.upsertCharge({
+                type,
+                externalId: applicationFee.id + ':' + type,
+                amount: -amount,
+                settlementId: settlement.id,
+                applicationFeeId: applicationFee.id,
+                paymentId,
+                organizationId: this.stripeAccount.organizationId,
+                stripeAccountId: this.stripeAccount.id,
                 occurredAt,
             });
             reported.charge(charge);
@@ -349,7 +457,21 @@ export class StripePayoutSync {
             });
         }
 
+        this.#assertPaymentScope(payment, source.id);
         return payment;
+    }
+
+    /**
+     * Charge metadata is writable by the connected account's owner: a walked payment must belong
+     * to the walked account, or spoofed metadata could attach another organization's payment.
+     */
+    #assertPaymentScope(payment: Payment, chargeId: string) {
+        if (this.stripeAccount && payment.stripeAccountId !== this.stripeAccount.id) {
+            throw new SimpleError({
+                code: 'payment_scope_mismatch',
+                message: 'Payment ' + payment.id + ' referenced by charge ' + chargeId + ' does not belong to Stripe account ' + this.stripeAccount.accountId,
+            });
+        }
     }
 
     /**
@@ -412,6 +534,7 @@ export class StripePayoutSync {
             });
         }
 
+        this.#assertPaymentScope(candidates[0], charge.id);
         return candidates[0];
     }
 


### PR DESCRIPTION
Organization payouts walk with an account-scoped client: the application fee sits inside the payment's fee_details, so the walker writes the two negative deduction rows with the fee id from charge.application_fee, mirroring the Received rows (per applicationFeeId both sides of one kind sum to zero). Negative fee details fail the payout until they get their own mirrored type. Adds syncConnectedPayouts over all active accounts.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454338&installation_model_id=423362&pr_number=714&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F714&signature=931f11996fe349e5a4aba33ea528268b3e3698ef8b222795960297cc22d19d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->