### PR TITLE
Interrupt a running Stripe settlement sync on shutdown

### DIFF
--- a/backend/app/api/src/helpers/ProviderSettlementSyncRunner.ts
+++ b/backend/app/api/src/helpers/ProviderSettlementSyncRunner.ts
@@ -1,3 +1,5 @@
+import type { AbortSignal } from '@stamhoofd/queues';
+
 export type SettlementSyncSummary = {
     feeMonths: number;
     failedFeeMonths: number;
@@ -26,6 +28,12 @@ export type ProviderSyncRunOptions = {
      * Fired after each unit of work (a month for Stripe, an account for Mollie).
      */
     onProgress?: () => void;
+
+    /**
+     * Stops the walk at the next safe point (a restart). Aborting is not a sync failure: it leaves
+     * everything it touched retryable instead of counting or reporting it.
+     */
+    abort: AbortSignal;
 };
 
 /**

--- a/backend/app/api/src/helpers/SettlementSyncRunner.test.ts
+++ b/backend/app/api/src/helpers/SettlementSyncRunner.test.ts
@@ -1,7 +1,9 @@
 import type { Organization } from '@stamhoofd/models';
 import { MolliePayment, OrganizationFactory, Payment } from '@stamhoofd/models';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { AbortSignal } from '@stamhoofd/queues';
 import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
+import { STExpect } from '@stamhoofd/test-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { vi } from 'vitest';
 
@@ -138,6 +140,34 @@ describe('Helper.SettlementSyncRunner', () => {
 
         const mollieRow = await Settlement.select().where('externalId', mollieSettlement.id).first(true);
         expect(mollieRow.syncedAt).not.toBeNull();
+    });
+
+    test('An aborted run walks nothing and does not report a failure', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const stripePayment = await createStripePayment(organization);
+
+        const payout = stripeMocker.createPayout({ amount: 10000, arrivalDate: new Date(2026, 0, 20) });
+        stripeMocker.createBalanceTransaction({
+            type: 'charge',
+            amount: 10000,
+            created: new Date(2026, 0, 15),
+            payout: payout.id,
+            source: stripeMocker.createChargeObject({ metadata: { payment: stripePayment.id } }),
+        });
+
+        const abort = new AbortSignal();
+        abort.abort();
+
+        // Throwing instead of returning a summary: a caller may not read an interrupted run as a
+        // completed one
+        await expect(new SettlementSyncRunner().run({
+            start: new Date(2026, 0, 1),
+            end: new Date(2026, 0, 31),
+            providers: [PaymentProvider.Stripe, PaymentProvider.Mollie],
+            abort,
+        })).rejects.toThrow(STExpect.simpleError({ code: 'queue-aborted' }));
+
+        expect(await Settlement.select().where('externalId', payout.id).first(false)).toBeNull();
     });
 
     test('The stripe retryUnsynced option flows through the run', async () => {

--- a/backend/app/api/src/helpers/SettlementSyncRunner.ts
+++ b/backend/app/api/src/helpers/SettlementSyncRunner.ts
@@ -1,3 +1,4 @@
+import { AbortSignal } from '@stamhoofd/queues';
 import { PaymentProvider } from '@stamhoofd/structures';
 
 import { MollieSettlementSyncRunner } from './MollieSettlementSyncRunner.js';
@@ -19,11 +20,17 @@ export class SettlementSyncRunner {
      */
     callback: ((summary: SettlementSyncSummary) => void) | null = null;
 
-    async run({ start = new Date(2025, 0, 1), end, providers, stripe }: {
+    async run({ start = new Date(2025, 0, 1), end, providers, stripe, abort = new AbortSignal() }: {
         start?: Date;
         end?: Date | null;
         providers?: PaymentProvider[] | null;
         stripe?: StripeSyncOptions;
+
+        /**
+         * Stops the run at the next safe point, and throws what it was aborted with: a caller that
+         * treats a completed run as "done for today" may not mistake an interrupted one for it.
+         */
+        abort?: AbortSignal;
     } = {}): Promise<SettlementSyncSummary> {
         const summary: SettlementSyncSummary = { feeMonths: 0, failedFeeMonths: 0, synced: 0, skipped: 0, failed: 0 };
         const rangeEnd = end ?? new Date();
@@ -41,8 +48,12 @@ export class SettlementSyncRunner {
             if (includeStripe && STAMHOOFD.STRIPE_SECRET_KEY) {
                 const runner = new StripeSettlementSyncRunner({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY, ...stripe });
                 try {
-                    await runner.run({ start, end: rangeEnd, summary, onProgress });
+                    await runner.run({ start, end: rangeEnd, summary, onProgress, abort });
                 } catch (e) {
+                    // An interrupted provider stops the whole run: it didn't fail, and the
+                    // providers after it would only be interrupted at their first step too
+                    abort.throwIfAborted();
+
                     console.error('Stripe settlement sync failed', e);
                     summary.failed += 1;
                 }
@@ -51,12 +62,18 @@ export class SettlementSyncRunner {
             if (includeMollie) {
                 const runner = new MollieSettlementSyncRunner();
                 try {
-                    await runner.run({ start, end: rangeEnd, summary, onProgress });
+                    await runner.run({ start, end: rangeEnd, summary, onProgress, abort });
                 } catch (e) {
+                    abort.throwIfAborted();
+
                     console.error('Mollie settlement sync failed', e);
                     summary.failed += 1;
                 }
             }
+
+            // A provider that ignores the signal (or a run without providers) may not hand back a
+            // summary that reads as a completed run
+            abort.throwIfAborted();
 
             return summary;
         });

--- a/backend/app/api/src/helpers/StripeSettlementSync.test.ts
+++ b/backend/app/api/src/helpers/StripeSettlementSync.test.ts
@@ -8,6 +8,7 @@ import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js
 import type { Settlement as SettlementModel } from '@stamhoofd/models/models/Settlement.js';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
 import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { AbortSignal } from '@stamhoofd/queues';
 import { BalanceItemStatus, BalanceItemType, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
 import { ApplicationFeeType } from '@stamhoofd/structures/settlements/ApplicationFeeType.js';
 import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
@@ -1126,6 +1127,76 @@ describe('StripeSettlementSync', () => {
 
             const settlement = await getSettlement(payout);
             expect(settlement.syncedAt).toBeNull();
+        });
+    });
+
+    describe('Aborting', () => {
+        /**
+         * Aborts the walk while it stores its first row, so the payout is interrupted halfway.
+         */
+        const abortDuringWalk = () => {
+            const abort = new AbortSignal();
+            const upsertCharge = SettlementService.upsertCharge.bind(SettlementService);
+
+            const spy = vi.spyOn(SettlementService, 'upsertCharge').mockImplementation(async (data) => {
+                abort.abort();
+                return await upsertCharge(data);
+            });
+
+            return { abort, restore: () => spy.mockRestore() };
+        };
+
+        test('an interrupted walk gives up its synced state without counting a failure', async () => {
+            const payout = stripeMocker.createPayout({ amount: 2000, arrivalDate });
+            for (let i = 0; i < 2; i++) {
+                stripeMocker.createBalanceTransaction({ type: 'stripe_fee', amount: 1000, created, payout: payout.id, source: null });
+            }
+
+            expect(await createSync().syncPayouts({ start })).toEqual({ synced: 1, skipped: 0, failed: 0 });
+            expect((await getSettlement(payout)).syncedAt).not.toBeNull();
+
+            const { abort, restore } = abortDuringWalk();
+            try {
+                await WebmasterReport.group('Onderbroken synchronisatie', async () => {
+                    await expect(createSync().syncPayouts({ start, force: true, abort })).rejects.toThrow(
+                        STExpect.simpleError({ code: 'queue-aborted' }),
+                    );
+                });
+            } finally {
+                restore();
+            }
+
+            // Only part of the payout was walked, so it may not keep claiming it is synced. A
+            // restart is not a failure of this payout: it doesn't count towards the retry cap
+            const settlement = await getSettlement(payout);
+            expect(settlement.syncedAt).toBeNull();
+            expect(settlement.syncFailureCount).toBe(0);
+
+            const emails = (await EmailMocker.transactional.getSucceededEmails()).filter(e => e.subject.startsWith('Onderbroken synchronisatie'));
+            expect(emails).toHaveLength(0);
+        });
+
+        test('the payouts after an interrupted one are left untouched', async () => {
+            const interrupted = stripeMocker.createPayout({ amount: 2000, arrivalDate });
+            for (let i = 0; i < 2; i++) {
+                stripeMocker.createBalanceTransaction({ type: 'stripe_fee', amount: 1000, created, payout: interrupted.id, source: null });
+            }
+
+            const untouched = stripeMocker.createPayout({ amount: 1000, arrivalDate });
+            stripeMocker.createBalanceTransaction({ type: 'stripe_fee', amount: 1000, created, payout: untouched.id, source: null });
+
+            const { abort, restore } = abortDuringWalk();
+            try {
+                await expect(createSync().syncPayouts({ start, abort })).rejects.toThrow(
+                    STExpect.simpleError({ code: 'queue-aborted' }),
+                );
+            } finally {
+                restore();
+            }
+
+            // The loop stopped at the payout it was walking: the other one was never started
+            expect((await getSettlement(interrupted)).syncedAt).toBeNull();
+            expect(await Settlement.select().where('externalId', untouched.id).count()).toBe(0);
         });
     });
 });

--- a/backend/app/api/src/helpers/StripeSettlementSync.ts
+++ b/backend/app/api/src/helpers/StripeSettlementSync.ts
@@ -4,6 +4,7 @@ import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
 import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
 import type { Settlement } from '@stamhoofd/models/models/Settlement.js';
 import type { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import type { AbortSignal } from '@stamhoofd/queues';
 import { PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
 import { ApplicationFeeType } from '@stamhoofd/structures/settlements/ApplicationFeeType.js';
 import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
@@ -111,7 +112,7 @@ export class StripeSettlementSync {
      * Sync all paid payouts that arrived in the window. A failing payout is marked, reported and
      * skipped so the other payouts still sync; the summary tells the caller how bad it was.
      */
-    async syncPayouts({ start, end, force = false }: { start: Date; end?: Date; force?: boolean }): Promise<{ synced: number; skipped: number; failed: number }> {
+    async syncPayouts({ start, end, force = false, abort }: { start: Date; end?: Date; force?: boolean; abort?: AbortSignal }): Promise<{ synced: number; skipped: number; failed: number }> {
         const result = { synced: 0, skipped: 0, failed: 0 };
 
         // Fail once up front when no organization can own these payouts, instead of once per payout
@@ -127,14 +128,20 @@ export class StripeSettlementSync {
             },
             limit: 100,
         })) {
+            abort?.throwIfAborted();
+
             try {
-                const { skipped } = await this.syncPayout(payout, { force });
+                const { skipped } = await this.syncPayout(payout, { force, abort });
                 if (skipped) {
                     result.skipped += 1;
                 } else {
                     result.synced += 1;
                 }
             } catch (e) {
+                // An interrupted payout is not a failing payout: counting or reporting it would
+                // turn every restart into a wave of problems to look into
+                abort?.throwIfAborted();
+
                 console.error('Failed to sync Stripe payout ' + payout.id, e);
                 result.failed += 1;
 
@@ -150,7 +157,7 @@ export class StripeSettlementSync {
     /**
      * Re-sync one payout by its id, e.g. to retry a settlement that stayed unsynced.
      */
-    async syncPayoutById(externalId: string, options: { force?: boolean } = {}): Promise<{ settlement: Settlement; skipped: boolean }> {
+    async syncPayoutById(externalId: string, options: { force?: boolean; abort?: AbortSignal } = {}): Promise<{ settlement: Settlement; skipped: boolean }> {
         const payout = await this.stripe.payouts.retrieve(externalId);
         return await this.syncPayout(payout, options);
     }
@@ -161,7 +168,7 @@ export class StripeSettlementSync {
      * in the settlement links later. A broken fee doesn't block storing the others, but the walk
      * still fails loudly at the end: a month is only invoiced after a run without errors.
      */
-    async syncFees({ start, end }: { start: Date; end: Date }) {
+    async syncFees({ start, end, abort }: { start: Date; end: Date; abort?: AbortSignal }) {
         if (this.stripeAccount) {
             throw new SimpleError({
                 code: 'invalid_scope',
@@ -185,9 +192,16 @@ export class StripeSettlementSync {
                 expand: ['data.source', 'data.source.originating_transaction'],
                 limit: 100,
             })) {
+                abort?.throwIfAborted();
+
                 try {
                     await this.#handleApplicationFee(transaction, { invoicedFeeBalanceItemIds });
                 } catch (e) {
+                    // The month is only invoiced after a walk without errors, so an interrupted
+                    // walk has to stop the walk itself instead of joining the errors of its
+                    // transactions
+                    abort?.throwIfAborted();
+
                     console.error('Failed to sync application fee transaction ' + transaction.id, e);
                     errors.push(e);
                 }
@@ -388,7 +402,7 @@ export class StripeSettlementSync {
         return this.#organizationId;
     }
 
-    async syncPayout(payout: Stripe.Payout, { force = false }: { force?: boolean } = {}): Promise<{ settlement: Settlement; skipped: boolean }> {
+    async syncPayout(payout: Stripe.Payout, { force = false, abort }: { force?: boolean; abort?: AbortSignal } = {}): Promise<{ settlement: Settlement; skipped: boolean }> {
         // All amounts are stored in the same unit: a payout in another currency would be stored as
         // a plausible but wrong number
         if (payout.currency && payout.currency.toUpperCase() !== 'EUR') {
@@ -398,7 +412,7 @@ export class StripeSettlementSync {
             });
         }
 
-        return await SettlementService.lock(PaymentProvider.Stripe, payout.id, async () => {
+        return await SettlementService.lock(PaymentProvider.Stripe, payout.id, async (signal) => {
             const settlement = await SettlementService.upsertSettlement({
                 provider: PaymentProvider.Stripe,
                 externalId: payout.id,
@@ -436,17 +450,23 @@ export class StripeSettlementSync {
             }
 
             try {
-                await this.#walkPayout(payout, settlement);
+                await this.#walkPayout(payout, settlement, signal);
             } catch (e) {
-                await SettlementService.markSyncFailed(settlement);
+                // A walk that was interrupted stored only part of the payout: it has to be walked
+                // again, but it didn't fail
+                if (signal.isAborted) {
+                    await SettlementService.markSyncInterrupted(settlement);
+                } else {
+                    await SettlementService.markSyncFailed(settlement);
+                }
                 throw e;
             }
 
             return { settlement, skipped: false };
-        });
+        }, { abort });
     }
 
-    async #walkPayout(payout: Stripe.Payout, settlement: Settlement) {
+    async #walkPayout(payout: Stripe.Payout, settlement: Settlement, abort: AbortSignal) {
         const reported = new ReportedRows();
         let transactionCount = 0;
 
@@ -462,6 +482,10 @@ export class StripeSettlementSync {
                     ? ['data.source', 'data.source.application_fee', 'data.source.application_fee.originating_transaction', 'data.source.charge']
                     : ['data.source', 'data.source.originating_transaction', 'data.source.charge'],
             })) {
+                // Between two transactions is a safe point to stop: only a complete walk sweeps
+                // and marks the settlement synced, so an interrupted one is re-walked from scratch
+                abort.throwIfAborted();
+
                 transactionCount += 1;
                 await this.#handleTransaction(transaction, settlement, reported, invoicedFeeBalanceItemIds);
             }

--- a/backend/app/api/src/helpers/StripeSettlementSyncRunner.test.ts
+++ b/backend/app/api/src/helpers/StripeSettlementSyncRunner.test.ts
@@ -1,7 +1,9 @@
 import type { Organization } from '@stamhoofd/models';
 import { OrganizationFactory } from '@stamhoofd/models';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { AbortSignal } from '@stamhoofd/queues';
 import { PaymentProvider } from '@stamhoofd/structures';
+import { STExpect } from '@stamhoofd/test-utils';
 import { v4 as uuidv4 } from 'uuid';
 
 import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
@@ -62,5 +64,21 @@ describe('Helper.StripeSettlementSyncRunner', () => {
 
         const fresh = await Settlement.getByID(settlement.id);
         expect(fresh!.syncFailureCount).toBe(5);
+    });
+
+    test('an interrupted retry does not count towards the cap', async () => {
+        const settlement = await createUnsyncedSettlement(1);
+
+        const abort = new AbortSignal();
+        abort.abort();
+
+        const runner = new StripeSettlementSyncRunner({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+        await expect(runner.retryUnsyncedSettlements({ windowStart, abort })).rejects.toThrow(
+            STExpect.simpleError({ code: 'queue-aborted' }),
+        );
+
+        // A restart is not an attempt: the payout is still waiting for a real one
+        const fresh = await Settlement.getByID(settlement.id);
+        expect(fresh!.syncFailureCount).toBe(1);
     });
 });

--- a/backend/app/api/src/helpers/StripeSettlementSyncRunner.ts
+++ b/backend/app/api/src/helpers/StripeSettlementSyncRunner.ts
@@ -1,5 +1,6 @@
 import { StripeAccount } from '@stamhoofd/models';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { AbortSignal } from '@stamhoofd/queues';
 import { PaymentProvider } from '@stamhoofd/structures';
 import { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementStatus.js';
 
@@ -44,12 +45,14 @@ export class StripeSettlementSyncRunner implements ProviderSettlementSyncRunner 
      * Walks the window month by month: fees first, then our platform payouts, then the connected
      * accounts.
      */
-    async run({ start, end, summary, onProgress }: ProviderSyncRunOptions): Promise<void> {
+    async run({ start, end, summary, onProgress, abort }: ProviderSyncRunOptions): Promise<void> {
         const platformSync = new StripeSettlementSync({ secretKey: this.#secretKey });
 
         let currentMonth = new Date(start.getFullYear(), start.getMonth(), 1);
 
         while (true) {
+            abort.throwIfAborted();
+
             const { start: monthStartUnix, end: monthEndUnix } = SettlementService.getMonthUnixStartEnd(currentMonth);
             if (monthStartUnix * 1000 > end.getTime()) {
                 break;
@@ -59,21 +62,23 @@ export class StripeSettlementSyncRunner implements ProviderSettlementSyncRunner 
             const windowEnd = new Date(Math.min(monthEndUnix * 1000, end.getTime()));
 
             try {
-                await platformSync.syncFees({ start: windowStart, end: windowEnd });
+                await platformSync.syncFees({ start: windowStart, end: windowEnd, abort });
                 summary.feeMonths += 1;
             } catch (e) {
+                abort.throwIfAborted();
+
                 // syncFees already emailed nothing: it throws an aggregate, the month is retried by
                 // the next run and the month is not invoiced until it completes
                 console.error('Fee sync failed for month ' + currentMonth.toISOString(), e);
                 summary.failedFeeMonths += 1;
             }
 
-            const platformResult = await platformSync.syncPayouts({ start: windowStart, end: windowEnd, force: this.#force });
+            const platformResult = await platformSync.syncPayouts({ start: windowStart, end: windowEnd, force: this.#force, abort });
             summary.synced += platformResult.synced;
             summary.skipped += platformResult.skipped;
             summary.failed += platformResult.failed;
 
-            const connectedResult = await this.syncConnectedPayouts({ start: windowStart, end: windowEnd });
+            const connectedResult = await this.syncConnectedPayouts({ start: windowStart, end: windowEnd, abort });
             summary.synced += connectedResult.synced;
             summary.skipped += connectedResult.skipped;
             summary.failed += connectedResult.failed;
@@ -83,26 +88,32 @@ export class StripeSettlementSyncRunner implements ProviderSettlementSyncRunner 
         }
 
         if (this.#retryUnsynced) {
-            await this.retryUnsyncedSettlements({ windowStart: start });
+            await this.retryUnsyncedSettlements({ windowStart: start, abort });
         }
     }
 
     /**
      * Walks the payouts of every active connected account.
      */
-    async syncConnectedPayouts({ start, end }: { start: Date; end?: Date }): Promise<{ synced: number; skipped: number; failed: number }> {
+    async syncConnectedPayouts({ start, end, abort = new AbortSignal() }: { start: Date; end?: Date; abort?: AbortSignal }): Promise<{ synced: number; skipped: number; failed: number }> {
         const totals = { synced: 0, skipped: 0, failed: 0 };
 
         const accounts = await StripeAccount.select().where('status', 'active').fetch();
 
         for (const account of accounts) {
+            abort.throwIfAborted();
+
             try {
                 const sync = new StripeSettlementSync({ secretKey: this.#secretKey, stripeAccount: account });
-                const result = await sync.syncPayouts({ start, end, force: this.#force });
+                const result = await sync.syncPayouts({ start, end, force: this.#force, abort });
                 totals.synced += result.synced;
                 totals.skipped += result.skipped;
                 totals.failed += result.failed;
             } catch (e) {
+                // An interrupted account is not an account with a problem: it may not be marked
+                // inaccessible, counted or reported
+                abort.throwIfAborted();
+
                 if (e !== null && typeof e === 'object' && 'type' in e && e.type === 'StripePermissionError' && e.message.includes(account.accountId) && e.message.includes('does not have access to account')) {
                     // Stripe account no longer in active use
                     console.error(e, 'marking stripe account', account.id, account.accountId, 'as inaccessible because we do not seem to have access to it any longer');
@@ -127,7 +138,7 @@ export class StripeSettlementSyncRunner implements ProviderSettlementSyncRunner 
      * after MAXIMUM_FAILURE_COUNT attempts and waits in the problem report instead. Always forced,
      * regardless of the force configuration.
      */
-    async retryUnsyncedSettlements({ windowStart }: { windowStart: Date }): Promise<void> {
+    async retryUnsyncedSettlements({ windowStart, abort = new AbortSignal() }: { windowStart: Date; abort?: AbortSignal }): Promise<void> {
         const settlements = await Settlement.select()
             .where('provider', PaymentProvider.Stripe)
             .where('syncedAt', null)
@@ -140,12 +151,18 @@ export class StripeSettlementSyncRunner implements ProviderSettlementSyncRunner 
             .fetch();
 
         for (const settlement of settlements) {
+            abort.throwIfAborted();
+
             const failureCountBefore = settlement.syncFailureCount;
             try {
                 const stripeAccount = settlement.stripeAccountId ? await StripeAccount.getByID(settlement.stripeAccountId) : null;
                 const sync = new StripeSettlementSync({ secretKey: this.#secretKey, stripeAccount: stripeAccount ?? null });
-                await sync.syncPayoutById(settlement.externalId, { force: true });
+                await sync.syncPayoutById(settlement.externalId, { force: true, abort });
             } catch (e) {
+                // An interrupted retry may not count towards the cap: the payout is still waiting
+                // for a real attempt
+                abort.throwIfAborted();
+
                 console.error('Retry of settlement ' + settlement.externalId + ' failed', e);
 
                 // Errors before the walk (e.g. the payout can't be retrieved anymore) don't pass

--- a/backend/app/api/src/services/SettlementService.ts
+++ b/backend/app/api/src/services/SettlementService.ts
@@ -6,7 +6,7 @@ import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
 import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
 import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
-import { QueueHandler } from '@stamhoofd/queues';
+import { AbortSignal, QueueHandler } from '@stamhoofd/queues';
 import { SQL } from '@stamhoofd/sql';
 import type { PaymentProvider } from '@stamhoofd/structures';
 import { PaymentMethod, SettlementReference } from '@stamhoofd/structures';
@@ -114,9 +114,20 @@ export class SettlementService {
      * Serializes syncs of the same settlement, so cron and manual backfill can't race. In-process
      * only: across multiple API instances the tables' unique keys are the real guard, so a
      * concurrent sync surfaces as a duplicate-key error and is retryable.
+     *
+     * Interrupting a walk is opt-in: the caller's signal governs the whole sync (so it stops as
+     * one, and every caller in it recognizes the abort), and a caller without one walks to the end.
      */
-    static lock<T>(provider: PaymentProvider, externalId: string, handler: () => Promise<T>): Promise<T> {
-        return QueueHandler.schedule('settlement-sync-' + provider + '-' + externalId, handler);
+    static lock<T>(provider: PaymentProvider, externalId: string, handler: (abort: AbortSignal) => Promise<T>, { abort }: { abort?: AbortSignal } = {}): Promise<T> {
+        return QueueHandler.schedule('settlement-sync-' + provider + '-' + externalId, async () => {
+            const signal = abort ?? new AbortSignal();
+
+            // Waiting behind another settlement may have taken a while: don't start a walk that is
+            // interrupted at its first step anyway
+            signal.throwIfAborted();
+
+            return await handler(signal);
+        });
     }
 
     /**
@@ -573,6 +584,18 @@ export class SettlementService {
         for (const payment of payments) {
             await this.updatePaymentSettlementsForAccountDeductionPayment(payment);
         }
+    }
+
+    /**
+     * A walk that was interrupted halfway (a restart aborted it) stored only part of what the
+     * provider reports, so the settlement may not keep claiming it is synced: the next run walks it
+     * again. Unlike a failed sync it doesn't count towards the retry cap — nothing is wrong with
+     * this settlement.
+     */
+    static async markSyncInterrupted(settlement: Settlement): Promise<Settlement> {
+        settlement.syncedAt = null;
+        await settlement.save();
+        return settlement;
     }
 
     /**

--- a/backend/app/api/src/services/SettlementService.ts
+++ b/backend/app/api/src/services/SettlementService.ts
@@ -119,8 +119,8 @@ export class SettlementService {
      * one, and every caller in it recognizes the abort), and a caller without one walks to the end.
      */
     static lock<T>(provider: PaymentProvider, externalId: string, handler: (abort: AbortSignal) => Promise<T>, { abort }: { abort?: AbortSignal } = {}): Promise<T> {
-        return QueueHandler.schedule('settlement-sync-' + provider + '-' + externalId, async () => {
-            const signal = abort ?? new AbortSignal();
+        return QueueHandler.schedule('settlement-sync-' + provider + '-' + externalId, async (o) => {
+            const signal = abort ?? o.abort;
 
             // Waiting behind another settlement may have taken a while: don't start a walk that is
             // interrupted at its first step anyway


### PR DESCRIPTION
A restart during a sync had to wait for the whole walk, and killing it
mid-payout left rows behind that nothing revisited. The sync now takes the
QueueHandler's abort signal and stops at safe points: between months,
accounts, payouts and balance transactions, never inside a settlement's
invariants.

An abort is not a failure: every catch that counts, reports or retries
rethrows it first, so a restart doesn't send webmaster mails or push a
healthy payout towards the retry cap. A walk that stopped halfway clears
syncedAt through the new markSyncInterrupted (leaving syncFailureCount
alone), so the next run walks it again from scratch.

Interrupting is opt-in: SettlementService.lock hands the walk the caller's
signal, and a caller without one walks to the end as before.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199521&installation_model_id=423362&pr_number=736&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F736&signature=5c5aa5d6207ca78b5e7171ea4242f42c9625bd5f7994ebd07005ef46004dfb75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->