### PR TITLE
✨ Mollie settlements dual-write the new rows

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/mollie/ConnectMollieEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/mollie/ConnectMollieEndpoint.ts
@@ -53,7 +53,7 @@ export class ConnectMollieEndpoint extends Endpoint<Params, Query, Body, Respons
             await service.setupOnboarding();
 
             // Check settlements after linking (shouldn't block)
-            checkMollieSettlementsFor(mollieToken.accessToken, true).catch(console.error);
+            checkMollieSettlementsFor(mollieToken.accessToken, organization.id, true).catch(console.error);
         }
 
         return new Response(await AuthenticatedStructures.organization(organization));

--- a/backend/app/api/src/helpers/CheckSettlements.test.ts
+++ b/backend/app/api/src/helpers/CheckSettlements.test.ts
@@ -1,5 +1,9 @@
 import { MolliePayment, OrganizationFactory, Payment } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
 import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
 import type { MollieMockPayment, MollieMockRefund } from '../../tests/helpers/MollieMocker.js';
 import { MollieMocker } from '../../tests/helpers/MollieMocker.js';
 import { checkMollieSettlementsFor } from './CheckSettlements.js';
@@ -80,8 +84,8 @@ describe('Helper.CheckSettlements', () => {
         return { organization, token, payment, refundPayment, mockPayment, mockRefund };
     };
 
-    const runCron = async (token: { accessToken: string }) => {
-        await checkMollieSettlementsFor(token.accessToken, true);
+    const runCron = async (token: { accessToken: string; organizationId: string }) => {
+        await checkMollieSettlementsFor(token.accessToken, token.organizationId, true);
     };
 
     /**
@@ -166,6 +170,112 @@ describe('Helper.CheckSettlements', () => {
             id: settlement.id,
             reference: settlement.reference,
             amount: 100_0000,
+        });
+    });
+
+    describe('Settlement rows', () => {
+        const getSettlementRow = async (externalId: string) => {
+            return await Settlement.select().where('externalId', externalId).first(true);
+        };
+
+        test('legacy JSON and new rows agree, and the settlement reconciles to zero', async () => {
+            const { organization, token, payment, refundPayment, mockPayment, mockRefund } = await init();
+
+            // 50.00 - 20.00 in entries, minus 0.30 costs + 0.06 VAT
+            const settlement = mollieMocker.createSettlement({
+                payments: [mockPayment],
+                refunds: [mockRefund],
+                value: '29.64',
+                invoiceId: 'inv_123',
+                periods: {
+                    2026: {
+                        '01': {
+                            costs: [{
+                                description: 'Bancontact betalingen',
+                                method: 'bancontact',
+                                amountNet: { currency: 'EUR', value: '0.30' },
+                                amountVat: { currency: 'EUR', value: '0.06' },
+                            }],
+                        },
+                    },
+                },
+            });
+
+            await runCron(token);
+
+            const row = await getSettlementRow(settlement.id);
+            expect(row).toMatchObject({
+                provider: PaymentProvider.Mollie,
+                organizationId: organization.id,
+                reference: settlement.reference,
+                amount: 29_6400,
+                unexplainedAmount: 0,
+            });
+            expect(row.syncedAt).not.toBeNull();
+
+            const lines = await PaymentSettlement.select().where('settlementId', row.id).fetch();
+            expect(lines.map(l => [l.externalId, l.paymentId, l.amount]).sort()).toEqual([
+                [mockPayment.id, payment.id, 50_0000],
+                [mockRefund.id, refundPayment.id, -20_0000],
+            ].sort());
+
+            const charges = await SettlementCharge.select().where('settlementId', row.id).fetch();
+            expect(charges.map(c => ({ type: c.type, amount: c.amount, providerInvoiceId: c.providerInvoiceId, occurredAt: c.occurredAt })).sort((a, b) => a.amount - b.amount)).toEqual([
+                { type: SettlementChargeType.ProviderTransactionFee, amount: -30_00, providerInvoiceId: 'inv_123', occurredAt: new Date(2026, 0, 1) },
+                { type: SettlementChargeType.Tax, amount: -6_00, providerInvoiceId: 'inv_123', occurredAt: new Date(2026, 0, 1) },
+            ]);
+
+            // The legacy blob agrees with the new settlement row
+            const updatedPayment = await Payment.getByID(payment.id);
+            expect(updatedPayment!.settlement!.id).toBe(row.externalId);
+            expect(updatedPayment!.settlement!.amount).toBe(row.amount);
+        });
+
+        test('the invoiceId is filled in on a later re-walk', async () => {
+            const { token, mockPayment } = await init();
+            const settlement = mollieMocker.createSettlement({
+                payments: [mockPayment],
+                value: '49.70',
+                periods: {
+                    2026: {
+                        '01': {
+                            costs: [{
+                                description: 'Bancontact betalingen',
+                                method: 'bancontact',
+                                amountNet: { currency: 'EUR', value: '0.30' },
+                                amountVat: { currency: 'EUR', value: '0.00' },
+                            }],
+                        },
+                    },
+                },
+            });
+
+            await runCron(token);
+            const row = await getSettlementRow(settlement.id);
+            const costs = await SettlementCharge.select().where('settlementId', row.id).fetch();
+            expect(costs).toHaveLength(1);
+            expect(costs[0].providerInvoiceId).toBeNull();
+
+            // Mollie created the invoice since the last walk
+            settlement.invoiceId = 'inv_later';
+            await runCron(token);
+
+            const updated = await SettlementCharge.getByID(costs[0].id);
+            expect(updated!.providerInvoiceId).toBe('inv_later');
+        });
+
+        test('re-running stores identical rows', async () => {
+            const { token, mockPayment, mockRefund } = await init();
+            const settlement = mollieMocker.createSettlement({ payments: [mockPayment], refunds: [mockRefund], value: '30.00' });
+
+            await runCron(token);
+            const row = await getSettlementRow(settlement.id);
+            const before = (await PaymentSettlement.select().where('settlementId', row.id).fetch()).map(l => l.id).sort();
+
+            await runCron(token);
+            const after = (await PaymentSettlement.select().where('settlementId', row.id).fetch()).map(l => l.id).sort();
+            expect(after).toEqual(before);
+            expect(await Settlement.select().where('externalId', settlement.id).count()).toBe(1);
         });
     });
 

--- a/backend/app/api/src/helpers/CheckSettlements.ts
+++ b/backend/app/api/src/helpers/CheckSettlements.ts
@@ -1,8 +1,26 @@
 import { MolliePayment, MollieToken, Order, Organization, PayconiqPayment, Payment, StripeAccount } from '@stamhoofd/models';
-import { SettlementReference } from '@stamhoofd/structures';
+import type { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { PaymentProvider, SettlementReference } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementStatus.js';
 import axios from 'axios';
+import { createHash } from 'crypto';
 
+import { ReportedRows, SettlementService } from '../services/SettlementService.js';
 import { StripePayoutChecker } from './StripePayoutChecker.js';
+
+type MollieSettlementCost = {
+    description: string;
+    method: string | null;
+    amountNet: {
+        currency: string;
+        value: string;
+    };
+    amountVat: {
+        currency: string;
+        value: string;
+    } | null;
+};
 
 type MollieSettlement = {
     id: string;
@@ -14,7 +32,38 @@ type MollieSettlement = {
         currenty: string;
         value: string;
     };
+    /**
+     * "The ID of the oldest invoice created for all the periods": null until Mollie created it,
+     * filled in by the regular re-walk of recent settlements.
+     */
+    invoiceId?: string | null;
+    periods?: Record<string, Record<string, { costs?: MollieSettlementCost[]; invoiceId?: string | null }>>;
 };
+
+/**
+ * Everything the new-rows dual-write of one settlement walk needs to share between the resource
+ * pages.
+ */
+type SettlementSyncState = {
+    settlementRow: Settlement;
+    reported: ReportedRows;
+};
+
+/**
+ * Same expression as the legacy blob write, so the two can never disagree (euros → 4-decimal
+ * platform units).
+ */
+function mollieAmountToUnits(value: string): number {
+    return Math.round(parseFloat(value) * 100) * 100;
+}
+
+function getMollieSettlementStatus(status: MollieSettlement['status']): SettlementStatus {
+    switch (status) {
+        case 'paidout': return SettlementStatus.Paid;
+        case 'failed': return SettlementStatus.Failed;
+        default: return SettlementStatus.Pending;
+    }
+}
 
 /**
  * Both payments (tr_...) and refunds (re_...) settled in a settlement are matched to a local
@@ -67,7 +116,12 @@ export async function checkSettlements(checkAll = false) {
     if (!token) {
         console.error('Missing mollie organization token');
     } else {
-        await checkMollieSettlementsFor(token, checkAll);
+        try {
+            // The platform's own Mollie account belongs to the membership organization
+            await checkMollieSettlementsFor(token, await SettlementService.getPlatformOrganizationId(), checkAll);
+        } catch (e) {
+            console.error(e);
+        }
     }
 
     // Loop all mollie tokens created after given date (when settlement permission was added)
@@ -82,7 +136,7 @@ export async function checkSettlements(checkAll = false) {
             } else {
                 try {
                     await token.refreshIfNeeded();
-                    await checkMollieSettlementsFor(token.accessToken, checkAll);
+                    await checkMollieSettlementsFor(token.accessToken, token.organizationId, checkAll);
                 } catch (e) {
                     console.error(e);
                 }
@@ -93,8 +147,11 @@ export async function checkSettlements(checkAll = false) {
     }
 }
 
-// Check settlements once a week on tuesday morning/night
-export async function checkMollieSettlementsFor(token: string, checkAll = false) {
+/**
+ * Walk the settlements of one Mollie account. `organizationId` is the organization that owns the
+ * account the token belongs to: every settlement row it writes is theirs.
+ */
+export async function checkMollieSettlementsFor(token: string, organizationId: string, checkAll = false) {
     // Check last 2 weeks + 3 day margin, unless we check them all
     const d = new Date();
     d.setDate(d.getDate() - 17);
@@ -131,7 +188,7 @@ export async function checkMollieSettlementsFor(token: string, checkAll = false)
                         }
 
                         if (checkAll || settledAt > d) {
-                            await updateSettlement(token, settlement);
+                            await updateSettlement(token, settlement, organizationId);
                         }
                     }
                 } else {
@@ -150,17 +207,92 @@ export async function checkMollieSettlementsFor(token: string, checkAll = false)
     }
 }
 
-async function updateSettlement(token: string, settlement: MollieSettlement) {
-    // Regular payments settled in this settlement
-    await updateSettlementResource(token, settlement, 'payments');
+async function updateSettlement(token: string, settlement: MollieSettlement, organizationId: string) {
+    const settlementRow = await SettlementService.upsertSettlement({
+        provider: PaymentProvider.Mollie,
+        externalId: settlement.id,
+        stripeAccountId: null,
+        organizationId,
+        reference: settlement.reference,
+        amount: mollieAmountToUnits(settlement.amount.value),
+        status: getMollieSettlementStatus(settlement.status),
+        settledAt: new Date(settlement.settledAt),
+    });
 
-    // Refunds settled in this settlement. These are negative entries linked to a refund payment
-    // (created by the mollie-refunds cron), so we can set their settlement metadata too.
-    await updateSettlementResource(token, settlement, 'refunds');
+    const state: SettlementSyncState = {
+        settlementRow,
+        reported: new ReportedRows(),
+    };
 
-    // Chargebacks settled in this settlement. Like refunds, these are negative entries linked to a
-    // chargeback payment (created by the mollie-chargebacks cron).
-    await updateSettlementResource(token, settlement, 'chargebacks');
+    try {
+        // Regular payments settled in this settlement
+        await updateSettlementResource(token, settlement, 'payments', state);
+
+        // Refunds settled in this settlement. These are negative entries linked to a refund payment
+        // (created by the mollie-refunds cron), so we can set their settlement metadata too.
+        await updateSettlementResource(token, settlement, 'refunds', state);
+
+        // Chargebacks settled in this settlement. Like refunds, these are negative entries linked to a
+        // chargeback payment (created by the mollie-chargebacks cron).
+        await updateSettlementResource(token, settlement, 'chargebacks', state);
+
+        // Mollie's own costs, so the settlement reconciles to 0 like a Stripe one
+        await storeMollieCosts(settlement, state);
+
+        await SettlementService.sweepSettlement(settlementRow, state.reported);
+        await SettlementService.finishSync(settlementRow, {
+            transactionCount: state.reported.paymentLineExternalIds.size + state.reported.chargeExternalIds.size,
+        });
+    } catch (e) {
+        await SettlementService.markSyncFailed(settlementRow);
+        throw e;
+    }
+}
+
+/**
+ * Mollie invoices its costs per period: every cost line becomes a ProviderTransactionFee row plus
+ * a Tax row for its VAT, carrying the settlement's invoiceId so they can be matched against the
+ * invoice document.
+ */
+async function storeMollieCosts(settlement: MollieSettlement, state: SettlementSyncState) {
+    for (const [year, months] of Object.entries(settlement.periods ?? {})) {
+        for (const [month, period] of Object.entries(months)) {
+            // Mollie states the period explicitly: that month is the cost's date, so the monthly
+            // grouping stays derivable from occurredAt alone
+            const occurredAt = new Date(parseInt(year), parseInt(month) - 1, 1);
+
+            // A settlement can straddle a month boundary: each period can be billed on its own
+            // invoice, the settlement-level id is only "the oldest invoice of all the periods"
+            const invoiceId = period.invoiceId ?? settlement.invoiceId;
+
+            for (const cost of period.costs ?? []) {
+                // Mollie aggregates cost lines per description + method, so that pair identifies
+                // the line within the period (hashed to keep the externalId short)
+                const hash = createHash('sha256').update(cost.description + ':' + (cost.method ?? '')).digest('hex').slice(0, 16);
+                const externalId = settlement.id + ':' + year + '-' + month + ':cost:' + hash;
+                const description = cost.description + (cost.method ? ' (' + cost.method + ')' : '');
+
+                const rows = [
+                    { type: SettlementChargeType.ProviderTransactionFee, externalId, amount: -mollieAmountToUnits(cost.amountNet.value) },
+                    ...(cost.amountVat && mollieAmountToUnits(cost.amountVat.value) !== 0
+                        ? [{ type: SettlementChargeType.Tax, externalId: externalId + ':tax', amount: -mollieAmountToUnits(cost.amountVat.value) }]
+                        : []),
+                ];
+
+                for (const row of rows) {
+                    const charge = await SettlementService.upsertCharge({
+                        ...row,
+                        settlementId: state.settlementRow.id,
+                        organizationId: state.settlementRow.organizationId,
+                        ...(invoiceId ? { providerInvoiceId: invoiceId } : {}),
+                        description,
+                        occurredAt,
+                    });
+                    state.reported.charge(charge);
+                }
+            }
+        }
+    }
 }
 
 /**
@@ -168,7 +300,7 @@ async function updateSettlement(token: string, settlement: MollieSettlement) {
  * settlement metadata on the matching local payment. Every resource exposes its entries under
  * `_embedded[resource]` and uses the same pagination, so they share this logic.
  */
-async function updateSettlementResource(token: string, settlement: MollieSettlement, resource: 'payments' | 'refunds' | 'chargebacks', fromId?: string) {
+async function updateSettlementResource(token: string, settlement: MollieSettlement, resource: 'payments' | 'refunds' | 'chargebacks', state: SettlementSyncState, fromId?: string) {
     const limit = 250;
 
     const request = await axios.get('https://api.mollie.com/v2/settlements/' + settlement.id + '/' + resource + '?limit=' + limit + (fromId ? ('&from=' + encodeURIComponent(fromId)) : ''), {
@@ -181,12 +313,12 @@ async function updateSettlementResource(token: string, settlement: MollieSettlem
         const entries = request.data._embedded[resource] as MollieSettlementEntryJSON[];
 
         for (const entry of entries) {
-            await applySettlementToPayment(settlement, entry.id);
+            await applySettlementToPayment(settlement, entry.id, state);
         }
 
         // Check next page
         if (request.data._links.next && entries.length > 0) {
-            await updateSettlementResource(token, settlement, resource, entries[entries.length - 1].id);
+            await updateSettlementResource(token, settlement, resource, state, entries[entries.length - 1].id);
         }
     } else {
         console.error(request.data);
@@ -195,19 +327,28 @@ async function updateSettlementResource(token: string, settlement: MollieSettlem
 
 /**
  * Find the local payment linked to a Mollie payment or refund id and store the settlement metadata.
+ * Entries without a local payment belong to a different system on the same Mollie account: they are
+ * skipped, and the settlement's unexplainedAmount shows the gap.
  */
-async function applySettlementToPayment(settlement: MollieSettlement, mollieId: string) {
+async function applySettlementToPayment(settlement: MollieSettlement, mollieId: string, state: SettlementSyncState) {
     // Search payment
     const mps = await MolliePayment.where({ mollieId });
     if (mps.length === 1) {
         const mp = mps[0];
         const payment = await Payment.getByID(mp.paymentId);
         if (payment) {
+            state.reported.paymentLine(await SettlementService.upsertPaymentLine(state.settlementRow, {
+                paymentId: payment.id,
+                amount: payment.price,
+                externalId: mollieId,
+                occurredAt: new Date(settlement.settledAt),
+            }));
+
             payment.settlement = SettlementReference.create({
                 id: settlement.id,
                 reference: settlement.reference,
                 settledAt: new Date(settlement.settledAt),
-                amount: Math.round(parseFloat(settlement.amount.value) * 100) * 100,
+                amount: mollieAmountToUnits(settlement.amount.value),
             });
             const saved = await payment.save();
 

--- a/backend/app/api/tests/helpers/MollieMocker.ts
+++ b/backend/app/api/tests/helpers/MollieMocker.ts
@@ -53,6 +53,13 @@ export type MollieMockRefund = {
     metadata: Record<string, unknown> | null;
 };
 
+export type MollieMockSettlementCost = {
+    description: string;
+    method: string | null;
+    amountNet: { currency: string; value: string };
+    amountVat: { currency: string; value: string } | null;
+};
+
 export type MollieMockSettlement = {
     id: string;
     reference: string;
@@ -61,6 +68,10 @@ export type MollieMockSettlement = {
     createdAt: string;
     /** null for the still-open settlement, a date once it has been paid out */
     settledAt: string | null;
+    /** id of the invoice Mollie created for the settlement costs, null until it exists */
+    invoiceId: string | null;
+    /** Mollie's own costs per period, keyed year → month */
+    periods: Record<string, Record<string, { costs: MollieMockSettlementCost[]; invoiceId?: string | null }>>;
     /** Mollie payment ids (tr_...) settled in this settlement */
     paymentIds: string[];
     /** Mollie refund ids (re_...) settled in this settlement */
@@ -556,7 +567,7 @@ export class MollieMocker {
      * Register a settled (paid out) settlement that groups the given payments and refunds.
      * Used to drive the settlements cron (CheckSettlements).
      */
-    createSettlement(options: { payments?: MollieMockPayment[]; refunds?: MollieMockRefund[]; chargebacks?: MollieMockChargeback[]; value?: string; settledAt?: Date } = {}): MollieMockSettlement {
+    createSettlement(options: { payments?: MollieMockPayment[]; refunds?: MollieMockRefund[]; chargebacks?: MollieMockChargeback[]; value?: string; settledAt?: Date; invoiceId?: string | null; periods?: Record<string, Record<string, { costs: MollieMockSettlementCost[]; invoiceId?: string | null }>> } = {}): MollieMockSettlement {
         const settlement: MollieMockSettlement = {
             id: this.createId('stl'),
             reference: '1234567.' + (this.settlements.length + 1).toString().padStart(4, '0') + '.01',
@@ -564,6 +575,8 @@ export class MollieMocker {
             amount: { currency: 'EUR', value: options.value ?? '0.00' },
             createdAt: new Date().toISOString(),
             settledAt: (options.settledAt ?? new Date()).toISOString(),
+            invoiceId: options.invoiceId ?? null,
+            periods: options.periods ?? {},
             paymentIds: (options.payments ?? []).map(p => p.id),
             refundIds: (options.refunds ?? []).map(r => r.id),
             chargebackIds: (options.chargebacks ?? []).map(c => c.id),
@@ -581,6 +594,8 @@ export class MollieMocker {
             amount: settlement.amount,
             createdAt: settlement.createdAt,
             settledAt: settlement.settledAt ?? null,
+            invoiceId: settlement.invoiceId,
+            periods: settlement.periods,
             _links: { self: { href: 'https://api.mollie.com/v2/settlements/' + settlement.id, type: 'application/hal+json' } },
         };
     }


### PR DESCRIPTION
The existing daily walk now upserts the settlement, one payment line per entry (amount from the same expression as the legacy blob) and the period cost lines as ProviderTransactionFee+Tax rows carrying Mollie's invoiceId, so Mollie settlements reconcile to 0 like Stripe's. Entries of other systems on the same Mollie account stay skipped: the gap shows as unexplainedAmount.

Every settlement row belongs to the organization that owns the walked Mollie token (the platform token belongs to the membership organization).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
