### PR TITLE
✨ PrivatePayment.settlements + settlements SQL filter

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/payments/GetPaymentsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/payments/GetPaymentsEndpoint.test.ts
@@ -1,9 +1,11 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, User } from '@stamhoofd/models';
-import { BalanceItem, BalanceItemFactory, BalanceItemPayment, OrderFactory, OrganizationFactory, Payment, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
+import { BalanceItem, BalanceItemFactory, BalanceItemPayment, OrderFactory, OrganizationFactory, Payment, StripeAccount, Token, UserFactory, WebshopFactory } from '@stamhoofd/models';
 import type { PaginatedResponse, PaymentGeneral, StamhoofdFilter } from '@stamhoofd/structures';
-import { BalanceItemRelation, BalanceItemRelationType, BalanceItemType, LimitedFilteredRequest, PaymentMethod, PaymentStatus, PermissionLevel, Permissions, TranslatedString } from '@stamhoofd/structures';
+import { BalanceItemRelation, BalanceItemRelationType, BalanceItemType, LimitedFilteredRequest, PaymentMethod, PaymentProvider, PaymentStatus, PermissionLevel, Permissions, TranslatedString } from '@stamhoofd/structures';
+import { v4 as uuidv4 } from 'uuid';
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { SettlementService } from '../../../../services/SettlementService.js';
 import { GetPaymentsEndpoint } from './GetPaymentsEndpoint.js';
 
 // These tests exercise the balance-item filters reused inside the payments query (balanceItemPayments ->
@@ -153,6 +155,152 @@ describe('Endpoint.GetPaymentsEndpoint', () => {
 
             expect(response.status).toBe(200);
             expect(response.body.results.map(r => r.id)).toEqual([matchingPayment.id]);
+        });
+    });
+
+    describe('Settlements of a payment', () => {
+        const createSettledPayment = async (organization: Organization) => {
+            const payment = new Payment();
+            payment.method = PaymentMethod.Bancontact;
+            payment.provider = PaymentProvider.Stripe;
+            payment.status = PaymentStatus.Succeeded;
+            payment.organizationId = organization.id;
+            payment.price = 50_00_00;
+            payment.paidAt = new Date();
+            await payment.save();
+
+            const settlement = await SettlementService.upsertSettlement({
+                provider: PaymentProvider.Stripe,
+                externalId: 'po_' + payment.id,
+                organizationId: organization.id,
+                reference: 'STRIPE PAYOUT',
+                amount: 49_00_00,
+                settledAt: new Date(2026, 0, 15),
+            });
+            await SettlementService.upsertPaymentLine(settlement, {
+                paymentId: payment.id,
+                amount: 50_00_00,
+                externalId: 'txn_' + payment.id,
+                occurredAt: new Date(2026, 0, 14),
+            });
+
+            return { payment, settlement };
+        };
+
+        test('the m2m settlement filter selects only payments in a matching payout', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const user = await createFinanceUser(organization);
+
+            const { payment, settlement } = await createSettledPayment(organization);
+
+            // Negative control: a payment without settlement rows
+            const other = new Payment();
+            other.method = PaymentMethod.Bancontact;
+            other.provider = PaymentProvider.Stripe;
+            other.status = PaymentStatus.Succeeded;
+            other.organizationId = organization.id;
+            other.price = 10_00_00;
+            await other.save();
+
+            const response = await getPayments({
+                filter: {
+                    settlements: {
+                        $elemMatch: {
+                            settlement: {
+                                externalId: settlement.externalId,
+                            },
+                        },
+                    },
+                },
+                organization,
+                user,
+            });
+
+            expect(response.status).toBe(200);
+            expect(response.body.results.map(r => r.id)).toEqual([payment.id]);
+        });
+
+        test('an admin of the organization receives the settlements of a payment', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const user = await createFinanceUser(organization);
+
+            const { payment, settlement } = await createSettledPayment(organization);
+
+            const response = await getPayments({
+                filter: { id: payment.id },
+                organization,
+                user,
+            });
+
+            expect(response.status).toBe(200);
+            expect(response.body.results).toHaveLength(1);
+
+            const result = response.body.results[0];
+            expect(result.settlements).toHaveLength(1);
+            expect(result.settlements[0]).toMatchObject({
+                paymentId: payment.id,
+                amount: 50_00_00,
+                externalId: 'txn_' + payment.id,
+            });
+            expect(result.settlements[0].settlement).toMatchObject({
+                externalId: settlement.externalId,
+                reference: 'STRIPE PAYOUT',
+                amount: 49_00_00,
+            });
+        });
+
+        test('the platform payout of a destination charge is never returned to the organization', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const user = await createFinanceUser(organization);
+
+            const stripeAccount = new StripeAccount();
+            stripeAccount.organizationId = organization.id;
+            stripeAccount.accountId = 'acct_' + uuidv4();
+            await stripeAccount.save();
+
+            const payment = new Payment();
+            payment.method = PaymentMethod.Bancontact;
+            payment.provider = PaymentProvider.Stripe;
+            payment.status = PaymentStatus.Succeeded;
+            payment.organizationId = organization.id;
+            payment.stripeAccountId = stripeAccount.id;
+            payment.price = 50_00_00;
+            payment.paidAt = new Date();
+            await payment.save();
+
+            const organizationPayout = await SettlementService.upsertSettlement({
+                provider: PaymentProvider.Stripe,
+                externalId: 'po_org_' + payment.id,
+                stripeAccountId: stripeAccount.id,
+                organizationId: organization.id,
+                amount: 49_00_00,
+                settledAt: new Date(2026, 0, 15),
+            });
+            await SettlementService.upsertPaymentLine(organizationPayout, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_org_' + payment.id, occurredAt: new Date(2026, 0, 14),
+            });
+
+            // The same gross charge also sits in our platform payout, owned by the membership
+            // organization
+            const membershipOrganization = await new OrganizationFactory({}).create();
+            const platformPayout = await SettlementService.upsertSettlement({
+                provider: PaymentProvider.Stripe,
+                externalId: 'po_platform_' + payment.id,
+                stripeAccountId: null,
+                organizationId: membershipOrganization.id,
+                amount: 1234_00_00,
+                settledAt: new Date(2026, 0, 12),
+            });
+            await SettlementService.upsertPaymentLine(platformPayout, {
+                paymentId: payment.id, amount: 50_00_00, externalId: 'txn_platform_' + payment.id, occurredAt: new Date(2026, 0, 11),
+            });
+
+            const response = await getPayments({ filter: { id: payment.id }, organization, user });
+
+            expect(response.status).toBe(200);
+            const result = response.body.results[0];
+            expect(result.settlements).toHaveLength(1);
+            expect(result.settlements[0].settlement.externalId).toBe(organizationPayout.externalId);
         });
     });
 });

--- a/backend/app/api/src/helpers/AuthenticatedStructures.ts
+++ b/backend/app/api/src/helpers/AuthenticatedStructures.ts
@@ -46,12 +46,15 @@ export class AuthenticatedStructures {
         const includeSettlements = checkPermissions && !!Context.user && !!Context.user.permissions && payments.every(p => !!Context.optionalAuth?.checkScope(p.organizationId));
 
         const { payingOrganizations } = await Payment.loadPayingOrganizations(payments);
+        const { paymentSettlements, settlements } = includeSettlements ? await Payment.loadSettlements(payments) : { paymentSettlements: [], settlements: [] };
 
         return Payment.getGeneralStructureFromRelations({
             payments,
             balanceItemPayments,
             balanceItems,
             payingOrganizations,
+            paymentSettlements,
+            settlements,
         }, includeSettlements);
     }
 

--- a/backend/app/api/src/sql-filters/payments.ts
+++ b/backend/app/api/src/sql-filters/payments.ts
@@ -180,6 +180,79 @@ export const paymentFilterCompilers: SQLFilterDefinitions = {
             ),
         balanceItemPaymentsCompilers,
     ),
+    // The stored payouts this payment was part of (the m2m rows, not the legacy JSON blob above)
+    settlements: createExistsFilter(
+        SQL.select()
+            .from(
+                SQL.table('payment_settlements'),
+            ).join(
+                SQL.join(
+                    SQL.table('settlements'),
+                ).where(
+                    SQL.column('settlements', 'id'),
+                    SQL.column('payment_settlements', 'settlementId'),
+                ),
+            ).where(
+                SQL.column('payment_settlements', 'paymentId'),
+                SQL.column('payments', 'id'),
+            ),
+        {
+            ...baseSQLFilterCompilers,
+            amount: createColumnFilter({
+                expression: SQL.column('payment_settlements', 'amount'),
+                type: SQLValueType.Number,
+                nullable: false,
+            }),
+            externalId: createColumnFilter({
+                expression: SQL.column('payment_settlements', 'externalId'),
+                type: SQLValueType.String,
+                nullable: false,
+            }),
+            occurredAt: createColumnFilter({
+                expression: SQL.column('payment_settlements', 'occurredAt'),
+                type: SQLValueType.Datetime,
+                nullable: false,
+            }),
+            settlement: {
+                ...baseSQLFilterCompilers,
+                id: createColumnFilter({
+                    expression: SQL.column('settlements', 'id'),
+                    type: SQLValueType.String,
+                    nullable: false,
+                }),
+                provider: createColumnFilter({
+                    expression: SQL.column('settlements', 'provider'),
+                    type: SQLValueType.String,
+                    nullable: false,
+                }),
+                externalId: createColumnFilter({
+                    expression: SQL.column('settlements', 'externalId'),
+                    type: SQLValueType.String,
+                    nullable: false,
+                }),
+                reference: createColumnFilter({
+                    expression: SQL.column('settlements', 'reference'),
+                    type: SQLValueType.String,
+                    nullable: false,
+                }),
+                settledAt: createColumnFilter({
+                    expression: SQL.column('settlements', 'settledAt'),
+                    type: SQLValueType.Datetime,
+                    nullable: false,
+                }),
+                amount: createColumnFilter({
+                    expression: SQL.column('settlements', 'amount'),
+                    type: SQLValueType.Number,
+                    nullable: false,
+                }),
+                stripeAccountId: createColumnFilter({
+                    expression: SQL.column('settlements', 'stripeAccountId'),
+                    type: SQLValueType.String,
+                    nullable: true,
+                }),
+            },
+        },
+    ),
 };
 
 /**

--- a/backend/shared/models/src/models/Payment.ts
+++ b/backend/shared/models/src/models/Payment.ts
@@ -1,5 +1,9 @@
 import { column } from '@simonbackx/simple-database';
 import { BalanceItemDetailed, BalanceItemPaymentDetailed, BaseOrganization, PaymentCustomer, PaymentGeneral, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, SettlementReference, TransferSettings } from '@stamhoofd/structures';
+import { PaymentSettlementDetailed } from '@stamhoofd/structures/settlements/PaymentSettlement.js';
+import { Settlement as SettlementStruct } from '@stamhoofd/structures/settlements/Settlement.js';
+import type { PaymentSettlement as PaymentSettlementModel } from './PaymentSettlement.js';
+import type { Settlement as SettlementModel } from './Settlement.js';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -271,20 +275,25 @@ export class Payment extends QueryableModel {
 
         const { balanceItemPayments, balanceItems } = await Payment.loadBalanceItems(payments);
         const { payingOrganizations } = await Payment.loadPayingOrganizations(payments);
+        const { paymentSettlements, settlements } = includeSettlements ? await Payment.loadSettlements(payments) : { paymentSettlements: [], settlements: [] };
 
         return this.getGeneralStructureFromRelations({
             payments,
             balanceItemPayments,
             balanceItems,
             payingOrganizations,
+            paymentSettlements,
+            settlements,
         }, includeSettlements);
     }
 
-    static getGeneralStructureFromRelations({ payments, balanceItemPayments, balanceItems, payingOrganizations }: {
+    static getGeneralStructureFromRelations({ payments, balanceItemPayments, balanceItems, payingOrganizations, paymentSettlements, settlements }: {
         payments: Payment[];
         balanceItemPayments: BalanceItemPayment[];
         balanceItems: BalanceItem[];
         payingOrganizations: Organization[];
+        paymentSettlements?: PaymentSettlementModel[];
+        settlements?: SettlementModel[];
     }, includeSettlements = false): PaymentGeneral[] {
         if (payments.length === 0) {
             return [];
@@ -310,7 +319,26 @@ export class Payment extends QueryableModel {
                     });
                 }),
                 ...(payment.provider !== PaymentProvider.Stripe ? { stripeAccountId: null } : {}),
-                ...(!includeSettlements) ? { settlement: null, transferFee: 0, stripeAccountId: null, serviceFeeManual: 0, serviceFeeManualCharged: 0, serviceFeePayout: 0 } : {},
+                ...(includeSettlements
+                    ? {
+                            settlements: (paymentSettlements ?? []).filter((line) => {
+                                if (line.paymentId !== payment.id) {
+                                    return false;
+                                }
+                                // A destination charge also sits gross in our platform payout:
+                                // only the payout of the payment's own account may be returned,
+                                // or the organization would see our platform payout
+                                const settlement = (settlements ?? []).find(s => s.id === line.settlementId);
+                                return settlement !== undefined && settlement.stripeAccountId === payment.stripeAccountId;
+                            }).map((line) => {
+                                const settlement = (settlements ?? []).find(s => s.id === line.settlementId);
+                                return PaymentSettlementDetailed.create({
+                                    ...line,
+                                    settlement: SettlementStruct.create({ ...settlement }),
+                                });
+                            }),
+                        }
+                    : { settlement: null, settlements: [], transferFee: 0, stripeAccountId: null, serviceFeeManual: 0, serviceFeeManualCharged: 0, serviceFeePayout: 0 }),
             });
         });
     }
@@ -342,6 +370,28 @@ export class Payment extends QueryableModel {
         const balanceItems = await BalanceItem.getByIDs(...ids);
 
         return { balanceItemPayments, balanceItems };
+    }
+
+    /**
+     * Mirrors loadBalanceItems for the settlements a payment was part of.
+     */
+    static async loadSettlements(payments: Payment[]) {
+        if (payments.length === 0) {
+            return { paymentSettlements: [], settlements: [] };
+        }
+        const { PaymentSettlement } = await import('./PaymentSettlement.js');
+        const { Settlement } = await import('./Settlement.js');
+
+        const paymentSettlements = await PaymentSettlement.select()
+            .where('paymentId', payments.map(p => p.id))
+            .fetch();
+
+        const ids = Formatter.uniqueArray(paymentSettlements.map(line => line.settlementId));
+        const settlements = ids.length > 0
+            ? await Settlement.select().where('id', ids).fetch()
+            : [];
+
+        return { paymentSettlements, settlements };
     }
 
     static async loadPayingOrganizations(payments: Payment[]) {

--- a/shared/structures/src/members/Payment.ts
+++ b/shared/structures/src/members/Payment.ts
@@ -1,8 +1,9 @@
-import { AutoEncoder, DateDecoder, EnumDecoder, field, IntegerDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { ArrayDecoder, AutoEncoder, DateDecoder, EnumDecoder, field, IntegerDecoder, StringDecoder } from '@simonbackx/simple-encoding';
 import { Formatter } from '@stamhoofd/utility';
 import { v4 as uuidv4 } from 'uuid';
 
 import { PaymentCustomer } from '../PaymentCustomer.js';
+import { PaymentSettlementDetailed } from '../settlements/PaymentSettlement.js';
 import { downgradePaymentMethodV150, PaymentMethod, PaymentMethodHelper, PaymentMethodV150 } from '../PaymentMethod.js';
 import { PaymentProvider } from '../PaymentProvider.js';
 import { PaymentStatus } from '../PaymentStatus.js';
@@ -238,6 +239,13 @@ export class SettlementReference extends AutoEncoder {
 export class PrivatePayment extends Payment {
     @field({ decoder: SettlementReference, nullable: true })
     settlement: SettlementReference | null = null;
+
+    /**
+     * All settlements this payment was part of (e.g. the payment in one payout, its refund in a
+     * later one). Admin-only, stripped like the legacy settlement blob.
+     */
+    @field({ decoder: new ArrayDecoder(PaymentSettlementDetailed), ...NextVersion })
+    settlements: PaymentSettlementDetailed[] = [];
 
     @field({ decoder: StringDecoder, nullable: true, version: 153 })
     iban: string | null = null;


### PR DESCRIPTION
Admin-only settlements array on PrivatePayment (NextVersion), loaded like balance items and stripped with the other settlement fields. New exists-filter key 'settlements' over the m2m table next to the untouched JSON filter.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461398&installation_model_id=423362&pr_number=718&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F718&signature=4306c3fbd5c92bc35e2e5f8746553061243bc7107f80ba59b1820b0635c4682a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->