### PR TITLE
✨ Nightly settlement sync cron

### DIFF
--- a/backend/app/api/src/crons.ts
+++ b/backend/app/api/src/crons.ts
@@ -355,6 +355,7 @@ async function checkReservedUntil() {
     }
 }
 
+// Legacy blob writes for Stripe + the canonical Mollie walk; see crons/stripe-settlement-sync.ts
 registerCron('checkSettlements', checkSettlements);
 registerCron('checkExpirationEmails', checkExpirationEmails);
 registerCron('checkReservedUntil', checkReservedUntil);

--- a/backend/app/api/src/crons/index.ts
+++ b/backend/app/api/src/crons/index.ts
@@ -13,6 +13,7 @@ import './fake-settlements.js';
 import './invoices.js';
 import './service-fees.js';
 import './members-fees.js';
+import './stripe-settlement-sync.js';
 import './stripe-invoices.js';
 import './stripe-payout-reports.js';
 import './transfer-fees.js';

--- a/backend/app/api/src/crons/stripe-settlement-sync.test.ts
+++ b/backend/app/api/src/crons/stripe-settlement-sync.test.ts
@@ -1,0 +1,71 @@
+import { EmailMocker } from '@stamhoofd/email';
+import type { Organization } from '@stamhoofd/models';
+import { OrganizationFactory } from '@stamhoofd/models';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { PaymentProvider } from '@stamhoofd/structures';
+import { v4 as uuidv4 } from 'uuid';
+
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import { SettlementService } from '../services/SettlementService.js';
+import { reportProblemSettlements, retryUnsyncedSettlements } from './stripe-settlement-sync.js';
+
+describe('Cron.stripe-settlement-sync', () => {
+    const stripeMocker = new StripeMocker();
+    let organization: Organization;
+
+    beforeAll(async () => {
+        stripeMocker.start();
+        organization = await new OrganizationFactory({}).create();
+    });
+
+    afterAll(() => {
+        stripeMocker.stop();
+    });
+
+    // Old dates that no other test uses, so the settledAt window only selects this test's rows
+    const settledAt = new Date(1990, 0, 5);
+    const windowStart = new Date(1990, 1, 1);
+
+    const createUnsyncedSettlement = async (failureCount: number) => {
+        const settlement = await SettlementService.upsertSettlement({
+            provider: PaymentProvider.Stripe,
+            externalId: 'po_' + uuidv4(),
+            organizationId: organization.id,
+            amount: 100_00_00,
+            settledAt,
+        });
+        for (let i = 0; i < failureCount; i++) {
+            await SettlementService.markSyncFailed(settlement);
+        }
+        return settlement;
+    };
+
+    test('a retry that cannot retrieve the payout anymore still counts towards the cap', async () => {
+        const settlement = await createUnsyncedSettlement(1);
+
+        // The mocker has no payout with this id: the retrieve fails with a 404
+        await retryUnsyncedSettlements(STAMHOOFD.STRIPE_SECRET_KEY!, windowStart);
+
+        const fresh = await Settlement.getByID(settlement.id);
+        expect(fresh!.syncFailureCount).toBe(2);
+        expect(fresh!.syncedAt).toBeNull();
+    });
+
+    test('a settlement at the failure cap is not retried anymore', async () => {
+        const settlement = await createUnsyncedSettlement(5);
+
+        await retryUnsyncedSettlements(STAMHOOFD.STRIPE_SECRET_KEY!, windowStart);
+
+        const fresh = await Settlement.getByID(settlement.id);
+        expect(fresh!.syncFailureCount).toBe(5);
+    });
+
+    test('problem settlements are reported to the webmaster', async () => {
+        await createUnsyncedSettlement(5);
+
+        await reportProblemSettlements();
+
+        const emails = await EmailMocker.transactional.getSucceededEmails();
+        expect(emails.find(e => e.subject.startsWith('Uitbetalingen met problemen'))).toBeDefined();
+    });
+});

--- a/backend/app/api/src/crons/stripe-settlement-sync.ts
+++ b/backend/app/api/src/crons/stripe-settlement-sync.ts
@@ -1,0 +1,144 @@
+// Stripe only. The older 'checkSettlements' cron (crons.ts -> helpers/CheckSettlements.ts) stays
+// the canonical Mollie walk: Mollie exposes no per-account payout listing to re-walk cheaply, so
+// its daily walk writes the legacy blob and the new settlement rows in one pass. For Stripe that
+// cron only writes the legacy blob (StripePayoutChecker); this cron writes the settlement tables.
+// Both run during the rollout so old and new can be compared; the legacy Stripe checker disappears
+// after the switch.
+import { registerCron } from '@stamhoofd/crons';
+import { Email } from '@stamhoofd/email';
+import { StripeAccount } from '@stamhoofd/models';
+import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { PaymentProvider } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+
+import { SettlementService } from '../services/SettlementService.js';
+import { SettlementSyncRunner } from '../helpers/SettlementSyncRunner.js';
+import type { StripePaymentIdCache } from '../helpers/resolveStripePaymentId.js';
+import { StripePayoutSync } from '../helpers/StripePayoutSync.js';
+
+registerCron('stripe-settlement-sync', syncStripeSettlements);
+
+/**
+ * How many days of payouts the nightly run re-walks. Everything is an upsert and synced payouts
+ * are skipped, so this window is cheap.
+ */
+const SYNC_WINDOW_DAYS = 30;
+
+/**
+ * A settlement that keeps failing needs a human: stop retrying after this many attempts.
+ */
+const MAXIMUM_FAILURE_COUNT = 5;
+
+let lastSettlementSync: Date | null = null;
+
+async function syncStripeSettlements() {
+    if (STAMHOOFD.environment !== 'production') {
+        return;
+    }
+
+    if (STAMHOOFD.userMode === 'platform') {
+        return;
+    }
+
+    if (STAMHOOFD.STRIPE_CONNECT_METHOD === 'standard') {
+        return;
+    }
+
+    // Wait for the next day before doing a new sync
+    const today = new Date();
+    if (lastSettlementSync && Formatter.dateIso(lastSettlementSync) === Formatter.dateIso(today)) {
+        console.log('Settlement sync done for this day');
+        return;
+    }
+
+    if (!STAMHOOFD.STRIPE_SECRET_KEY) {
+        console.log('No stripe key set');
+        return;
+    }
+    const secretKey = STAMHOOFD.STRIPE_SECRET_KEY;
+
+    console.log('Syncing settlements...');
+
+    const start = new Date(today.getTime() - SYNC_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+    // Mollie is not included here: the existing CheckSettlements walk already runs daily and
+    // dual-writes the new rows
+    const runner = new SettlementSyncRunner();
+    await runner.run({ start, providers: [PaymentProvider.Stripe] });
+
+    const cache: StripePaymentIdCache = new Map();
+    await retryUnsyncedSettlements(secretKey, start, cache);
+    await reportProblemSettlements();
+
+    lastSettlementSync = new Date();
+}
+
+/**
+ * Settlements outside the nightly window that never completed a sync (syncedAt IS NULL is the whole
+ * error queue). Every failed retry bumps syncFailureCount, so a broken payout stops retrying after
+ * MAXIMUM_FAILURE_COUNT attempts and waits in the problem report instead.
+ *
+ * Exported for tests only.
+ */
+export async function retryUnsyncedSettlements(secretKey: string, windowStart: Date, cache: StripePaymentIdCache = new Map()) {
+    const settlements = await Settlement.select()
+        .where('provider', PaymentProvider.Stripe)
+        .where('syncedAt', null)
+        .where('syncFailureCount', '<', MAXIMUM_FAILURE_COUNT)
+        // The window walk already attempted (and counted) recent payouts tonight
+        .where('settledAt', '<', windowStart)
+        .limit(50)
+        .fetch();
+
+    for (const settlement of settlements) {
+        const failureCountBefore = settlement.syncFailureCount;
+        try {
+            const stripeAccount = settlement.stripeAccountId ? await StripeAccount.getByID(settlement.stripeAccountId) : null;
+            const sync = new StripePayoutSync({ secretKey, stripeAccount: stripeAccount ?? null, cache });
+            await sync.syncPayoutById(settlement.externalId, { force: true });
+        } catch (e) {
+            console.error('Retry of settlement ' + settlement.externalId + ' failed', e);
+
+            // Errors before the walk (e.g. the payout can't be retrieved anymore) don't pass
+            // markSyncFailed: count them here or the retry cap never triggers
+            const fresh = await Settlement.getByID(settlement.id);
+            if (fresh && fresh.syncFailureCount === failureCountBefore) {
+                await SettlementService.markSyncFailed(fresh);
+            }
+        }
+    }
+}
+
+/**
+ * Every unsynced settlement or non-zero delta is a real question to answer, not noise.
+ *
+ * Exported for tests only.
+ */
+export async function reportProblemSettlements() {
+    const unexplained = await Settlement.select()
+        .where('unexplainedAmount', '!=', 0)
+        .limit(50)
+        .fetch();
+
+    const unsynced = await Settlement.select()
+        .where('syncedAt', null)
+        .limit(50)
+        .fetch();
+
+    if (unexplained.length === 0 && unsynced.length === 0) {
+        return;
+    }
+
+    const total = new Set([...unexplained, ...unsynced].map(s => s.id)).size;
+
+    const describe = (settlement: Settlement) => {
+        return settlement.provider + ' ' + settlement.externalId + ' (' + Formatter.dateIso(settlement.settledAt) + ', ' + Formatter.price(settlement.unexplainedAmount) + ' onverklaard, ' + settlement.syncFailureCount + ' mislukte pogingen)';
+    };
+
+    Email.sendWebmaster({
+        subject: 'Uitbetalingen met problemen: ' + total,
+        html: 'Deze uitbetalingen kloppen niet of konden niet gesynchroniseerd worden: <br><br>'
+            + 'Onverklaard verschil:<br>' + (unexplained.map(describe).join('<br>') || 'geen') + '<br><br>'
+            + 'Niet gesynchroniseerd:<br>' + (unsynced.map(describe).join('<br>') || 'geen'),
+    });
+}

--- a/backend/app/api/src/helpers/StripePayoutSync.ts
+++ b/backend/app/api/src/helpers/StripePayoutSync.ts
@@ -133,6 +133,14 @@ export class StripePayoutSync {
     #organizationId: string | null = null;
 
     /**
+     * Re-sync one payout by its id, e.g. to retry a settlement that stayed unsynced.
+     */
+    async syncPayoutById(externalId: string, options: { force?: boolean } = {}): Promise<{ settlement: Settlement; skipped: boolean }> {
+        const payout = await this.stripe.payouts.retrieve(externalId);
+        return await this.syncPayout(payout, options);
+    }
+
+    /**
      * The organization that owns the walked account: the connected account's organization, or the
      * platform membership organization for our own platform account (resolved once per instance).
      */


### PR DESCRIPTION
Production-only daily run: fees + Stripe payouts of the last 30 days (synced payouts skip), retries unsynced settlements up to 5 attempts, and emails a report of every settlement that is unsynced or has a non-zero unexplained amount. Mollie stays with the existing CheckSettlements walk.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461408&installation_model_id=423362&pr_number=721&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F721&signature=93abd929cab52df931e1cd5ae70c9a3e24185ae7d693da133c472a6936ce9449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->