### PR TITLE
Interrupt a running Mollie settlement sync on shutdown

### DIFF
--- a/backend/app/api/src/helpers/MollieSettlementSync.test.ts
+++ b/backend/app/api/src/helpers/MollieSettlementSync.test.ts
@@ -3,10 +3,14 @@ import { MolliePayment, OrganizationFactory, Payment } from '@stamhoofd/models';
 import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
 import { SettlementCharge } from '@stamhoofd/models/models/SettlementCharge.js';
+import { AbortSignal } from '@stamhoofd/queues';
 import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
 import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
+import { STExpect } from '@stamhoofd/test-utils';
+import { vi } from 'vitest';
 import type { MollieMockPayment, MollieMockRefund } from '../../tests/helpers/MollieMocker.js';
 import { MollieMocker } from '../../tests/helpers/MollieMocker.js';
+import { SettlementService } from '../services/SettlementService.js';
 import { MollieSettlementSync } from './MollieSettlementSync.js';
 import type { SettlementSyncSummary } from './ProviderSettlementSyncRunner.js';
 
@@ -338,6 +342,45 @@ describe('Helper.MollieSettlementSync', () => {
 
         expect(summary.synced).toBe(1);
         expect(summary.failed).toBe(0);
+    });
+
+    test('An interrupted walk gives up its synced state without counting a failure', async () => {
+        const { token, mockPayment, mockRefund } = await init();
+
+        const settlement = mollieMocker.createSettlement({ payments: [mockPayment], refunds: [mockRefund], value: '30.00', settledAt: new Date(2026, 2, 3) });
+
+        await runCron(token);
+        expect((await Settlement.select().where('externalId', settlement.id).first(true)).syncedAt).not.toBeNull();
+
+        // Older, so the newest-first walk only reaches it after the one it is interrupted in
+        const untouched = mollieMocker.createSettlement({ payments: [mockPayment], value: '50.00', settledAt: new Date(2026, 2, 2) });
+
+        // Abort while the walk stores its first entry, so the settlement is only walked halfway
+        const abort = new AbortSignal();
+        const upsertPaymentLine = SettlementService.upsertPaymentLine.bind(SettlementService);
+        const spy = vi.spyOn(SettlementService, 'upsertPaymentLine').mockImplementation(async (row, data) => {
+            abort.abort();
+            return await upsertPaymentLine(row, data);
+        });
+
+        const summary: SettlementSyncSummary = { feeMonths: 0, failedFeeMonths: 0, synced: 0, skipped: 0, failed: 0 };
+        try {
+            await expect(new MollieSettlementSync({ token }).syncSettlements({
+                start: new Date(2020, 0, 1),
+                summary,
+                abort,
+            })).rejects.toThrow(STExpect.simpleError({ code: 'queue-aborted' }));
+        } finally {
+            spy.mockRestore();
+        }
+
+        const row = await Settlement.select().where('externalId', settlement.id).first(true);
+        expect(row.syncedAt).toBeNull();
+        expect(row.syncFailureCount).toBe(0);
+        expect(summary).toMatchObject({ synced: 0, failed: 0 });
+
+        // The walk stopped at the settlement it was in: the next one was never started
+        expect(await Settlement.select().where('externalId', untouched.id).count()).toBe(0);
     });
 
     test('An unlinked refund entry in a settlement is skipped without affecting the known refund', async () => {

--- a/backend/app/api/src/helpers/MollieSettlementSync.ts
+++ b/backend/app/api/src/helpers/MollieSettlementSync.ts
@@ -1,6 +1,7 @@
 import type { MollieToken } from '@stamhoofd/models';
 import { MolliePayment, Payment } from '@stamhoofd/models';
 import type { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import type { AbortSignal } from '@stamhoofd/queues';
 import { PaymentProvider } from '@stamhoofd/structures';
 import { SettlementChargeType } from '@stamhoofd/structures/settlements/SettlementChargeType.js';
 import { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementStatus.js';
@@ -47,6 +48,11 @@ type MollieSettlement = {
 type SettlementSyncState = {
     settlementRow: Settlement;
     reported: ReportedRows;
+
+    /**
+     * Stops the walk at the next entry (a restart).
+     */
+    abort: AbortSignal;
 };
 
 /**
@@ -89,14 +95,17 @@ export class MollieSettlementSync {
     /**
      * Walk the settlements newest first, until they settle before `start`.
      */
-    async syncSettlements({ start, end = new Date(), summary }: {
+    async syncSettlements({ start, end = new Date(), summary, abort }: {
         start: Date;
         end?: Date;
         summary?: SettlementSyncSummary;
+        abort?: AbortSignal;
     }): Promise<void> {
         let url: string | null = 'https://api.mollie.com/v2/settlements?limit=250';
 
         while (url) {
+            abort?.throwIfAborted();
+
             const request = await this.#get(url);
 
             if (request.status !== 200) {
@@ -112,6 +121,8 @@ export class MollieSettlementSync {
             }
 
             for (const settlement of settlements) {
+                abort?.throwIfAborted();
+
                 if (settlement.settledAt === null) {
                     // Skip: this is the open settlement
                     continue;
@@ -134,11 +145,14 @@ export class MollieSettlementSync {
                 }
 
                 try {
-                    await SettlementService.lock(PaymentProvider.Mollie, settlement.id, () => this.#syncSettlement(settlement));
+                    await SettlementService.lock(PaymentProvider.Mollie, settlement.id, signal => this.#syncSettlement(settlement, signal), { abort });
                     if (summary) {
                         summary.synced += 1;
                     }
                 } catch (e) {
+                    // An interrupted settlement is not a failing settlement
+                    abort?.throwIfAborted();
+
                     console.error('Sync of Mollie settlement ' + settlement.id + ' failed', e);
                     if (summary) {
                         summary.failed += 1;
@@ -163,7 +177,7 @@ export class MollieSettlementSync {
         });
     }
 
-    async #syncSettlement(settlement: MollieSettlement) {
+    async #syncSettlement(settlement: MollieSettlement, abort: AbortSignal) {
         const settlementRow = await SettlementService.upsertSettlement({
             provider: PaymentProvider.Mollie,
             externalId: settlement.id,
@@ -178,6 +192,7 @@ export class MollieSettlementSync {
         const state: SettlementSyncState = {
             settlementRow,
             reported: new ReportedRows(),
+            abort,
         };
 
         try {
@@ -200,7 +215,13 @@ export class MollieSettlementSync {
                 transactionCount: state.reported.paymentLineExternalIds.size + state.reported.chargeExternalIds.size,
             });
         } catch (e) {
-            await SettlementService.markSyncFailed(settlementRow);
+            // A walk that was interrupted stored only part of the settlement: it has to be walked
+            // again, but it didn't fail
+            if (abort.isAborted) {
+                await SettlementService.markSyncInterrupted(settlementRow);
+            } else {
+                await SettlementService.markSyncFailed(settlementRow);
+            }
             throw e;
         }
     }
@@ -265,6 +286,10 @@ export class MollieSettlementSync {
             const entries = request.data._embedded[resource] as MollieSettlementEntryJSON[];
 
             for (const entry of entries) {
+                // Between two entries is a safe point to stop: the settlement only claims to be
+                // synced after the sweep, so an interrupted walk is re-walked from the start
+                state.abort.throwIfAborted();
+
                 await this.#applySettlementToPayment(settlement, entry.id, state);
             }
 

--- a/backend/app/api/src/helpers/MollieSettlementSyncRunner.ts
+++ b/backend/app/api/src/helpers/MollieSettlementSyncRunner.ts
@@ -10,7 +10,7 @@ import type { ProviderSettlementSyncRunner, ProviderSyncRunOptions } from './Pro
  * (STAMHOOFD.MOLLIE_ORGANIZATION_TOKEN for the platform, a MollieToken row per organization).
  */
 export class MollieSettlementSyncRunner implements ProviderSettlementSyncRunner {
-    async run({ start, end, summary, onProgress }: ProviderSyncRunOptions): Promise<void> {
+    async run({ start, end, summary, onProgress, abort }: ProviderSyncRunOptions): Promise<void> {
         const accessToken = STAMHOOFD.MOLLIE_ORGANIZATION_TOKEN;
         if (!accessToken) {
             console.error('Missing mollie organization token');
@@ -24,8 +24,11 @@ export class MollieSettlementSyncRunner implements ProviderSettlementSyncRunner 
                 // A plain access token without a refresh flow: the future expiry keeps
                 // refreshIfNeeded from attempting one
                 token.expiresOn = new Date(new Date().getTime() + 24 * 60 * 60 * 1000);
-                await new MollieSettlementSync({ token }).syncSettlements({ start, end, summary });
+                await new MollieSettlementSync({ token }).syncSettlements({ start, end, summary, abort });
             } catch (e) {
+                // An interrupted account is not a failing account
+                abort.throwIfAborted();
+
                 console.error(e);
                 summary.failed += 1;
             }
@@ -34,6 +37,8 @@ export class MollieSettlementSyncRunner implements ProviderSettlementSyncRunner 
 
         const mollieTokens = await MollieToken.all();
         for (const token of mollieTokens) {
+            abort.throwIfAborted();
+
             // Tokens created before the settlements permission was added to the OAuth scope
             // cannot read settlements
             if (token.createdAt < new Date(2021, 8 /* september! */, 8)) {
@@ -42,8 +47,10 @@ export class MollieSettlementSyncRunner implements ProviderSettlementSyncRunner 
             }
 
             try {
-                await new MollieSettlementSync({ token }).syncSettlements({ start, end, summary });
+                await new MollieSettlementSync({ token }).syncSettlements({ start, end, summary, abort });
             } catch (e) {
+                abort.throwIfAborted();
+
                 console.error(e);
                 summary.failed += 1;
             }

--- a/backend/app/api/src/helpers/SettlementSyncRunner.test.ts
+++ b/backend/app/api/src/helpers/SettlementSyncRunner.test.ts
@@ -170,6 +170,29 @@ describe('Helper.SettlementSyncRunner', () => {
         expect(await Settlement.select().where('externalId', payout.id).first(false)).toBeNull();
     });
 
+    test('An aborted run walks nothing of a provider Stripe never reached', async () => {
+        const mollieOrganization = await new OrganizationFactory({}).create();
+        await mollieMocker.setupToken(mollieOrganization);
+        const { mockPayment } = await createMolliePayment(mollieOrganization);
+        const mollieSettlement = mollieMocker.createSettlement({
+            payments: [mockPayment],
+            value: '50.00',
+            settledAt: new Date(2026, 0, 20),
+        });
+
+        const abort = new AbortSignal();
+        abort.abort();
+
+        await expect(new SettlementSyncRunner().run({
+            start: new Date(2026, 0, 1),
+            end: new Date(2026, 0, 31),
+            providers: [PaymentProvider.Mollie],
+            abort,
+        })).rejects.toThrow(STExpect.simpleError({ code: 'queue-aborted' }));
+
+        expect(await Settlement.select().where('externalId', mollieSettlement.id).first(false)).toBeNull();
+    });
+
     test('The stripe retryUnsynced option flows through the run', async () => {
         const organization = await new OrganizationFactory({}).create();
         const settlement = await SettlementService.upsertSettlement({


### PR DESCRIPTION
The same abort handling as the Stripe half: the walk stops between
settlements and between the entries of one, an abort is never counted as a
failure, and a settlement that was only walked halfway clears syncedAt
without counting an attempt, so the next run walks it again.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199525&installation_model_id=423362&pr_number=737&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F737&signature=79c7528a99cd86897fa13a2fd48bd22bc6bb8cef8cabe35de7d5b039976a5ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->