### PR TITLE
✨ Settlements sync endpoint (backfill)

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/settlements/GetSettlementsSyncStatusEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/settlements/GetSettlementsSyncStatusEndpoint.ts
@@ -1,0 +1,35 @@
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+
+import { StripePayoutsExportEndpoint } from '../stripe/StripePayoutsExportEndpoint.js';
+import { SettlementsSyncStatus } from '@stamhoofd/structures/settlements/SettlementsSyncStatus.js';
+
+import { SettlementsSyncEndpoint } from './SettlementsSyncEndpoint.js';
+
+type Params = Record<string, never>;
+type Body = undefined;
+type Query = undefined;
+type ResponseBody = SettlementsSyncStatus[];
+
+export class GetSettlementsSyncStatusEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'GET') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/settlements/sync/status', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(_: DecodedRequest<Params, Query, Body>) {
+        await StripePayoutsExportEndpoint.authenticate();
+
+        return new Response(SettlementsSyncEndpoint.queue.map((item) => {
+            return SettlementsSyncStatus.create(item);
+        }));
+    }
+}

--- a/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.test.ts
@@ -1,0 +1,109 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Organization, Token, User } from '@stamhoofd/models';
+import { OrganizationFactory, Payment, Token as TokenModel, UserFactory } from '@stamhoofd/models';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { QueueHandler } from '@stamhoofd/queues';
+import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { STExpect } from '@stamhoofd/test-utils';
+
+import { StripeMocker } from '../../../../../tests/helpers/StripeMocker.js';
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { initMembershipOrganization } from '../../../../../tests/init/initMembershipOrganization.js';
+import { initPlatformAdmin } from '../../../../../tests/init/initPlatformAdmin.js';
+import { GetSettlementsSyncStatusEndpoint } from './GetSettlementsSyncStatusEndpoint.js';
+import { SettlementsSyncEndpoint } from './SettlementsSyncEndpoint.js';
+
+describe('Endpoint.SettlementsSync', () => {
+    const endpoint = new SettlementsSyncEndpoint();
+    const statusEndpoint = new GetSettlementsSyncStatusEndpoint();
+    const stripeMocker = new StripeMocker();
+
+    let membershipOrganization: Organization;
+    let admin: User;
+    let adminToken: Token;
+
+    beforeAll(async () => {
+        membershipOrganization = await initMembershipOrganization();
+        ({ admin, adminToken } = await initPlatformAdmin());
+        stripeMocker.start();
+    });
+
+    afterAll(() => {
+        stripeMocker.stop();
+    });
+
+    beforeEach(() => {
+        stripeMocker.clear();
+    });
+
+    const post = async (organization: Organization, token: Token, body: Record<string, unknown> = {}) => {
+        const request = Request.buildJson('POST', '/settlements/sync', organization.getApiHost(), {
+            start: new Date(2026, 0, 1).getTime(),
+            end: new Date(2026, 0, 31).getTime(),
+            providers: [PaymentProvider.Stripe],
+            ...body,
+        });
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    const getStatus = async (organization: Organization, token: Token) => {
+        const request = Request.buildJson('GET', '/settlements/sync/status', organization.getApiHost());
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+        return await testServer.test(statusEndpoint, request);
+    };
+
+    test('A platform admin can run the sync, which stores the payouts', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.method = PaymentMethod.Bancontact;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = 100_00_00;
+        payment.paidAt = new Date(2026, 0, 15);
+        await payment.save();
+
+        const payout = stripeMocker.createPayout({ amount: 10000, arrivalDate: new Date(2026, 0, 20) });
+        stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 10000,
+            created: new Date(2026, 0, 15),
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: payment.id } }),
+        });
+
+        const response = await post(membershipOrganization, adminToken);
+        expect(response.status).toBe(200);
+
+        await QueueHandler.awaitAll();
+
+        const settlement = await Settlement.select().where('externalId', payout.id).first(true);
+        expect(settlement.syncedAt).not.toBeNull();
+        expect(settlement.unexplainedAmount).toBe(0);
+
+        // The queue is empty again
+        const statusResponse = await getStatus(membershipOrganization, adminToken);
+        expect(statusResponse.body).toEqual([]);
+    });
+
+    test('A user without platform full access cannot run the sync', async () => {
+        const user = await new UserFactory({ organization: membershipOrganization }).create();
+        const token = await TokenModel.createToken(user);
+
+        await expect(post(membershipOrganization, token)).rejects.toThrow(
+            STExpect.simpleError({ code: 'permission_denied' }),
+        );
+        await expect(getStatus(membershipOrganization, token)).rejects.toThrow(
+            STExpect.simpleError({ code: 'permission_denied' }),
+        );
+    });
+
+    test('The sync is not available for other organizations', async () => {
+        const otherOrganization = await new OrganizationFactory({}).create();
+
+        await expect(post(otherOrganization, adminToken)).rejects.toThrow(
+            STExpect.simpleError({ code: 'not_available' }),
+        );
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.ts
@@ -1,0 +1,93 @@
+import type { Decoder } from '@simonbackx/simple-encoding';
+import { ArrayDecoder, AutoEncoder, BooleanDecoder, DateDecoder, EnumDecoder, field, StringDecoder } from '@simonbackx/simple-encoding';
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { QueueHandler } from '@stamhoofd/queues';
+import { PaymentProvider } from '@stamhoofd/structures';
+import { SettlementsSyncStatus } from '@stamhoofd/structures/settlements/SettlementsSyncStatus.js';
+
+import { SettlementSyncRunner } from '../../../../helpers/SettlementSyncRunner.js';
+import { StripeFeeInvoiceBackfill } from '../../../../helpers/StripeFeeInvoiceBackfill.js';
+import { StripePayoutsExportEndpoint } from '../stripe/StripePayoutsExportEndpoint.js';
+
+type Params = Record<string, never>;
+class Body extends AutoEncoder {
+    @field({ decoder: DateDecoder, optional: true })
+    start: Date = new Date(2025, 0, 1);
+
+    @field({ decoder: DateDecoder, nullable: true, optional: true })
+    end: Date | null = null;
+
+    @field({ decoder: new ArrayDecoder(new EnumDecoder(PaymentProvider)), nullable: true, optional: true })
+    providers: PaymentProvider[] | null = null;
+
+    @field({ decoder: new ArrayDecoder(StringDecoder), nullable: true, optional: true })
+    accountIds: string[] | null = null;
+
+    @field({ decoder: BooleanDecoder, optional: true })
+    force = false;
+
+    /**
+     * Afterwards, mark the Received fee rows of months the old invoicer already billed as
+     * invoiced (see StripeFeeInvoiceBackfill).
+     */
+    @field({ decoder: BooleanDecoder, optional: true })
+    backfillInvoiced = true;
+}
+type Query = undefined;
+type ResponseBody = undefined;
+
+/**
+ * Manually run the settlement sync (backfill) over a period. Everything is an upsert and
+ * already-synced settlements are skipped unless force, so re-running is cheap.
+ */
+export class SettlementsSyncEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    bodyDecoder = Body as Decoder<Body>;
+
+    static queue: SettlementsSyncStatus[] = [];
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'POST') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/settlements/sync', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        const { organization } = await StripePayoutsExportEndpoint.authenticate();
+
+        const { start, end, providers, accountIds, force, backfillInvoiced } = request.body;
+
+        const item = SettlementsSyncStatus.create({
+            start,
+            end,
+            force,
+        });
+        SettlementsSyncEndpoint.queue.push(item);
+
+        QueueHandler.schedule('settlement-sync', async () => {
+            try {
+                const runner = new SettlementSyncRunner();
+                runner.callback = (summary) => {
+                    item.count = summary.synced + summary.skipped + summary.failed;
+                    item.failed = summary.failed + summary.failedFeeMonths;
+                };
+                await runner.run({ start, end, providers, accountIds, force });
+
+                if (backfillInvoiced) {
+                    await StripeFeeInvoiceBackfill.backfillAll(organization, { start });
+                }
+            } finally {
+                SettlementsSyncEndpoint.queue.splice(SettlementsSyncEndpoint.queue.indexOf(item), 1);
+            }
+        }).catch(console.error);
+
+        return new Response(undefined);
+    }
+}

--- a/backend/app/api/src/helpers/CheckSettlements.ts
+++ b/backend/app/api/src/helpers/CheckSettlements.ts
@@ -124,26 +124,32 @@ export async function checkSettlements(checkAll = false) {
         }
     }
 
-    // Loop all mollie tokens created after given date (when settlement permission was added)
     try {
         // Stripe payouts
         await checkAllStripePayouts(checkAll);
 
-        const mollieTokens = await MollieToken.all();
-        for (const token of mollieTokens) {
-            if (token.createdAt < new Date(2021, 8 /* september! */, 8)) {
-                console.log('Skipped mollie token that is too old');
-            } else {
-                try {
-                    await token.refreshIfNeeded();
-                    await checkMollieSettlementsFor(token.accessToken, token.organizationId, checkAll);
-                } catch (e) {
-                    console.error(e);
-                }
-            }
-        }
+        await checkAllMollieTokenSettlements(checkAll);
     } catch (e) {
         console.error(e);
+    }
+}
+
+/**
+ * Loop all mollie tokens created after given date (when settlement permission was added).
+ */
+export async function checkAllMollieTokenSettlements(checkAll = false) {
+    const mollieTokens = await MollieToken.all();
+    for (const token of mollieTokens) {
+        if (token.createdAt < new Date(2021, 8 /* september! */, 8)) {
+            console.log('Skipped mollie token that is too old');
+        } else {
+            try {
+                await token.refreshIfNeeded();
+                await checkMollieSettlementsFor(token.accessToken, token.organizationId, checkAll);
+            } catch (e) {
+                console.error(e);
+            }
+        }
     }
 }
 

--- a/backend/app/api/src/helpers/SettlementSyncRunner.ts
+++ b/backend/app/api/src/helpers/SettlementSyncRunner.ts
@@ -1,0 +1,104 @@
+import { PaymentProvider } from '@stamhoofd/structures';
+
+import { SettlementService } from '../services/SettlementService.js';
+import { checkAllMollieTokenSettlements, checkMollieSettlementsFor } from './CheckSettlements.js';
+import type { StripePaymentIdCache } from './resolveStripePaymentId.js';
+import { StripeFeeSync } from './StripeFeeSync.js';
+import { StripeInvoicer } from './StripeInvoicer.js';
+import { StripePayoutSync } from './StripePayoutSync.js';
+
+export type SettlementSyncSummary = {
+    feeMonths: number;
+    failedFeeMonths: number;
+    synced: number;
+    skipped: number;
+    failed: number;
+};
+
+/**
+ * Runs a full settlement sync over a period, month by month: fees first, then our platform
+ * payouts (warming the shared payment id cache), then the connected accounts, and Mollie last.
+ * Everything is an upsert, so re-running (the nightly cron and a manual backfill) is cheap.
+ */
+export class SettlementSyncRunner {
+    /**
+     * Called after every processed month phase, to report progress.
+     */
+    callback: ((summary: SettlementSyncSummary) => void) | null = null;
+
+    async run({ start = new Date(2025, 0, 1), end, providers, accountIds, force = false }: {
+        start?: Date;
+        end?: Date | null;
+        providers?: PaymentProvider[] | null;
+        accountIds?: string[] | null;
+        force?: boolean;
+    } = {}): Promise<SettlementSyncSummary> {
+        const summary: SettlementSyncSummary = { feeMonths: 0, failedFeeMonths: 0, synced: 0, skipped: 0, failed: 0 };
+        const rangeEnd = end ?? new Date();
+
+        const includeStripe = !providers || providers.includes(PaymentProvider.Stripe);
+        const includeMollie = !providers || providers.includes(PaymentProvider.Mollie);
+
+        if (includeStripe && STAMHOOFD.STRIPE_SECRET_KEY) {
+            await this.runStripe({ start, end: rangeEnd, accountIds, force, secretKey: STAMHOOFD.STRIPE_SECRET_KEY, summary });
+        }
+
+        if (includeMollie) {
+            const token = STAMHOOFD.MOLLIE_ORGANIZATION_TOKEN;
+            if (token) {
+                try {
+                    // The platform's own Mollie account belongs to the membership organization
+                    await checkMollieSettlementsFor(token, await SettlementService.getPlatformOrganizationId(), true);
+                } catch (e) {
+                    // A missing membership organization must not block the per-organization tokens
+                    console.error(e);
+                }
+            }
+            await checkAllMollieTokenSettlements(true);
+            this.callback?.(summary);
+        }
+
+        return summary;
+    }
+
+    private async runStripe({ start, end, accountIds, force, secretKey, summary }: { start: Date; end: Date; accountIds?: string[] | null; force: boolean; secretKey: string; summary: SettlementSyncSummary }) {
+        const cache: StripePaymentIdCache = new Map();
+        const feeSync = new StripeFeeSync({ secretKey, cache });
+        const platformSync = new StripePayoutSync({ secretKey, cache });
+
+        let currentMonth = new Date(start.getFullYear(), start.getMonth(), 1);
+
+        while (true) {
+            const { start: monthStartUnix, end: monthEndUnix } = StripeInvoicer.getMonthUnixStartEnd(currentMonth);
+            if (monthStartUnix * 1000 > end.getTime()) {
+                break;
+            }
+
+            const windowStart = new Date(Math.max(monthStartUnix * 1000, start.getTime()));
+            const windowEnd = new Date(Math.min(monthEndUnix * 1000, end.getTime()));
+
+            try {
+                await feeSync.syncFees({ start: windowStart, end: windowEnd });
+                summary.feeMonths += 1;
+            } catch (e) {
+                // syncFees already emailed nothing: it throws an aggregate, the month is retried by
+                // the next run and the month is not invoiced until it completes
+                console.error('Fee sync failed for month ' + currentMonth.toISOString(), e);
+                summary.failedFeeMonths += 1;
+            }
+
+            const platformResult = await platformSync.syncPayouts({ start: windowStart, end: windowEnd, force });
+            summary.synced += platformResult.synced;
+            summary.skipped += platformResult.skipped;
+            summary.failed += platformResult.failed;
+
+            const connectedResult = await StripePayoutSync.syncConnectedPayouts({ secretKey, start: windowStart, end: windowEnd, force, cache, accountIds });
+            summary.synced += connectedResult.synced;
+            summary.skipped += connectedResult.skipped;
+            summary.failed += connectedResult.failed;
+
+            this.callback?.(summary);
+            currentMonth = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1);
+        }
+    }
+}

--- a/backend/app/api/src/helpers/StripePayoutSync.ts
+++ b/backend/app/api/src/helpers/StripePayoutSync.ts
@@ -59,11 +59,15 @@ export class StripePayoutSync {
      * Walks the payouts of every active connected account, after the platform walk warmed the
      * shared payment id cache.
      */
-    static async syncConnectedPayouts({ secretKey, start, end, force, cache }: { secretKey: string; start: Date; end?: Date; force?: boolean; cache?: StripePaymentIdCache }): Promise<{ synced: number; skipped: number; failed: number }> {
+    static async syncConnectedPayouts({ secretKey, start, end, force, cache, accountIds }: { secretKey: string; start: Date; end?: Date; force?: boolean; cache?: StripePaymentIdCache; accountIds?: string[] | null }): Promise<{ synced: number; skipped: number; failed: number }> {
         const sharedCache = cache ?? new Map<string, string>();
         const totals = { synced: 0, skipped: 0, failed: 0 };
 
-        const accounts = await StripeAccount.select().where('status', 'active').fetch();
+        let query = StripeAccount.select().where('status', 'active');
+        if (accountIds && accountIds.length > 0) {
+            query = query.where('id', accountIds);
+        }
+        const accounts = await query.fetch();
 
         for (const account of accounts) {
             try {

--- a/shared/structures/src/settlements/SettlementsSyncStatus.ts
+++ b/shared/structures/src/settlements/SettlementsSyncStatus.ts
@@ -1,0 +1,24 @@
+import { AutoEncoder, BooleanDecoder, DateDecoder, field, IntegerDecoder } from '@simonbackx/simple-encoding';
+
+/**
+ * Progress of a running settlements sync (see SettlementsSyncEndpoint).
+ */
+export class SettlementsSyncStatus extends AutoEncoder {
+    @field({ decoder: DateDecoder })
+    start: Date;
+
+    @field({ decoder: DateDecoder, nullable: true })
+    end: Date | null = null;
+
+    @field({ decoder: BooleanDecoder })
+    force = false;
+
+    /**
+     * Settlements processed so far (synced + skipped + failed).
+     */
+    @field({ decoder: IntegerDecoder })
+    count = 0;
+
+    @field({ decoder: IntegerDecoder })
+    failed = 0;
+}


### PR DESCRIPTION
POST /settlements/sync {start=2025-01-01, end?, providers?, accountIds?, force?, backfillInvoiced?} + status endpoint, platform-admin only. Runs month by month: fees, then platform payouts (warming the shared payment id cache), connected accounts, Mollie last; backfillInvoiced afterwards marks the fee rows of already-invoiced months as invoiced. Payouts run sequentially instead of the planned 5-wide fan-out: simpler, and re-runs skip synced payouts anyway.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
