### PR TITLE
Stop waiting for work that ignores the shutdown

### DIFF
--- a/backend/app/api/src/boot.ts
+++ b/backend/app/api/src/boot.ts
@@ -16,6 +16,7 @@ import { Platform } from '@stamhoofd/models';
 import { QueueHandler } from '@stamhoofd/queues';
 import { resumeEmails } from './helpers/EmailResumer.js';
 import { GlobalHelper } from './helpers/GlobalHelper.js';
+import { waitUntilDeadline } from './helpers/waitUntilDeadline.js';
 import { SetupStepUpdater } from './helpers/SetupStepUpdater.js';
 import { ContextMiddleware } from './middleware/ContextMiddleware.js';
 import { TenantScopeMiddleware } from './middleware/TenantScopeMiddleware.js';
@@ -50,6 +51,13 @@ if (STAMHOOFD.environment === 'development') {
 if (new Date().getTimezoneOffset() !== 0) {
     throw new Error('Process should always run in UTC timezone');
 }
+
+/**
+ * How long a shutdown waits for the running crons, queue jobs and emails together. Aborting them is
+ * a request: a job that never checks it, or that hangs on a network call, may not keep the restart
+ * waiting. Everything left behind runs again after the restart.
+ */
+const MAXIMUM_SHUTDOWN_WAIT = 60 * 1000;
 
 const seeds = async (options: { shutdown: () => Promise<void> }) => {
     if (await checkReadOnly()) {
@@ -238,25 +246,29 @@ export const boot = async (options: { killProcess: boolean }) => {
         }
 
         await BalanceItemService.flushAll();
-        await waitForCrons();
-        QueueHandler.abortAll(
-            new SimpleError({
-                code: 'SHUTDOWN',
-                message: 'Shutting down',
-                statusCode: 503,
-            }),
-        );
-        await QueueHandler.awaitAll();
 
-        try {
+        const shutdownError = new SimpleError({
+            code: 'SHUTDOWN',
+            message: 'Shutting down',
+            statusCode: 503,
+        });
+        const deadline = new Date(Date.now() + MAXIMUM_SHUTDOWN_WAIT);
+
+        // A cron can be waiting on a long queue job (a settlement sync walks months of payouts):
+        // tell those jobs to stop before waiting for the crons, or the restart waits for the job
+        QueueHandler.abortAll(shutdownError);
+        await waitUntilDeadline(waitForCrons(), { deadline, description: 'crons' });
+
+        // Again for anything the crons started while they were finishing up
+        QueueHandler.abortAll(shutdownError);
+        await waitUntilDeadline(QueueHandler.awaitAll(), { deadline, description: 'queues' });
+
+        await waitUntilDeadline((async () => {
             while (Email.currentQueue.length > 0) {
                 console.log(`${Email.currentQueue.length} emails still in queue. Waiting 500ms...`);
                 await sleep(500);
             }
-        } catch (err) {
-            console.error('Failed to wait for emails to finish:');
-            console.error(err);
-        }
+        })(), { deadline, description: 'emails' });
 
         try {
             await Database.end();

--- a/backend/app/api/src/helpers/waitUntilDeadline.test.ts
+++ b/backend/app/api/src/helpers/waitUntilDeadline.test.ts
@@ -1,0 +1,48 @@
+import { sleep } from '@stamhoofd/utility';
+import { vi } from 'vitest';
+
+import { waitUntilDeadline } from './waitUntilDeadline.js';
+
+describe('Helper.waitUntilDeadline', () => {
+    let errors: string[];
+
+    beforeEach(() => {
+        errors = [];
+        vi.spyOn(console, 'error').mockImplementation((message: unknown) => {
+            errors.push(typeof message === 'string' ? message : String(message));
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const deadlineIn = (ms: number) => new Date(Date.now() + ms);
+
+    test('returns as soon as the work finishes', async () => {
+        const started = Date.now();
+        await waitUntilDeadline(sleep(10), { deadline: deadlineIn(60_000), description: 'work' });
+
+        expect(Date.now() - started).toBeLessThan(1000);
+        expect(errors).toHaveLength(0);
+    });
+
+    test('gives up on work that never finishes', async () => {
+        await waitUntilDeadline(new Promise(() => {}), { deadline: deadlineIn(20), description: 'work' });
+
+        expect(errors).toContain('Gave up waiting for work to finish');
+    });
+
+    test('a deadline that already passed does not wait', async () => {
+        await waitUntilDeadline(sleep(60_000), { deadline: deadlineIn(-1000), description: 'work' });
+
+        expect(errors).toContain('Gave up waiting for work to finish');
+    });
+
+    test('a failure in the work is logged instead of thrown', async () => {
+        await waitUntilDeadline(Promise.reject(new Error('Broken')), { deadline: deadlineIn(60_000), description: 'work' });
+
+        expect(errors).toContain('Failed to wait for work:');
+        expect(errors).not.toContain('Gave up waiting for work to finish');
+    });
+});

--- a/backend/app/api/src/helpers/waitUntilDeadline.ts
+++ b/backend/app/api/src/helpers/waitUntilDeadline.ts
@@ -1,0 +1,28 @@
+/**
+ * Waits for `promise`, but gives up at `deadline`: a shutdown may not hang on work that never
+ * checks its abort signal, or that is stuck on a network call. What is left behind runs again after
+ * the restart.
+ *
+ * A failure in the awaited work is logged instead of thrown: it may not stop the shutdown either.
+ */
+export async function waitUntilDeadline(promise: Promise<unknown>, { deadline, description }: { deadline: Date; description: string }): Promise<void> {
+    let timer: NodeJS.Timeout | undefined;
+
+    const timedOut = await Promise.race([
+        promise.then(() => false).catch((error) => {
+            console.error('Failed to wait for ' + description + ':');
+            console.error(error);
+            return false;
+        }),
+        new Promise<boolean>((resolve) => {
+            timer = setTimeout(() => resolve(true), Math.max(deadline.getTime() - Date.now(), 0));
+        }),
+    ]);
+
+    // Or the timer keeps the process alive until the deadline it no longer needs
+    clearTimeout(timer);
+
+    if (timedOut) {
+        console.error('Gave up waiting for ' + description + ' to finish');
+    }
+}


### PR DESCRIPTION
Queue jobs were only aborted after waiting for the crons, so a cron that
waits on a queue job (the next commit puts the settlement sync there) kept
the restart waiting for the whole job. Aborting now happens before that
wait, and again after it for whatever the crons started while finishing up.

Aborting is a request though: a job that never checks its signal, or that
hangs on a network call, could still hold the process forever. Crons,
queues and the email queue now share one 60 second budget, after which the
shutdown continues and leaves the rest for the next boot.

Note the earlier abort also rejects the queue items of other crons that are
pending at that moment; they were all written to be re-runnable.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199528&installation_model_id=423362&pr_number=738&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F738&signature=58551949c03da473c3ece42c38153a4fbafbdd638e018e14c486ea20f604a6c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->