### PR TITLE
✨ Stripe invoicer reads local settlement data

### DIFF
--- a/backend/app/api/src/helpers/StripeInvoicer.test.ts
+++ b/backend/app/api/src/helpers/StripeInvoicer.test.ts
@@ -1,0 +1,168 @@
+import type { StripeAccount } from '@stamhoofd/models';
+import { BalanceItem, BalanceItemPayment, Organization, OrganizationFactory, Payment } from '@stamhoofd/models';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { Address, BalanceItemType, Company, PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { Country } from '@stamhoofd/types/Country';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import { initMembershipOrganization } from '../../tests/init/initMembershipOrganization.js';
+import { StripeInvoicer } from './StripeInvoicer.js';
+
+describe('StripeInvoicer', () => {
+    const stripeMocker = new StripeMocker();
+    let membershipOrganization: Organization;
+
+    // Invoice May 2030: a month no other test writes fee rows in
+    const month = new Date(2030, 4, 15);
+    const created = new Date(2030, 4, 10);
+    const reference = 'stripe-fees-2030-05-01';
+
+    const belgianAddress = () => Address.create({
+        street: 'Teststraat',
+        number: '1',
+        postalCode: '9000',
+        city: 'Gent',
+        country: Country.Belgium,
+    });
+
+    beforeAll(async () => {
+        stripeMocker.start();
+
+        membershipOrganization = await initMembershipOrganization();
+        membershipOrganization.meta.companies = [
+            Company.create({
+                name: 'Platform BV',
+                companyNumber: '0700000000',
+                VATNumber: 'BE0700000000',
+                address: belgianAddress(),
+            }),
+        ];
+        await membershipOrganization.save();
+    });
+
+    afterAll(() => {
+        stripeMocker.stop();
+    });
+
+    beforeEach(async () => {
+        stripeMocker.clear();
+
+        // The test database persists across runs: remove this month's leftover fee rows (earlier
+        // runs' organizations were cleaned up, cascading their account link away)
+        await SettlementCharge.delete()
+            .where('occurredAt', '>=', new Date(2030, 4, 1))
+            .where('occurredAt', '<', new Date(2030, 5, 1));
+    });
+
+    const init = async () => {
+        const organization = await new OrganizationFactory({}).create();
+        organization.meta.companies = [
+            Company.create({
+                name: 'Testvereniging VZW ' + organization.id,
+                companyNumber: '0500000000',
+                VATNumber: 'BE0500000000',
+                address: belgianAddress(),
+            }),
+        ];
+        await organization.save();
+
+        const stripeAccount = await stripeMocker.createStripeAccount(organization.id);
+
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.stripeAccountId = stripeAccount.id;
+        payment.method = PaymentMethod.Bancontact;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = 25_00_00;
+        payment.paidAt = created;
+        await payment.save();
+
+        return { organization, stripeAccount, payment };
+    };
+
+    /**
+     * The application fee the fee sync will find for the month: 2.50 with a 0.30 service part.
+     */
+    const mockFeeTransaction = (stripeAccount: StripeAccount, payment: Payment, { feeCents = 250, serviceFeeCents = '30' as string | null } = {}) => {
+        const metadata: Record<string, string> = { payment: payment.id };
+        if (serviceFeeCents !== null) {
+            metadata.serviceFee = serviceFeeCents;
+        }
+
+        return stripeMocker.createBalanceTransaction({
+            type: 'application_fee',
+            amount: feeCents,
+            created,
+            source: stripeMocker.createApplicationFee({
+                amount: feeCents,
+                account: stripeAccount.accountId,
+                originatingTransaction: stripeMocker.createChargeObject({ metadata }),
+            }),
+        });
+    };
+
+    const getFeePayment = async (organization: Organization) => {
+        return await Payment.select()
+            .where('payingOrganizationId', organization.id)
+            .where('reference', reference)
+            .where('method', PaymentMethod.AccountDeductions)
+            .first(false);
+    };
+
+    test('a month is invoiced from the stored fee rows and the rows are marked invoiced', async () => {
+        const { organization, stripeAccount, payment } = await init();
+        mockFeeTransaction(stripeAccount, payment);
+
+        const invoicer = new StripeInvoicer({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+        await invoicer.generateInvoices(membershipOrganization, month, { force: true });
+
+        const feePayment = await getFeePayment(organization);
+        expect(feePayment).not.toBeNull();
+        expect(feePayment!.price).toBe(2_50_00);
+        expect(feePayment!.status).toBe(PaymentStatus.Succeeded);
+        expect(feePayment!.provider).toBe(PaymentProvider.Stripe);
+        expect(feePayment!.stripeAccountId).toBe(stripeAccount.id);
+
+        const balanceItemPayments = await BalanceItemPayment.select().where('paymentId', feePayment!.id).fetch();
+        const balanceItems = await BalanceItem.select().where('id', balanceItemPayments.map(b => b.balanceItemId)).fetch();
+        const serviceItem = balanceItems.find(i => i.type === BalanceItemType.ServiceFee);
+        const transferItem = balanceItems.find(i => i.type === BalanceItemType.TransferFee);
+
+        expect(serviceItem?.unitPrice).toBe(30_00);
+        expect(transferItem?.unitPrice).toBe(2_20_00);
+
+        // The invoiced fee rows carry the balance item that billed them
+        const rows = await SettlementCharge.select().where('stripeAccountId', stripeAccount.id).fetch();
+        expect(rows).toHaveLength(2);
+        expect(rows.find(r => r.type === SettlementChargeType.ReceivedApplicationFeeService)?.balanceItemId).toBe(serviceItem!.id);
+        expect(rows.find(r => r.type === SettlementChargeType.ReceivedApplicationFeeTransfer)?.balanceItemId).toBe(transferItem!.id);
+    });
+
+    test('re-running an invoiced month creates no second payment', async () => {
+        const { organization, stripeAccount, payment } = await init();
+        mockFeeTransaction(stripeAccount, payment);
+
+        const invoicer = new StripeInvoicer({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+        await invoicer.generateInvoices(membershipOrganization, month, { force: true });
+        await invoicer.generateInvoices(membershipOrganization, month, { force: true });
+
+        const feePayments = await Payment.select()
+            .where('payingOrganizationId', organization.id)
+            .where('reference', reference)
+            .where('method', PaymentMethod.AccountDeductions)
+            .fetch();
+        expect(feePayments).toHaveLength(1);
+    });
+
+    test('a month with a broken fee waits instead of invoicing short', async () => {
+        const { organization, stripeAccount, payment } = await init();
+        mockFeeTransaction(stripeAccount, payment, { serviceFeeCents: null });
+
+        const invoicer = new StripeInvoicer({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+        await invoicer.generateInvoices(membershipOrganization, month, { force: true });
+
+        expect(await getFeePayment(organization)).toBeNull();
+    });
+});

--- a/backend/app/api/src/helpers/StripeInvoicer.ts
+++ b/backend/app/api/src/helpers/StripeInvoicer.ts
@@ -1,13 +1,17 @@
 import { SimpleError } from '@simonbackx/simple-errors';
 import { Email } from '@stamhoofd/email';
 import { BalanceItem, BalanceItemPayment, Organization, Payment, StripeAccount, User } from '@stamhoofd/models';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
 import { QueueHandler } from '@stamhoofd/queues';
 import { BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, getPaymentProviderName, PaymentCustomer, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, TranslatedString } from '@stamhoofd/structures';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
 import { Formatter } from '@stamhoofd/utility';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 import { PaymentService } from '../services/PaymentService.js';
+import { SettlementService } from '../services/SettlementService.js';
 import { VATService } from '../services/VATService.js';
 import { SQL } from '@stamhoofd/sql';
+import { StripeFeeSync } from './StripeFeeSync.js';
 
 export class ApplicationFeeDetails {
     transferFee = 0;
@@ -72,36 +76,16 @@ export class ApplicationFeeDetails {
 
 class StripeReport {
     readonly applicationFeesPerAccount = new Map<string, ApplicationFeeDetails>();
-
-    add(balanceTransaction: Stripe.BalanceTransaction) {
-        if (balanceTransaction.type === 'application_fee' || balanceTransaction.type === 'application_fee_refund') {
-            const source = balanceTransaction.source as Stripe.ApplicationFee;
-            const account = typeof source.account === 'string' ? source.account : source.account.id;
-
-            if (account) {
-                // We don't included refunded fees because these are test payments from test account
-                const currentAmount = this.applicationFeesPerAccount.get(account);
-                if (currentAmount === undefined) {
-                    this.applicationFeesPerAccount.set(account, ApplicationFeeDetails.fromStripe(balanceTransaction));
-                } else {
-                    currentAmount.add(balanceTransaction);
-                }
-            }
-        }
-    }
-
-    combine(report: StripeReport) {
-        for (const [account, amount] of report.applicationFeesPerAccount.entries()) {
-            const currentAmount = this.applicationFeesPerAccount.get(account);
-            if (currentAmount === undefined) {
-                this.applicationFeesPerAccount.set(account, amount);
-            } else {
-                currentAmount.combine(amount);
-            }
-        }
-        return this;
-    }
 }
+
+/**
+ * The balance items of one fee invoice, per fee kind. A kind is null when nothing of that kind was
+ * charged that month.
+ */
+export type FeeBalanceItems = {
+    serviceFee: BalanceItem | null;
+    transferFee: BalanceItem | null;
+};
 
 export class StripeReportInvoicer {
     private readonly report: StripeReport;
@@ -114,14 +98,16 @@ export class StripeReportInvoicer {
         this.end = end;
     }
 
-    async generateInvoices(sellingOrganization: Organization, reference: string) {
-        const payments: Payment[] = [];
+    /**
+     * Creates one invoice payment per account. `onInvoiced` runs directly after each created
+     * invoice: an error for one account (creating or the onInvoiced step) can never affect the
+     * invoices already created for other accounts.
+     */
+    async generateInvoices(sellingOrganization: Organization, reference: string, onInvoiced?: (accountId: string, balanceItems: FeeBalanceItems) => Promise<void>): Promise<void> {
         for (const [account, details] of this.report.applicationFeesPerAccount) {
+            let result: { payment: Payment; balanceItems: FeeBalanceItems } | undefined;
             try {
-                const payment = await this.generateInvoice(sellingOrganization, reference, account, details);
-                if (payment) {
-                    payments.push(payment);
-                }
+                result = await this.generateInvoice(sellingOrganization, reference, account, details);
             } catch (e) {
                 console.error(e);
                 // Send email notification of this error
@@ -129,9 +115,25 @@ export class StripeReportInvoicer {
                     subject: 'Aanmaken Stripe facturen voor ' + account + ' - ' + reference + ' mislukt',
                     html: 'Aanmaken Stripe facturen voor ' + account + ' - ' + reference + ' mislukt. <br><br> ' + e.toString(),
                 });
+                continue;
+            }
+
+            if (!result) {
+                continue;
+            }
+
+            try {
+                await onInvoiced?.(account, result.balanceItems);
+            } catch (e) {
+                // The invoice exists: only the follow-up failed, which needs a different repair
+                // (a re-run skips the account because the payment already exists)
+                console.error(e);
+                Email.sendWebmaster({
+                    subject: 'Factuur aangemaakt maar kosten markeren als gefactureerd mislukt voor ' + account + ' - ' + reference,
+                    html: 'De factuur voor ' + account + ' - ' + reference + ' is aangemaakt, maar de opgeslagen kosten konden niet gemarkeerd worden als gefactureerd. Een synchronisatie met backfill herstelt dit. <br><br> ' + e.toString(),
+                });
             }
         }
-        return payments;
     }
 
     static async hasPayment(sellingOrganization: Organization, reference: string) {
@@ -214,7 +216,7 @@ export class StripeReportInvoicer {
             });
         }
 
-        const balanceItems: BalanceItem[] = [];
+        const feeBalanceItems: FeeBalanceItems = { serviceFee: null, transferFee: null };
 
         if (applicationFee.serviceFee !== 0) {
             const item = new BalanceItem();
@@ -243,7 +245,7 @@ export class StripeReportInvoicer {
             item.startDate = this.start;
             item.endDate = this.end;
             await item.save();
-            balanceItems.push(item);
+            feeBalanceItems.serviceFee = item;
         }
 
         if (applicationFee.transferFee !== 0) {
@@ -273,8 +275,10 @@ export class StripeReportInvoicer {
             item.startDate = this.start;
             item.endDate = this.end;
             await item.save();
-            balanceItems.push(item);
+            feeBalanceItems.transferFee = item;
         }
+
+        const balanceItems = [feeBalanceItems.serviceFee, feeBalanceItems.transferFee].filter(item => item !== null);
 
         let total = 0;
         for (const balanceItem of balanceItems) {
@@ -323,15 +327,15 @@ export class StripeReportInvoicer {
         }
 
         await PaymentService.handlePaymentStatusUpdate(payment, sellingOrganization, PaymentStatus.Succeeded, this.start);
-        return payment;
+        return { payment, balanceItems: feeBalanceItems };
     }
 }
 
 export class StripeInvoicer {
-    private stripe: Stripe;
+    private secretKey: string;
 
     constructor({ secretKey }: { secretKey: string }) {
-        this.stripe = new Stripe(secretKey, { apiVersion: '2024-06-20', typescript: true, maxNetworkRetries: 1, timeout: 10000 });
+        this.secretKey = secretKey;
     }
 
     static getMonthUnixStartEnd(date: Date) {
@@ -373,26 +377,20 @@ export class StripeInvoicer {
                 }
 
                 console.log('Generating invoices for ', reference, start, end);
-                const reportFees = await this.fetchBalanceItems({
-                    created: {
-                        gte: start,
-                        lte: end,
-                    },
-                    type: 'application_fee',
-                    expand: ['data.source', 'data.source.originating_transaction'],
-                });
-                const reportRefund = await this.fetchBalanceItems({
-                    created: {
-                        gte: start,
-                        lte: end,
-                    },
-                    type: 'application_fee_refund',
-                    expand: ['data.source', 'data.source.originating_transaction'],
+
+                // Only a complete, error-free fee sync may invoice the month: a missing fee means
+                // the month waits (and someone gets an email), never a short invoice
+                await new StripeFeeSync({ secretKey: this.secretKey }).syncFees({
+                    start: new Date(start * 1000),
+                    end: new Date(end * 1000),
                 });
 
-                const report = reportFees.combine(reportRefund);
+                const { report, rowsPerAccount } = await this.buildLocalReport(start, end);
                 const invoicer = new StripeReportInvoicer(report, new Date(start * 1000), new Date(end * 1000));
-                await invoicer.generateInvoices(sellingOrganization, reference);
+
+                await invoicer.generateInvoices(sellingOrganization, reference, async (accountId, balanceItems) => {
+                    await this.markRowsInvoiced(rowsPerAccount.get(accountId) ?? [], balanceItems);
+                });
             });
         } catch (e) {
             console.error(e);
@@ -405,15 +403,85 @@ export class StripeInvoicer {
         }
     }
 
-    private async fetchBalanceItems(options: Stripe.BalanceTransactionListParams) {
-        // For the given payout, fetch all balance items
-        const params = { ...options };
-        const report = new StripeReport();
+    /**
+     * The same report the old code built by scanning the Stripe API, now from the stored Received
+     * fee rows grouped per account.
+     */
+    private async buildLocalReport(startUnix: number, endUnix: number): Promise<{ report: StripeReport; rowsPerAccount: Map<string, SettlementCharge[]> }> {
+        const rows = await SettlementCharge.select()
+            .where('type', [SettlementChargeType.ReceivedApplicationFeeService, SettlementChargeType.ReceivedApplicationFeeTransfer])
+            .where('occurredAt', '>=', new Date(startUnix * 1000))
+            .where('occurredAt', '<=', new Date(endUnix * 1000))
+            .fetch();
 
-        for await (const balanceItem of this.stripe.balanceTransactions.list(params)) {
-            report.add(balanceItem);
+        const accountIds = Formatter.uniqueArray(rows.map(row => row.stripeAccountId)).filter((id): id is string => id !== null);
+        if (accountIds.length !== Formatter.uniqueArray(rows.map(row => row.stripeAccountId)).length) {
+            throw new SimpleError({
+                code: 'missing_stripe_account',
+                message: 'Received fee rows without a Stripe account in the invoiced month',
+            });
+        }
+        const accounts = accountIds.length > 0
+            ? await StripeAccount.select().where('id', accountIds).fetch()
+            : [];
+
+        const report = new StripeReport();
+        const rowsPerAccount = new Map<string, SettlementCharge[]>();
+        const feeIdsPerAccount = new Map<string, Set<string>>();
+
+        for (const row of rows) {
+            const account = accounts.find(a => a.id === row.stripeAccountId);
+            if (!account) {
+                throw new SimpleError({
+                    code: 'stripe_account_not_found',
+                    message: 'Stripe account ' + row.stripeAccountId + ' of fee row ' + row.externalId + ' does not exist',
+                });
+            }
+
+            // The report is keyed on Stripe's acct_… id, like the API scan was
+            const accountRows = rowsPerAccount.get(account.accountId) ?? [];
+            accountRows.push(row);
+            rowsPerAccount.set(account.accountId, accountRows);
+
+            const feeIds = feeIdsPerAccount.get(account.accountId) ?? new Set<string>();
+            if (row.applicationFeeId) {
+                feeIds.add(row.applicationFeeId);
+            }
+            feeIdsPerAccount.set(account.accountId, feeIds);
+
+            const details = report.applicationFeesPerAccount.get(account.accountId) ?? new ApplicationFeeDetails({
+                serviceFee: 0,
+                transferFee: 0,
+                minimumDate: null,
+                maximumDate: null,
+            });
+            details.combine(new ApplicationFeeDetails({
+                serviceFee: row.type === SettlementChargeType.ReceivedApplicationFeeService ? row.amount : 0,
+                transferFee: row.type === SettlementChargeType.ReceivedApplicationFeeTransfer ? row.amount : 0,
+                minimumDate: row.occurredAt,
+                maximumDate: row.occurredAt,
+            }));
+            details.count = feeIdsPerAccount.get(account.accountId)!.size;
+            report.applicationFeesPerAccount.set(account.accountId, details);
         }
 
-        return report;
+        return { report, rowsPerAccount };
+    }
+
+    /**
+     * Records for every invoiced fee row which balance item billed it: service rows the ServiceFee
+     * item, transfer rows the TransferFee item.
+     */
+    private async markRowsInvoiced(rows: SettlementCharge[], balanceItems: FeeBalanceItems) {
+        for (const row of rows) {
+            const item = row.type === SettlementChargeType.ReceivedApplicationFeeService ? balanceItems.serviceFee : balanceItems.transferFee;
+            if (!item) {
+                throw new SimpleError({
+                    code: 'missing_balance_item',
+                    message: 'No ' + row.type + ' balance item was created for fee row ' + row.externalId,
+                });
+            }
+            await SettlementService.markInvoiced(row, item.id);
+        }
     }
 }


### PR DESCRIPTION
The monthly invoicing builds ApplicationFeeDetails from the stored Received fee rows grouped per account and feeds them to the unchanged StripeReportInvoicer: same balance items, payment, reference and idempotency check. Each month first runs the fee sync as its gate — an error means the month waits, never a short invoice — and directly after each created invoice its fee rows are marked invoiced with the typed balance item pair that billed them (a later account's failure can't leave an earlier invoice unmarked; a marking failure gets its own webmaster email because the invoice does exist). The API-scan path is removed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
