### PR TITLE
🐛 Fixed inviting from event waiting lists for platform admins (STA-1361)

### DIFF
--- a/backend/app/api/src/endpoints/global/registration-invitations/PatchRegistrationInvitationsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/registration-invitations/PatchRegistrationInvitationsEndpoint.test.ts
@@ -2,17 +2,18 @@ import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray } from '@simonbackx/simple-encoding';
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, User } from '@stamhoofd/models';
-import { GroupFactory, MemberFactory, OrganizationFactory, RegistrationFactory, RegistrationInvitationFactory, Token, UserFactory } from '@stamhoofd/models';
+import { GroupFactory, MemberFactory, OrganizationFactory, RegistrationFactory, RegistrationInvitation, RegistrationInvitationFactory, Token, UserFactory } from '@stamhoofd/models';
 import type { RegistrationInvitation as RegistrationInvitationStruct } from '@stamhoofd/structures';
-import { PermissionLevel, Permissions, PermissionsResourceType, RegistrationInvitationRequest, ResourcePermissions, TranslatedString } from '@stamhoofd/structures';
+import { GroupType, PermissionLevel, Permissions, PermissionsResourceType, RegistrationInvitationRequest, ResourcePermissions, TranslatedString } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { testServer } from '../../../../tests/helpers/TestServer.js';
 import { PatchRegistrationInvitationsEndpoint } from './PatchRegistrationInvitationsEndpoint.js';
 
 describe('Endpoint.PatchRegistrationInvitationsEndpoint', () => {
     const endpoint = new PatchRegistrationInvitationsEndpoint();
 
-    const patchInvitations = async ({ patch, organization, user }: { patch: PatchableArrayAutoEncoder<RegistrationInvitationRequest>; organization: Organization; user: User | null }) => {
-        const request = Request.buildJson('PATCH', '/registration-invitations', organization.getApiHost(), patch);
+    const patchInvitations = async ({ patch, organization, user }: { patch: PatchableArrayAutoEncoder<RegistrationInvitationRequest>; organization: Organization | null; user: User | null }) => {
+        const request = Request.buildJson('PATCH', '/registration-invitations', organization?.getApiHost(), patch);
         if (user) {
             const token = await Token.createToken(user);
             request.headers.authorization = 'Bearer ' + token.accessToken;
@@ -399,6 +400,155 @@ describe('Endpoint.PatchRegistrationInvitationsEndpoint', () => {
                 organization,
                 user,
             })).rejects.toThrow('Je hebt geen toegangsrechten om deze uitnodiging te verwijderen.');
+        });
+    });
+
+    describe('Without organization scope (platform admins)', () => {
+        beforeEach(() => {
+            TestUtils.setEnvironment('userMode', 'platform');
+        });
+
+        test('A platform admin can invite for an event group', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const group = await new GroupFactory({ organization, type: GroupType.EventRegistration, name: new TranslatedString('test event') }).create();
+
+            const admin = await new UserFactory({
+                globalPermissions: Permissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            }).create();
+
+            const member = await new MemberFactory({
+                organization,
+                firstName: 'John',
+                lastName: 'Doe',
+                birthDay: { year: 1994, month: 6, day: 24 },
+            }).create();
+
+            const patch: PatchableArrayAutoEncoder<RegistrationInvitationRequest> = new PatchableArray();
+
+            patch.addPut(RegistrationInvitationRequest.create({
+                groupId: group.id,
+                memberId: member.id,
+            }));
+
+            const response = await patchInvitations({
+                patch,
+                organization: null,
+                user: admin,
+            });
+
+            expect(response.body).toHaveLength(1);
+            expect(response.body[0].group.id).toBe(group.id);
+            expect(response.body[0].member.id).toBe(member.id);
+
+            // The invitation belongs to the organization of the group
+            const invitation = await RegistrationInvitation.getByID(response.body[0].id);
+            expect(invitation?.organizationId).toBe(organization.id);
+        });
+
+        test('Should fail for a user without platform access', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const group = await new GroupFactory({ organization, type: GroupType.EventRegistration, name: new TranslatedString('test event') }).create();
+
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            }).create();
+
+            const member = await new MemberFactory({
+                organization,
+                firstName: 'John',
+                lastName: 'Doe',
+                birthDay: { year: 1994, month: 6, day: 24 },
+            }).create();
+
+            const patch: PatchableArrayAutoEncoder<RegistrationInvitationRequest> = new PatchableArray();
+
+            patch.addPut(RegistrationInvitationRequest.create({
+                groupId: group.id,
+                memberId: member.id,
+            }));
+
+            await expect(patchInvitations({
+                patch,
+                organization: null,
+                user,
+            })).rejects.toThrow(STExpect.simpleError({ code: 'permission_denied' }));
+        });
+
+        test('Should fail for a platform admin without access to the group', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const group = await new GroupFactory({ organization, type: GroupType.EventRegistration, name: new TranslatedString('test event') }).create();
+
+            // Some platform access (passes the fast throw), but no rights on this group or its organization
+            const admin = await new UserFactory({
+                globalPermissions: Permissions.create({
+                    level: PermissionLevel.None,
+                    resources: new Map([
+                        [PermissionsResourceType.OrganizationTags, new Map([
+                            ['unrelated-tag-id', ResourcePermissions.create({
+                                level: PermissionLevel.Read,
+                            })],
+                        ])],
+                    ]),
+                }),
+            }).create();
+
+            const member = await new MemberFactory({
+                organization,
+                firstName: 'John',
+                lastName: 'Doe',
+                birthDay: { year: 1994, month: 6, day: 24 },
+            }).create();
+
+            const patch: PatchableArrayAutoEncoder<RegistrationInvitationRequest> = new PatchableArray();
+
+            patch.addPut(RegistrationInvitationRequest.create({
+                groupId: group.id,
+                memberId: member.id,
+            }));
+
+            await expect(patchInvitations({
+                patch,
+                organization: null,
+                user: admin,
+            })).rejects.toThrow(STExpect.simpleError({ code: 'permission_denied' }));
+        });
+
+        test('A platform admin can delete an invitation', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const group = await new GroupFactory({ organization, type: GroupType.EventRegistration, name: new TranslatedString('test event') }).create();
+
+            const admin = await new UserFactory({
+                globalPermissions: Permissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            }).create();
+
+            const member = await new MemberFactory({
+                organization,
+                firstName: 'John',
+                lastName: 'Doe',
+                birthDay: { year: 1994, month: 6, day: 24 },
+            }).create();
+
+            const invitation = await new RegistrationInvitationFactory({ member, group, organization }).create();
+
+            const patch: PatchableArrayAutoEncoder<RegistrationInvitationRequest> = new PatchableArray();
+
+            patch.addDelete(invitation.id);
+
+            const response = await patchInvitations({
+                patch,
+                organization: null,
+                user: admin,
+            });
+
+            expect(response.body).toHaveLength(0);
+            expect(await RegistrationInvitation.getByID(invitation.id)).toBeUndefined();
         });
     });
 });

--- a/backend/app/api/src/endpoints/global/registration-invitations/PatchRegistrationInvitationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration-invitations/PatchRegistrationInvitationsEndpoint.ts
@@ -35,11 +35,15 @@ export class PatchRegistrationInvitationsEndpoint extends Endpoint<Params, Query
     }
 
     async handle(request: DecodedRequest<Params, Query, Body>) {
-        const organization = await Context.setOrganizationScope();
+        const organization = await Context.setOptionalOrganizationScope();
         await Context.authenticate();
 
         // Fast throw first (more in depth checking for patches later)
-        if (!await Context.auth.hasSomeAccess(organization.id)) {
+        if (organization) {
+            if (!await Context.auth.hasSomeAccess(organization.id)) {
+                throw Context.auth.error();
+            }
+        } else if (!Context.auth.hasSomePlatformAccess()) {
             throw Context.auth.error();
         }
 
@@ -48,11 +52,11 @@ export class PatchRegistrationInvitationsEndpoint extends Endpoint<Params, Query
 
         const puts = request.body.getPuts();
         for (const { put } of puts) {
-            await this.checkCanCreateRegistrationInvitation(put, organization.id);
+            const group = await this.checkCanCreateRegistrationInvitation(put, organization?.id ?? null);
 
             const invitation = new RegistrationInvitation();
             invitation.id = put.id;
-            invitation.organizationId = organization.id;
+            invitation.organizationId = group.organizationId;
             invitation.groupId = put.groupId;
             invitation.memberId = put.memberId;
 
@@ -125,12 +129,13 @@ export class PatchRegistrationInvitationsEndpoint extends Endpoint<Params, Query
     /**
      * Will throw if not allowed to invite.
      * @param invitation
-     * @param organizationId id of organization to invite for, should match the organizationId in the invitation
+     * @param organizationId organization scope of the request; when set, the group must belong to it (platform admins can invite without a scope)
+     * @returns the group to invite for
      */
-    private async checkCanCreateRegistrationInvitation(invitation: RegistrationInvitationRequest, organizationId: string) {
+    private async checkCanCreateRegistrationInvitation(invitation: RegistrationInvitationRequest, organizationId: string | null): Promise<Group> {
         const group = await Group.getByID(invitation.groupId);
 
-        if (!group || group.organizationId !== organizationId || !await Context.auth.canAccessGroup(group, PermissionLevel.Write)) {
+        if (!group || (organizationId !== null && group.organizationId !== organizationId) || !await Context.auth.canAccessGroup(group, PermissionLevel.Write)) {
             throw Context.auth.error($t(`%1ST`));
         }
 
@@ -147,7 +152,7 @@ export class PatchRegistrationInvitationsEndpoint extends Endpoint<Params, Query
 
         if (!member
             // in userMode 'organization' we can only invite members from the same organization
-            || (STAMHOOFD.userMode === 'organization' && member.organizationId !== organizationId)
+            || (STAMHOOFD.userMode === 'organization' && member.organizationId !== group.organizationId)
             // read access is suficient
             || !await Context.auth.canAccessMember(member, PermissionLevel.Read)
         ) {
@@ -163,5 +168,7 @@ export class PatchRegistrationInvitationsEndpoint extends Endpoint<Params, Query
                 human: $t('%1S2'),
             });
         }
+
+        return group;
     }
 }

--- a/frontend/shared/components/src/members/classes/MemberActionBuilder.test.ts
+++ b/frontend/shared/components/src/members/classes/MemberActionBuilder.test.ts
@@ -42,22 +42,22 @@ function buildEventWaitingList(organizationId: string, periodId: string) {
 // The invite actions only depend on groups, organizations and the resolved periods, so the
 // other collaborators can stay empty stubs.
 const builderFactories = {
-    MemberActionBuilder: (waitingList: Group, organization: Organization) => new MemberActionBuilder({
+    MemberActionBuilder: (waitingList: Group, organizations: Organization[]) => new MemberActionBuilder({
         present: (async () => {}) as any,
         context: {} as any,
         groups: [waitingList],
         platform: {} as any,
-        organizations: [organization],
+        organizations,
         platformFamilyManager: {} as any,
         owner: {},
         categories: [],
     }),
-    RegistrationActionBuilder: (waitingList: Group, organization: Organization) => new RegistrationActionBuilder({
+    RegistrationActionBuilder: (waitingList: Group, organizations: Organization[]) => new RegistrationActionBuilder({
         present: (async () => {}) as any,
         context: {} as any,
         groups: [waitingList],
         platform: {} as any,
-        organizations: [organization],
+        organizations,
         platformFamilyManager: {} as any,
         owner: {},
         categories: [],
@@ -78,7 +78,7 @@ describe.each(Object.entries(builderFactories))('%s.getInviteMemberForGroupActio
         const organization = buildOrganization(currentPeriod);
         const { eventGroup, waitingList } = buildEventWaitingList(organization.id, eventPeriod.id);
 
-        const builder = buildBuilder(waitingList, organization);
+        const builder = buildBuilder(waitingList, [organization]);
         const actions = getInviteActions(builder);
 
         expect(actions).toHaveLength(2);
@@ -90,7 +90,7 @@ describe.each(Object.entries(builderFactories))('%s.getInviteMemberForGroupActio
         const organization = buildOrganization(currentPeriod);
         const { eventGroup, waitingList } = buildEventWaitingList(organization.id, currentPeriod.id);
 
-        const builder = buildBuilder(waitingList, organization);
+        const builder = buildBuilder(waitingList, [organization]);
         const actions = getInviteActions(builder);
 
         expect(actions).toHaveLength(2);
@@ -115,7 +115,7 @@ describe.each(Object.entries(builderFactories))('%s.getInviteMemberForGroupActio
         waitingList.organizationId = organization.id;
         membershipGroup.organizationId = organization.id;
 
-        const builder = buildBuilder(waitingList, organization);
+        const builder = buildBuilder(waitingList, [organization]);
         const actions = getInviteActions(builder);
 
         expect(actions).toHaveLength(2);
@@ -132,7 +132,33 @@ describe.each(Object.entries(builderFactories))('%s.getInviteMemberForGroupActio
             settings: GroupSettings.create({}),
         });
 
-        const builder = buildBuilder(waitingList, organization);
+        const builder = buildBuilder(waitingList, [organization]);
+        const actions = getInviteActions(builder);
+
+        expect(actions).toHaveLength(0);
+    });
+
+    test('offers invite actions for an event waiting list without an organization in context', () => {
+        // Platform admins in the admin app have no organization in context.
+        const eventPeriod = RegistrationPeriod.create({ id: 'period-current' });
+        const { eventGroup, waitingList } = buildEventWaitingList('organization-1', eventPeriod.id);
+
+        const builder = buildBuilder(waitingList, []);
+        const actions = getInviteActions(builder);
+
+        expect(actions).toHaveLength(2);
+        expect(builder.allGroupsLinkedToWaitingList.map(g => g.id)).toEqual([eventGroup.id]);
+    });
+
+    test('offers no invite actions for a membership waiting list without an organization in context', () => {
+        const waitingList = Group.create({
+            organizationId: 'organization-1',
+            periodId: 'period-current',
+            type: GroupType.WaitingList,
+            settings: GroupSettings.create({}),
+        });
+
+        const builder = buildBuilder(waitingList, []);
         const actions = getInviteActions(builder);
 
         expect(actions).toHaveLength(0);

--- a/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
+++ b/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
@@ -624,17 +624,16 @@ export class MemberActionBuilder {
     }
 
     private getInviteMemberForGroupActionsWithGroups(): TableAction<PlatformMember>[] {
-        if (this.organizations.length === 0) {
-            return [];
-        }
-
         // Each entry is a period (null for waiting lists) and the category tree to invite into.
         const periodTrees: { period: OrganizationRegistrationPeriod | null; categoryTree: GroupCategoryTree }[] = [];
 
         if (this.isWaitingList) {
-            const tree = getCategoryTreeOfGroupsLinkedToWaitingList({ waitingList: this.groups[0], periods: this.getResolvedPeriods(this.organizations[0]) });
-            if (tree) {
-                periodTrees.push({ period: null, categoryTree: tree });
+            // Platform admins have no organization in context: they can still invite via parentGroup below.
+            if (this.organizations.length > 0) {
+                const tree = getCategoryTreeOfGroupsLinkedToWaitingList({ waitingList: this.groups[0], periods: this.getResolvedPeriods(this.organizations[0]) });
+                if (tree) {
+                    periodTrees.push({ period: null, categoryTree: tree });
+                }
             }
         } else if (this.organizations.length === 1) {
             for (const period of this.getResolvedPeriods(this.organizations[0])) {

--- a/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
+++ b/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
@@ -929,17 +929,16 @@ export class RegistrationActionBuilder {
     }
 
     private getInviteMemberForGroupActionsWithGroups(): TableAction<PlatformRegistration>[] {
-        if (this.organizations.length === 0) {
-            return [];
-        }
-
         // Each entry is a period (null for waiting lists) and the category tree to invite into.
         const periodTrees: { period: OrganizationRegistrationPeriod | null; categoryTree: GroupCategoryTree }[] = [];
 
         if (this.isWaitingList) {
-            const tree = getCategoryTreeOfGroupsLinkedToWaitingList({ waitingList: this.groups[0], periods: this.getResolvedPeriods(this.organizations[0]) });
-            if (tree) {
-                periodTrees.push({ period: null, categoryTree: tree });
+            // Platform admins have no organization in context: they can still invite via parentGroup below.
+            if (this.organizations.length > 0) {
+                const tree = getCategoryTreeOfGroupsLinkedToWaitingList({ waitingList: this.groups[0], periods: this.getResolvedPeriods(this.organizations[0]) });
+                if (tree) {
+                    periodTrees.push({ period: null, categoryTree: tree });
+                }
             }
         } else if (this.organizations.length === 1) {
             for (const period of this.getResolvedPeriods(this.organizations[0])) {


### PR DESCRIPTION
Second part of STA-1361, stacked on #730: platform admins in the admin app saw no invite actions on event waiting lists at all, and could not have called the endpoint even if they had.

## Why

Two independent blockers:

- **Frontend**: `getInviteMemberForGroupActionsWithGroups` (both builders) returned `[]` when `organizations` was empty — which is always the case in the admin app, where there is no organization in context. The category-tree branch now only runs with an organization, and the `parentGroup` fallback from #730 works without one.
- **Backend**: `PatchRegistrationInvitationsEndpoint` required a host-based organization scope (`setOrganizationScope`), so unscoped admin-app requests failed before any permission check. It now uses `setOptionalOrganizationScope` (same pattern as `PatchEventsEndpoint`): unscoped requests require some platform access, the real gate stays `canAccessGroup(group, Write)` per put/delete, and the invitation's `organizationId` is derived from the group instead of the request scope. Scoped behavior is unchanged (the group-belongs-to-scope check is preserved).

## Tests

- Backend: platform admin can invite and delete unscoped for an event group (invitation row gets the group's organization); a user without platform access and a platform admin without rights on the group are both rejected. Full api suite passes.
- Frontend: event waiting list is invitable with empty `organizations` (fails pre-fix on both builders); membership waiting list without organization still yields no actions. 

## Review notes (self-review remarks not addressed here)

- Self-review traced the scope relaxation for privilege escalation and found none: unscoped requests from organization users are rejected at authentication, and every `canAccessGroup` path that grants write also passed the old scoped gate.
- Deduplicating the ~150-line invite-action method shared by both builders remains a follow-up (second commit in a row editing both in lockstep).
- Pre-existing, worth a separate look: `AdminPermissionChecker.canAccessGroup` contains a commented-out `checkScope` early-return — this endpoint's unscoped path is where that dead code would matter if it were ever intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)