### PR TITLE
Block deleting an organization that still has to pay

### DIFF
--- a/.claude/skills/self-review/methodology.md
+++ b/.claude/skills/self-review/methodology.md
@@ -30,6 +30,7 @@ Create the following checklist in your memory and review the code changes in sco
    - Tests named after an endpoint should not contain tests that call a different endpoint. 
    - When patterns emerge where we do certain things a couple of times, or when a group of files could be published as a (useful) open-sourced library, always prefer to create new package (in shared, frontend/shared or backend/shared) over adding it in an existing package;
    - This is not limited to the examples above, use common sense and best practices for code placement.
+9. .sql migrations can never contain more than 1 statement, unless the migration is idempotent
 
 ## Pre-existing issues count — don't grade on a curve
 

--- a/backend/app/api/src/endpoints/admin/organizations/PatchOrganizationsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/admin/organizations/PatchOrganizationsEndpoint.test.ts
@@ -1,0 +1,165 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import { BalanceItemFactory, Invoice, Organization, OrganizationFactory, Payment } from '@stamhoofd/models';
+import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
+import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { PatchableArray } from '@simonbackx/simple-encoding';
+import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
+import type { Organization as OrganizationStruct } from '@stamhoofd/structures';
+import { PaymentMethod, PaymentStatus } from '@stamhoofd/structures';
+import { ApplicationFeeType } from '@stamhoofd/structures/settlements/ApplicationFeeType.js';
+import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+import { v4 as uuidv4 } from 'uuid';
+import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { initPlatformAdmin } from '../../../../tests/init/index.js';
+import { initMembershipOrganization } from '../../../../tests/init/initMembershipOrganization.js';
+import { PatchOrganizationsEndpoint } from './PatchOrganizationsEndpoint.js';
+
+const baseUrl = `/admin/organizations`;
+const endpoint = new PatchOrganizationsEndpoint();
+
+describe('Endpoint.PatchOrganizationsEndpoint', () => {
+    let membershipOrganization: Organization;
+
+    beforeEach(async () => {
+        TestUtils.setEnvironment('userMode', 'organization');
+    });
+
+    beforeAll(async () => {
+        membershipOrganization = await initMembershipOrganization();
+    });
+
+    const deleteOrganization = async (organization: Organization) => {
+        const { adminToken } = await initPlatformAdmin();
+
+        const patch: PatchableArrayAutoEncoder<OrganizationStruct> = new PatchableArray();
+        patch.addDelete(organization.id);
+
+        // Platform admins are not scoped to an organization, so no host is required
+        const request = Request.patch({
+            path: baseUrl,
+            host: '',
+            body: patch,
+            headers: {
+                authorization: 'Bearer ' + adminToken.accessToken,
+            },
+        });
+
+        return await testServer.test(endpoint, request);
+    };
+
+    const createPayment = async ({ payingOrganizationId }: { payingOrganizationId: string | null }) => {
+        const payment = new Payment();
+        payment.organizationId = membershipOrganization.id;
+        payment.payingOrganizationId = payingOrganizationId;
+        payment.method = PaymentMethod.Transfer;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = 10_00;
+        await payment.save();
+        return payment;
+    };
+
+    const createApplicationFee = async ({ payingOrganizationId }: { payingOrganizationId: string }) => {
+        const charge = new SettlementCharge();
+        charge.type = SettlementChargeType.ApplicationFeeService;
+        charge.externalId = uuidv4();
+        charge.amount = -30_00;
+        charge.organizationId = payingOrganizationId;
+        charge.occurredAt = new Date();
+        await charge.save();
+
+        const fee = new ApplicationFee();
+        fee.externalId = uuidv4();
+        fee.type = ApplicationFeeType.Service;
+        fee.amount = 30_00;
+        fee.organizationId = membershipOrganization.id;
+        fee.payingOrganizationId = payingOrganizationId;
+        fee.settlementChargeId = charge.id;
+        fee.occurredAt = new Date();
+        await fee.save();
+        return fee;
+    };
+
+    const createInvoice = async ({ payingOrganizationId }: { payingOrganizationId: string | null }) => {
+        const invoice = new Invoice();
+        invoice.organizationId = membershipOrganization.id;
+        invoice.payingOrganizationId = payingOrganizationId;
+        await invoice.save();
+        return invoice;
+    };
+
+    test('An organization without financial records can be deleted', async () => {
+        const organization = await new OrganizationFactory({}).create();
+
+        const response = await deleteOrganization(organization);
+
+        expect(response.status).toBe(200);
+        expect(await Organization.getByID(organization.id)).toBeUndefined();
+    });
+
+    const payerRecords = [
+        {
+            name: 'a balance item it owes',
+            create: async (organization: Organization) => {
+                await new BalanceItemFactory({
+                    organizationId: membershipOrganization.id,
+                    payingOrganizationId: organization.id,
+                    amount: 1,
+                    unitPrice: 10_00,
+                }).create();
+            },
+        },
+        {
+            name: 'a payment it made',
+            create: async (organization: Organization) => {
+                await createPayment({ payingOrganizationId: organization.id });
+            },
+        },
+        {
+            name: 'an application fee it was charged',
+            create: async (organization: Organization) => {
+                await createApplicationFee({ payingOrganizationId: organization.id });
+            },
+        },
+        {
+            name: 'an invoice it has to pay',
+            create: async (organization: Organization) => {
+                await createInvoice({ payingOrganizationId: organization.id });
+            },
+        },
+    ];
+
+    test.each(payerRecords)('An organization with $name cannot be deleted', async ({ create }) => {
+        const organization = await new OrganizationFactory({}).create();
+        await create(organization);
+
+        await expect(deleteOrganization(organization)).rejects.toThrow(STExpect.errorWithCode('organization_has_financial_records'));
+        expect(await Organization.getByID(organization.id)).toBeDefined();
+    });
+
+    test('Financial records the organization received do not block the delete', async () => {
+        const organization = await new OrganizationFactory({}).create();
+
+        await new BalanceItemFactory({
+            organizationId: organization.id,
+            amount: 1,
+            unitPrice: 10_00,
+        }).create();
+
+        const payment = new Payment();
+        payment.organizationId = organization.id;
+        payment.method = PaymentMethod.Transfer;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = 10_00;
+        await payment.save();
+
+        const invoice = new Invoice();
+        invoice.organizationId = organization.id;
+        await invoice.save();
+
+        const response = await deleteOrganization(organization);
+
+        expect(response.status).toBe(200);
+        expect(await Organization.getByID(organization.id)).toBeUndefined();
+    });
+});

--- a/backend/app/api/src/endpoints/admin/organizations/PatchOrganizationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/admin/organizations/PatchOrganizationsEndpoint.ts
@@ -3,7 +3,8 @@ import { PatchableArrayDecoder, StringDecoder } from '@simonbackx/simple-encodin
 import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { Organization, OrganizationRegistrationPeriod, Platform, RegistrationPeriod } from '@stamhoofd/models';
+import { BalanceItem, Invoice, Organization, OrganizationRegistrationPeriod, Payment, Platform, RegistrationPeriod } from '@stamhoofd/models';
+import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
 import { Organization as OrganizationStruct } from '@stamhoofd/structures';
 
 import { Formatter } from '@stamhoofd/utility';
@@ -58,6 +59,22 @@ export class PatchOrganizationsEndpoint extends Endpoint<Params, Query, Body, Re
                     code: 'cannot_delete_membership_organization',
                     message: 'Cannot delete membership organization',
                     human: $t(`%Cx`),
+                });
+            }
+
+            // Financial records may not disappear together with the organization that had to pay them
+            const payerRecordCounts = await Promise.all([
+                BalanceItem.select().where('payingOrganizationId', id).count(),
+                Payment.select().where('payingOrganizationId', id).count(),
+                ApplicationFee.select().where('payingOrganizationId', id).count(),
+                Invoice.select().where('payingOrganizationId', id).count(),
+            ]);
+
+            if (payerRecordCounts.some(count => count > 0)) {
+                throw new SimpleError({
+                    code: 'organization_has_financial_records',
+                    message: 'Organization is still referenced as paying organization',
+                    human: $t('Er zijn nog openstaande bedragen, betalingen, transactiekosten of facturen waarvoor {organization} moet betalen of betaald heeft. Die gegevens mogen niet verloren gaan.', { organization: organization.name }),
                 });
             }
 

--- a/backend/app/api/src/services/ApplicationFeeService.ts
+++ b/backend/app/api/src/services/ApplicationFeeService.ts
@@ -217,7 +217,9 @@ export class ApplicationFeeService {
             .where('id', balanceItemPayments.map(b => b.balanceItemId))
             .fetch();
         const balanceItemType = type === ApplicationFeeType.Service ? BalanceItemType.ServiceFee : BalanceItemType.TransferFee;
-        return balanceItems.find(item => item.type === balanceItemType) ?? null;
+
+        // In legacy migrations, the type has been set to 'Other' - fallback to that (contains both service fees and transfer fees in one balance item)
+        return balanceItems.find(item => item.type === balanceItemType) ?? (balanceItems.length === 1 ? balanceItems.find(item => item.type === BalanceItemType.Other) : null) ?? null;
     }
 
     /**

--- a/frontend/app/admin/src/views/organizations/OrganizationView.vue
+++ b/frontend/app/admin/src/views/organizations/OrganizationView.vue
@@ -215,9 +215,10 @@
 <script lang="ts" setup>
 import type { AutoEncoderPatchType, Decoder, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { PatchableArray } from '@simonbackx/simple-encoding';
+import { isSimpleError, isSimpleErrors } from '@simonbackx/simple-errors';
 import { ComponentWithProperties, defineRoutes, useNavigate, usePop, usePresent } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '@stamhoofd/components/containers/AsyncComponent.ts';
-import { CenteredMessage } from '@stamhoofd/components/overlays/CenteredMessage.ts';
+import { CenteredMessage, CenteredMessageButton } from '@stamhoofd/components/overlays/CenteredMessage.ts';
 import { GlobalEventBus } from '@stamhoofd/components/EventBus.ts';
 import MemberCountSpan from '@stamhoofd/components/members/components/MemberCountSpan.vue';
 import SetupStepRows from '@stamhoofd/components/setupSteps/SetupStepRows.vue';
@@ -371,10 +372,46 @@ async function deleteMe() {
         Toast.success($t('%1LO')).show();
         await pop({ force: true });
     } catch (e) {
-        Toast.fromError(e).show();
+        if ((isSimpleError(e) || isSimpleErrors(e)) && e.hasCode('organization_has_financial_records')) {
+            suggestDeactivation(e.getHuman());
+        } else {
+            Toast.fromError(e).show();
+        }
     }
 
     deleting.value = false;
+}
+
+function suggestDeactivation(description: string) {
+    const canDeactivate = props.organization.active;
+    const message = new CenteredMessage(
+        $t('Deze vereniging kan niet verwijderd worden'),
+        canDeactivate ? description + ' ' + $t('Zet ze op inactief in plaats van ze te verwijderen.') : description,
+        'error',
+    );
+
+    if (canDeactivate) {
+        message.addButton(new CenteredMessageButton($t('Op inactief zetten'), {
+            action: deactivate,
+        }));
+    }
+
+    message.addCloseButton().show();
+}
+
+async function deactivate() {
+    const patch = Organization.patch({ id: props.organization.id, active: false });
+    const response = await context.value.getAuthenticatedServerForOrganization(props.organization.id).request({
+        method: 'PATCH',
+        path: '/organization',
+        body: patch,
+        shouldRetry: false,
+        owner,
+        decoder: Organization as Decoder<Organization>,
+    });
+
+    props.organization.deepSet(response.data);
+    Toast.success($t('De vereniging staat nu op inactief')).show();
 }
 
 </script>

--- a/frontend/app/mobile/android/app/build.gradle
+++ b/frontend/app/mobile/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.stamhoofd.stamhoofd"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 500
-        versionName "2.140.0"
+        versionCode 504
+        versionName "2.141.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/app/mobile/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/app/mobile/ios/App/App.xcodeproj/project.pbxproj
@@ -331,7 +331,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 499;
+				CURRENT_PROJECT_VERSION = 503;
 				DEVELOPMENT_TEAM = FQ76GJ7XBM;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Stamhoofd;
@@ -341,7 +341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.140.0;
+				MARKETING_VERSION = 2.141.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stamhoofd.stamhoofd;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -364,7 +364,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/AppRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 499;
+				CURRENT_PROJECT_VERSION = 503;
 				DEVELOPMENT_TEAM = FQ76GJ7XBM;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Stamhoofd;
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.140.0;
+				MARKETING_VERSION = 2.141.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stamhoofd.stamhoofd;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Deleting an organization from the admin panel silently nulled or destroyed financial records that belong to *other* organizations: `balance_items`, `payments` and `invoices` have `payingOrganizationId` on `ON DELETE SET NULL`, `application_fees` on `ON DELETE CASCADE`. So deleting a member organization wiped the platform's record of what it still owed.

`PATCH /admin/organizations` now refuses the delete when any of those four tables still reference the organization as payer, and the admin panel offers to set it inactive instead — one click, straight from the error dialog.

## Notes from self-review

- **No foreign key changes.** A first version switched those four FKs to `ON DELETE RESTRICT` as a second line of defence. Reverted on request to keep the change small — the guard is application-level only. Worth knowing: a stale compiled migration in `backend/shared/models/dist/migrations/` kept running after the source was deleted, because the build's `rsync --delete --exclude='*.js'` never removes it.
- **`registrations.payingOrganizationId` is not covered.** It is also `ON DELETE SET NULL`, and zero-price registrations paid by another organization create no balance item (`skipZero`), so that payer link can still be nulled. Out of the four tables that were asked for; say the word and I'll add it.
- **The check is not transactional.** A record inserted between the count and the delete would still be cascaded. Only reachable with a concurrent write during a platform-admin delete.
- **The two adjacent guards in the same loop stay untested** (non-platform admin refused, membership organization refused). Pre-existing gap, left alone to keep the diff focused.
- The duplicated `PATCH /organization` request in `OrganizationView.vue` (`deactivate` vs `editOrganization`'s `saveHandler`) was left as-is rather than extracted, for the same reason.

## Testing

`yarn stam test api --clear` → 1576 passed. `yarn lint` clean; `--noEmit` typecheck clean for `api` and the admin frontend. The new test asserts the four blocking record types plus the two cases that must still delete: no records at all, and records where the organization is the *receiving* party.

🤖 Generated with [Claude Code](https://claude.com/claude-code)