### PR TITLE
Always update fee payments of the fees a Stripe walk stored

### DIFF
--- a/backend/app/api/src/helpers/StripeSettlementSync.test.ts
+++ b/backend/app/api/src/helpers/StripeSettlementSync.test.ts
@@ -2,17 +2,24 @@ import { EmailMocker } from '@stamhoofd/email';
 import type { Organization, StripeAccount } from '@stamhoofd/models';
 import { OrganizationFactory, Payment, Platform } from '@stamhoofd/models';
 import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
+import { BalanceItem } from '@stamhoofd/models/models/BalanceItem.js';
+import { BalanceItemPayment } from '@stamhoofd/models/models/BalanceItemPayment.js';
 import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
+import type { Settlement as SettlementModel } from '@stamhoofd/models/models/Settlement.js';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
 import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
-import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
+import { BalanceItemStatus, BalanceItemType, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
 import { ApplicationFeeType } from '@stamhoofd/structures/settlements/ApplicationFeeType.js';
 import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
 import { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementStatus.js';
+import { STExpect } from '@stamhoofd/test-utils';
 import { v4 as uuidv4 } from 'uuid';
+import { vi } from 'vitest';
 
 import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
 import type { StripeObject } from '../../tests/helpers/StripeMocker.js';
+import { ApplicationFeeService } from '../services/ApplicationFeeService.js';
+import { SettlementService } from '../services/SettlementService.js';
 import { StripeSettlementSync } from './StripeSettlementSync.js';
 import { StripeSettlementSyncRunner } from './StripeSettlementSyncRunner.js';
 import { WebmasterReport } from './WebmasterReport.js';
@@ -69,6 +76,54 @@ describe('StripeSettlementSync', () => {
 
     const getSettlement = async (payout: StripeObject) => {
         return await Settlement.select().where('externalId', payout.id).first(true);
+    };
+
+    /**
+     * A fee we already invoiced to the organization, like the ApplicationFeeInvoicer stores it: the
+     * membership organization bills it, the organization pays it. Every payout that contains such a
+     * fee needs a derived line on its fee payment.
+     */
+    const createInvoicedFee = async (externalId: string, amount: number, { settlement = null as SettlementModel | null } = {}) => {
+        const payment = new Payment();
+        payment.organizationId = membershipOrganization.id;
+        payment.payingOrganizationId = organization.id;
+        payment.stripeAccountId = stripeAccount.id;
+        payment.method = PaymentMethod.AccountDeductions;
+        payment.provider = PaymentProvider.Stripe;
+        payment.status = PaymentStatus.Succeeded;
+        payment.price = amount;
+        payment.paidAt = created;
+        await payment.save();
+
+        const balanceItem = new BalanceItem();
+        balanceItem.type = BalanceItemType.ServiceFee;
+        balanceItem.organizationId = membershipOrganization.id;
+        balanceItem.payingOrganizationId = organization.id;
+        balanceItem.unitPrice = amount;
+        balanceItem.quantity = 1;
+        balanceItem.status = BalanceItemStatus.Hidden;
+        await balanceItem.save();
+
+        const balanceItemPayment = new BalanceItemPayment();
+        balanceItemPayment.balanceItemId = balanceItem.id;
+        balanceItemPayment.paymentId = payment.id;
+        balanceItemPayment.organizationId = payment.organizationId;
+        balanceItemPayment.price = amount;
+        await balanceItemPayment.save();
+
+        const fee = new ApplicationFee();
+        fee.externalId = externalId;
+        fee.type = ApplicationFeeType.Service;
+        fee.amount = amount;
+        fee.organizationId = membershipOrganization.id;
+        fee.payingOrganizationId = organization.id;
+        fee.payingStripeAccountId = stripeAccount.id;
+        fee.balanceItemId = balanceItem.id;
+        fee.settlementId = settlement?.id ?? null;
+        fee.occurredAt = created;
+        await fee.save();
+
+        return { payment, fee };
     };
 
     test('a full destination-charge payout reconciles to zero', async () => {
@@ -357,6 +412,85 @@ describe('StripeSettlementSync', () => {
         expect(emails).toHaveLength(1);
         expect(emails[0].html).toContain(first.id);
         expect(emails[0].html).toContain(second.id);
+    });
+
+    test('a walk that fails still updates the fee payments of what it stored', async () => {
+        const payerPayment = await createPayment();
+        const stripeFee = stripeMocker.createApplicationFee({
+            amount: 250,
+            account: stripeAccount.accountId,
+            originatingTransaction: stripeMocker.createChargeObject({ metadata: { payment: payerPayment.id, serviceFee: '250' } }),
+        });
+        const { payment: feePayment } = await createInvoicedFee(stripeFee.id, 2_50_00);
+
+        const payout = stripeMocker.createPayout({ amount: 250, arrivalDate });
+        stripeMocker.createBalanceTransaction({ type: 'application_fee', amount: 250, created, payout: payout.id, source: stripeFee });
+
+        // Fails the walk after the fee was linked to the payout
+        stripeMocker.createBalanceTransaction({ type: 'issuing_authorization_hold', amount: 100, created, payout: payout.id, source: null });
+
+        expect(await createSync().syncPayouts({ start })).toEqual({ synced: 0, skipped: 0, failed: 1 });
+
+        // The walk linked the fee to this payout before it failed, so the fee payment gets its
+        // derived line: a fee may never sit in a payout that has no line for it
+        const settlement = await getSettlement(payout);
+        expect(settlement.syncedAt).toBeNull();
+
+        const derived = await PaymentSettlement.select().where('paymentId', feePayment.id).fetch();
+        expect(derived).toHaveLength(1);
+        expect(derived[0]).toMatchObject({
+            settlementId: settlement.id,
+            externalId: null,
+            amount: 2_50_00,
+        });
+    });
+
+    test('a fee walk updates the fee payments of the fees it stored before one failed', async () => {
+        const payerPayment = await createPayment();
+        const stripeFee = stripeMocker.createApplicationFee({
+            amount: 250,
+            account: stripeAccount.accountId,
+            // Both a service and a transfer part, so the fee is stored as two rows
+            originatingTransaction: stripeMocker.createChargeObject({ metadata: { payment: payerPayment.id, serviceFee: '30' } }),
+        });
+
+        // Already paid out and invoiced before this walk: the payout it sits in explains it through
+        // the derived line of its fee payment
+        const settlement = await SettlementService.upsertSettlement({
+            provider: PaymentProvider.Stripe,
+            externalId: 'po_' + uuidv4(),
+            organizationId: membershipOrganization.id,
+            amount: 30_00,
+            settledAt: arrivalDate,
+        });
+        const { payment: feePayment } = await createInvoicedFee(stripeFee.id, 30_00, { settlement });
+
+        stripeMocker.createBalanceTransaction({ type: 'application_fee', amount: 250, created, source: stripeFee });
+
+        // The service fee is stored, the transfer fee of the same transaction fails after it
+        const upsertFee = ApplicationFeeService.upsertFee.bind(ApplicationFeeService);
+        const spy = vi.spyOn(ApplicationFeeService, 'upsertFee').mockImplementation(async (data) => {
+            if (data.type === ApplicationFeeType.Transfer) {
+                throw new Error('Storing the transfer fee failed');
+            }
+            return await upsertFee(data);
+        });
+
+        try {
+            await expect(createSync().syncFees({ start, end: arrivalDate })).rejects.toThrow(
+                STExpect.simpleError({ code: 'stripe_fee_sync_failed' }),
+            );
+        } finally {
+            spy.mockRestore();
+        }
+
+        const derived = await PaymentSettlement.select().where('paymentId', feePayment.id).fetch();
+        expect(derived).toHaveLength(1);
+        expect(derived[0]).toMatchObject({
+            settlementId: settlement.id,
+            externalId: null,
+            amount: 30_00,
+        });
     });
 
     test('a payout that failed after being paid keeps its status current', async () => {

--- a/backend/app/api/src/helpers/StripeSettlementSync.ts
+++ b/backend/app/api/src/helpers/StripeSettlementSync.ts
@@ -175,26 +175,28 @@ export class StripeSettlementSync {
         // billed). When it is already paid out, its payout needs the derived line for it
         const invoicedFeeBalanceItemIds = new Set<string>();
 
-        for await (const transaction of this.stripe.balanceTransactions.list({
-            type: 'application_fee',
-            created: {
-                gte: Math.floor(start.getTime() / 1000),
-                lte: Math.floor(end.getTime() / 1000),
-            },
-            expand: ['data.source', 'data.source.originating_transaction'],
-            limit: 100,
-        })) {
-            try {
-                const { fees } = await this.#handleApplicationFee(transaction);
-                for (const fee of fees) {
-                    if (fee.balanceItemId && fee.settlementId) {
-                        invoicedFeeBalanceItemIds.add(fee.balanceItemId);
-                    }
+        try {
+            for await (const transaction of this.stripe.balanceTransactions.list({
+                type: 'application_fee',
+                created: {
+                    gte: Math.floor(start.getTime() / 1000),
+                    lte: Math.floor(end.getTime() / 1000),
+                },
+                expand: ['data.source', 'data.source.originating_transaction'],
+                limit: 100,
+            })) {
+                try {
+                    await this.#handleApplicationFee(transaction, { invoicedFeeBalanceItemIds });
+                } catch (e) {
+                    console.error('Failed to sync application fee transaction ' + transaction.id, e);
+                    errors.push(e);
                 }
-            } catch (e) {
-                console.error('Failed to sync application fee transaction ' + transaction.id, e);
-                errors.push(e);
             }
+        } catch (e) {
+            // The payouts of the fees stored so far still need their derived lines, but failing to
+            // update them may not hide what broke the walk
+            await SettlementService.updatePaymentSettlementsForAccountDeductionBalanceItems([...invoicedFeeBalanceItemIds]).catch(console.error);
+            throw e;
         }
 
         await SettlementService.updatePaymentSettlementsForAccountDeductionBalanceItems([...invoicedFeeBalanceItemIds]);
@@ -210,7 +212,16 @@ export class StripeSettlementSync {
     /**
      * Stores the SettlementCharge for the connected account (costs) and ApplicationFee for the platform account (revenue), related to an application fee in Stripe.
      */
-    async #handleApplicationFee(transaction: Stripe.BalanceTransaction, options: { settlementId?: string } = {}): Promise<{ fees: ApplicationFee[]; charges: SettlementCharge[] }> {
+    async #handleApplicationFee(transaction: Stripe.BalanceTransaction, options: {
+        settlementId?: string;
+
+        /**
+         * Collects the balance items of the invoiced fees stored here, so their fee payments can
+         * be updated afterwards. Filled while storing, not from the return value: a fee that is
+         * stored before a later one throws still needs its derived line.
+         */
+        invoicedFeeBalanceItemIds?: Set<string>;
+    } = {}): Promise<{ fees: ApplicationFee[]; charges: SettlementCharge[] }> {
         const fee = transaction.source as Stripe.ApplicationFee;
         const payingAccountId = typeof fee.account === 'string' ? fee.account : fee.account.id;
 
@@ -273,7 +284,7 @@ export class StripeSettlementSync {
                 charges.push(charge);
             }
 
-            fees.push(await ApplicationFeeService.upsertFee({
+            const storedFee = await ApplicationFeeService.upsertFee({
                 externalId: fee.id,
                 type: feeType,
                 amount,
@@ -286,7 +297,14 @@ export class StripeSettlementSync {
                 settlementChargeId: charge?.id ?? undefined,
                 settlementId: options.settlementId,
                 occurredAt,
-            }));
+            });
+            fees.push(storedFee);
+
+            // An invoiced fee is explained by the derived line of its fee payment instead of by
+            // itself, so the payouts it sits in have to rebuild those lines
+            if (storedFee.balanceItemId && storedFee.settlementId) {
+                options.invoicedFeeBalanceItemIds?.add(storedFee.balanceItemId);
+            }
         }
 
         return { fees, charges };
@@ -436,31 +454,41 @@ export class StripeSettlementSync {
         // payments' derived lines must follow
         const invoicedFeeBalanceItemIds = new Set<string>();
 
-        for await (const transaction of this.stripe.balanceTransactions.list({
-            payout: payout.id,
-            limit: 100,
-            expand: this.stripeAccount
-                ? ['data.source', 'data.source.application_fee', 'data.source.application_fee.originating_transaction', 'data.source.charge']
-                : ['data.source', 'data.source.originating_transaction', 'data.source.charge'],
-        })) {
-            transactionCount += 1;
-            await this.#handleTransaction(transaction, settlement, reported, invoicedFeeBalanceItemIds);
-        }
-
-        // Stripe reported nothing for money that did move: storing that as a complete sync would
-        // silently hide the whole payout
-        if (transactionCount === 0 && settlement.amount !== 0) {
-            throw new SimpleError({
-                code: 'empty_payout',
-                message: 'Payout ' + payout.id + ' of ' + settlement.amount + ' has no balance transactions',
-            });
-        }
-
-        const { unlinkedFees } = await SettlementService.sweepSettlement(settlement, reported);
-        for (const fee of unlinkedFees) {
-            if (fee.balanceItemId) {
-                invoicedFeeBalanceItemIds.add(fee.balanceItemId);
+        try {
+            for await (const transaction of this.stripe.balanceTransactions.list({
+                payout: payout.id,
+                limit: 100,
+                expand: this.stripeAccount
+                    ? ['data.source', 'data.source.application_fee', 'data.source.application_fee.originating_transaction', 'data.source.charge']
+                    : ['data.source', 'data.source.originating_transaction', 'data.source.charge'],
+            })) {
+                transactionCount += 1;
+                await this.#handleTransaction(transaction, settlement, reported, invoicedFeeBalanceItemIds);
             }
+
+            // Stripe reported nothing for money that did move: storing that as a complete sync
+            // would silently hide the whole payout
+            if (transactionCount === 0 && settlement.amount !== 0) {
+                throw new SimpleError({
+                    code: 'empty_payout',
+                    message: 'Payout ' + payout.id + ' of ' + settlement.amount + ' has no balance transactions',
+                });
+            }
+
+            // Only a complete walk may sweep: it can't tell a row that moved away from one this
+            // walk never reached
+            const { unlinkedFees } = await SettlementService.sweepSettlement(settlement, reported);
+            for (const fee of unlinkedFees) {
+                if (fee.balanceItemId) {
+                    invoicedFeeBalanceItemIds.add(fee.balanceItemId);
+                }
+            }
+        } catch (e) {
+            // The fee payments still follow the fees this walk linked before it broke (a fee may
+            // never sit in a payout that has no line for it), but failing to update them may not
+            // hide what broke the walk
+            await SettlementService.updatePaymentSettlementsForAccountDeductionBalanceItems([...invoicedFeeBalanceItemIds]).catch(console.error);
+            throw e;
         }
 
         await SettlementService.updatePaymentSettlementsForAccountDeductionBalanceItems([...invoicedFeeBalanceItemIds]);
@@ -528,15 +556,8 @@ export class StripeSettlementSync {
 
             case 'application_fee': {
                 // The fee rows, now linked to the platform payout that contains them
-                const { fees } = await this.#handleApplicationFee(transaction, { settlementId: settlement.id });
+                const { fees } = await this.#handleApplicationFee(transaction, { settlementId: settlement.id, invoicedFeeBalanceItemIds });
                 reported.applicationFees(fees);
-                for (const fee of fees) {
-                    if (fee.balanceItemId) {
-                        // Make sure we update the AccountDeduction payments and settlements that are connected to this
-                        // application fee.
-                        invoicedFeeBalanceItemIds.add(fee.balanceItemId);
-                    }
-                }
                 await this.#storePaidFeesForTransaction(transaction, settlement, reported, { paymentId: null });
                 return;
             }

--- a/backend/app/api/tests/vitest.setup.ts
+++ b/backend/app/api/tests/vitest.setup.ts
@@ -56,9 +56,10 @@ beforeAll(async () => {
     await Database.delete('DELETE FROM `groups`');
     await Database.delete('DELETE FROM `email_addresses`');
 
-    // invoiced_balance_items restricts deleting balance items, which blocks the organizations
-    // cascade below, so it has to be cleared first
+    // invoiced_balance_items and application_fees restrict deleting balance items, which blocks the
+    // organizations cascade below, so they have to be cleared first
     await Database.delete('DELETE FROM `invoiced_balance_items`');
+    await Database.delete('DELETE FROM `application_fees`');
     await Database.delete('DELETE FROM `invoices`');
 
     // payments restrict deleting stripe accounts (which cascade from organizations), and a payment


### PR DESCRIPTION
A payout walk and the fee walk collect the balance items of invoiced
application fees and only rebuild the derived lines of their fee payments
at the very end. A walk that threw halfway left a fee linked to a payout
while its fee payment had no line for it, so the payout kept a wrong
unexplained amount until a later complete walk.

Both walks now flush that work on every exit, and the fees are collected
while they are stored instead of from the returned array (a throw between
the service and transfer row skipped the one already stored). The sweep
still only runs on a complete walk: it can't tell a row that moved away
from one the walk never reached.

application_fees restricts deleting balance items, so the test cleanup has
to clear it before the organizations cascade, like invoiced_balance_items.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199518&installation_model_id=423362&pr_number=735&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F735&signature=454836556baf7a6b1e7e43500ee2ec9e044f29faa479b0023e55dcdb78b8cb9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->