### PR TITLE
✨ Mark historically invoiced Stripe fees on the stored rows

### DIFF
--- a/backend/app/api/src/helpers/StripeFeeInvoiceBackfill.test.ts
+++ b/backend/app/api/src/helpers/StripeFeeInvoiceBackfill.test.ts
@@ -1,0 +1,173 @@
+import type { Organization, StripeAccount } from '@stamhoofd/models';
+import { BalanceItemFactory, BalanceItemPayment, OrganizationFactory, Payment } from '@stamhoofd/models';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { BalanceItemStatus, BalanceItemType, PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { v4 as uuidv4 } from 'uuid';
+
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import { SettlementService } from '../services/SettlementService.js';
+import { StripeFeeInvoiceBackfill } from './StripeFeeInvoiceBackfill.js';
+
+describe('StripeFeeInvoiceBackfill', () => {
+    const stripeMocker = new StripeMocker();
+    let sellingOrganization: Organization;
+
+    const month = new Date(2026, 0, 1);
+
+    beforeAll(async () => {
+        sellingOrganization = await new OrganizationFactory({}).create();
+    });
+
+    const init = async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const stripeAccount = await stripeMocker.createStripeAccount(organization.id);
+        return { organization, stripeAccount };
+    };
+
+    /**
+     * The Received rows the fee sync would have stored for this month.
+     */
+    const createReceivedRows = async (stripeAccount: StripeAccount, { serviceFee = 30_00, transferFee = 2_20_00 } = {}) => {
+        const applicationFeeId = 'fee_' + uuidv4();
+        const rows: SettlementCharge[] = [];
+
+        for (const [type, amount] of [
+            [SettlementChargeType.ReceivedApplicationFeeService, serviceFee],
+            [SettlementChargeType.ReceivedApplicationFeeTransfer, transferFee],
+        ] as const) {
+            if (amount === 0) {
+                continue;
+            }
+            rows.push(await SettlementService.upsertCharge({
+                type,
+                externalId: applicationFeeId + ':' + type,
+                amount,
+                applicationFeeId,
+                organizationId: stripeAccount.organizationId,
+                stripeAccountId: stripeAccount.id,
+                occurredAt: new Date(2026, 0, 15),
+            }));
+        }
+        return rows;
+    };
+
+    /**
+     * The fee payment + balance items the old invoicer created for this month.
+     */
+    const createInvoicedPayment = async (organization: Organization, stripeAccount: StripeAccount, { serviceFee = 30_00, transferFee = 2_20_00, stripeAccountId = stripeAccount.id as string | null } = {}) => {
+        const items = [] as { type: BalanceItemType; price: number }[];
+        if (serviceFee !== 0) {
+            items.push({ type: BalanceItemType.ServiceFee, price: serviceFee });
+        }
+        if (transferFee !== 0) {
+            items.push({ type: BalanceItemType.TransferFee, price: transferFee });
+        }
+
+        const payment = new Payment();
+        payment.organizationId = sellingOrganization.id;
+        payment.payingOrganizationId = organization.id;
+        payment.stripeAccountId = stripeAccountId;
+        payment.reference = 'stripe-fees-2026-01-01';
+        payment.method = PaymentMethod.AccountDeductions;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = items.reduce((total, item) => total + item.price, 0);
+        payment.paidAt = new Date(2026, 0, 31);
+        await payment.save();
+
+        const balanceItems = [] as { type: BalanceItemType; id: string }[];
+        for (const item of items) {
+            const balanceItem = await new BalanceItemFactory({
+                organizationId: sellingOrganization.id,
+                payingOrganizationId: organization.id,
+                type: item.type,
+                amount: 1,
+                unitPrice: item.price,
+                status: BalanceItemStatus.Hidden,
+            }).create();
+
+            const balanceItemPayment = new BalanceItemPayment();
+            balanceItemPayment.balanceItemId = balanceItem.id;
+            balanceItemPayment.paymentId = payment.id;
+            balanceItemPayment.organizationId = sellingOrganization.id;
+            balanceItemPayment.price = item.price;
+            await balanceItemPayment.save();
+
+            balanceItems.push({ type: item.type, id: balanceItem.id });
+        }
+
+        return { payment, balanceItems };
+    };
+
+    const reload = async (rows: SettlementCharge[]) => {
+        return await Promise.all(rows.map(async row => (await SettlementCharge.getByID(row.id))!));
+    };
+
+    test('service rows get the ServiceFee item, transfer rows the TransferFee item', async () => {
+        const { organization, stripeAccount } = await init();
+        const rows = await createReceivedRows(stripeAccount);
+        const { balanceItems } = await createInvoicedPayment(organization, stripeAccount);
+
+        await StripeFeeInvoiceBackfill.backfillMonth(sellingOrganization, month);
+
+        const [serviceRow, transferRow] = await reload(rows);
+        expect(serviceRow.balanceItemId).toBe(balanceItems.find(i => i.type === BalanceItemType.ServiceFee)!.id);
+        expect(transferRow.balanceItemId).toBe(balanceItems.find(i => i.type === BalanceItemType.TransferFee)!.id);
+
+        // Idempotent
+        await StripeFeeInvoiceBackfill.backfillMonth(sellingOrganization, month);
+        expect((await reload(rows))[0].balanceItemId).toBe(serviceRow.balanceItemId);
+    });
+
+    test('a legacy fee payment without stripeAccountId is still found', async () => {
+        const { organization, stripeAccount } = await init();
+        const rows = await createReceivedRows(stripeAccount);
+        const { balanceItems } = await createInvoicedPayment(organization, stripeAccount, { stripeAccountId: null });
+
+        await StripeFeeInvoiceBackfill.backfillMonth(sellingOrganization, month);
+
+        const [serviceRow] = await reload(rows);
+        expect(serviceRow.balanceItemId).toBe(balanceItems.find(i => i.type === BalanceItemType.ServiceFee)!.id);
+    });
+
+    test('a sum mismatch marks nothing as invoiced', async () => {
+        const { organization, stripeAccount } = await init();
+        const rows = await createReceivedRows(stripeAccount, { serviceFee: 30_00, transferFee: 2_20_00 });
+
+        // The invoicer charged a different amount than the stored rows sum to
+        await createInvoicedPayment(organization, stripeAccount, { serviceFee: 40_00, transferFee: 2_20_00 });
+
+        // The counters are global over the shared test database, so only this test's rows are asserted
+        await StripeFeeInvoiceBackfill.backfillMonth(sellingOrganization, month);
+
+        for (const row of await reload(rows)) {
+            expect(row.balanceItemId).toBeNull();
+        }
+    });
+
+    test('a matching total with a different service/transfer split marks nothing as invoiced', async () => {
+        const { organization, stripeAccount } = await init();
+        const rows = await createReceivedRows(stripeAccount, { serviceFee: 40_00, transferFee: 2_10_00 });
+
+        // Same total, different split
+        await createInvoicedPayment(organization, stripeAccount, { serviceFee: 30_00, transferFee: 2_20_00 });
+
+        await StripeFeeInvoiceBackfill.backfillMonth(sellingOrganization, month);
+
+        for (const row of await reload(rows)) {
+            expect(row.balanceItemId).toBeNull();
+        }
+    });
+
+    test('a month that was never invoiced waits', async () => {
+        const { stripeAccount } = await init();
+        const rows = await createReceivedRows(stripeAccount);
+
+        await StripeFeeInvoiceBackfill.backfillMonth(sellingOrganization, month);
+
+        for (const row of await reload(rows)) {
+            expect(row.balanceItemId).toBeNull();
+        }
+    });
+});

--- a/backend/app/api/src/helpers/StripeFeeInvoiceBackfill.ts
+++ b/backend/app/api/src/helpers/StripeFeeInvoiceBackfill.ts
@@ -1,0 +1,179 @@
+import { Email } from '@stamhoofd/email';
+import type { Organization } from '@stamhoofd/models';
+import { BalanceItem, BalanceItemPayment, Payment, StripeAccount } from '@stamhoofd/models';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { SQL } from '@stamhoofd/sql';
+import { BalanceItemType, PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { Formatter } from '@stamhoofd/utility';
+
+import { SettlementService } from '../services/SettlementService.js';
+import { StripeInvoicer } from './StripeInvoicer.js';
+
+export type BackfillResult = {
+    /**
+     * Received fee rows marked as invoiced.
+     */
+    invoicedCount: number;
+
+    /**
+     * (account, month) buckets whose stored rows disagree with what was actually charged.
+     */
+    mismatchCount: number;
+
+    /**
+     * (account, month) buckets the invoicer didn't reach yet.
+     */
+    notInvoicedCount: number;
+};
+
+/**
+ * Marks the stored Received fee rows of months the old invoicer already billed as invoiced:
+ * service rows get the month's ServiceFee balance item, transfer rows the TransferFee item.
+ *
+ * Per (account, month) the sum of the stored rows must equal the fee payment's price — that
+ * assertion doubles as the proof that the stored data reproduces what was actually charged, the
+ * gate for switching the invoicer to local data. A mismatch marks nothing and sends an email.
+ */
+export class StripeFeeInvoiceBackfill {
+    /**
+     * Backfill every month from `start` up to the last full month.
+     */
+    static async backfillAll(sellingOrganization: Organization, { start = new Date(2025, 0, 1) }: { start?: Date } = {}): Promise<BackfillResult> {
+        const result: BackfillResult = { invoicedCount: 0, mismatchCount: 0, notInvoicedCount: 0 };
+        let currentMonth = new Date(start.getFullYear(), start.getMonth(), 1);
+
+        while (true) {
+            const { end } = StripeInvoicer.getMonthUnixStartEnd(currentMonth);
+            if (end >= Date.now() / 1000) {
+                break;
+            }
+
+            const monthResult = await this.backfillMonth(sellingOrganization, currentMonth);
+            result.invoicedCount += monthResult.invoicedCount;
+            result.mismatchCount += monthResult.mismatchCount;
+            result.notInvoicedCount += monthResult.notInvoicedCount;
+
+            currentMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1);
+        }
+
+        return result;
+    }
+
+    static async backfillMonth(sellingOrganization: Organization, month: Date): Promise<BackfillResult> {
+        const result: BackfillResult = { invoicedCount: 0, mismatchCount: 0, notInvoicedCount: 0 };
+
+        const periodStart = SettlementService.getPeriodStart(month);
+        const nextPeriodStart = new Date(periodStart.getFullYear(), periodStart.getMonth() + 1, 1);
+        const reference = 'stripe-fees-' + Formatter.dateIso(periodStart);
+
+        // The month bucket is derived from the fee's created date, exactly like the old invoicer
+        // scans the Stripe API per month
+        const rows = await SettlementCharge.select()
+            .where('type', [SettlementChargeType.ReceivedApplicationFeeService, SettlementChargeType.ReceivedApplicationFeeTransfer])
+            .where('occurredAt', '>=', periodStart)
+            .where('occurredAt', '<', nextPeriodStart)
+            .fetch();
+
+        const byAccount = new Map<string | null, SettlementCharge[]>();
+        for (const row of rows) {
+            const group = byAccount.get(row.stripeAccountId);
+            if (group) {
+                group.push(row);
+            } else {
+                byAccount.set(row.stripeAccountId, [row]);
+            }
+        }
+
+        for (const [stripeAccountId, accountRows] of byAccount) {
+            const mismatch = (reason: string) => {
+                result.mismatchCount += 1;
+                console.error('Invoice backfill mismatch for ' + reference + ' / account ' + stripeAccountId + ': ' + reason);
+                Email.sendWebmaster({
+                    subject: 'Stripe kosten afpunten met de factuur mislukt voor ' + reference,
+                    html: 'De opgeslagen Stripe kosten voor ' + reference + ' (account ' + stripeAccountId + ') komen niet overeen met wat gefactureerd is. Er is niets afgepunt. <br><br> ' + Formatter.escapeHtml(reason),
+                });
+            };
+
+            if (!stripeAccountId) {
+                mismatch('Received fee rows without a Stripe account');
+                continue;
+            }
+
+            const stripeAccount = await StripeAccount.getByID(stripeAccountId);
+            if (!stripeAccount) {
+                mismatch('Stripe account ' + stripeAccountId + ' does not exist');
+                continue;
+            }
+
+            // Same query as the invoicer's idempotency check: the OR NULL clause covers legacy
+            // payments that were created without a stripeAccountId
+            const payments = await Payment.select()
+                .where('organizationId', sellingOrganization.id)
+                .where('payingOrganizationId', stripeAccount.organizationId)
+                .where(
+                    SQL.where('stripeAccountId', stripeAccount.id)
+                        .or('stripeAccountId', null),
+                )
+                .where('reference', reference)
+                .where('method', PaymentMethod.AccountDeductions)
+                .where('provider', PaymentProvider.Stripe)
+                .where('status', PaymentStatus.Succeeded)
+                .fetch();
+
+            if (payments.length === 0) {
+                // Not invoiced yet: the month waits for the invoicer, nothing to mark
+                result.notInvoicedCount += 1;
+                continue;
+            }
+
+            if (payments.length > 1) {
+                mismatch('Found ' + payments.length + ' fee payments for the same month');
+                continue;
+            }
+
+            const payment = payments[0];
+            const total = accountRows.reduce((sum, row) => sum + row.amount, 0);
+
+            if (total !== payment.price) {
+                mismatch('Stored fee rows sum to ' + total + ' but the fee payment charged ' + payment.price + ' (payment ' + payment.id + ')');
+                continue;
+            }
+
+            const balanceItemPayments = await BalanceItemPayment.select()
+                .where('paymentId', payment.id)
+                .fetch();
+            const balanceItems = balanceItemPayments.length > 0
+                ? await BalanceItem.select().where('id', balanceItemPayments.map(b => b.balanceItemId)).fetch()
+                : [];
+
+            const itemPerType = new Map<SettlementChargeType, BalanceItem | undefined>([
+                [SettlementChargeType.ReceivedApplicationFeeService, balanceItems.find(i => i.type === BalanceItemType.ServiceFee)],
+                [SettlementChargeType.ReceivedApplicationFeeTransfer, balanceItems.find(i => i.type === BalanceItemType.TransferFee)],
+            ]);
+
+            const missing = accountRows.find(row => !itemPerType.get(row.type));
+            if (missing) {
+                mismatch('The fee payment has no ' + (missing.type === SettlementChargeType.ReceivedApplicationFeeService ? 'ServiceFee' : 'TransferFee') + ' balance item (payment ' + payment.id + ')');
+                continue;
+            }
+
+            // Marking is permanent: also assert the service/transfer split, not just the total
+            const splitMismatch = [...itemPerType.entries()].find(([type, item]) => {
+                const typeTotal = accountRows.filter(row => row.type === type).reduce((sum, row) => sum + row.amount, 0);
+                return item !== undefined && typeTotal !== item.priceWithVAT;
+            });
+            if (splitMismatch) {
+                mismatch('The stored ' + splitMismatch[0] + ' rows do not sum to the ' + splitMismatch[1]!.type + ' balance item of payment ' + payment.id);
+                continue;
+            }
+
+            for (const row of accountRows) {
+                await SettlementService.markInvoiced(row, itemPerType.get(row.type)!.id);
+                result.invoicedCount += 1;
+            }
+        }
+
+        return result;
+    }
+}

--- a/backend/app/api/src/services/SettlementService.ts
+++ b/backend/app/api/src/services/SettlementService.ts
@@ -178,8 +178,8 @@ export class SettlementService {
     /**
      * Upsert on the globally unique externalId. Fields that are undefined keep their stored value,
      * so the fee sync (which doesn't know the settlement yet) can't unlink a charge the payout sync
-     * linked earlier. balanceItemId is deliberately not settable here: it is only stamped when
-     * invoicing.
+     * attached earlier. balanceItemId is deliberately not settable here: only markInvoiced writes
+     * it, when the fee is invoiced.
      */
     static async upsertCharge(data: ChargeData): Promise<SettlementCharge> {
         const charge = await SettlementCharge.select()
@@ -214,6 +214,16 @@ export class SettlementService {
         }
         await charge.save();
         return charge;
+    }
+
+    /**
+     * Records that the charge was invoiced, and by which balance item. The only writer of
+     * balanceItemId: called when the fee is invoiced, or by StripeFeeInvoiceBackfill for months
+     * that were already invoiced before these rows existed.
+     */
+    static async markInvoiced(charge: SettlementCharge, balanceItemId: string) {
+        charge.balanceItemId = balanceItemId;
+        await charge.save();
     }
 
     /**


### PR DESCRIPTION
Stamps the stored Received fee rows with the balance items the old invoicer already billed, per (account, month), asserting the stored rows sum exactly to the fee payment's price — the proof that local data reproduces what was charged, and the gate for the invoicer switch. A mismatch stamps nothing and emails the webmaster.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461393&installation_model_id=423362&pr_number=717&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F717&signature=81e17427ec29c2d749df269822823ef3163b0a757f592afd6ddc1fed8107bf1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->