### PR TITLE
✨ Settlements export: DB-only reconciliation report

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsExportEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsExportEndpoint.test.ts
@@ -1,0 +1,155 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import { EmailMocker } from '@stamhoofd/email';
+import type { Organization, Token, User } from '@stamhoofd/models';
+import { OrganizationFactory, Payment, Token as TokenModel, UserFactory } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
+import { PaymentMethod, PaymentProvider, PaymentStatus, PermissionLevel, Permissions } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { STExpect } from '@stamhoofd/test-utils';
+import { v4 as uuidv4 } from 'uuid';
+
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { initMembershipOrganization } from '../../../../../tests/init/initMembershipOrganization.js';
+import { initPlatformAdmin } from '../../../../../tests/init/initPlatformAdmin.js';
+import { SettlementService } from '../../../../services/SettlementService.js';
+import { SettlementsExportEndpoint } from './SettlementsExportEndpoint.js';
+
+describe('Endpoint.SettlementsExport', () => {
+    const endpoint = new SettlementsExportEndpoint();
+
+    let membershipOrganization: Organization;
+    let admin: User;
+    let adminToken: Token;
+
+    beforeAll(async () => {
+        membershipOrganization = await initMembershipOrganization();
+        membershipOrganization.privateMeta.featureFlags = ['settlements'];
+        await membershipOrganization.save();
+
+        ({ admin, adminToken } = await initPlatformAdmin());
+    });
+
+    const createFinanceAdmin = async (organization: Organization) => {
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({ level: PermissionLevel.Full }),
+        }).create();
+        return { user, token: await TokenModel.createToken(user) };
+    };
+
+    const post = async (organization: Organization, token: Token, { start = new Date(2026, 0, 1), end = new Date(2026, 1, 1) } = {}) => {
+        const request = Request.buildJson('POST', '/settlements/export', organization.getApiHost(), {
+            start: start.getTime(),
+            end: end.getTime(),
+        });
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    const createSettledPayment = async () => {
+        const organization = await new OrganizationFactory({}).create();
+
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.method = PaymentMethod.Bancontact;
+        payment.provider = PaymentProvider.Mollie;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = 50_00_00;
+        payment.paidAt = new Date(2026, 0, 10);
+        await payment.save();
+
+        const settlement = await SettlementService.upsertSettlement({
+            provider: PaymentProvider.Mollie,
+            externalId: 'stl_' + uuidv4(),
+            organizationId: organization.id,
+            reference: '1234567.2601.01',
+            amount: 49_63_70,
+            settledAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.upsertPaymentLine(settlement, {
+            paymentId: payment.id,
+            amount: 50_00_00,
+            externalId: 'tr_' + uuidv4(),
+            occurredAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.upsertCharge({
+            type: SettlementChargeType.ProviderTransactionFee,
+            externalId: settlement.externalId + ':cost:0',
+            amount: -30_00,
+            settlementId: settlement.id,
+            providerInvoiceId: 'inv_123',
+            description: 'Transactiekosten',
+            occurredAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.upsertCharge({
+            type: SettlementChargeType.Tax,
+            externalId: settlement.externalId + ':cost:0:tax',
+            amount: -6_30,
+            settlementId: settlement.id,
+            providerInvoiceId: 'inv_123',
+            description: 'BTW op transactiekosten',
+            occurredAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.finishSync(settlement, { transactionCount: 3 });
+
+        return { organization, payment, settlement };
+    };
+
+    test('A platform admin receives the report by email', async () => {
+        await createSettledPayment();
+
+        const response = await post(membershipOrganization, adminToken);
+        expect(response.status).toBe(200);
+
+        await QueueHandler.awaitAll();
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        const reportEmail = emails.find(e => e.subject.startsWith('Uitbetalingen export'));
+        expect(reportEmail).toBeDefined();
+        expect(reportEmail!.attachments).toHaveLength(1);
+        expect(reportEmail!.attachments![0].filename).toContain('.xlsx');
+        expect(reportEmail!.to).toContain(admin.email);
+    });
+
+    test('A user without finance access cannot export settlements', async () => {
+        const user = await new UserFactory({ organization: membershipOrganization }).create();
+        const token = await TokenModel.createToken(user);
+
+        await expect(post(membershipOrganization, token)).rejects.toThrow(
+            STExpect.simpleError({ code: 'permission_denied' }),
+        );
+    });
+
+    test('A finance admin exports the settlements of their own organization', async () => {
+        const { organization } = await createSettledPayment();
+        organization.privateMeta.featureFlags = ['settlements'];
+        await organization.save();
+
+        const { user, token } = await createFinanceAdmin(organization);
+
+        const response = await post(organization, token);
+        expect(response.status).toBe(200);
+
+        await QueueHandler.awaitAll();
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        const reportEmail = emails.filter(e => e.subject.startsWith('Uitbetalingen export')).at(-1);
+        expect(reportEmail).toBeDefined();
+        expect(reportEmail!.to).toContain(user.email);
+    });
+
+    test('Without the feature flag the export is not available', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const { token } = await createFinanceAdmin(organization);
+
+        await expect(post(organization, token)).rejects.toThrow(
+            STExpect.simpleError({ code: 'not_available' }),
+        );
+    });
+
+    test('An unbounded range is rejected', async () => {
+        await expect(post(membershipOrganization, adminToken, { start: new Date(2020, 0, 1), end: new Date(2026, 0, 1) })).rejects.toThrow(
+            STExpect.simpleError({ code: 'range_too_large' }),
+        );
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsExportEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsExportEndpoint.ts
@@ -1,0 +1,122 @@
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { AutoEncoder, DateDecoder, EnumDecoder, field } from '@simonbackx/simple-encoding';
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { SimpleError } from '@simonbackx/simple-errors';
+import { Organization, Platform } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
+import { PaymentProvider } from '@stamhoofd/structures';
+
+import { Context } from '../../../../helpers/Context.js';
+import { SettlementExporter } from '../../../../helpers/SettlementExporter.js';
+
+/**
+ * payment_settlements grows like payments, so an export can't span an unbounded range.
+ */
+const MAXIMUM_RANGE_MS = 1100 * 24 * 60 * 60 * 1000;
+
+type Params = Record<string, never>;
+class Body extends AutoEncoder {
+    @field({ decoder: DateDecoder })
+    start: Date;
+
+    @field({ decoder: DateDecoder })
+    end: Date;
+
+    @field({ decoder: new EnumDecoder(PaymentProvider), nullable: true, optional: true })
+    provider: PaymentProvider | null = null;
+}
+type Query = undefined;
+type ResponseBody = undefined;
+
+/**
+ * Build the settlements reconciliation report (from the stored tables only, no provider API calls)
+ * and email it to the requesting admin.
+ *
+ * An export always covers exactly the payouts of the organization in context, for any finance
+ * admin of that organization. The platform's own payouts belong to the membership organization, so
+ * platform admins export those by scoping to the membership organization like any other.
+ */
+export class SettlementsExportEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    bodyDecoder = Body as Decoder<Body>;
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'POST') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/settlements/export', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    static async authenticate() {
+        const organization = await Context.setOrganizationScope();
+        const { user } = await Context.authenticate();
+
+        if (!await Context.auth.canManageFinances(organization.id)) {
+            throw Context.auth.error();
+        }
+
+        const platform = await Platform.getSharedStruct();
+        const enabled = platform.config.featureFlags.includes('settlements')
+            || organization.privateMeta.featureFlags.includes('settlements');
+
+        if (!enabled) {
+            throw new SimpleError({
+                code: 'not_available',
+                message: 'Settlements are not enabled for this organization',
+                statusCode: 400,
+            });
+        }
+
+        return { organization, user, platform };
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        const { organization, user, platform } = await SettlementsExportEndpoint.authenticate();
+
+        const { start, end, provider } = request.body;
+
+        if (end.getTime() - start.getTime() > MAXIMUM_RANGE_MS) {
+            throw new SimpleError({
+                code: 'range_too_large',
+                message: 'The requested export range is too large',
+                statusCode: 400,
+            });
+        }
+
+        // The membership organization sells the platform's fee invoices, and its own export is the
+        // platform-wide one (its payouts hold the received fees of every organization)
+        const membershipOrganization = platform.membershipOrganizationId ? await Organization.getByID(platform.membershipOrganizationId) : null;
+        if (!membershipOrganization) {
+            throw new SimpleError({
+                code: 'missing_membership_organization',
+                message: 'Platform has no membership organization configured',
+                statusCode: 400,
+            });
+        }
+        const platformScope = membershipOrganization.id === organization.id;
+
+        // Serialized so concurrent exports can't compete for memory; the result arrives by email
+        QueueHandler.schedule('settlements-export', async () => {
+            const exporter = new SettlementExporter({
+                start,
+                end,
+                provider,
+                organizationId: organization.id,
+                platformScope,
+                sellingOrganization: membershipOrganization,
+            });
+
+            await exporter.sendEmail({
+                to: [{ email: user.email, name: user.name }],
+            });
+        }).catch(console.error);
+
+        return new Response(undefined);
+    }
+}

--- a/backend/app/api/src/helpers/SettlementExporter.test.ts
+++ b/backend/app/api/src/helpers/SettlementExporter.test.ts
@@ -1,0 +1,175 @@
+import type { Organization } from '@stamhoofd/models';
+import { OrganizationFactory, Payment } from '@stamhoofd/models';
+import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { v4 as uuidv4 } from 'uuid';
+
+import { initMembershipOrganization } from '../../tests/init/initMembershipOrganization.js';
+import { SettlementService } from '../services/SettlementService.js';
+import { SettlementExporter } from './SettlementExporter.js';
+
+describe('SettlementExporter', () => {
+    let membershipOrganization: Organization;
+
+    beforeAll(async () => {
+        membershipOrganization = await initMembershipOrganization();
+    });
+
+    /**
+     * A fresh organization with one settled Mollie payment: a payout of 49,63 explained by a 50,00
+     * payment line and Mollie's 0,30 + 0,063 VAT cost rows (invoice inv_123).
+     */
+    const createSettledPayment = async () => {
+        const organization = await new OrganizationFactory({}).create();
+
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.method = PaymentMethod.Bancontact;
+        payment.provider = PaymentProvider.Mollie;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = 50_00_00;
+        payment.paidAt = new Date(2026, 0, 10);
+        await payment.save();
+
+        const settlement = await SettlementService.upsertSettlement({
+            provider: PaymentProvider.Mollie,
+            externalId: 'stl_' + uuidv4(),
+            organizationId: organization.id,
+            reference: '1234567.2601.01',
+            amount: 49_63_70,
+            settledAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.upsertPaymentLine(settlement, {
+            paymentId: payment.id,
+            amount: 50_00_00,
+            externalId: 'tr_' + uuidv4(),
+            occurredAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.upsertCharge({
+            type: SettlementChargeType.ProviderTransactionFee,
+            externalId: settlement.externalId + ':cost:0',
+            amount: -30_00,
+            settlementId: settlement.id,
+            providerInvoiceId: 'inv_123',
+            description: 'Transactiekosten',
+            occurredAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.upsertCharge({
+            type: SettlementChargeType.Tax,
+            externalId: settlement.externalId + ':cost:0:tax',
+            amount: -6_30,
+            settlementId: settlement.id,
+            providerInvoiceId: 'inv_123',
+            description: 'BTW op transactiekosten',
+            occurredAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.finishSync(settlement, { transactionCount: 3 });
+
+        return { organization, payment, settlement };
+    };
+
+    const createExporter = (organization: Organization) => {
+        return new SettlementExporter({
+            start: new Date(2026, 0, 1),
+            end: new Date(2026, 1, 1),
+            organizationId: organization.id,
+            sellingOrganization: membershipOrganization,
+        });
+    };
+
+    test('only walks the settlements of the exported organization', async () => {
+        const { organization } = await createSettledPayment();
+        await createSettledPayment();
+
+        const exporter = createExporter(organization);
+        let count = 0;
+        exporter.callback = () => count++;
+        await exporter.build();
+
+        expect(count).toBe(1);
+    });
+
+    test('a platform payout is included in its owning organization\'s export', async () => {
+        // The platform's own payouts belong to the membership organization: there is no separate
+        // platform-only mode, scoping to that organization is the platform export
+        const owner = await new OrganizationFactory({}).create();
+        const platformSettlement = await SettlementService.upsertSettlement({
+            provider: PaymentProvider.Stripe,
+            externalId: 'po_platform_' + uuidv4(),
+            stripeAccountId: null,
+            organizationId: owner.id,
+            amount: 12_34_00,
+            settledAt: new Date(2026, 0, 20),
+        });
+        await SettlementService.finishSync(platformSettlement, { transactionCount: 0 });
+        await createSettledPayment();
+
+        const exporter = createExporter(owner);
+        let count = 0;
+        exporter.callback = () => count++;
+        await exporter.build();
+
+        expect(count).toBe(1);
+    });
+
+    test('charges group into the invoice of the party that bills them', async () => {
+        const { organization, payment, settlement } = await createSettledPayment();
+
+        // Application fees the platform deducted: billed by the membership organization's monthly
+        // fee invoice
+        await SettlementService.upsertCharge({
+            type: SettlementChargeType.ApplicationFeeService,
+            externalId: 'fee_' + uuidv4() + ':ApplicationFeeService',
+            amount: -1_00_00,
+            settlementId: settlement.id,
+            paymentId: payment.id,
+            organizationId: organization.id,
+            occurredAt: new Date(2026, 0, 15),
+        });
+        await SettlementService.upsertCharge({
+            type: SettlementChargeType.ApplicationFeeTransfer,
+            externalId: 'fee_' + uuidv4() + ':ApplicationFeeTransfer',
+            amount: -50_00,
+            settlementId: settlement.id,
+            paymentId: payment.id,
+            organizationId: organization.id,
+            occurredAt: new Date(2026, 0, 15),
+        });
+
+        // Money movement: part of no invoice
+        await SettlementService.upsertCharge({
+            type: SettlementChargeType.Transfer,
+            externalId: 'trf_' + uuidv4(),
+            amount: -10_00_00,
+            settlementId: settlement.id,
+            occurredAt: new Date(2026, 0, 15),
+        });
+
+        const exporter = createExporter(organization);
+        await exporter.build();
+
+        const totals = exporter.getProviderInvoiceTotals();
+        expect(totals).toHaveLength(2);
+
+        // Mollie's own costs on its invoice document, with the VAT split out
+        expect(totals).toContainEqual({
+            invoicedBy: PaymentProvider.Mollie,
+            invoiceId: 'inv_123',
+            transactionFees: 30_00,
+            serviceFees: 0,
+            accountFees: 0,
+            vat: 6_30,
+        });
+
+        // The deducted application fees on the platform's monthly fee invoice, as billed
+        // (positive) amounts
+        expect(totals).toContainEqual({
+            invoicedBy: membershipOrganization.name,
+            invoiceId: '2026-01',
+            transactionFees: 50_00,
+            serviceFees: 1_00_00,
+            accountFees: 0,
+            vat: 0,
+        });
+    });
+});

--- a/backend/app/api/src/helpers/SettlementExporter.ts
+++ b/backend/app/api/src/helpers/SettlementExporter.ts
@@ -1,0 +1,503 @@
+import type { CellValue } from '@stamhoofd/excel-writer';
+import { ArchiverWriterAdapter, XlsxBuiltInNumberFormat, XlsxWriter } from '@stamhoofd/excel-writer';
+import type { EmailInterfaceRecipient } from '@stamhoofd/email';
+import { Email } from '@stamhoofd/email';
+import { Invoice, Organization, Payment, StripeAccount } from '@stamhoofd/models';
+import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { SQL } from '@stamhoofd/sql';
+import type { PaymentProvider } from '@stamhoofd/structures';
+import { PaymentMethod, PaymentProvider as PaymentProviderEnum, PaymentStatus } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { Formatter } from '@stamhoofd/utility';
+import { Writable } from 'node:stream';
+
+import { SettlementService } from '../services/SettlementService.js';
+
+const SETTLEMENT_BATCH_SIZE = 100;
+
+const RECEIVED_FEE_TYPES = [SettlementChargeType.ReceivedApplicationFeeService, SettlementChargeType.ReceivedApplicationFeeTransfer];
+
+function currencyCell(amount: number | null, width?: number): CellValue {
+    return {
+        value: amount === null ? null : amount / 1_0000,
+        width,
+        style: {
+            numberFormat: {
+                id: XlsxBuiltInNumberFormat.Currency2DecimalWithoutRed,
+            },
+        },
+    };
+}
+
+function dateCell(date: Date | null, width?: number): CellValue {
+    return {
+        value: date,
+        width,
+        style: {
+            numberFormat: {
+                id: XlsxBuiltInNumberFormat.DateSlash,
+            },
+        },
+    };
+}
+
+function textCell(value: string, width?: number): CellValue {
+    return { value, width };
+}
+
+const empty = textCell('');
+
+/**
+ * The totals of one invoice the exported organization receives. Amounts are stored as billed
+ * (positive).
+ */
+type ProviderInvoiceTotals = {
+    invoicedBy: string;
+    invoiceId: string;
+    transactionFees: number;
+    serviceFees: number;
+    accountFees: number;
+    vat: number;
+};
+
+/**
+ * Builds the settlements reconciliation report of one organization from the stored tables only: no
+ * provider API calls. The sheets stream per settlement batch, because payment_settlements grows
+ * like payments.
+ */
+export class SettlementExporter {
+    start: Date;
+    end: Date;
+    provider: PaymentProvider | null;
+    organizationId: string;
+
+    /**
+     * True when the exported organization is the platform membership organization: its export is
+     * the platform-wide one, so the invoicing check covers every organization.
+     */
+    platformScope: boolean;
+
+    /**
+     * The platform membership organization: the seller of the platform's fee invoices.
+     */
+    sellingOrganization: Organization;
+
+    /**
+     * Called per processed settlement, to report progress.
+     */
+    callback: (() => void) | null = null;
+
+    /**
+     * Invoice totals accumulated from the Kosten rows (settlements in range).
+     */
+    private invoiceTotals = new Map<string, ProviderInvoiceTotals>();
+
+    constructor({ start, end, provider, organizationId, platformScope, sellingOrganization }: { start: Date; end: Date; provider?: PaymentProvider | null; organizationId: string; platformScope?: boolean; sellingOrganization: Organization }) {
+        this.start = start;
+        this.end = end;
+        this.provider = provider ?? null;
+        this.organizationId = organizationId;
+        this.platformScope = platformScope ?? false;
+        this.sellingOrganization = sellingOrganization;
+    }
+
+    private selectSettlements() {
+        let query = Settlement.select()
+            .where('organizationId', this.organizationId)
+            .where('settledAt', '>=', this.start)
+            .where('settledAt', '<=', this.end);
+
+        if (this.provider) {
+            query = query.where('provider', this.provider);
+        }
+        return query;
+    }
+
+    async build(): Promise<Buffer> {
+        const chunks: Buffer[] = [];
+        const output = new Writable({
+            write(chunk: Buffer, _encoding, callback) {
+                chunks.push(chunk);
+                callback();
+            },
+        });
+        const finishPromise = new Promise<void>((resolve, reject) => {
+            output.on('finish', () => resolve());
+            output.on('error', reject);
+        });
+
+        const zipWriterAdapter = new ArchiverWriterAdapter(output);
+        const writer = new XlsxWriter(zipWriterAdapter);
+
+        const settlementsSheet = await writer.addSheet('Uitbetalingen');
+        const paymentsSheet = await writer.addSheet('Betalingen');
+        const chargesSheet = await writer.addSheet('Kosten');
+        const providerInvoicesSheet = await writer.addSheet('Facturen provider');
+        const invoicingCheckSheet = await writer.addSheet('Controle facturatie');
+        await writer.ready();
+
+        try {
+            await this.writeSettlementSheets(writer, { settlementsSheet, paymentsSheet, chargesSheet });
+            await this.writeProviderInvoices(writer, providerInvoicesSheet);
+            await this.writeInvoicingCheck(writer, invoicingCheckSheet);
+            await writer.close();
+        } catch (error) {
+            await writer.abort();
+            throw error;
+        }
+
+        await finishPromise;
+        return Buffer.concat(chunks);
+    }
+
+    /**
+     * Sheets 1-3 in one streaming pass over the settlements in range.
+     */
+    private async writeSettlementSheets(writer: XlsxWriter, sheets: { settlementsSheet: symbol; paymentsSheet: symbol; chargesSheet: symbol }) {
+        await writer.addRow(sheets.settlementsSheet, [
+            textCell('Provider', 10),
+            textCell('Uitbetaling', 30),
+            textCell('Referentie', 25),
+            textCell('Uitbetaald op', 13),
+            textCell('Bedrag', 13),
+            textCell('Totaal betalingen', 16),
+            textCell('Totaal kosten', 13),
+            textCell('Status', 10),
+            textCell('Gesynchroniseerd', 16),
+            textCell('Transacties', 11),
+            textCell('Onverklaard', 13),
+            textCell('Check', 12),
+        ]);
+
+        await writer.addRow(sheets.paymentsSheet, [
+            textCell('Uitbetaling', 30),
+            textCell('Uitbetaald op', 13),
+            textCell('Betaling', 36),
+            textCell('Type', 12),
+            textCell('Bedrag', 13),
+            textCell('Transactie', 30),
+            textCell('Datum', 13),
+        ]);
+
+        await writer.addRow(sheets.chargesSheet, [
+            textCell('Uitbetaling', 30),
+            textCell('Type', 32),
+            textCell('Bedrag', 13),
+            textCell('Beschrijving', 45),
+            textCell('Factuur provider', 18),
+            textCell('Periode', 13),
+        ]);
+
+        // The settlement headers are small (the heavy line/charge data still streams per batch),
+        // and the batched iterator only supports id order
+        const settlements: Settlement[] = [];
+        for await (const batch of this.selectSettlements().limit(SETTLEMENT_BATCH_SIZE).allBatched()) {
+            settlements.push(...batch);
+        }
+        settlements.sort((a, b) => a.settledAt.getTime() - b.settledAt.getTime() || a.externalId.localeCompare(b.externalId));
+
+        for (let offset = 0; offset < settlements.length; offset += SETTLEMENT_BATCH_SIZE) {
+            const batch = settlements.slice(offset, offset + SETTLEMENT_BATCH_SIZE);
+            const settlementIds = batch.map(s => s.id);
+            const lines = await PaymentSettlement.select().where('settlementId', settlementIds).fetch();
+            const charges = await SettlementCharge.select().where('settlementId', settlementIds).fetch();
+            const payments = lines.length > 0
+                ? await Payment.select().where('id', Formatter.uniqueArray(lines.map(l => l.paymentId))).fetch()
+                : [];
+
+            for (const settlement of batch) {
+                const settlementLines = lines.filter(l => l.settlementId === settlement.id);
+                const settlementCharges = charges.filter(c => c.settlementId === settlement.id);
+                await this.writeSettlement(writer, sheets, settlement, settlementLines, settlementCharges, payments);
+                this.callback?.();
+            }
+        }
+    }
+
+    private async writeSettlement(writer: XlsxWriter, sheets: { settlementsSheet: symbol; paymentsSheet: symbol; chargesSheet: symbol }, settlement: Settlement, lines: PaymentSettlement[], charges: SettlementCharge[], payments: Payment[]) {
+        const linesTotal = lines.reduce((total, line) => total + line.amount, 0);
+        const chargesTotal = charges.reduce((total, charge) => total + charge.amount, 0);
+        const unexplained = settlement.amount - linesTotal - chargesTotal;
+
+        // The payout amount must be explained by its payments and charges:
+        // amount = totaal betalingen + totaal kosten
+        await writer.addRow(sheets.settlementsSheet, [
+            textCell(settlement.provider),
+            textCell(settlement.externalId),
+            textCell(settlement.reference),
+            dateCell(settlement.settledAt),
+            currencyCell(settlement.amount),
+            currencyCell(linesTotal),
+            currencyCell(chargesTotal),
+            textCell(settlement.status),
+            textCell(settlement.syncedAt ? '✓' : 'Niet gesynchroniseerd'),
+            textCell(settlement.transactionCount.toString()),
+            currencyCell(settlement.unexplainedAmount),
+            textCell(unexplained === 0 ? '✓' : 'Klopt niet!'),
+        ]);
+
+        for (const [index, line] of lines.entries()) {
+            const payment = payments.find(p => p.id === line.paymentId);
+            await writer.addRow(sheets.paymentsSheet, [
+                index > 0 ? empty : textCell(settlement.externalId),
+                index > 0 ? empty : dateCell(settlement.settledAt),
+                textCell(line.paymentId),
+                textCell(payment?.type ?? ''),
+                currencyCell(line.amount),
+                textCell(line.externalId),
+                dateCell(line.occurredAt),
+            ]);
+        }
+
+        if (lines.length > 0) {
+            await writer.addRow(sheets.paymentsSheet, []);
+        }
+
+        for (const [index, charge] of charges.entries()) {
+            await writer.addRow(sheets.chargesSheet, [
+                index > 0 ? empty : textCell(settlement.externalId),
+                textCell(charge.type),
+                currencyCell(charge.amount),
+                textCell(charge.description),
+                textCell(charge.providerInvoiceId ?? ''),
+                dateCell(SettlementService.getPeriodStart(charge.occurredAt)),
+            ]);
+
+            this.addToProviderInvoice(settlement, charge);
+        }
+
+        if (charges.length > 0) {
+            await writer.addRow(sheets.chargesSheet, []);
+        }
+    }
+
+    /**
+     * The invoice that bills a charge to the exported organization. Three parties send such
+     * invoices: the provider of the settlement (Mollie, and Stripe both for our platform account
+     * and for Standard accounts) bills its own fees and their VAT; the platform membership
+     * organization bills the application fees it deducted, with its monthly fee invoice. Every
+     * other charge type is money movement (transfers, reserves, disputes, the received mirror side
+     * of application fees): no invoice bills those.
+     */
+    private getInvoicingParty(settlement: Settlement, charge: SettlementCharge): { invoicedBy: string; invoiceId: string } | null {
+        switch (charge.type) {
+            case SettlementChargeType.ProviderTransactionFee:
+            case SettlementChargeType.ProviderAccountFee:
+            case SettlementChargeType.Tax:
+                // A missing invoice id only happens for Mollie costs whose invoice document isn't
+                // created yet: group those per month until it is
+                return {
+                    invoicedBy: settlement.provider,
+                    invoiceId: charge.providerInvoiceId ?? (settlement.provider.toLowerCase() + '-' + SettlementService.getPeriodKey(charge.occurredAt)),
+                };
+
+            case SettlementChargeType.ApplicationFeeService:
+            case SettlementChargeType.ApplicationFeeTransfer:
+                // Billed per month by the platform's fee invoicers: the month bucket is the invoice
+                return {
+                    invoicedBy: this.sellingOrganization.name,
+                    invoiceId: SettlementService.getPeriodKey(charge.occurredAt),
+                };
+
+            case SettlementChargeType.ReceivedApplicationFeeService:
+            case SettlementChargeType.ReceivedApplicationFeeTransfer:
+            case SettlementChargeType.ApplicationFeeRefund:
+            case SettlementChargeType.Transfer:
+            case SettlementChargeType.TransferReversal:
+            case SettlementChargeType.Reserve:
+            case SettlementChargeType.Adjustment:
+                return null;
+        }
+    }
+
+    private addToProviderInvoice(settlement: Settlement, charge: SettlementCharge) {
+        const invoice = this.getInvoicingParty(settlement, charge);
+        if (!invoice) {
+            return;
+        }
+
+        const key = invoice.invoicedBy + ':' + invoice.invoiceId;
+        const totals = this.invoiceTotals.get(key) ?? { ...invoice, transactionFees: 0, serviceFees: 0, accountFees: 0, vat: 0 };
+
+        // Charges reduce the payout (negative); the invoice bills them as positive amounts
+        const billed = -charge.amount;
+        switch (charge.type) {
+            case SettlementChargeType.ProviderTransactionFee:
+            case SettlementChargeType.ApplicationFeeTransfer:
+                totals.transactionFees += billed;
+                break;
+            case SettlementChargeType.ApplicationFeeService:
+                totals.serviceFees += billed;
+                break;
+            case SettlementChargeType.ProviderAccountFee:
+                totals.accountFees += billed;
+                break;
+            default:
+                totals.vat += billed;
+        }
+        this.invoiceTotals.set(key, totals);
+    }
+
+    /**
+     * One row per invoice the exported organization receives: the stored fee rows that the invoice
+     * document must match — Mollie's and Stripe's own invoices, and the platform's monthly fee
+     * invoice (so an organization can verify what the platform billed them). Derived only from the
+     * settlements this export selected, so it always agrees with the Kosten sheet; comparing with
+     * the real document is the human step.
+     */
+    /**
+     * The accumulated invoice rows (after build), sorted as the sheet writes them.
+     */
+    getProviderInvoiceTotals(): ProviderInvoiceTotals[] {
+        return [...this.invoiceTotals.values()].sort((a, b) => a.invoicedBy.localeCompare(b.invoicedBy) || a.invoiceId.localeCompare(b.invoiceId));
+    }
+
+    private async writeProviderInvoices(writer: XlsxWriter, sheet: symbol) {
+        await writer.addRow(sheet, [
+            textCell('Gefactureerd door', 17),
+            textCell('Factuur', 20),
+            textCell('Transactiekosten', 16),
+            textCell('Servicekosten', 16),
+            textCell('Accountkosten', 16),
+            textCell('BTW', 13),
+            textCell('Totaal', 13),
+        ]);
+
+        for (const totals of this.getProviderInvoiceTotals()) {
+            const total = totals.transactionFees + totals.serviceFees + totals.accountFees + totals.vat;
+
+            await writer.addRow(sheet, [
+                textCell(totals.invoicedBy),
+                textCell(totals.invoiceId),
+                currencyCell(totals.transactionFees),
+                currencyCell(totals.serviceFees),
+                currencyCell(totals.accountFees),
+                currencyCell(totals.vat),
+                currencyCell(total),
+            ]);
+        }
+    }
+
+    /**
+     * One row per (organization, month): the stored Received fee rows next to the AccountDeductions
+     * payment the old invoicer created. Every row must show a difference of 0,00: that is the
+     * go/no-go check for the invoicer switch. The platform export covers every organization; an
+     * organization's own export only shows its own rows.
+     */
+    private async writeInvoicingCheck(writer: XlsxWriter, sheet: symbol) {
+        await writer.addRow(sheet, [
+            textCell('Stripe account', 36),
+            textCell('Maand', 13),
+            textCell('Opgeslagen kosten', 17),
+            textCell('Aangerekend', 13),
+            textCell('Verschil', 13),
+            textCell('Check', 12),
+            textCell('Factuur', 25),
+        ]);
+
+        // Group the stored Received rows per (account, month of the fee's created date): the same
+        // bucket the invoicer bills by. Extended to whole months, or a range ending mid-month
+        // would compare a partial sum against the full month's fee payment
+        const rangeEnd = new Date(this.end.getFullYear(), this.end.getMonth() + 1, 1);
+        const groups = new Map<string, { stripeAccountId: string | null; periodStart: Date; total: number }>();
+        let receivedQuery = SettlementCharge.select()
+            .where('type', RECEIVED_FEE_TYPES)
+            .where('occurredAt', '>=', SettlementService.getPeriodStart(this.start))
+            .where('occurredAt', '<', rangeEnd);
+        if (!this.platformScope) {
+            receivedQuery = receivedQuery.where('organizationId', this.organizationId);
+        }
+        for await (const rows of receivedQuery
+            .limit(SETTLEMENT_BATCH_SIZE)
+            .allBatched()) {
+            for (const row of rows) {
+                const periodStart = SettlementService.getPeriodStart(row.occurredAt);
+                const key = (row.stripeAccountId ?? 'unknown') + ':' + periodStart.getTime();
+                const group = groups.get(key) ?? { stripeAccountId: row.stripeAccountId, periodStart, total: 0 };
+                group.total += row.amount;
+                groups.set(key, group);
+            }
+        }
+
+        const sorted = [...groups.values()].sort((a, b) => a.periodStart.getTime() - b.periodStart.getTime() || (a.stripeAccountId ?? '').localeCompare(b.stripeAccountId ?? ''));
+
+        for (const group of sorted) {
+            const { payment, invoiceNumber, organizationName } = await this.findFeePayment(group.stripeAccountId, group.periodStart);
+            const charged = payment?.price ?? 0;
+            const difference = group.total - charged;
+
+            await writer.addRow(sheet, [
+                textCell(organizationName ?? (group.stripeAccountId ?? 'Onbekend')),
+                dateCell(group.periodStart),
+                currencyCell(group.total),
+                currencyCell(payment ? charged : null),
+                currencyCell(payment ? difference : null),
+                // A month the invoicer didn't reach yet is not a mismatch: it is still waiting
+                textCell(payment ? (difference === 0 ? '✓' : 'Klopt niet!') : 'Nog niet gefactureerd'),
+                textCell(payment ? (invoiceNumber ?? 'Betaling nog niet gefactureerd') : ''),
+            ]);
+        }
+    }
+
+    private async findFeePayment(stripeAccountId: string | null, periodStart: Date): Promise<{ payment: Payment | null; invoiceNumber: string | null; organizationName: string | null }> {
+        if (!stripeAccountId) {
+            return { payment: null, invoiceNumber: null, organizationName: null };
+        }
+
+        const stripeAccount = await StripeAccount.getByID(stripeAccountId);
+        if (!stripeAccount) {
+            return { payment: null, invoiceNumber: null, organizationName: null };
+        }
+
+        const organization = await Organization.getByID(stripeAccount.organizationId);
+        const organizationName = organization ? organization.name + ' (' + stripeAccount.accountId + ')' : null;
+
+        const reference = 'stripe-fees-' + Formatter.dateIso(periodStart);
+
+        // Same query as the invoicer's idempotency check (the OR NULL covers legacy payments)
+        const payment = await Payment.select()
+            .where('organizationId', this.sellingOrganization.id)
+            .where('payingOrganizationId', stripeAccount.organizationId)
+            .where(
+                SQL.where('stripeAccountId', stripeAccount.id)
+                    .or('stripeAccountId', null),
+            )
+            .where('reference', reference)
+            .where('method', PaymentMethod.AccountDeductions)
+            .where('provider', PaymentProviderEnum.Stripe)
+            .where('status', PaymentStatus.Succeeded)
+            .first(false);
+
+        if (!payment) {
+            return { payment: null, invoiceNumber: null, organizationName };
+        }
+
+        const invoice = payment.invoiceId ? await Invoice.getByID(payment.invoiceId) : null;
+        return { payment, invoiceNumber: invoice?.number !== null && invoice?.number !== undefined ? ('Factuur ' + invoice.number) : null, organizationName };
+    }
+
+    async sendEmail({ to }: { to: EmailInterfaceRecipient[] }): Promise<void> {
+        const buffer = await this.build();
+
+        const startMonth = Formatter.dateWithoutDay(this.start, { timezone: 'UTC' });
+        const endMonth = Formatter.dateWithoutDay(this.end, { timezone: 'UTC' });
+        const subject = 'Uitbetalingen export ' + startMonth + ((endMonth !== startMonth) ? (' - ' + endMonth) : '');
+
+        Email.send({
+            from: Email.getWebmasterFromEmail(),
+            to,
+            subject,
+            text: 'In bijlage het overzicht van de opgeslagen uitbetalingen van ' + Formatter.dateTime(this.start) + ' tot ' + Formatter.dateTime(this.end) + '.\n',
+            type: 'transactional',
+            attachments: [
+                {
+                    filename: Formatter.fileSlug(subject) + '.xlsx',
+                    content: buffer,
+                    contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                },
+            ],
+        });
+    }
+}


### PR DESCRIPTION
POST /settlements/export emails an xlsx with five sheets: Uitbetalingen (with the per-payout payment and charge totals as columns), Betalingen, Kosten, Facturen provider and Controle facturatie — the last one is the go/no-go check for the invoicer switch. Sheets stream per settlement batch and the range is capped.

The export is strictly scoped to the organization in context: any finance admin (behind the 'settlements' feature flag) exports their own payouts, and the platform export is simply the membership organization's own export. The Facturen provider sheet groups every charge into the invoice of the party that bills it — Mollie, Stripe (platform and Standard accounts) or the membership organization's monthly fee invoice — via an exhaustive mapping per charge type; money movement belongs to no invoice, so organizations can verify what the platform billed them. No status endpoint: the export reads only local tables and the result arrives by email.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
