### PR TITLE
Pay-what-you-want product prices for webshops

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/ProductPriceBox.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/ProductPriceBox.vue
@@ -6,7 +6,7 @@
 
         <STInputBox error-fields="price" :error-box="errorBox" :title="$t(`%1IP`)">
             <LoadingInputBox :loading="uitpasSocialTariffLoading">
-                <PriceInput v-model="price" :min="null" :placeholder="$t(`%1Mn`)" :disabled="uitpasFeature && !!product.uitpasEvent && enableUitpasSocialTariff" />
+                <PriceInput v-model="price" :min="allowCustomPrice ? ProductPrice.customPriceMinimum : null" :placeholder="$t(`%1Mn`)" :disabled="uitpasFeature && !!product.uitpasEvent && enableUitpasSocialTariff" />
             </LoadingInputBox>
             <p v-if="uitpasFeature && !!product.uitpasEvent" class="style-description-small">
                 {{ $t('%1AL') }}
@@ -14,6 +14,20 @@
         </STInputBox>
 
         <STList>
+            <STListItem v-if="customPricePossible" :selectable="true" element-name="label">
+                <template #left>
+                    <Checkbox v-model="allowCustomPrice" />
+                </template>
+
+                <h3 class="style-title-list">
+                    {{ $t('Vrije invoer van bedrag (minstens 1 euro)') }}
+                </h3>
+
+                <p v-if="allowCustomPrice" class="style-description-small">
+                    {{ $t("Bezoekers kiezen zelf hoeveel ze willen betalen, met de hierboven ingestelde prijs als suggestie. Als je het optioneel gratis wilt maken, voeg dan nog een extra prijskeuze van 0 euro toe.") }}
+                </p>
+            </STListItem>
+
             <STListItem v-if="discountPossible" :selectable="true" element-name="label">
                 <template #left>
                     <Checkbox v-model="useDiscount" />
@@ -25,9 +39,6 @@
 
                 <p v-if="useDiscount" class="style-description-small" @click.stop.prevent>
                     {{ $t("%U9") }}
-                </p>
-                <p v-if="!discountPossible" class="style-description-small" @click.stop.prevent>
-                    {{ $t('%1C2') }}
                 </p>
 
                 <div v-if="useDiscount" class="split-inputs option" @click.stop.prevent>
@@ -68,7 +79,7 @@
                 </div>
             </STListItem>
 
-            <STListItem v-if="uitpasFeature && (!isSingle || enableUitpasSocialTariff)" :selectable="true" element-name="label" :disabled="productPricesAvailableForUitpasBaseProductPrice.length === 0">
+            <STListItem v-if="uitpasFeature && (!isSingle || enableUitpasSocialTariff) && !allowCustomPrice" :selectable="true" element-name="label" :disabled="productPricesAvailableForUitpasBaseProductPrice.length === 0">
                 <template #left>
                     <Checkbox v-model="enableUitpasSocialTariff" :disabled="productPricesAvailableForUitpasBaseProductPrice.length === 0" />
                 </template>
@@ -144,8 +155,14 @@ const { goToUitpasConfiguration } = useGoToUitpasConfiguration(patchedProduct, a
 const uitpasSocialTariffLoading = ref(false);
 
 const discountPossible = computed(() => {
-    // if not UiTPAS social tariff
-    return !patchedProductPrice.value.uitpasBaseProductPriceId;
+    // Not possible for a UiTPAS social tariff or when the customer chooses the price
+    return !patchedProductPrice.value.uitpasBaseProductPriceId && !patchedProductPrice.value.allowCustomPrice;
+});
+
+const customPricePossible = computed(() => {
+    // Not possible for a UiTPAS social tariff or its base price: those prices are calculated and verified
+    return !patchedProductPrice.value.uitpasBaseProductPriceId
+        && !patchedProduct.value.prices.some(p => p.uitpasBaseProductPriceId === patchedProductPrice.value.id);
 });
 
 onMounted(async () => {
@@ -159,6 +176,17 @@ const name = computed({
     get: () => patchedProductPrice.value.name,
     set: (name: string) => {
         addPricePatch(ProductPrice.patch({ name }));
+    },
+});
+
+const allowCustomPrice = computed({
+    get: () => patchedProductPrice.value.allowCustomPrice,
+    set: (allowCustomPrice: boolean) => {
+        if (allowCustomPrice) {
+            // A quantity discount would silently override the chosen price
+            useDiscount.value = false;
+        }
+        addPricePatch(ProductPrice.patch({ allowCustomPrice }));
     },
 });
 
@@ -191,8 +219,7 @@ const useDiscount = computed({
         }
         if (value) {
             discountPrice.value = price.value;
-        }
-        else {
+        } else {
             discountPrice.value = null;
         }
     },
@@ -259,11 +286,9 @@ async function updateUitpasSocialTariff() {
         const basePrice = patchedProduct.value.prices.find(p => p.id === uitpasBaseProductPriceId.value)?.price ?? 0;
         try {
             price.value = await getOfficialUitpasSocialTariff(patchedProduct.value.uitpasEvent.url, basePrice);
-        }
-        catch (e) {
+        } catch (e) {
             Toast.fromError(e).show();
-        }
-        finally {
+        } finally {
             uitpasSocialTariffLoading.value = false;
         }
     }
@@ -299,7 +324,7 @@ const productPricesAvailableForUitpasBaseProductPrice = computed(() => {
         // This price is already a base price for another uitpas social tariff, so it cannot be a UiTPAS social tariff.
         return [];
     }
-    return patchedProduct.value.prices.filter(p => (p.uitpasBaseProductPriceId === null && p.id !== patchedProductPrice.value.id));
+    return patchedProduct.value.prices.filter(p => (p.uitpasBaseProductPriceId === null && p.id !== patchedProductPrice.value.id && !p.allowCustomPrice));
 });
 
 </script>

--- a/frontend/shared/components/src/inputs/useNumberInput.ts
+++ b/frontend/shared/components/src/inputs/useNumberInput.ts
@@ -1,13 +1,14 @@
+import { Formatter } from '@stamhoofd/utility';
 import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 
-type UseNumberInputOptions = { required: boolean; min: number | null; max: number | null; fractionDigits: number; roundFractionDigits: number | null;  };
+type UseNumberInputOptions = { required: boolean; min: number | null; max: number | null; suffix?: string | null; suffixSingular?: string | null; fractionDigits: number; roundFractionDigits: number | null };
 
 export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
     const multipier = computed(() => Math.pow(10, options.value.fractionDigits));
 
     const roundFractions = (v: number) => {
-        const {roundFractionDigits, fractionDigits} = options.value;
+        const { roundFractionDigits, fractionDigits } = options.value;
 
         if (roundFractionDigits === null) {
             return v;
@@ -21,7 +22,7 @@ export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
         const roundMultiplier = Math.pow(10, multiplyAmount);
 
         return Math.round(v / roundMultiplier) * roundMultiplier;
-    } 
+    };
 
     const validateText = (value: string, { valueIfNaN }: { valueIfNaN: number | null }): { isValid: boolean; value: number | null } => {
         const { required } = options.value;
@@ -116,8 +117,11 @@ export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
     }
 
     const formatValue = (value: number) => {
-        return (value / multipier.value).toString();
-    }
+        // Use all fraction digits so a min/max bound is never displayed rounded in error messages
+        const float = value / multipier.value;
+        const suffix = (float === 1 ? options.value.suffixSingular : null) ?? options.value.suffix;
+        return Formatter.float(float, { maximumFractionDigits: options.value.fractionDigits }) + (suffix ? ' ' + suffix : '');
+    };
 
     const validateConstraints = (value: number): { isValid: false; errorMessage: string; value: number } | { isValid: true; value: number } => {
         const { min, max, required } = options.value;
@@ -166,7 +170,7 @@ export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
     };
 
     const numberToString = (value: number | null, { valueIfNaN }: { valueIfNaN: string }) => {
-        const {fractionDigits} = options.value;
+        const { fractionDigits } = options.value;
 
         if (value === null) {
             return '';
@@ -191,7 +195,7 @@ export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
                     + getDecimalSeparator()
                     + ('' + fractions / 100).padStart(fractionDigits - 2, '0');
             }
-            
+
             if (fractions % 10 === 0) {
                 return (float < 0 ? '-' : '')
                     + Math.floor(abs)
@@ -236,7 +240,6 @@ export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
         const { min, max } = options.value;
 
         if (value === null || isNaN(value)) {
-            
             return min ?? 0;
         }
 
@@ -251,7 +254,7 @@ export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
         }
 
         return newValue;
-    }
+    };
 
     /**
      * Returns the decimal separator of the system. Might be wrong if the system has a region set different from the language with an unknown combination.
@@ -269,6 +272,6 @@ export function useNumberInput(options: ComputedRef<UseNumberInputOptions>) {
         numberToString,
         stringToNumber,
         step,
-        multipier
+        multipier,
     };
 }

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -2,7 +2,7 @@
     <form class="st-view cart-item-view" data-testid="cart-item-view" @submit.prevent="addToCart">
         <STNavigationBar :title="cartItem.product.name">
             <template #left>
-                <p v-if="!webshop.isAllFree || pricedItem.getPriceWithDiscounts()">
+                <p v-if="(!webshop.isAllFree || pricedItem.getPriceWithDiscounts()) && !cartItem.productPrice.allowCustomPrice">
                     <span v-if="formattedPriceWithDiscount" class="style-tag discount">{{ formattedPriceWithDiscount }}</span>
                     <span v-else class="style-tag">{{ formattedPriceWithoutDiscount }}</span>
                 </p>
@@ -72,29 +72,38 @@
             </STList>
 
             <div v-if="cartItem.product.filteredPrices({admin}).length > 1" class="container">
-                <hr><STList>
+                <hr>
+                <STList>
                     <STListItem v-for="price in cartItem.product.filteredPrices({admin})" :key="price.id" class="no-border right-price" :selectable="canSelectPrice(price)" :disabled="!canSelectPrice(price)" element-name="label">
                         <template #left>
-                            <Radio v-model="cartItem.productPrice" :value="price" :name="cartItem.product.id+'price'" :disabled="!canSelectPrice(price)" />
+                            <Radio v-model="selectedPrice" :value="price" :name="cartItem.product.id+'price'" :disabled="!canSelectPrice(price)" />
                         </template>
                         <h4 class="style-title-list">
-                            {{ price.name || 'Naamloos' }}
+                            {{ price.name || $t('Naamloos') }}
                         </h4>
 
                         <p v-if="price.discountPrice" class="style-description-small">
-                            {{ formatPrice(price.discountPrice) }} / stuk vanaf {{ price.discountAmount }} {{ price.discountAmount === 1 ? 'stuk' : 'stuks' }}
+                            {{ price.discountAmount === 1
+                                ? $t('{price} / stuk vanaf {amount} stuk', { price: formatPrice(price.discountPrice), amount: price.discountAmount.toString() })
+                                : $t('{price} / stuk vanaf {amount} stuks', { price: formatPrice(price.discountPrice), amount: price.discountAmount.toString() }) }}
                         </p>
 
                         <p v-if="getPriceStockText(price)" class="style-description-small">
                             {{ getPriceStockText(price) }}
                         </p>
 
-                        <template #right>
+                        <template v-if="!price.allowCustomPrice" #right>
                             {{ formatPrice(price.price) }}
                         </template>
                     </STListItem>
                 </STList>
             </div>
+
+            <template v-if="cartItem.productPrice.allowCustomPrice">
+                <hr>
+                <h2>{{ cartItem.productPrice.name || $t('Kies een bedrag') }}</h2>
+                <PriceInputBox v-model="cartItem.productPrice.price" class="max" data-testid="custom-price-input" :validator="errors.validator" :min="ProductPrice.customPriceMinimum" :max="ProductPrice.customPriceMaximum" />
+            </template>
 
             <OptionMenuBox v-for="optionMenu in cartItem.product.optionMenus" :key="optionMenu.id" :error-box="errors.errorBox" :cart-item="cartItem" :option-menu="optionMenu" :cart="cart" :old-item="oldItem" :admin="admin" :webshop="webshop" />
 
@@ -167,10 +176,10 @@
 
 <script lang="ts" setup>
 import { Request } from '@simonbackx/simple-networking';
-import { ComponentWithProperties, useCanDismiss, useDismiss, usePresent, useShow } from '@simonbackx/vue-app-navigation';
+import { useCanDismiss, useDismiss, usePresent, useShow } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '#containers/AsyncComponent.ts';
-import type { CartItem, Checkout, ProductDateRange, ProductPrice, Webshop } from '@stamhoofd/structures';
-import { CartStockHelper, ProductType, UitpasNumberAndPrice, UitpasPriceCheckRequest, UitpasPriceCheckResponse } from '@stamhoofd/structures';
+import type { CartItem, Checkout, ProductDateRange, Webshop } from '@stamhoofd/structures';
+import { CartStockHelper, ProductPrice, ProductType, UitpasNumberAndPrice, UitpasPriceCheckRequest, UitpasPriceCheckResponse } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 
 import type { Decoder } from '@simonbackx/simple-encoding';
@@ -194,6 +203,7 @@ import { CenteredMessage } from '../overlays/CenteredMessage';
 import FieldBox from './FieldBox.vue';
 import OptionMenuBox from './OptionMenuBox.vue';
 import PriceBreakdownBox from './PriceBreakdownBox.vue';
+import PriceInputBox from '#inputs/PriceInputBox.vue';
 
 const props = withDefaults(defineProps<{
     admin?: boolean;
@@ -221,6 +231,18 @@ const owner = useRequestOwner();
 const willNeedSeats = computed(() => withSeats.value);
 const cart = computed(() => props.checkout.cart);
 const originalSelectedPriceId = ref('');
+
+// Match on id: the cart item price can differ from the product price when allowCustomPrice is enabled
+const selectedPrice = computed({
+    get: () => props.cartItem.product.filteredPrices({ admin: props.admin }).find(p => p.id === props.cartItem.productPrice.id) ?? props.cartItem.productPrice,
+    set: (price: ProductPrice) => {
+        if (props.cartItem.productPrice.id === price.id) {
+            return;
+        }
+        // Clone: the cart item owns its own instance, so a custom price never mutates the webshop structure
+        props.cartItem.productPrice = price.clone();
+    },
+});
 
 onMounted(() => {
     onChangeItem();

--- a/frontend/shared/components/src/views/ProductBox.vue
+++ b/frontend/shared/components/src/views/ProductBox.vue
@@ -72,6 +72,11 @@ const priceString = computed(() => {
         return prices.length > 0 ? $t('Vrij bedrag') : '';
     }
 
+    if (fixedPrices.length < prices.length) {
+        // Hide ugly selection list
+        return '';
+    }
+
     const priceRanges = Formatter.uniqueArray(fixedPrices.map(p => p.price));
     if (priceRanges.length === 1) {
         if (priceRanges[0] === 0) {

--- a/frontend/shared/components/src/views/ProductBox.vue
+++ b/frontend/shared/components/src/views/ProductBox.vue
@@ -15,7 +15,7 @@
                 <p v-else-if="product.description" class="description" v-text="product.description" />
 
                 <p class="price">
-                    <span class="price-value">{{ priceString }}</span>
+                    <span v-if="priceString" class="price-value">{{ priceString }}</span>
 
                     <span v-if="product.enableInFuture" class="style-tag">{{ $t('%kR', {date: product.enableAfter ? formatDateTime(product.enableAfter) : '?'}) }}</span>
                     <span v-else-if="!product.isEnabled && !admin" class="style-tag error">{{ $t('%Tk') }}</span>
@@ -65,7 +65,14 @@ const canDismiss = useCanDismiss();
 const cart = computed(() => props.checkout.cart);
 
 const priceString = computed(() => {
-    const priceRanges = Formatter.uniqueArray(props.product.filteredPrices({ admin: props.admin }).map(p => p.price));
+    const prices = props.product.filteredPrices({ admin: props.admin });
+    const fixedPrices = prices.filter(p => !p.allowCustomPrice);
+    if (fixedPrices.length === 0) {
+        // The customer chooses the price
+        return prices.length > 0 ? $t('Vrij bedrag') : '';
+    }
+
+    const priceRanges = Formatter.uniqueArray(fixedPrices.map(p => p.price));
     if (priceRanges.length === 1) {
         if (priceRanges[0] === 0) {
             if (props.webshop.isAllFree) {

--- a/shared/structures/src/webshops/CartItem.test.ts
+++ b/shared/structures/src/webshops/CartItem.test.ts
@@ -1,6 +1,6 @@
 import { Cart } from './Cart.js';
 import { CartItem, CartItemOption } from './CartItem.js';
-import { Option, OptionMenu, Product } from './Product.js';
+import { Option, OptionMenu, Product, ProductPrice } from './Product.js';
 import { Webshop } from './Webshop.js';
 
 describe('Structure.CartItem', () => {
@@ -60,5 +60,125 @@ describe('Structure.CartItem', () => {
             products: [product],
         });
         expect(() => cartItem.validate(webshop, Cart.create({}))).toThrow();
+    });
+
+    describe('refresh with allowCustomPrice', () => {
+        const suggestedPrice = 5_00_00;
+
+        function buildWebshop({ allowCustomPrice }: { allowCustomPrice: boolean }) {
+            const productPrice = ProductPrice.create({
+                name: 'Support us',
+                price: suggestedPrice,
+                allowCustomPrice,
+            });
+            const product = Product.create({
+                name: 'Donation',
+                prices: [productPrice],
+            });
+            const webshop = Webshop.create({
+                products: [product],
+            });
+            return { webshop, product, productPrice };
+        }
+
+        function buildCartItem(product: Product, price: number) {
+            const cartItem = CartItem.create({
+                product,
+                productPrice: product.prices[0].clone(),
+            });
+            cartItem.productPrice.price = price;
+            return cartItem;
+        }
+
+        it('keeps the chosen price and does not mutate the webshop structure', () => {
+            const { webshop, product, productPrice } = buildWebshop({ allowCustomPrice: true });
+            const cartItem = buildCartItem(product, 10_00_00);
+
+            cartItem.refresh(webshop);
+
+            expect(cartItem.productPrice.price).toBe(10_00_00);
+            expect(cartItem.productPrice).not.toBe(productPrice);
+            expect(productPrice.price).toBe(suggestedPrice);
+        });
+
+        it('keeps the boundary values', () => {
+            const { webshop, product } = buildWebshop({ allowCustomPrice: true });
+
+            const minimumItem = buildCartItem(product, ProductPrice.customPriceMinimum);
+            minimumItem.refresh(webshop);
+            expect(minimumItem.productPrice.price).toBe(ProductPrice.customPriceMinimum);
+
+            const maximumItem = buildCartItem(product, ProductPrice.customPriceMaximum);
+            maximumItem.refresh(webshop);
+            expect(maximumItem.productPrice.price).toBe(ProductPrice.customPriceMaximum);
+        });
+
+        it('rounds the chosen price to whole cents', () => {
+            const { webshop, product } = buildWebshop({ allowCustomPrice: true });
+            const cartItem = buildCartItem(product, 10_00_49);
+
+            cartItem.refresh(webshop);
+
+            expect(cartItem.productPrice.price).toBe(10_00_00);
+        });
+
+        it('clamps a price below the minimum to the minimum', () => {
+            const { webshop, product } = buildWebshop({ allowCustomPrice: true });
+            const cartItem = buildCartItem(product, 50_00);
+
+            cartItem.refresh(webshop);
+
+            expect(cartItem.productPrice.price).toBe(ProductPrice.customPriceMinimum);
+        });
+
+        it('clamps a price above the maximum to the maximum', () => {
+            const { webshop, product } = buildWebshop({ allowCustomPrice: true });
+            const cartItem = buildCartItem(product, ProductPrice.customPriceMaximum + 1_00);
+
+            cartItem.refresh(webshop);
+
+            expect(cartItem.productPrice.price).toBe(ProductPrice.customPriceMaximum);
+        });
+
+        it('ignores a tampered price when allowCustomPrice is disabled', () => {
+            const { webshop, product } = buildWebshop({ allowCustomPrice: false });
+            const cartItem = buildCartItem(product, 1_00);
+
+            cartItem.refresh(webshop);
+
+            expect(cartItem.productPrice.price).toBe(suggestedPrice);
+        });
+
+        it('createDefault clones the product price so edits do not mutate the webshop structure', () => {
+            const { webshop, product, productPrice } = buildWebshop({ allowCustomPrice: true });
+            const cartItem = CartItem.createDefault(product, Cart.create({}), webshop, { admin: false });
+
+            expect(cartItem.productPrice).not.toBe(productPrice);
+            cartItem.productPrice.price = 20_00_00;
+            expect(productPrice.price).toBe(suggestedPrice);
+        });
+
+        it('does not merge cart items with a different custom price', () => {
+            const { product } = buildWebshop({ allowCustomPrice: true });
+            const cart = Cart.create({});
+
+            cart.addItem(buildCartItem(product, 20_00_00));
+            cart.addItem(buildCartItem(product, 5_00_00));
+
+            expect(cart.items).toHaveLength(2);
+            expect(cart.items.map(i => i.productPrice.price)).toEqual([20_00_00, 5_00_00]);
+        });
+
+        it('merges cart items with the same custom price', () => {
+            const { product } = buildWebshop({ allowCustomPrice: true });
+            const cart = Cart.create({});
+
+            cart.addItem(buildCartItem(product, 20_00_00));
+            cart.addItem(buildCartItem(product, 20_00_00));
+
+            expect(cart.items).toHaveLength(1);
+            expect(cart.items[0].amount).toBe(2);
+            expect(cart.items[0].productPrice.price).toBe(20_00_00);
+        });
     });
 });

--- a/shared/structures/src/webshops/CartItem.ts
+++ b/shared/structures/src/webshops/CartItem.ts
@@ -220,9 +220,10 @@ export class CartItem extends AutoEncoder {
         }
 
         // Default
+        // Clone the price: the cart item owns its own instance, so a custom price never mutates the webshop structure
         return CartItem.create({
             product: product,
-            productPrice: chosenPrice ?? product.filteredPrices(data)[0],
+            productPrice: (chosenPrice ?? product.filteredPrices(data)[0]).clone(),
             options,
         });
     }
@@ -261,7 +262,9 @@ export class CartItem extends AutoEncoder {
     }
 
     get codeWithoutFields(): string {
-        return this.product.id + '.' + this.productPrice.id + '.' + this.options.map(o => o.option.id).join('.');
+        // A chosen custom price is part of the identity: only items with the same price may merge in the cart
+        const customPrice = this.productPrice.allowCustomPrice ? '.' + this.productPrice.price : '';
+        return this.product.id + '.' + this.productPrice.id + customPrice + '.' + this.options.map(o => o.option.id).join('.');
     }
 
     /**
@@ -584,7 +587,14 @@ export class CartItem extends AutoEncoder {
                 }
             } else {
                 // Only set product if we did find our product price
-                this.productPrice = productPrice;
+                const savedPrice = this.productPrice.price;
+                this.productPrice = productPrice.clone();
+
+                if (productPrice.allowCustomPrice) {
+                    // Keep the price the customer chose: rounded to whole cents and clamped to the allowed bounds
+                    const customPrice = Math.round(savedPrice / 100) * 100;
+                    this.productPrice.price = Math.min(Math.max(customPrice, ProductPrice.customPriceMinimum), ProductPrice.customPriceMaximum);
+                }
             }
 
             // Check all options

--- a/shared/structures/src/webshops/Product.ts
+++ b/shared/structures/src/webshops/Product.ts
@@ -11,6 +11,13 @@ import { WebshopField } from './WebshopField.js';
 import { upgradePriceFrom2To4DecimalPlaces } from '../upgradePriceFrom2To4DecimalPlaces.js';
 
 export class ProductPrice extends AutoEncoder {
+    /**
+     * Bounds for the price a customer can choose when `allowCustomPrice` is enabled.
+     * Enforced in the checkout UI and in `CartItem.refresh` (which also runs server side).
+     */
+    static readonly customPriceMinimum = 1_00_00;
+    static readonly customPriceMaximum = 25_000_00_00;
+
     @field({ decoder: StringDecoder, defaultValue: () => uuidv4() })
     id: string;
 
@@ -35,6 +42,9 @@ export class ProductPrice extends AutoEncoder {
 
     @field({ decoder: BooleanDecoder, version: 219 })
     hidden = false;
+
+    @field({ decoder: BooleanDecoder, ...NextVersion })
+    allowCustomPrice = false;
 
     /**
      * Total stock, excluding already sold items into account

--- a/shared/utility/src/Formatter.ts
+++ b/shared/utility/src/Formatter.ts
@@ -446,8 +446,8 @@ export class Formatter {
         return v;
     }
 
-    static float(value: number): string {
-        const formatted = new Intl.NumberFormat('nl-BE', { maximumFractionDigits: 4 }).format(Math.abs(value));
+    static float(value: number, options?: { maximumFractionDigits?: number }): string {
+        const formatted = new Intl.NumberFormat('nl-BE', { maximumFractionDigits: options?.maximumFractionDigits ?? 4 }).format(Math.abs(value));
 
         const v = (value < 0 ? '- ' : '') + formatted;
 

--- a/tests/playwright/src/helpers/test-data/TestWebshops.ts
+++ b/tests/playwright/src/helpers/test-data/TestWebshops.ts
@@ -17,6 +17,8 @@ export interface CreateWebshopOptions {
     withSeatingPlan?: boolean;
     /** Price per product in cents (default € 15,00). Use 0 for a free shop. */
     price?: number;
+    /** Build the prices of each product (called once per product). Defaults to one fixed price of `price` cents. */
+    buildPrices?: () => ProductPrice[];
     /** Allowed payment methods on the webshop */
     paymentMethods?: PaymentMethod[];
     /** Link a Stripe account so online payments route to Stripe */
@@ -51,6 +53,7 @@ export class TestWebshops {
             cartEnabled = true,
             withSeatingPlan = false,
             price = 15_0000,
+            buildPrices,
             paymentMethods = [PaymentMethod.PointOfSale],
             stripeAccountId,
             customDomainPrefix,
@@ -77,7 +80,7 @@ export class TestWebshops {
         for (let i = 0; i < productCount; i++) {
             products.push(Product.create({
                 name: `Product ${i + 1}`,
-                prices: [ProductPrice.create({ name: `Price ${i + 1}`, price })],
+                prices: buildPrices?.() ?? [ProductPrice.create({ name: `Price ${i + 1}`, price })],
                 type: productType,
                 seatingPlanId: withSeatingPlan ? seatingPlanId : null,
             }));

--- a/tests/playwright/src/tests/webshop-orders.spec.ts
+++ b/tests/playwright/src/tests/webshop-orders.spec.ts
@@ -7,7 +7,7 @@ import type { Browser, Page } from '@playwright/test';
 import { devices, expect } from '@playwright/test';
 import { MollieMocker, PayconiqMocker, STPackageService, StripeMocker } from '@stamhoofd/backend/tests/helpers';
 import type { User } from '@stamhoofd/models';
-import { OrderFactory, Organization, OrganizationFactory, Payment, TicketFactory, Token, UserFactory } from '@stamhoofd/models';
+import { Order, OrderFactory, Organization, OrganizationFactory, Payment, TicketFactory, Token, UserFactory } from '@stamhoofd/models';
 import {
     MollieOnboarding,
     MollieStatus,
@@ -17,6 +17,7 @@ import {
     PaymentType,
     PermissionLevel,
     Permissions,
+    ProductPrice,
     STPackageBundle,
     Token as TokenStruct,
     Version,
@@ -1034,6 +1035,108 @@ function registerWebshopOrderTests() {
         // The failure message is shown; closing it returns to the payment selection step
         await page.getByTestId('centered-message-button').click();
         await flow.expectBackOnPaymentSelection();
+    });
+
+    test('Pay-what-you-want product: customer chooses the price', async ({ page }) => {
+        const organization = await createWebshopOrganization('CustomPrice');
+        const { webshop } = await TestWebshops.create({
+            organization,
+            name: `Custom price shop ${WorkerData.id}`,
+            productCount: 1,
+            cartEnabled: false,
+            paymentMethods: [PaymentMethod.PointOfSale],
+            buildPrices: () => [ProductPrice.create({ name: 'Steun ons', price: 15_00_00, allowCustomPrice: true })],
+        });
+
+        const flow = new WebshopOrderFlow(page, { cartEnabled: false });
+        await flow.goto(WorkerData.urls.webshopUri(webshop.uri));
+
+        // The product box shows a free-choice label instead of a fixed price
+        await expect(page.getByTestId('product-box').first()).toContainText('Vrij bedrag');
+
+        await page.getByTestId('product-box').first().click();
+        const cartItemView = page.getByTestId('cart-item-view');
+        await expect(cartItemView).toBeVisible();
+
+        // The configured price is prefilled as a suggestion (€ 15)
+        const priceInput = cartItemView.getByTestId('custom-price-input').locator('input');
+        await expect(priceInput).toHaveValue('15');
+
+        // Below the € 1 minimum: saving is blocked with an error
+        await priceInput.fill('0,50');
+        await cartItemView.getByTestId('save-button').click();
+        await expect(cartItemView).toContainText('Het minimum is 1 euro');
+
+        // Choose € 20,50 and complete the order
+        await priceInput.fill('20,5');
+        await cartItemView.getByTestId('save-button').click();
+
+        await flow.goToCheckout();
+        await flow.fillCustomer();
+        await flow.selectPaymentMethod(PaymentLabel.PointOfSale);
+        await flow.confirmPayment();
+        await flow.expectOrderConfirmed();
+
+        // The order total is the chosen price
+        await expect(page.getByTestId('order-view')).toContainText('20,50');
+
+        // The backend stored the chosen price (4 decimal places)
+        const orders = await Order.where({ webshopId: webshop.id });
+        expect(orders).toHaveLength(1);
+        expect(orders[0].data.cart.items[0].productPrice.price).toBe(20_50_00);
+        expect(orders[0].data.totalPrice).toBe(20_50_00);
+    });
+
+    test('Custom price and selection survive editing the cart item, without altering the shop', async ({ page }) => {
+        const organization = await createWebshopOrganization('CustomPriceEdit');
+        const { webshop } = await TestWebshops.create({
+            organization,
+            name: `Custom price edit ${WorkerData.id}`,
+            productCount: 1,
+            cartEnabled: true,
+            paymentMethods: [PaymentMethod.PointOfSale],
+            buildPrices: () => [
+                ProductPrice.create({ name: 'Standaard', price: 15_00_00 }),
+                ProductPrice.create({ name: 'Kies zelf', price: 15_00_00, allowCustomPrice: true }),
+            ],
+        });
+
+        const flow = new WebshopOrderFlow(page, { cartEnabled: true });
+        await flow.goto(WorkerData.urls.webshopUri(webshop.uri));
+
+        // A fixed price exists next to the custom one, so the product box shows the fixed price
+        await expect(page.getByTestId('product-box').first()).toContainText('15');
+
+        await page.getByTestId('product-box').first().click();
+        const cartItemView = page.getByTestId('cart-item-view');
+        await expect(cartItemView).toBeVisible();
+
+        // Select the custom price: the price input appears with the suggested amount
+        await cartItemView.locator('label').filter({ hasText: 'Kies zelf' }).click();
+        const priceInput = cartItemView.getByTestId('custom-price-input').locator('input');
+        await expect(priceInput).toHaveValue('15');
+
+        // Choose € 20,50 and add it to the cart
+        await priceInput.fill('20,5');
+        await cartItemView.getByTestId('save-button').click();
+        await expect(page.getByTestId('cart-add-more-button')).toBeVisible();
+        await expect(page.locator('.cart-item-row')).toContainText('20,50');
+
+        // Reopen the item from the cart: the custom price is still selected with the chosen amount
+        await page.locator('.cart-item-row h3').click();
+        await expect(cartItemView).toBeVisible();
+        await expect(cartItemView.locator('label').filter({ hasText: 'Kies zelf' }).locator('input[type="radio"]')).toBeChecked();
+        await expect(priceInput).toHaveValue(/^20[.,]50$/);
+        await cartItemView.getByTestId('save-button').click();
+        await expect(page.getByTestId('cart-add-more-button')).toBeVisible();
+
+        // A new item of the same product still gets the original suggestion:
+        // the chosen amount never leaks into the webshop structure
+        await page.getByTestId('cart-add-more-button').click();
+        await page.getByTestId('product-box').first().click();
+        await expect(cartItemView).toBeVisible();
+        await cartItemView.locator('label').filter({ hasText: 'Kies zelf' }).click();
+        await expect(priceInput).toHaveValue('15');
     });
 
     test('Zero-price order skips payment and tickets are downloadable', async ({ page }) => {


### PR DESCRIPTION
Adds `allowCustomPrice` to `ProductPrice`: visitors choose their own amount (min € 1, max € 25 000, shared constants on `ProductPrice`) with the configured price prefilled as suggestion. Not combinable with quantity discounts or UiTPAS social tariffs.

Gotchas:
- `CartItem.refresh` (also runs server-side on order placement) rounds the chosen price to whole cents and clamps it into bounds, so tampered requests can't order below the minimum. The cart item always owns a clone of its `ProductPrice` so a chosen price never mutates the in-memory webshop; the price radio matches by id for the same reason.
- The chosen amount is part of the cart item `code`: identical amounts merge in the cart, different amounts stay separate rows. Statistics and exports therefore group per chosen amount.
- Consciously skipped from self-review: no Playwright coverage of the dashboard checkbox itself (plain computed properties; the checkout half is covered end-to-end incl. the € 1 minimum) and the dashboard price list doesn't visually mark free-input prices yet (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789215337&installation_model_id=423362&pr_number=741&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F741&signature=b947211ee87739d5dff191998ceaca79c323a5ec002dfc6a631dceee1719df0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->