### PR TITLE
✨ Invoice settlements: per-payout amounts in view and export

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/invoices/InvoicesExcelExport.ts
+++ b/frontend/app/dashboard/src/views/dashboard/invoices/InvoicesExcelExport.ts
@@ -8,8 +8,12 @@ import { ExcelHelper } from '../../../classes/ExcelHelper';
 export class InvoicesExcelExport {
     /**
      * List of all products for every order
+     *
+     * With `useStoredSettlements` the payout columns come from the stored settlement rows: one row
+     * per payout a payment was part of, with the amount that payout contained of the payment. The
+     * legacy blob shows one payout per payment at most.
      */
-    static createSheet(invoices: InvoiceStruct[]): XLSX.WorkSheet {
+    static createSheet(invoices: InvoiceStruct[], { useStoredSettlements = false }: { useStoredSettlements?: boolean } = {}): XLSX.WorkSheet {
         /// Should we repeat all the duplicate fields for multiple lines in an order?
 
         // Columns
@@ -73,15 +77,36 @@ export class InvoicesExcelExport {
             }
 
             for (const [index, payment] of invoice.payments.entries()) {
-                wsData.push([
-                    ...(index === 0 ? invoiceColumns : emptyInvoiceColumns),
+                const paymentColumns: RowValue[] = [
                     {
                         value: payment.price / 100_00,
                         format: '€0.00',
                     },
                     PaymentMethodHelper.getNameCapitalized(payment.method),
-                    payment.method === PaymentMethod.Transfer && !payment.provider ? 'Overschrijving' : (payment.settlement?.settledAt ? Formatter.dateIso(payment.settlement.settledAt) : '/'),
-                    payment.method === PaymentMethod.Transfer && !payment.provider ? (payment.transferDescription ?? '/') : (payment.settlement?.reference ?? '/'),
+                ];
+                const isTransfer = payment.method === PaymentMethod.Transfer && !payment.provider;
+
+                if (useStoredSettlements && !isTransfer && payment.settlements.length > 0) {
+                    for (const [lineIndex, line] of payment.settlements.entries()) {
+                        wsData.push([
+                            ...(index === 0 && lineIndex === 0 ? invoiceColumns : emptyInvoiceColumns),
+                            ...(lineIndex === 0 ? paymentColumns : ['', '']),
+                            Formatter.dateIso(line.settlement.settledAt),
+                            line.settlement.reference || line.settlement.externalId,
+                            {
+                                value: line.amount / 100_00,
+                                format: '€0.00',
+                            },
+                        ]);
+                    }
+                    continue;
+                }
+
+                wsData.push([
+                    ...(index === 0 ? invoiceColumns : emptyInvoiceColumns),
+                    ...paymentColumns,
+                    isTransfer ? 'Overschrijving' : (payment.settlement?.settledAt ? Formatter.dateIso(payment.settlement.settledAt) : '/'),
+                    isTransfer ? (payment.transferDescription ?? '/') : (payment.settlement?.reference ?? '/'),
                     {
                         value: payment.settlement?.amount ? payment.settlement.amount / 100_00 : 0,
                         format: '€0.00',
@@ -95,10 +120,10 @@ export class InvoicesExcelExport {
         });
     }
 
-    static export(invoices: InvoiceStruct[]) {
+    static export(invoices: InvoiceStruct[], options: { useStoredSettlements?: boolean } = {}) {
         const wb = XLSX.utils.book_new();
         /* Add the worksheet to the workbook */
-        XLSX.utils.book_append_sheet(wb, this.createSheet(invoices), 'Facturen');
+        XLSX.utils.book_append_sheet(wb, this.createSheet(invoices, options), 'Facturen');
         return XLSX.write(wb, { type: 'array' }) as Promise<ArrayBuffer>;
     }
 }

--- a/frontend/app/dashboard/src/views/dashboard/invoices/InvoicesTableView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/invoices/InvoicesTableView.vue
@@ -38,6 +38,7 @@ import type { Invoice, StamhoofdFilter } from '@stamhoofd/structures';
 import { InvoiceStruct } from '@stamhoofd/structures';
 import { Formatter, Sorter } from '@stamhoofd/utility';
 import { computed, ref } from 'vue';
+import { useFeatureFlagComputed } from '@stamhoofd/components/hooks/useFeatureFlag.ts';
 import { InvoicesExcelExport } from './InvoicesExcelExport';
 import InvoiceView from '@stamhoofd/components/payments/InvoiceView.vue';
 
@@ -58,6 +59,7 @@ const configurationId = computed(() => {
 const organization = useOrganization();
 const platform = usePlatform();
 const context = useContext();
+const hasSettlementsFlag = useFeatureFlagComputed('settlements');
 const filterBuilders = getInvoicesUIFilterBuilders();
 const title = computed(() => {
     return $t('%1JA');
@@ -407,7 +409,7 @@ async function downloadInvoices(invoices: Invoice[], onlyVAT?: boolean) {
             // Sort group based on number here
             group.sort((a, b) => Sorter.byStringValue(b.number ?? '0', a.number ?? '0'));
 
-            const excel = await InvoicesExcelExport.export(group);
+            const excel = await InvoicesExcelExport.export(group, { useStoredSettlements: hasSettlementsFlag.value });
             folder.file('0000-overzicht-' + month + '.xlsx', excel);
 
             for (const invoice of group) {

--- a/frontend/shared/components/src/payments/InvoiceView.vue
+++ b/frontend/shared/components/src/payments/InvoiceView.vue
@@ -154,6 +154,28 @@
             <STList v-else>
                 <PaymentRow v-for="payment of invoice.payments" :key="payment.id" :payment="payment" :payments="invoice.payments" :price="payment.isFailed ? 0 : payment.price" />
             </STList>
+
+            <template v-if="hasSettlementsFlag && invoiceSettlements.length > 0">
+                <hr>
+                <h2>{{ $t('Uitbetalingen') }}</h2>
+                <p class="style-description">
+                    {{ $t('Hoeveel van de betalingen van deze factuur in elke uitbetaling zat.') }}
+                </p>
+
+                <STList>
+                    <STListItem v-for="row of invoiceSettlements" :key="row.settlement.id">
+                        <h3 class="style-title-list">
+                            {{ row.settlement.reference || row.settlement.externalId }}
+                        </h3>
+                        <p class="style-description-small">
+                            {{ formatDate(row.settlement.settledAt) }}
+                        </p>
+                        <template #right>
+                            {{ formatPrice(row.amount) }}
+                        </template>
+                    </STListItem>
+                </STList>
+            </template>
         </main>
     </div>
 </template>
@@ -174,6 +196,8 @@ import InvoiceItemsBox from './InvoiceItemsBox.vue';
 import PaymentRow from '#payments/components/PaymentRow.vue';
 import { useDownloadInvoice } from './hooks/useDownloadInvoice.ts';
 import { useContext } from '#hooks/useContext.ts';
+import { useFeatureFlagComputed } from '#hooks/useFeatureFlag.ts';
+import type { Settlement } from '@stamhoofd/structures/settlements/Settlement.js';
 import { ArrayDecoder, deepSetArray, PatchableArray } from '@simonbackx/simple-encoding';
 import type { Decoder, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import LoadingButton from '#navigation/LoadingButton.vue';
@@ -191,6 +215,24 @@ const props = withDefaults(
 );
 
 const { hasNext, hasPrevious, goBack, goForward } = useBackForward('invoice', props);
+const hasSettlementsFlag = useFeatureFlagComputed('settlements');
+
+// How much of this invoice's payments each payout contained
+const invoiceSettlements = computed(() => {
+    const grouped = new Map<string, { settlement: Settlement; amount: number }>();
+    for (const payment of props.invoice.payments) {
+        for (const line of payment.settlements) {
+            const existing = grouped.get(line.settlement.id);
+            if (existing) {
+                existing.amount += line.amount;
+            }
+            else {
+                grouped.set(line.settlement.id, { settlement: line.settlement, amount: line.amount });
+            }
+        }
+    }
+    return [...grouped.values()].sort((a, b) => Sorter.byDateValue(b.settlement.settledAt, a.settlement.settledAt));
+});
 const errors = useErrors();
 const title = props.invoice.number ?? '/';
 const { downloadInvoice, downloadInvoicePdf } = useDownloadInvoice();


### PR DESCRIPTION
The invoice view lists how much of the invoice's payments each payout contained (from the payments' settlements array), and the invoices Excel export writes one payout row per payment line instead of the single legacy blob. Both behind the 'settlements' feature flag; without it the export output is unchanged.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788472387&installation_model_id=423362&pr_number=725&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F725&signature=455c10c475c3b20bf787152efeedd6cd2d0eaec0cc58dcbfa283f1d4e3220cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->