### PR TITLE
🐛 Fixed invite actions missing for event waiting lists (STA-1361)

### DIFF
--- a/frontend/shared/components/src/events/EventOverview.vue
+++ b/frontend/shared/components/src/events/EventOverview.vue
@@ -585,6 +585,9 @@ defineRoute({
                         if (updatedWaitingList) {
                             waitingList.deepSet(updatedWaitingList);
 
+                            // deepSet copies parentGroup (null on a standalone-decoded group), restore the back-reference
+                            waitingList.parentGroup = props.event.group;
+
                             if (updatedWaitingList.deletedAt) {
                                 props.event.group.waitingList = null;
                             }

--- a/frontend/shared/components/src/members/classes/MemberActionBuilder.test.ts
+++ b/frontend/shared/components/src/members/classes/MemberActionBuilder.test.ts
@@ -1,0 +1,140 @@
+import { Group, GroupCategory, GroupSettings, GroupType, Organization, OrganizationRegistrationPeriod, OrganizationRegistrationPeriodSettings, RegistrationPeriod } from '@stamhoofd/structures';
+import { describe, expect, test } from 'vitest';
+import { RegistrationActionBuilder } from '#registrations/classes/RegistrationActionBuilder.ts';
+import { MemberActionBuilder } from './MemberActionBuilder';
+
+function buildOrganization(period: RegistrationPeriod, groups: Group[] = [], categories: GroupCategory[] = []) {
+    const rootCategory = GroupCategory.create({ id: 'root', categoryIds: categories.map(c => c.id) });
+
+    return Organization.create({
+        name: 'Test organization',
+        uri: 'test-organization',
+        period: OrganizationRegistrationPeriod.create({
+            period,
+            groups,
+            settings: OrganizationRegistrationPeriodSettings.create({
+                categories: [rootCategory, ...categories],
+                rootCategoryId: rootCategory.id,
+            }),
+        }),
+    });
+}
+
+function buildEventWaitingList(organizationId: string, periodId: string) {
+    const eventGroup = Group.create({
+        organizationId,
+        periodId,
+        type: GroupType.EventRegistration,
+        settings: GroupSettings.create({}),
+    });
+    const waitingList = Group.create({
+        organizationId,
+        periodId,
+        type: GroupType.WaitingList,
+        settings: GroupSettings.create({}),
+    });
+    eventGroup.waitingList = waitingList;
+    waitingList.parentGroup = eventGroup;
+
+    return { eventGroup, waitingList };
+}
+
+// The invite actions only depend on groups, organizations and the resolved periods, so the
+// other collaborators can stay empty stubs.
+const builderFactories = {
+    MemberActionBuilder: (waitingList: Group, organization: Organization) => new MemberActionBuilder({
+        present: (async () => {}) as any,
+        context: {} as any,
+        groups: [waitingList],
+        platform: {} as any,
+        organizations: [organization],
+        platformFamilyManager: {} as any,
+        owner: {},
+        categories: [],
+    }),
+    RegistrationActionBuilder: (waitingList: Group, organization: Organization) => new RegistrationActionBuilder({
+        present: (async () => {}) as any,
+        context: {} as any,
+        groups: [waitingList],
+        platform: {} as any,
+        organizations: [organization],
+        platformFamilyManager: {} as any,
+        owner: {},
+        categories: [],
+    }),
+};
+
+function getInviteActions(builder: MemberActionBuilder | RegistrationActionBuilder) {
+    return (builder as any).getInviteMemberForGroupActionsWithGroups() as { name: string }[];
+}
+
+describe.each(Object.entries(builderFactories))('%s.getInviteMemberForGroupActionsWithGroups', (_name, buildBuilder) => {
+    test('offers invite actions for an event waiting list in an unresolvable period', () => {
+        // Regression test for STA-1361: the event lies in a period that is not part of the
+        // resolved organization periods (e.g. the next werkjaar, or an admin without full
+        // access), so no period tree can be built. The event group must remain invitable.
+        const currentPeriod = RegistrationPeriod.create({ id: 'period-current' });
+        const eventPeriod = RegistrationPeriod.create({ id: 'period-next' });
+        const organization = buildOrganization(currentPeriod);
+        const { eventGroup, waitingList } = buildEventWaitingList(organization.id, eventPeriod.id);
+
+        const builder = buildBuilder(waitingList, organization);
+        const actions = getInviteActions(builder);
+
+        expect(actions).toHaveLength(2);
+        expect(builder.allGroupsLinkedToWaitingList.map(g => g.id)).toEqual([eventGroup.id]);
+    });
+
+    test('offers invite actions for an event waiting list in the current period', () => {
+        const currentPeriod = RegistrationPeriod.create({ id: 'period-current' });
+        const organization = buildOrganization(currentPeriod);
+        const { eventGroup, waitingList } = buildEventWaitingList(organization.id, currentPeriod.id);
+
+        const builder = buildBuilder(waitingList, organization);
+        const actions = getInviteActions(builder);
+
+        expect(actions).toHaveLength(2);
+        expect(builder.allGroupsLinkedToWaitingList.map(g => g.id)).toEqual([eventGroup.id]);
+    });
+
+    test('offers invite actions for a membership waiting list via the category tree', () => {
+        const currentPeriod = RegistrationPeriod.create({ id: 'period-current' });
+        const waitingList = Group.create({
+            periodId: currentPeriod.id,
+            type: GroupType.WaitingList,
+            settings: GroupSettings.create({}),
+        });
+        const membershipGroup = Group.create({
+            periodId: currentPeriod.id,
+            type: GroupType.Membership,
+            settings: GroupSettings.create({}),
+            waitingList,
+        });
+        const category = GroupCategory.create({ groupIds: [membershipGroup.id] });
+        const organization = buildOrganization(currentPeriod, [membershipGroup], [category]);
+        waitingList.organizationId = organization.id;
+        membershipGroup.organizationId = organization.id;
+
+        const builder = buildBuilder(waitingList, organization);
+        const actions = getInviteActions(builder);
+
+        expect(actions).toHaveLength(2);
+        expect(builder.allGroupsLinkedToWaitingList.map(g => g.id)).toEqual([membershipGroup.id]);
+    });
+
+    test('offers no invite actions for a waiting list without linked groups', () => {
+        const currentPeriod = RegistrationPeriod.create({ id: 'period-current' });
+        const organization = buildOrganization(currentPeriod);
+        const waitingList = Group.create({
+            organizationId: organization.id,
+            periodId: currentPeriod.id,
+            type: GroupType.WaitingList,
+            settings: GroupSettings.create({}),
+        });
+
+        const builder = buildBuilder(waitingList, organization);
+        const actions = getInviteActions(builder);
+
+        expect(actions).toHaveLength(0);
+    });
+});

--- a/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
+++ b/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
@@ -6,7 +6,6 @@ import { usePlatform } from '#hooks/usePlatform.ts';
 import { checkoutDefaultItem, chooseOrganizationMembersForGroup } from '#members/checkout/useCheckoutRegisterItem.ts';
 import EditMemberAllBox from '#members/components/edit/EditMemberAllBox.vue';
 import { RegistrationInvitationEventBus } from '#registrations/classes/useRegistrationInvitationEventListener.ts';
-import { fetchAll } from '#tables/classes/ObjectFetcher.ts';
 import type { TableAction, TableActionSelection } from '#tables/classes/TableAction.ts';
 import { AsyncTableAction, InMemoryTableAction, MenuTableAction } from '#tables/classes/TableAction.ts';
 import type { Decoder, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
@@ -18,13 +17,12 @@ import type { SessionContext } from '@stamhoofd/networking/SessionContext';
 import { useFetchOrganizationRegistrationPeriods } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import type { Group, GroupCategoryTree, Organization, OrganizationRegistrationPeriod, Platform, PlatformMember } from '@stamhoofd/structures';
-import { EmailRecipientSubfilter, ExcelExportType, GroupType, LimitedFilteredRequest, MemberDetails, MemberWithRegistrationsBlob, PermissionLevel, PermissionsResourceType, RegistrationInvitation, RegistrationInvitationRequest, RegistrationWithPlatformMember, mergeFilters } from '@stamhoofd/structures';
+import { EmailRecipientSubfilter, ExcelExportType, GroupType, MemberDetails, MemberWithRegistrationsBlob, PermissionLevel, PermissionsResourceType, RegistrationInvitation, RegistrationInvitationRequest, RegistrationWithPlatformMember, mergeFilters } from '@stamhoofd/structures';
 import { EmailRecipientFilterType } from '@stamhoofd/structures/email/EmailRecipientFilterType.js';
 import { Formatter } from '@stamhoofd/utility';
 import { markRaw } from 'vue';
 import { GlobalEventBus } from '../../EventBus';
 import type { RecipientChooseOneOption } from '../../email/EmailView.vue';
-import { useGroupsObjectFetcher } from '../../fetchers/useGroupsObjectsFetcher';
 import { CenteredMessage } from '../../overlays/CenteredMessage';
 import { Toast } from '../../overlays/Toast';
 import type { NavigationActions } from '../../types/NavigationActions';
@@ -644,11 +642,15 @@ export class MemberActionBuilder {
             }
         }
 
-        if (periodTrees.length === 0) {
+        // An event waiting list reaches its event group only via parentGroup (event groups are
+        // never part of a category tree), so a missing period tree may not block those invites.
+        const parentGroups = this.groups.flatMap(g => g.parentGroup ? [g.parentGroup] : []);
+
+        if (periodTrees.length === 0 && parentGroups.length === 0) {
             return [];
         }
 
-        const allGroups = periodTrees.flatMap(t => t.categoryTree.getAllGroups()).concat(this.groups.flatMap(g => g.parentGroup ? [g.parentGroup] : []));
+        const allGroups = periodTrees.flatMap(t => t.categoryTree.getAllGroups()).concat(parentGroups);
         this._allGroupsLinkedToWaitingList = allGroups;
 
         if (allGroups.length === 0) {
@@ -731,6 +733,10 @@ export class MemberActionBuilder {
                         childActions: () => buildForTree(entry.categoryTree),
                     });
                 }));
+            }
+
+            if (periodTrees.length === 0) {
+                return childActions;
             }
 
             return childActions.concat(buildForTree(periodTrees[0].categoryTree));

--- a/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
+++ b/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
@@ -947,11 +947,15 @@ export class RegistrationActionBuilder {
             }
         }
 
-        if (periodTrees.length === 0) {
+        // An event waiting list reaches its event group only via parentGroup (event groups are
+        // never part of a category tree), so a missing period tree may not block those invites.
+        const parentGroups = this.groups.flatMap(g => g.parentGroup ? [g.parentGroup] : []);
+
+        if (periodTrees.length === 0 && parentGroups.length === 0) {
             return [];
         }
 
-        const allGroups = periodTrees.flatMap(t => t.categoryTree.getAllGroups()).concat(this.groups.flatMap(g => g.parentGroup ? [g.parentGroup] : []));
+        const allGroups = periodTrees.flatMap(t => t.categoryTree.getAllGroups()).concat(parentGroups);
         this._allGroupsLinkedToWaitingList = allGroups;
 
         if (allGroups.length === 0) {
@@ -1034,6 +1038,10 @@ export class RegistrationActionBuilder {
                         childActions: () => buildForTree(entry.categoryTree),
                     });
                 }));
+            }
+
+            if (periodTrees.length === 0) {
+                return childActions;
             }
 
             return childActions.concat(buildForTree(periodTrees[0].categoryTree));


### PR DESCRIPTION
Fixes STA-1361: the "Uitnodigen" action disappeared from event waiting lists (activities module), while it still worked for age/work groups.

## Why

In both `MemberActionBuilder` and `RegistrationActionBuilder`, `getInviteMemberForGroupActionsWithGroups` returned early when no resolved organization period matched the waiting list's `periodId` — before the `parentGroup` fallback ran. Event groups are never part of a category tree, so an event waiting list reaches its event group *only* through `parentGroup`. Any event whose period couldn't be resolved (admins without full access see only the current period, events in a period the organization doesn't have yet, locked periods) lost all invite actions. Regressed in #546; e50f42f60 replaced the server-side event-group fetch with the `parentGroup` fallback but left the early return in front of it.

The fix hoists the `parentGroup` lookup above the early return and only bails when both sources are empty. Also guards a latent `periodTrees[0]` crash in `getChildActions`, restores `parentGroup` after the `deepSet` in `EventOverview.vue` (deepSet copies the null back-reference from a standalone-decoded group), and drops imports left unused by e50f42f60.

## Tests

Regression test covers both builders (`describe.each`): the unresolvable-period scenario fails pre-fix and passes post-fix, plus current-period, category-tree, and no-linked-groups scenarios. Lint, full typecheck and the component suite pass.

## Review notes (self-review remarks not addressed here)

- Deduplicating the ~150-line method shared by both builders is a worthwhile follow-up, kept out of an urgent bugfix.
- Tests call the private method directly; going through `getActions()` needs a stubbed `SessionContext` and drags in unrelated actions. The one test file covers both builders because they share fixtures.
- The pre-existing `organizations.length === 0` guard still hides invite actions in the platform admin app — predates this regression, separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789024096&installation_model_id=423362&pr_number=730&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F730&signature=81ebd63f8061030ea915a8f7fbd6c581a80455e8fa4baa3ada285d24634efc9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->