### PR TITLE
🐛 Fixed missing separator and header above own responsibilities

### DIFF
--- a/frontend/shared/components/src/responsibilities/EditResponsibilitiesView.vue
+++ b/frontend/shared/components/src/responsibilities/EditResponsibilitiesView.vue
@@ -22,7 +22,7 @@
         </template>
 
         <div v-for="group of groupedDraggableResponsibilites" :key="group.id" class="container">
-            <template v-if="groupedDraggableResponsibilites.length > 1">
+            <template v-if="groupedDraggableResponsibilites.length > 1 || inheritedResponsibilitiesWithGroup.length">
                 <hr>
                 <h2>{{ group.title }}</h2>
                 <p v-if="group.description">


### PR DESCRIPTION
Probleem:
<img width="910" height="555" alt="Screenshot 2026-08-12 at 03 27 35" src="https://github.com/user-attachments/assets/f60d1ae2-dd4e-47cb-a176-7e60690d4c1a" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789090222&installation_model_id=423362&pr_number=731&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F731&signature=b2d0d049b38f6cb6f86bb2831610833245a12519e9e150163046bdd235186df3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->