### PR TITLE
Abort the settlement sync from the endpoint and the cron

### DIFF
--- a/backend/app/api/src/crons/settlement-sync.test.ts
+++ b/backend/app/api/src/crons/settlement-sync.test.ts
@@ -1,11 +1,15 @@
 import { EmailMocker } from '@stamhoofd/email';
 import type { Organization } from '@stamhoofd/models';
 import { OrganizationFactory } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
 import { PaymentProvider } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { v4 as uuidv4 } from 'uuid';
+import { vi } from 'vitest';
 
+import { SettlementSyncRunner } from '../helpers/SettlementSyncRunner.js';
 import { SettlementService } from '../services/SettlementService.js';
-import { reportProblemSettlements } from './settlement-sync.js';
+import { reportProblemSettlements, syncSettlements } from './settlement-sync.js';
 
 describe('Cron.settlement-sync', () => {
     let organization: Organization;
@@ -35,5 +39,59 @@ describe('Cron.settlement-sync', () => {
 
         const emails = await EmailMocker.transactional.getSucceededEmails();
         expect(emails.find(e => e.subject.startsWith('Uitbetalingen met problemen'))).toBeDefined();
+    });
+
+    describe('The nightly run', () => {
+        /**
+         * The run only starts between 5 and 6 AM Brussels time, and remembers the day it ran: every
+         * test needs its own day.
+         */
+        const arriveAt5AM = (dayOfMarch: number) => {
+            vi.setSystemTime(new Date(Date.UTC(2026, 2, dayOfMarch, 4, 30)));
+        };
+
+        beforeEach(() => {
+            TestUtils.setEnvironment('environment', 'production');
+            vi.useFakeTimers({ shouldAdvanceTime: true, toFake: ['Date'] });
+        });
+
+        afterEach(() => {
+            vi.useRealTimers();
+            vi.restoreAllMocks();
+        });
+
+        test('runs on the same queue as the manual sync, and only once a day', async () => {
+            arriveAt5AM(10);
+
+            const runs: string[][] = [];
+            vi.spyOn(SettlementSyncRunner.prototype, 'run').mockImplementation(async () => {
+                // Nested in the queue of the manual sync, so the two never walk at once
+                runs.push(QueueHandler.asyncLocalStorage.getStore() ?? []);
+                return { feeMonths: 0, failedFeeMonths: 0, synced: 0, skipped: 0, failed: 0 };
+            });
+
+            await syncSettlements();
+            await syncSettlements();
+
+            expect(runs).toEqual([['settlement-sync']]);
+        });
+
+        test('an interrupted run is not remembered as the sync of this day', async () => {
+            arriveAt5AM(11);
+
+            const spy = vi.spyOn(SettlementSyncRunner.prototype, 'run').mockImplementation(async ({ abort } = {}) => {
+                abort?.abort();
+                abort?.throwIfAborted();
+                return { feeMonths: 0, failedFeeMonths: 0, synced: 0, skipped: 0, failed: 0 };
+            });
+
+            await expect(syncSettlements()).rejects.toThrow(STExpect.simpleError({ code: 'queue-aborted' }));
+
+            // A restart may not skip the sync of this day: the next tick starts over
+            spy.mockResolvedValue({ feeMonths: 0, failedFeeMonths: 0, synced: 0, skipped: 0, failed: 0 });
+            await syncSettlements();
+
+            expect(spy).toHaveBeenCalledTimes(2);
+        });
     });
 });

--- a/backend/app/api/src/crons/settlement-sync.ts
+++ b/backend/app/api/src/crons/settlement-sync.ts
@@ -3,6 +3,7 @@
 import { registerCron } from '@stamhoofd/crons';
 import { Email } from '@stamhoofd/email';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import { QueueHandler } from '@stamhoofd/queues';
 import { PaymentProvider } from '@stamhoofd/structures';
 import { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementStatus.js';
 import { Formatter } from '@stamhoofd/utility';
@@ -25,7 +26,10 @@ const MAXIMUM_PENDING_FEES_AGE_MS = 31 * 24 * 60 * 60 * 1000;
 
 let lastSettlementSync: Date | null = null;
 
-async function syncSettlements() {
+/**
+ * Exported for tests only.
+ */
+export async function syncSettlements() {
     if (STAMHOOFD.environment !== 'production') {
         return;
     }
@@ -46,14 +50,21 @@ async function syncSettlements() {
 
     const start = new Date(today.getTime() - SYNC_WINDOW_DAYS * 24 * 60 * 60 * 1000);
 
-    const runner = new SettlementSyncRunner();
-    await runner.run({
-        start,
-        providers: [PaymentProvider.Stripe, PaymentProvider.Mollie],
-        stripe: { retryUnsynced: true },
-    });
+    // The same queue as the manual backfill: the two never walk the same period at once, and a
+    // shutdown aborts this run instead of waiting for the whole window. An aborted run throws, so
+    // it is not remembered as the sync of this day: a later tick within the hour runs it again,
+    // and otherwise the next day re-walks the same window anyway
+    await QueueHandler.schedule('settlement-sync', async ({ abort }) => {
+        const runner = new SettlementSyncRunner();
+        await runner.run({
+            start,
+            providers: [PaymentProvider.Stripe, PaymentProvider.Mollie],
+            stripe: { retryUnsynced: true },
+            abort,
+        });
 
-    await reportProblemSettlements();
+        await reportProblemSettlements();
+    });
 
     lastSettlementSync = new Date();
 }

--- a/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.test.ts
@@ -1,12 +1,16 @@
 import { Request } from '@simonbackx/simple-endpoints';
+import { SimpleError } from '@simonbackx/simple-errors';
 import type { Organization, Token, User } from '@stamhoofd/models';
 import { OrganizationFactory, Payment, Token as TokenModel, UserFactory } from '@stamhoofd/models';
 import { Settlement } from '@stamhoofd/models/models/Settlement.js';
+import type { AbortSignal } from '@stamhoofd/queues';
 import { QueueHandler } from '@stamhoofd/queues';
 import { PaymentMethod, PaymentProvider, PaymentStatus } from '@stamhoofd/structures';
 import { STExpect } from '@stamhoofd/test-utils';
+import { vi } from 'vitest';
 
 import { StripeMocker } from '../../../../../tests/helpers/StripeMocker.js';
+import { SettlementSyncRunner } from '../../../../helpers/SettlementSyncRunner.js';
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
 import { initMembershipOrganization } from '../../../../../tests/init/initMembershipOrganization.js';
 import { initPlatformAdmin } from '../../../../../tests/init/initPlatformAdmin.js';
@@ -86,6 +90,86 @@ describe('Endpoint.SettlementsSync', () => {
         // The queue is empty again
         const statusResponse = await getStatus(membershipOrganization, adminToken);
         expect(statusResponse.body).toEqual([]);
+    });
+
+    const shutdown = () => {
+        QueueHandler.abortAll(new SimpleError({
+            code: 'SHUTDOWN',
+            message: 'Shutting down',
+            statusCode: 503,
+        }));
+    };
+
+    test('A sync that is canceled by a shutdown walks nothing and leaves no status behind', async () => {
+        const payout = stripeMocker.createPayout({ amount: 10000, arrivalDate: new Date(2026, 0, 20) });
+        stripeMocker.createBalanceTransaction({
+            type: 'stripe_fee',
+            amount: 10000,
+            created: new Date(2026, 0, 15),
+            payout: payout.id,
+            source: null,
+        });
+
+        // Occupy the queue, so the sync is still waiting its turn when the shutdown aborts it
+        let release = () => {};
+        const occupied = QueueHandler.schedule('settlement-sync', async () => {
+            await new Promise<void>((resolve) => {
+                release = resolve;
+            });
+        });
+
+        try {
+            const response = await post(membershipOrganization, adminToken);
+            expect(response.status).toBe(200);
+            expect((await getStatus(membershipOrganization, adminToken)).body).toHaveLength(1);
+
+            shutdown();
+        } finally {
+            release();
+        }
+
+        await occupied;
+        await QueueHandler.awaitAll();
+
+        expect(await Settlement.select().where('externalId', payout.id).count()).toBe(0);
+
+        // The status list may not keep a sync that never ran
+        expect((await getStatus(membershipOrganization, adminToken)).body).toEqual([]);
+    });
+
+    test('A shutdown interrupts a sync that is already walking', async () => {
+        let running: AbortSignal | null = null;
+        let stopWalking = () => {};
+
+        const spy = vi.spyOn(SettlementSyncRunner.prototype, 'run').mockImplementation(async ({ abort } = {}) => {
+            running = abort ?? null;
+
+            // Walk until the shutdown asks us to stop
+            await new Promise<void>((resolve) => {
+                stopWalking = resolve;
+                abort?.on('abort', () => resolve());
+            });
+            abort?.throwIfAborted();
+
+            return { feeMonths: 0, failedFeeMonths: 0, synced: 0, skipped: 0, failed: 0 };
+        });
+
+        try {
+            const response = await post(membershipOrganization, adminToken);
+            expect(response.status).toBe(200);
+            await vi.waitFor(() => expect(running).not.toBeNull());
+
+            shutdown();
+            await QueueHandler.awaitAll();
+        } finally {
+            // A failed assertion may not leave the walk (and the queue behind it) parked forever
+            stopWalking();
+            spy.mockRestore();
+        }
+
+        // The signal of the queue job reaches the runner, so the walk stops at its next safe point
+        expect(running!.isAborted).toBe(true);
+        expect((await getStatus(membershipOrganization, adminToken)).body).toEqual([]);
     });
 
     test('A user without platform full access cannot run the sync', async () => {

--- a/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/settlements/SettlementsSyncEndpoint.ts
@@ -86,17 +86,18 @@ export class SettlementsSyncEndpoint extends Endpoint<Params, Query, Body, Respo
         });
         SettlementsSyncEndpoint.queue.push(item);
 
-        QueueHandler.schedule('settlement-sync', async () => {
-            try {
-                const runner = new SettlementSyncRunner();
-                runner.callback = (summary) => {
-                    item.count = summary.synced + summary.skipped + summary.failed;
-                    item.failed = summary.failed + summary.failedFeeMonths;
-                };
-                await runner.run({ start, end, providers, stripe: { force } });
-            } finally {
-                SettlementsSyncEndpoint.queue.splice(SettlementsSyncEndpoint.queue.indexOf(item), 1);
-            }
+        // A shutdown aborts the queue: the run stops at its next safe point instead of holding up
+        // the restart, and the status list is cleaned up whether the run finished, was aborted, or
+        // was canceled before it started
+        QueueHandler.schedule('settlement-sync', async ({ abort }) => {
+            const runner = new SettlementSyncRunner();
+            runner.callback = (summary) => {
+                item.count = summary.synced + summary.skipped + summary.failed;
+                item.failed = summary.failed + summary.failedFeeMonths;
+            };
+            await runner.run({ start, end, providers, stripe: { force }, abort });
+        }).finally(() => {
+            SettlementsSyncEndpoint.queue = SettlementsSyncEndpoint.queue.filter(queued => queued !== item);
         }).catch(console.error);
 
         return new Response(undefined);


### PR DESCRIPTION
The manual sync now forwards the abort signal of its queue job to the
runner, so a restart stops the walk at its next safe point instead of
holding up the shutdown. Its status list is cleaned up from the scheduled
promise, or a sync that is canceled while still queued (its handler never
runs) would show as running forever.

The nightly cron runs on that same queue: the two can no longer walk the
same period at once, and an interrupted run throws, so it is not remembered
as the sync of this day.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199533&installation_model_id=423362&pr_number=739&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F739&signature=57d776184d9bcf1a8fced8a2192f7b8fa9418f09a13df8dc65859846bf4e6959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->