### PR TITLE
🐛 Fixed custom start date can be set for events or waiting lists

### DIFF
--- a/frontend/shared/components/src/groups/EditGroupView.vue
+++ b/frontend/shared/components/src/groups/EditGroupView.vue
@@ -58,7 +58,7 @@
                     {{ $t('%cK') }}
                 </p>
 
-                <STList v-if="STAMHOOFD.userMode === 'organization' || hasCustomDates">
+                <STList v-if="(STAMHOOFD.userMode === 'organization' && type === GroupType.Membership) || hasCustomDates">
                     <STListItem :selectable="true" element-name="label">
                         <template #left>
                             <Checkbox v-model="hasCustomDates" />
@@ -794,16 +794,16 @@ import GroupOptionMenuBox from './components/GroupOptionMenuBox.vue';
 
 import GroupPriceBox from './components/GroupPriceBox.vue';
 
+import GroupTag from '#auth/components/GroupTag.vue';
+import { useGroupsObjectFetcher } from '#fetchers/useGroupsObjectsFetcher.ts';
 import { useExternalOrganization } from '#groups/hooks/useExternalOrganization.ts';
 import { useFinancialSupportSettings } from '#groups/hooks/useFinancialSupportSettings.ts';
 import ImageInput from '#inputs/ImageInput.vue';
 import CategorizedBox from '#layout/categorized-view/CategorizedBox.vue';
 import CategorizedView from '#layout/categorized-view/CategorizedView.vue';
 import { useOrganizationRegistrationRecordSettingsRoute } from '#records/useOrganizationRegistrationRecordSettingsRoute.ts';
-import { LocalizedDomains } from '@stamhoofd/frontend-i18n/LocalizedDomains';
-import { useGroupsObjectFetcher } from '#fetchers/useGroupsObjectsFetcher.ts';
 import { Request } from '@simonbackx/simple-networking';
-import GroupTag from '#auth/components/GroupTag.vue';
+import { LocalizedDomains } from '@stamhoofd/frontend-i18n/LocalizedDomains';
 
 const props = withDefaults(
     defineProps<{


### PR DESCRIPTION
fixes STA-1373

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788525620&installation_model_id=423362&pr_number=729&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F729&signature=a5e330ed2f29dad4ef1e1030ace1e3858e98ab6f23fb1251b73a565d3ae4e146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->