### PR TITLE
Webshop crowdfunding: goal and revenue progress

### DIFF
--- a/backend/app/api/src/boot.ts
+++ b/backend/app/api/src/boot.ts
@@ -30,6 +30,7 @@ import { UitpasService } from './services/uitpas/UitpasService.js';
 import { UniqueMemberNumberService } from './services/UniqueMemberNumberService.js';
 import { UniqueUserService } from './services/UniqueUserService.js';
 import { QueryableModel, SQLLogger } from '@stamhoofd/sql';
+import { WebshopCrowdfundingService } from './services/WebshopCrowdfundingService.js';
 
 process.on('unhandledRejection', (error: Error) => {
     console.error('unhandledRejection');
@@ -246,6 +247,7 @@ export const boot = async (options: { killProcess: boolean }) => {
         }
 
         await BalanceItemService.flushAll();
+        await WebshopCrowdfundingService.flush();
 
         const shutdownError = new SimpleError({
             code: 'SHUTDOWN',

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopEndpoint.ts
@@ -9,6 +9,7 @@ import { Formatter, isReservedWebshopPathSegment } from '@stamhoofd/utility';
 
 import { Context } from '../../../../helpers/Context.js';
 import { RecordAnswerHelper } from '../../../../helpers/RecordAnswerHelper.js';
+import { WebshopCrowdfundingService } from '../../../../services/WebshopCrowdfundingService.js';
 
 type Params = { id: string };
 type Query = undefined;
@@ -224,6 +225,11 @@ export class PatchWebshopEndpoint extends Endpoint<Params, Query, Body, Response
                     });
                 }
                 throw e;
+            }
+
+            if (request.body.meta?.crowdfunding !== undefined) {
+                // A changed crowdfunding configuration (e.g. just enabled) requires a recalculation of the cached amounts
+                await WebshopCrowdfundingService.updateWebshop(webshop);
             }
 
             return new Response(PrivateWebshop.create(webshop));

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
@@ -10,6 +10,7 @@ import { AuditLogSource, BalanceItemRelation, BalanceItemRelationType, BalanceIt
 import { Context } from '../../../../helpers/Context.js';
 import { ServiceFeeHelper } from '../../../../helpers/ServiceFeeHelper.js';
 import { AuditLogService } from '../../../../services/AuditLogService.js';
+import { BalanceItemService } from '../../../../services/BalanceItemService.js';
 import { OrderService } from '../../../../services/OrderService.js';
 import { PaymentService } from '../../../../services/PaymentService.js';
 import { shouldReserveUitpasNumbers, UitpasService } from '../../../../services/uitpas/UitpasService.js';
@@ -232,6 +233,9 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
 
                         balanceItem.description = order.generateBalanceDescription(webshop);
                         await balanceItem.save();
+
+                        // Update the cached pricePending of the balance item, so the unresolved payment is visible
+                        await BalanceItemService.updatePaidAndPending([balanceItem]);
                     }
                 } catch (e) {
                     await order.deleteOrderBecauseOfCreationError();

--- a/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
@@ -15,6 +15,7 @@ import { Context } from '../../../helpers/Context.js';
 import { ServiceFeeHelper } from '../../../helpers/ServiceFeeHelper.js';
 import { StripeHelper } from '../../../helpers/StripeHelper.js';
 import { AuditLogService } from '../../../services/AuditLogService.js';
+import { BalanceItemService } from '../../../services/BalanceItemService.js';
 import { MollieService } from '../../../services/MollieService.js';
 import { OrderService } from '../../../services/OrderService.js';
 import { PaymentService } from '../../../services/PaymentService.js';
@@ -355,6 +356,9 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                         throw new Error('Unknown payment provider');
                     }
                 }
+
+                // Update the cached pricePending of the balance item, so the unresolved payment is visible
+                await BalanceItemService.updatePaidAndPending([balanceItem]);
 
                 return new Response(OrderResponse.create({
                     paymentUrl: paymentUrl,

--- a/backend/app/api/src/services/BalanceItemService.ts
+++ b/backend/app/api/src/services/BalanceItemService.ts
@@ -11,6 +11,7 @@ import { OrderService } from './OrderService.js';
 import { PaymentReallocationService } from './PaymentReallocationService.js';
 import { RegistrationService } from './RegistrationService.js';
 import { STPackageService } from './STPackageService.js';
+import { WebshopCrowdfundingService } from './WebshopCrowdfundingService.js';
 
 const memberUpdateQueue = new GroupedThrottledQueue(async (organizationId: string, memberIds: string[]) => {
     await CachedBalance.updateForMembers(organizationId, memberIds);
@@ -182,6 +183,10 @@ export class BalanceItemService {
 
             if (item.registrationId) {
                 registrationUpdateQueue.addItem(item.organizationId, item.registrationId);
+            }
+
+            if (item.orderId) {
+                WebshopCrowdfundingService.scheduleUpdateForOrder(item.orderId);
             }
         }
     }

--- a/backend/app/api/src/services/WebshopCrowdfundingService.test.ts
+++ b/backend/app/api/src/services/WebshopCrowdfundingService.test.ts
@@ -1,0 +1,433 @@
+import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
+import { PatchableArray } from '@simonbackx/simple-encoding';
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Organization, StripeAccount } from '@stamhoofd/models';
+import { BalanceItem, BalanceItemFactory, BalanceItemPayment, Order, OrderFactory, OrganizationFactory, Payment, Token, UserFactory, Webshop, WebshopFactory } from '@stamhoofd/models';
+import type { OrderResponse } from '@stamhoofd/structures';
+import { BalanceItemStatus, Cart, CartItem, Customer, OrderData, OrderStatus, PaymentConfiguration, PaymentMethod, PaymentStatus, PermissionLevel, Permissions, PrivateOrder, PrivatePaymentConfiguration, PrivateWebshop, Product, ProductPrice, TransferSettings, WebshopCrowdfunding, WebshopMetaData, WebshopPrivateMetaData } from '@stamhoofd/structures';
+import { v4 as uuidv4 } from 'uuid';
+
+import type { StripeObject } from '../../tests/helpers/StripeMocker.js';
+import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
+import { initMembershipOrganization } from '../../tests/init/initMembershipOrganization.js';
+import { testServer } from '../../tests/helpers/TestServer.js';
+import { PatchWebshopEndpoint } from '../endpoints/organization/dashboard/webshops/PatchWebshopEndpoint.js';
+import { PatchWebshopOrdersEndpoint } from '../endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.js';
+import { PlaceOrderEndpoint } from '../endpoints/organization/webshops/PlaceOrderEndpoint.js';
+import { BalanceItemService } from './BalanceItemService.js';
+import { PaymentService } from './PaymentService.js';
+import { WebshopCrowdfundingService } from './WebshopCrowdfundingService.js';
+
+describe('WebshopCrowdfundingService', () => {
+    async function createWebshop(crowdfunding: WebshopCrowdfunding | null) {
+        const organization = await new OrganizationFactory({}).create();
+        return await new WebshopFactory({
+            organizationId: organization.id,
+            meta: WebshopMetaData.patch({ crowdfunding }),
+        }).create();
+    }
+
+    async function createOrderBalanceItem(order: Order, { pricePaid = 0, pricePending = 0, status = BalanceItemStatus.Due }: { pricePaid?: number; pricePending?: number; status?: BalanceItemStatus }) {
+        return await new BalanceItemFactory({
+            organizationId: order.organizationId,
+            orderId: order.id,
+            amount: 1,
+            unitPrice: pricePaid + pricePending,
+            pricePaid,
+            pricePending,
+            status,
+        }).create();
+    }
+
+    async function getMeta(webshop: Webshop) {
+        const updated = await Webshop.getByID(webshop.id);
+        return updated!.meta;
+    }
+
+    async function createPayment(balanceItem: BalanceItem, price: number, status: PaymentStatus) {
+        const payment = new Payment();
+        payment.organizationId = balanceItem.organizationId;
+        payment.method = PaymentMethod.Transfer;
+        payment.status = status;
+        payment.price = price;
+        await payment.save();
+
+        const balanceItemPayment = new BalanceItemPayment();
+        balanceItemPayment.organizationId = balanceItem.organizationId;
+        balanceItemPayment.paymentId = payment.id;
+        balanceItemPayment.balanceItemId = balanceItem.id;
+        balanceItemPayment.price = price;
+        await balanceItemPayment.save();
+
+        return payment;
+    }
+
+    test('updates the paid and pending amounts of the webshop', async () => {
+        const webshop = await createWebshop(WebshopCrowdfunding.create({ goalAmount: 500_0000 }));
+        const order1 = await new OrderFactory({ webshop }).create();
+        const order2 = await new OrderFactory({ webshop }).create();
+
+        await createOrderBalanceItem(order1, { pricePaid: 50_0000 });
+        await createOrderBalanceItem(order2, { pricePaid: 10_0000, pricePending: 20_0000 });
+
+        // Hidden balance items are ignored (online payments keep their balance item hidden until
+        // the payment succeeds)
+        await createOrderBalanceItem(order1, { pricePaid: 5_0000, pricePending: 3_0000, status: BalanceItemStatus.Hidden });
+
+        // Balance items of other webshops are ignored
+        const otherWebshop = await new WebshopFactory({ organizationId: webshop.organizationId }).create();
+        const otherOrder = await new OrderFactory({ webshop: otherWebshop }).create();
+        await createOrderBalanceItem(otherOrder, { pricePaid: 7_0000 });
+
+        await WebshopCrowdfundingService.updateForWebshop(webshop.id);
+
+        const meta = await getMeta(webshop);
+        expect(meta.crowdfunding).toEqual(WebshopCrowdfunding.create({
+            goalAmount: 500_0000,
+            progressAmount: 60_0000,
+            pendingAmount: 20_0000,
+        }));
+    });
+
+    test('resets the amounts when there are no balance items', async () => {
+        const webshop = await createWebshop(WebshopCrowdfunding.create({
+            progressAmount: 60_0000,
+            pendingAmount: 20_0000,
+        }));
+
+        await WebshopCrowdfundingService.updateForWebshop(webshop.id);
+
+        const meta = await getMeta(webshop);
+        expect(meta.crowdfunding).toEqual(WebshopCrowdfunding.create({
+            goalAmount: null,
+            progressAmount: 0,
+            pendingAmount: 0,
+        }));
+    });
+
+    test('does not calculate anything when crowdfunding is disabled', async () => {
+        const webshop = await createWebshop(null);
+        const order = await new OrderFactory({ webshop }).create();
+        await createOrderBalanceItem(order, { pricePaid: 50_0000 });
+
+        await WebshopCrowdfundingService.updateForWebshop(webshop.id);
+
+        const meta = await getMeta(webshop);
+        expect(meta.crowdfunding).toBeNull();
+    });
+
+    test('multiple scheduled updates result in a single update per webshop', async () => {
+        const webshop = await createWebshop(WebshopCrowdfunding.create({}));
+        const order1 = await new OrderFactory({ webshop }).create();
+        const order2 = await new OrderFactory({ webshop }).create();
+        await createOrderBalanceItem(order1, { pricePaid: 50_0000 });
+
+        // Drain the updates scheduled by the balance item creations (via model events)
+        await WebshopCrowdfundingService.flush();
+
+        const spy = vi.spyOn(WebshopCrowdfundingService, 'updateForWebshop');
+        try {
+            WebshopCrowdfundingService.scheduleUpdateForOrder(order1.id);
+            WebshopCrowdfundingService.scheduleUpdateForOrder(order1.id);
+            WebshopCrowdfundingService.scheduleUpdateForOrder(order2.id);
+            await WebshopCrowdfundingService.flush();
+
+            expect(spy).toHaveBeenCalledOnce();
+        } finally {
+            spy.mockRestore();
+        }
+
+        const meta = await getMeta(webshop);
+        expect(meta.crowdfunding!.progressAmount).toBe(50_0000);
+    });
+
+    test('placing an order with a balance item schedules a crowdfunding update', async () => {
+        const webshop = await createWebshop(WebshopCrowdfunding.create({}));
+        const order = await new OrderFactory({ webshop }).create();
+
+        // Creating the balance item fires a model event that schedules the update
+        await createOrderBalanceItem(order, { pricePaid: 30_0000, pricePending: 10_0000 });
+        await WebshopCrowdfundingService.flush();
+
+        const meta = await getMeta(webshop);
+        expect(meta.crowdfunding).toEqual(WebshopCrowdfunding.create({
+            progressAmount: 30_0000,
+            pendingAmount: 10_0000,
+        }));
+    });
+
+    test('paying an order updates the crowdfunding amounts', async () => {
+        const webshop = await createWebshop(WebshopCrowdfunding.create({}));
+        const order = await new OrderFactory({ webshop }).create();
+        const balanceItem = await createOrderBalanceItem(order, {});
+        balanceItem.unitPrice = 40_0000;
+        await balanceItem.save();
+
+        await createPayment(balanceItem, 30_0000, PaymentStatus.Succeeded);
+        await createPayment(balanceItem, 10_0000, PaymentStatus.Pending);
+
+        await BalanceItemService.updatePaidAndPending([balanceItem]);
+        await WebshopCrowdfundingService.flush();
+
+        const meta = await getMeta(webshop);
+        expect(meta.crowdfunding).toEqual(WebshopCrowdfunding.create({
+            progressAmount: 30_0000,
+            pendingAmount: 10_0000,
+        }));
+    });
+
+    test('canceling or deleting an order schedules a crowdfunding update', async () => {
+        const webshop = await createWebshop(WebshopCrowdfunding.create({}));
+        const order = await new OrderFactory({ webshop }).create();
+        await createOrderBalanceItem(order, { pricePaid: 50_0000 });
+        await WebshopCrowdfundingService.flush();
+
+        const spy = vi.spyOn(WebshopCrowdfundingService, 'scheduleUpdateForOrder');
+        try {
+            // Canceling/deleting an order cancels its balance items, which schedules an update
+            await BalanceItem.deleteForDeletedOrders([order.id]);
+            expect(spy).toHaveBeenCalledWith(order.id);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    describe('Order lifecycle', () => {
+        const placeOrderEndpoint = new PlaceOrderEndpoint();
+        const patchWebshopOrdersEndpoint = new PatchWebshopOrdersEndpoint();
+        const patchWebshopEndpoint = new PatchWebshopEndpoint();
+
+        let stripeMocker: StripeMocker;
+        let stripeAccount: StripeAccount;
+        let organization: Organization;
+        let token: Token;
+
+        const productPrice = ProductPrice.create({
+            name: 'productPrice',
+            price: 10_0000,
+        });
+
+        const product = Product.create({
+            name: 'product',
+            prices: [productPrice],
+        });
+
+        const customer = Customer.create({
+            firstName: 'John',
+            lastName: 'Doe',
+            email: 'john@example.com',
+            phone: '+32412345678',
+        });
+
+        beforeAll(async () => {
+            // Required for the service fee VAT settings of online payments
+            await initMembershipOrganization();
+
+            stripeMocker = new StripeMocker();
+            stripeMocker.start();
+            organization = await new OrganizationFactory({}).create();
+            stripeAccount = await stripeMocker.createStripeAccount(organization.id);
+
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({
+                    level: PermissionLevel.Full,
+                }),
+            }).create();
+            token = await Token.createToken(user);
+        });
+
+        afterAll(() => {
+            stripeMocker.stop();
+        });
+
+        beforeEach(() => {
+            stripeMocker.reset();
+        });
+
+        async function createLifecycleWebshop(crowdfunding: WebshopCrowdfunding | null = WebshopCrowdfunding.create({ goalAmount: 100_0000 })) {
+            const paymentConfiguration = PaymentConfiguration.patch({
+                transferSettings: TransferSettings.create({
+                    iban: 'BE56587127952688', // = random IBAN
+                }),
+            });
+            paymentConfiguration.paymentMethods.addPut(PaymentMethod.Transfer);
+            paymentConfiguration.paymentMethods.addPut(PaymentMethod.Bancontact);
+
+            return await new WebshopFactory({
+                organizationId: organization.id,
+                meta: WebshopMetaData.patch({
+                    crowdfunding,
+                    paymentConfiguration,
+                }),
+                privateMeta: WebshopPrivateMetaData.patch({
+                    paymentConfiguration: PrivatePaymentConfiguration.patch({
+                        stripeAccountId: stripeAccount.id,
+                    }),
+                }),
+                products: [product],
+            }).create();
+        }
+
+        function buildOrderData(paymentMethod: PaymentMethod) {
+            return OrderData.create({
+                paymentMethod,
+                cart: Cart.create({
+                    items: [
+                        CartItem.create({
+                            product,
+                            productPrice,
+                            amount: 1,
+                        }),
+                    ],
+                }),
+                customer,
+            });
+        }
+
+        async function placeOrder(webshop: Webshop, paymentMethod: PaymentMethod) {
+            const r = Request.buildJson('POST', `/webshop/${webshop.id}/order`, organization.getApiHost(), buildOrderData(paymentMethod));
+            const response = await testServer.test(placeOrderEndpoint, r);
+            const body = response.body as OrderResponse;
+            const order = (await Order.getByID(body.order.id))!;
+            const payment = (await Payment.getByID(order.paymentId!))!;
+            return { order, payment };
+        }
+
+        async function getCrowdfunding(webshop: Webshop) {
+            await WebshopCrowdfundingService.flush();
+            return (await getMeta(webshop)).crowdfunding!;
+        }
+
+        test('an online payment only counts once it succeeds', async () => {
+            const webshop = await createLifecycleWebshop();
+            const { payment } = await placeOrder(webshop, PaymentMethod.Bancontact);
+
+            // Online payments don't count as pending: their balance item stays hidden
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 0, pendingAmount: 0 });
+
+            // Payment becomes pending at the payment provider
+            const intent = stripeMocker.getLastIntent() as StripeObject;
+            intent.status = 'processing';
+            await PaymentService.pollStatus(payment.id, organization);
+            expect((await Payment.getByID(payment.id))!.status).toBe(PaymentStatus.Pending);
+
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 0, pendingAmount: 0 });
+
+            // Payment succeeds
+            intent.status = 'succeeded';
+            intent.latest_charge = 'ch_mocked';
+            await PaymentService.pollStatus(payment.id, organization);
+            expect((await Payment.getByID(payment.id))!.status).toBe(PaymentStatus.Succeeded);
+
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 10_0000, pendingAmount: 0 });
+        });
+
+        test('a failed online payment does not count', async () => {
+            const webshop = await createLifecycleWebshop();
+            const { payment } = await placeOrder(webshop, PaymentMethod.Bancontact);
+
+            const intent = stripeMocker.getLastIntent() as StripeObject;
+            intent.status = 'processing';
+            await PaymentService.pollStatus(payment.id, organization);
+
+            intent.status = 'canceled';
+            await PaymentService.pollStatus(payment.id, organization);
+            expect((await Payment.getByID(payment.id))!.status).toBe(PaymentStatus.Failed);
+
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 0, pendingAmount: 0 });
+        });
+
+        test('a transfer order counts as pending and counts as progress once an admin marks the payment as paid', async () => {
+            const webshop = await createLifecycleWebshop();
+            const { payment } = await placeOrder(webshop, PaymentMethod.Transfer);
+
+            // The transfer that has not been received yet counts as pending
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 0, pendingAmount: 10_0000 });
+
+            // This is what PatchPaymentsEndpoint calls when an admin marks the transfer as paid
+            await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded);
+
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 10_0000, pendingAmount: 0 });
+        });
+
+        test('a transfer order stops counting when the payment is marked as failed afterwards', async () => {
+            const webshop = await createLifecycleWebshop();
+            const { payment } = await placeOrder(webshop, PaymentMethod.Transfer);
+
+            await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded);
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 10_0000, pendingAmount: 0 });
+
+            await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Failed);
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 0, pendingAmount: 0 });
+        });
+
+        test('an order created manually by an admin counts once paid', async () => {
+            const webshop = await createLifecycleWebshop();
+
+            const patchArray: PatchableArrayAutoEncoder<PrivateOrder> = new PatchableArray();
+            patchArray.addPut(PrivateOrder.create({
+                id: uuidv4(),
+                data: buildOrderData(PaymentMethod.Transfer),
+                webshopId: webshop.id,
+            }));
+
+            const r = Request.buildJson('PATCH', `/webshop/${webshop.id}/orders`, organization.getApiHost(), patchArray);
+            r.headers.authorization = 'Bearer ' + token.accessToken;
+            const response = await testServer.test(patchWebshopOrdersEndpoint, r);
+            expect(response.body).toHaveLength(1);
+
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 0, pendingAmount: 10_0000 });
+
+            const order = (await Order.getByID(response.body[0].id))!;
+            const payment = (await Payment.getByID(order.paymentId!))!;
+            await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded);
+
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 10_0000, pendingAmount: 0 });
+        });
+
+        test('an order canceled by an admin no longer counts', async () => {
+            const webshop = await createLifecycleWebshop();
+            const { order, payment } = await placeOrder(webshop, PaymentMethod.Transfer);
+
+            await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded);
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 10_0000, pendingAmount: 0 });
+
+            const patchArray: PatchableArrayAutoEncoder<PrivateOrder> = new PatchableArray();
+            patchArray.addPatch(PrivateOrder.patch({
+                id: order.id,
+                status: OrderStatus.Canceled,
+            }));
+
+            const r = Request.buildJson('PATCH', `/webshop/${webshop.id}/orders`, organization.getApiHost(), patchArray);
+            r.headers.authorization = 'Bearer ' + token.accessToken;
+            await testServer.test(patchWebshopOrdersEndpoint, r);
+
+            // Canceling cancels the balance items, so the paid amount no longer counts
+            expect(await getCrowdfunding(webshop)).toMatchObject({ progressAmount: 0, pendingAmount: 0 });
+        });
+
+        test('enabling crowdfunding recalculates the amounts of existing orders', async () => {
+            const webshop = await createLifecycleWebshop(null);
+            const { payment } = await placeOrder(webshop, PaymentMethod.Transfer);
+            await PaymentService.handlePaymentStatusUpdate(payment, organization, PaymentStatus.Succeeded);
+            await WebshopCrowdfundingService.flush();
+
+            expect((await getMeta(webshop)).crowdfunding).toBeNull();
+
+            const patch = PrivateWebshop.patch({
+                meta: WebshopMetaData.patch({
+                    crowdfunding: WebshopCrowdfunding.create({ goalAmount: 100_0000 }),
+                }),
+            });
+
+            const r = Request.buildJson('PATCH', `/webshop/${webshop.id}`, organization.getApiHost(), patch);
+            r.headers.authorization = 'Bearer ' + token.accessToken;
+            const response = await testServer.test(patchWebshopEndpoint, r);
+
+            // The response already contains the recalculated amounts
+            expect(response.body.meta.crowdfunding).toMatchObject({ progressAmount: 10_0000, pendingAmount: 0 });
+            expect((await getMeta(webshop)).crowdfunding).toMatchObject({ progressAmount: 10_0000, pendingAmount: 0 });
+        });
+    });
+});

--- a/backend/app/api/src/services/WebshopCrowdfundingService.ts
+++ b/backend/app/api/src/services/WebshopCrowdfundingService.ts
@@ -1,0 +1,98 @@
+import { BalanceItem, Order, Webshop } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
+import { SQL, SQLAlias, SQLSelectAs, SQLSum } from '@stamhoofd/sql';
+import { BalanceItemStatus } from '@stamhoofd/structures';
+import { Formatter } from '@stamhoofd/utility';
+
+import { ThrottledQueue } from '../helpers/ThrottledQueue.js';
+
+// Balance items only store the orderId, so the webshop is resolved inside the queue
+const orderUpdateQueue = new ThrottledQueue(async (orderIds: string[]) => {
+    const orders = await Order.getByIDs(...orderIds);
+    const webshopIds = Formatter.uniqueArray(orders.map(o => o.webshopId));
+
+    for (const webshopId of webshopIds) {
+        await WebshopCrowdfundingService.updateForWebshop(webshopId);
+    }
+});
+
+export class WebshopCrowdfundingService {
+    /**
+     * Update the cached crowdfunding amounts of the webshop of this order in the background.
+     * Multiple calls within the throttle window (10s) result in a single update per webshop.
+     */
+    static scheduleUpdateForOrder(orderId: string) {
+        // STAMHOOFD is not available yet when this module is loaded
+        orderUpdateQueue.maxDelay = STAMHOOFD.environment === 'development' ? 1000 : 10_000;
+        orderUpdateQueue.addItem(orderId);
+    }
+
+    /**
+     * Make sure all scheduled updates have run (on shutdown and in tests).
+     */
+    static async flush() {
+        await orderUpdateQueue.flushAndWait();
+    }
+
+    /**
+     * Recalculates meta.crowdfunding.progressAmount (paid) and .pendingAmount (pending payments)
+     * by summing the balance items of all orders of this webshop in a single query.
+     * Does nothing when crowdfunding is not enabled (meta.crowdfunding is null).
+     */
+    static async updateForWebshop(webshopId: string) {
+        // Same queue as stock updates: all webshop writes are serialized to prevent conflicting saves
+        await QueueHandler.schedule('webshop-stock/' + webshopId, async () => {
+            const webshop = await Webshop.getByID(webshopId);
+            if (!webshop) {
+                return;
+            }
+
+            await this.updateWebshop(webshop);
+        });
+    }
+
+    /**
+     * Same as updateForWebshop, but for an already loaded webshop. Should only be used inside
+     * the webshop-stock queue of this webshop (where updateForWebshop would deadlock).
+     */
+    static async updateWebshop(webshop: Webshop) {
+        const crowdfunding = webshop.meta.crowdfunding;
+        if (!crowdfunding) {
+            return;
+        }
+
+        // Only due balance items count: online payments keep their balance item hidden until
+        // the payment succeeds, so their unresolved payments don't increase the pending amount.
+        // Unconfirmed transfer and point of sale payments do (their balance item is due).
+        const row = await SQL.select(
+            new SQLSelectAs(
+                new SQLSum(SQL.column(BalanceItem.table, 'pricePaid')),
+                new SQLAlias('data__pricePaid'),
+            ),
+            new SQLSelectAs(
+                new SQLSum(SQL.column(BalanceItem.table, 'pricePending')),
+                new SQLAlias('data__pricePending'),
+            ),
+        )
+            .from(BalanceItem.table)
+            .join(
+                SQL.join(Order.table)
+                    .where(SQL.column(BalanceItem.table, 'orderId'), SQL.column(Order.table, 'id')),
+            )
+            .where(SQL.column(Order.table, 'webshopId'), webshop.id)
+            .where(SQL.column(BalanceItem.table, 'status'), BalanceItemStatus.Due)
+            .first(false);
+
+        // Sums are null when the webshop has no balance items
+        const progressAmount = typeof row?.['data']?.['pricePaid'] === 'number' ? row['data']['pricePaid'] : 0;
+        const pendingAmount = typeof row?.['data']?.['pricePending'] === 'number' ? row['data']['pricePending'] : 0;
+
+        if (crowdfunding.progressAmount === progressAmount && crowdfunding.pendingAmount === pendingAmount) {
+            return;
+        }
+
+        crowdfunding.progressAmount = progressAmount;
+        crowdfunding.pendingAmount = pendingAmount;
+        await webshop.save();
+    }
+}

--- a/backend/app/api/tests/vitest.setup.ts
+++ b/backend/app/api/tests/vitest.setup.ts
@@ -12,6 +12,7 @@ import { sleep } from '@stamhoofd/utility';
 import * as jose from 'jose';
 import { GlobalHelper } from '../src/helpers/GlobalHelper.js';
 import { BalanceItemService } from '../src/services/BalanceItemService.js';
+import { WebshopCrowdfundingService } from '../src/services/WebshopCrowdfundingService.js';
 import { PayconiqMocker } from './helpers/PayconiqMocker.js';
 import { resetNock } from './helpers/resetNock.js';
 
@@ -92,6 +93,7 @@ afterAll(async () => {
     // Call twice to also wait on items that are scheduled withing scheduled tasks
     await BalanceItemService.flushAll();
     await BalanceItemService.flushAll();
+    await WebshopCrowdfundingService.flush();
     QueueHandler.abortAll(
         new SimpleError({
             code: 'SHUTDOWN',

--- a/frontend/app/dashboard/src/views/dashboard/webshop/WebshopOverview.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/WebshopOverview.vue
@@ -210,7 +210,7 @@
                         </p>
 
                         <template #right>
-                            <span class="icon error " v-tooltip="$t('%Pq')" />
+                            <span v-tooltip="$t('%Pq')" class="icon error " />
                             <span class="icon arrow-right-small gray" />
                         </template>
                     </STListItem>
@@ -303,6 +303,21 @@
                         </h2>
                         <p class="style-description">
                             {{ $t('%Pu') }}
+                        </p>
+                        <template #right>
+                            <span class="icon arrow-right-small gray" />
+                        </template>
+                    </STListItem>
+
+                    <STListItem :selectable="true" class="left-center" @click="$navigate(Routes.EditCrowdfunding)">
+                        <template #left>
+                            <img src="@stamhoofd/assets/images/illustrations/credits.svg">
+                        </template>
+                        <h2 class="style-title-list">
+                            {{ $t('Ingezameld bedrag en vooruitgang') }}
+                        </h2>
+                        <p class="style-description">
+                            {{ $t('Toon de vooruitgang van je inzameling, crowdfunding of totale donaties.') }}
                         </p>
                         <template #right>
                             <span class="icon arrow-right-small gray" />
@@ -508,6 +523,7 @@ enum Routes {
     Statistics = 'statistieken',
     EditGeneral = 'algemeen',
     EditPage = 'vormgeving',
+    EditCrowdfunding = 'crowdfunding',
     EditLink = 'link',
     EditProducts = 'artikels',
     EditDiscounts = 'kortingen',
@@ -565,6 +581,13 @@ defineRoute({
     url: Routes.EditPage,
     present: 'popup',
     component: async () => (await import('./edit/EditWebshopPageView.vue')).default,
+    defaultProperties: loadWebshopProperties,
+});
+
+defineRoute({
+    url: Routes.EditCrowdfunding,
+    present: 'popup',
+    component: async () => (await import('./edit/EditWebshopCrowdfundingView.vue')).default,
     defaultProperties: loadWebshopProperties,
 });
 
@@ -962,6 +985,16 @@ const todoList = computed(() => {
                 || !!webshopManager.value.preview.meta.useLogo
                 || !!webshopManager.value.preview.meta.color
                 || !!webshopManager.value.preview.meta.title,
+        });
+    }
+
+    if (webshopManager.value.preview.meta.type === WebshopType.Donations) {
+        list.push({
+            icon: 'partially',
+            title: $t('Voeg een vooruitgangsbalk toe'),
+            description: $t('Stel een doelbedrag in, of toon het totaal ingezamelde bedrag'),
+            action: () => $navigate(Routes.EditCrowdfunding),
+            done: !!webshop.value?.meta.crowdfunding,
         });
     }
 

--- a/frontend/app/dashboard/src/views/dashboard/webshop/WebshopOverview.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/WebshopOverview.vue
@@ -309,7 +309,7 @@
                         </template>
                     </STListItem>
 
-                    <STListItem v-if="webshopManager.preview.meta.type === WebshopType.Donations" :selectable="true" class="left-center" @click="$navigate(Routes.EditCrowdfunding)">
+                    <STListItem v-if="webshopManager.preview.meta.type === WebshopType.Donations || webshopManager.preview.meta.crowdfunding" :selectable="true" class="left-center" @click="$navigate(Routes.EditCrowdfunding)">
                         <template #left>
                             <img src="@stamhoofd/assets/images/illustrations/credits.svg">
                         </template>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/WebshopOverview.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/WebshopOverview.vue
@@ -309,15 +309,15 @@
                         </template>
                     </STListItem>
 
-                    <STListItem :selectable="true" class="left-center" @click="$navigate(Routes.EditCrowdfunding)">
+                    <STListItem v-if="webshopManager.preview.meta.type === WebshopType.Donations" :selectable="true" class="left-center" @click="$navigate(Routes.EditCrowdfunding)">
                         <template #left>
                             <img src="@stamhoofd/assets/images/illustrations/credits.svg">
                         </template>
                         <h2 class="style-title-list">
-                            {{ $t('Ingezameld bedrag en vooruitgang') }}
+                            {{ $t('Doelbedrag en vooruitgang') }}
                         </h2>
                         <p class="style-description">
-                            {{ $t('Toon de vooruitgang van je inzameling, crowdfunding of totale donaties.') }}
+                            {{ $t('Toon de vooruitgang van je inzameling, crowdfunding of donaties.') }}
                         </p>
                         <template #right>
                             <span class="icon arrow-right-small gray" />

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopCrowdfundingView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopCrowdfundingView.vue
@@ -1,0 +1,75 @@
+<template>
+    <SaveView :title="viewTitle" :loading="saving" :disabled="!hasChanges" class="webshop-view-page" @save="save">
+        <h1>{{ viewTitle }}</h1>
+        <STErrorsDefault :error-box="errors.errorBox" />
+
+        <STList>
+            <CheckboxListItem v-model="enableCrowdfunding" :label="$t('Toon ingezameld bedrag')" />
+            <CheckboxListItem v-if="enableCrowdfunding" v-model="enableGoal" :label="$t('Toon doelbedrag')">
+                <PriceInputBox v-if="enableGoal" v-model="goalAmount" :validator="errors.validator" :title="$t('Doelbedrag')" :min="0" />
+            </CheckboxListItem>
+        </STList>
+    </SaveView>
+</template>
+
+<script lang="ts" setup>
+import STErrorsDefault from '@stamhoofd/components/errors/STErrorsDefault.vue';
+import SaveView from '@stamhoofd/components/navigation/SaveView.vue';
+
+import { PrivateWebshop, WebshopCrowdfunding, WebshopMetaData } from '@stamhoofd/structures';
+
+import { computed } from 'vue';
+import type { UseEditWebshopProps } from './useEditWebshop';
+import { useEditWebshop } from './useEditWebshop';
+import STList from '@stamhoofd/components/layout/STList.vue';
+import CheckboxListItem from '@stamhoofd/components/inputs/CheckboxListItem.vue';
+import PriceInputBox from '@stamhoofd/components/inputs/PriceInputBox.vue';
+
+const props = defineProps<UseEditWebshopProps>();
+
+const { webshop, addPatch, errors, saving, save, hasChanges, shouldNavigateAway, originalWebshop } = useEditWebshop({
+    getProps: () => props,
+});
+const viewTitle = $t('Crowdfunding instellen');
+
+const enableCrowdfunding = computed({
+    get: () => webshop.value.meta.crowdfunding !== null,
+    set: (enableCrowdfunding: boolean) => {
+        if (enableCrowdfunding === (webshop.value.meta.crowdfunding !== null)) {
+            return;
+        }
+        const patch = WebshopMetaData.patch({
+            crowdfunding: enableCrowdfunding ? (originalWebshop.meta.crowdfunding ?? WebshopCrowdfunding.create({})) : null,
+        });
+        addPatch(PrivateWebshop.patch({ meta: patch }));
+    },
+});
+
+const enableGoal = computed({
+    get: () => webshop.value.meta.crowdfunding?.goalAmount !== null,
+    set: (enableGoal: boolean) => {
+        const patch = WebshopMetaData.patch({
+            crowdfunding: WebshopCrowdfunding.patch({
+                goalAmount: enableGoal ? (originalWebshop.meta.crowdfunding?.goalAmount ?? 0) : null,
+            }),
+        });
+        addPatch(PrivateWebshop.patch({ meta: patch }));
+    },
+});
+
+const goalAmount = computed({
+    get: () => webshop.value.meta.crowdfunding?.goalAmount ?? 0,
+    set: (goalAmount: number) => {
+        const patch = WebshopMetaData.patch({
+            crowdfunding: WebshopCrowdfunding.patch({
+                goalAmount: goalAmount,
+            }),
+        });
+        addPatch(PrivateWebshop.patch({ meta: patch }));
+    },
+});
+
+defineExpose({
+    shouldNavigateAway,
+});
+</script>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/EditWebshopPageView.vue
@@ -89,7 +89,8 @@
             {{ $t('%RX') }}
         </p>
 
-        <hr><h2>{{ $t('%2D') }}</h2>
+        <hr>
+        <h2>{{ $t('%2D') }}</h2>
         <p>
             {{ $t('%RY') }}
         </p>
@@ -101,7 +102,8 @@
         <LogoEditor v-if="!useLogo" :meta-data="webshop.meta" :validator="errors.validator" :dark-mode="darkMode" @patch="addMetaPatch" />
 
         <template v-if="hasTickets">
-            <hr><EditSponsorsBox :config="sponsorConfig" @patch="patchSponsorConfig" />
+            <hr>
+            <EditSponsorsBox :config="sponsorConfig" @patch="patchSponsorConfig" />
 
             <p class="style-button-bar">
                 <button type="button" class="button text" @click="previewTicket">

--- a/frontend/app/webshop/src/views/WebshopView.vue
+++ b/frontend/app/webshop/src/views/WebshopView.vue
@@ -30,6 +30,11 @@
                         </figure>
                         <h1>{{ webshop.meta.title || webshop.meta.name }}</h1>
 
+                        <template v-if="webshop.meta.crowdfunding">
+                            <CrowdfundingBar :crowdfunding="webshop.meta.crowdfunding" />
+                            <hr class="style-hr">
+                        </template>
+
                         <!-- eslint-disable-next-line vue/no-v-html -> cleaned in backend -->
                         <div v-if="webshop.meta.description.html" class="style-wysiwyg gray" v-html="webshop.meta.description.html" />
                         <p v-else-if="webshop.meta.description.text" class="description" v-text="webshop.meta.description.text" />
@@ -94,6 +99,7 @@ import type { CheckoutStep } from './checkout/CheckoutStepsManager';
 import { CheckoutStepsManager } from './checkout/CheckoutStepsManager';
 
 import FullPageProduct from './FullPageProduct.vue';
+import CrowdfundingBar from './components/CrowdfundingBar.vue';
 
 const visible = ref(true);
 

--- a/frontend/app/webshop/src/views/checkout/PaymentSelectionView.vue
+++ b/frontend/app/webshop/src/views/checkout/PaymentSelectionView.vue
@@ -1,5 +1,5 @@
 <template>
-    <SaveView :title="title" :loading="loading" :save-text="$t('%Xv')" :prefer-large-button="true" data-testid="payment-step" @save="goNext">
+    <SaveView :title="title" :loading="loading" :save-text="confirmText" :prefer-large-button="true" data-testid="payment-step" @save="goNext">
         <template v-if="checkout.totalPrice > 0" #left>
             <span>{{ $t('%xL') }}: {{ formatPrice(checkout.totalPrice) }}</span>
         </template>
@@ -36,7 +36,7 @@ import { useNavigationActions } from '@stamhoofd/components/types/NavigationActi
 import { PaymentHandler } from '@stamhoofd/components/views/PaymentHandler.ts';
 import PaymentSelectionList from '@stamhoofd/components/views/PaymentSelectionList.vue';
 import type { Payment } from '@stamhoofd/structures';
-import { OrderData, OrderResponse, PaymentMethod } from '@stamhoofd/structures';
+import { OrderData, OrderResponse, PaymentMethod, WebshopType } from '@stamhoofd/structures';
 import { computed, ref } from 'vue';
 import { useCheckoutManager } from '../../composables/useCheckoutManager';
 import { useWebshopManager } from '../../composables/useWebshopManager';
@@ -71,6 +71,29 @@ const webshop = computed(() => webshopManager.webshop);
 const organization = computed(() => webshopManager.organization);
 const isTrial = computed(() => organization.value.meta.packages.isWebshopsTrial);
 const paymentConfiguration = computed(() => webshop.value.meta.paymentConfiguration);
+
+const confirmText = computed(() => {
+    if (webshop.value.meta.type === WebshopType.Donations) {
+        return $t('Bijdrage bevestigen');
+    }
+
+    if (webshop.value.meta.type === WebshopType.Registrations) {
+        return $t('Inschrijving bevestigen');
+    }
+
+    if (webshop.value.meta.type === WebshopType.Event) {
+        return $t('Inschrijving bevestigen');
+    }
+
+    if (webshop.value.meta.type === WebshopType.Webshop) {
+        return $t('%Xv');
+    }
+
+    if (checkout.value.totalPrice > 0) {
+        return $t('Aankoop bevestigen');
+    }
+    return $t('Bevestigen');
+});
 
 async function goToOrder(id: string, args: NavigationActions) {
     // Force reload webshop (stock will have changed: prevent invalidating the cart)

--- a/frontend/app/webshop/src/views/checkout/PaymentSelectionView.vue
+++ b/frontend/app/webshop/src/views/checkout/PaymentSelectionView.vue
@@ -81,10 +81,6 @@ const confirmText = computed(() => {
         return $t('Inschrijving bevestigen');
     }
 
-    if (webshop.value.meta.type === WebshopType.Event) {
-        return $t('Inschrijving bevestigen');
-    }
-
     if (webshop.value.meta.type === WebshopType.Webshop) {
         return $t('%Xv');
     }

--- a/frontend/app/webshop/src/views/components/CrowdfundingBar.vue
+++ b/frontend/app/webshop/src/views/components/CrowdfundingBar.vue
@@ -1,0 +1,78 @@
+<template>
+    <div class="crowdfunding-bar">
+        <div v-if="crowdfunding.goalAmount" class="progress-bar">
+            <div class="progress" :style="{width: progress.toFixed(2) + '%'}" />
+        </div>
+
+        <div class="split-inputs">
+            <div>
+                <h3 class="style-definition-label">
+                    {{ $t('Opgehaald') }}
+                </h3>
+                <p class="style-definition-text">
+                    {{ formatPrice(crowdfunding.progressAmount + crowdfunding.pendingAmount) }}
+                </p>
+            </div>
+
+            <div v-if="crowdfunding.goalAmount">
+                <h3 class="style-definition-label">
+                    {{ $t('Doel') }}
+                </h3>
+                <p class="style-definition-text">
+                    {{ formatPrice(crowdfunding.goalAmount) }}
+                </p>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import type { WebshopCrowdfunding } from '@stamhoofd/structures';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    crowdfunding: WebshopCrowdfunding;
+}>();
+
+const progress = computed(() => {
+    if (!props.crowdfunding.goalAmount) {
+        return 100;
+    }
+    return Math.max(0, Math.min(100, (props.crowdfunding.progressAmount + props.crowdfunding.pendingAmount) / props.crowdfunding.goalAmount * 100));
+});
+
+</script>
+
+<style lang="scss">
+@use "@stamhoofd/scss/base/variables.scss" as *;
+@use "@stamhoofd/scss/base/text-styles.scss" as *;
+
+.crowdfunding-bar {
+    .progress-bar {
+        background: $color-border;
+        height: 6px;
+        overflow: hidden;
+        margin: 15px 0;
+        position: relative;
+        border-radius: 10px;
+
+        .progress {
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            background: $color-primary;
+            border-radius: 10px;
+        }
+
+        .pending-progress {
+            position: absolute;
+            left: 0;
+            top: 0;
+            bottom: 0;
+            background: $color-primary-gray-light;
+            border-radius: 10px;
+        }
+    }
+}
+</style>

--- a/frontend/app/webshop/src/views/components/CrowdfundingBar.vue
+++ b/frontend/app/webshop/src/views/components/CrowdfundingBar.vue
@@ -4,7 +4,7 @@
             <div class="progress" :style="{width: progress.toFixed(2) + '%'}" />
         </div>
 
-        <div class="split-inputs">
+        <div class="split">
             <div>
                 <h3 class="style-definition-label">
                     {{ $t('Opgehaald') }}
@@ -73,6 +73,12 @@ const progress = computed(() => {
             background: $color-primary-gray-light;
             border-radius: 10px;
         }
+    }
+
+    .split {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+        gap: 15px;
     }
 }
 </style>

--- a/frontend/app/webshop/src/views/orders/OrderView.vue
+++ b/frontend/app/webshop/src/views/orders/OrderView.vue
@@ -9,15 +9,12 @@
 
             <main>
                 <p v-if="!webshop.meta.reduceBranding && STAMHOOFD.platformName === 'stamhoofd'" class="stamhoofd-header">
-                    <a :href="'https://' + LocalizedDomains.marketing + '?utm_medium=webshop'" target="_blank" class="button text"><span v-if="hasTickets">{{ $t('%Y3') }} </span><span v-else>{{ $t('%Y4') }}</span>  <Logo /></a>
+                    <a :href="'https://' + LocalizedDomains.marketing + '?utm_medium=webshop'" target="_blank" class="button text"><span v-if="hasTickets">{{ $t('%Y3') }} </span><span v-else>{{ $t('Gemaakt met') }}</span>  <Logo /></a>
                 </p>
                 <div class="box">
                     <main>
-                        <h1 v-if="success">
-                            {{ $t('%Y5') }}
-                        </h1>
-                        <h1 v-else>
-                            {{ $t('%Y6') }}
+                        <h1>
+                            {{ title }}
                         </h1>
 
                         <p v-if="success">
@@ -118,14 +115,14 @@
                             <hr><h2>{{ $t('%YI') }}</h2>
                         </template>
                         <p v-else-if="!isCanceled && !isPaid && isTransfer" class="warning-box">
-                            {{ $t('%YR') }}
+                            {{ $t('Je betaling wordt handmatig bevestigd. Zodra ze als betaald is gemarkeerd, ontvang je een bevestigingsmail. Dit kan enkele dagen duren. Via de knop onderaan bekijk je de instructies opnieuw.') }}
                         </p>
                         <p v-else-if="!isCanceled && !isPaid && !isTransfer" class="warning-box">
                             {{ $t('%YS') }} {{ getLowerCaseName(order.data.paymentMethod) }}
                         </p>
 
                         <STList class="info">
-                            <STListItem>
+                            <STListItem v-if="!success && order.createdAt < new Date(Date.now() - 1000 * 60 * 60 * 24 * 31)">
                                 <h3 class="style-definition-label">
                                     {{ $t('%1AV') }}
                                 </h3>
@@ -223,7 +220,7 @@
                                 </p>
                             </STListItem>
 
-                            <STListItem class="right-description">
+                            <STListItem v-if="order.status !== OrderStatus.Created" class="right-description">
                                 <h3 class="style-definition-label">
                                     {{ $t('%1A') }}
                                 </h3>
@@ -384,7 +381,7 @@ import { Toast } from '@stamhoofd/components/overlays/Toast.ts';
 
 import ViewRecordCategoryAnswersBox from '@stamhoofd/components/records/components/ViewRecordCategoryAnswersBox.vue';
 import type { Payment } from '@stamhoofd/structures';
-import { Gender, getGenderName, Order, OrderStatus, OrderStatusHelper, PaymentMethod, PaymentMethodHelper, PaymentStatus, ProductType, RecordCategory, TicketOrder, TicketPublic, WebshopTicketType } from '@stamhoofd/structures';
+import { Gender, getGenderName, Order, OrderStatus, OrderStatusHelper, PaymentMethod, PaymentMethodHelper, PaymentStatus, ProductType, RecordCategory, TicketOrder, TicketPublic, WebshopTicketType, WebshopType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { computed, onMounted, ref, watch } from 'vue';
 
@@ -419,6 +416,65 @@ const singleTicket = computed(() => tickets.value.length === 1 || webshop.value.
 const canShare = computed(() => !!navigator.share);
 const isPaid = computed(() => order.value && (order.value.payment === null || order.value.payment.status === PaymentStatus.Succeeded));
 const isTransfer = computed(() => getDefaultTransferPayment() !== null);
+
+const title = computed(() => {
+    if (props.success && isPaid.value) {
+        if (webshop.value.meta.type === WebshopType.Donations) {
+            return $t('Bijdrage bevestigd');
+        }
+
+        if (hasTickets.value) {
+            if (singleTicket.value) {
+                return $t('Jouw ticket is bevestigd');
+            }
+            return $t('Jouw tickets zijn bevestigd');
+        }
+
+        if (webshop.value.meta.type === WebshopType.Registrations) {
+            return $t('Inschrijving bevestigd');
+        }
+
+        return $t('Bestelling bevestigd');
+    } else if (!isPaid.value && !isCanceled.value && !isFailed.value && order.value?.data.paymentMethod !== PaymentMethod.PointOfSale) {
+        if (isTransfer.value) {
+            return $t('In afwachting van handmatige bevestiging');
+        }
+
+        if (webshop.value.meta.type === WebshopType.Donations) {
+            return $t('In afwachting van betaling');
+        }
+
+        if (hasTickets.value) {
+            if (singleTicket.value) {
+                return $t('Je ontvangt jouw ticket na betaling');
+            }
+            return $t('Je ontvangt jouw tickets na betaling');
+        }
+
+        if (webshop.value.meta.type === WebshopType.Registrations) {
+            return $t('Je inschrijving wordt bevestigd na je betaling');
+        }
+
+        return $t('Je bestelling wordt bevestigd na je betaling');
+    }
+
+    if (webshop.value.meta.type === WebshopType.Donations) {
+        return $t('Jouw bijdrage');
+    }
+
+    if (hasTickets.value) {
+        if (singleTicket.value) {
+            return $t('Jouw ticket');
+        }
+        return $t('Jouw tickets');
+    }
+
+    if (webshop.value.meta.type === WebshopType.Registrations) {
+        return $t('Jouw inschrijving');
+    }
+
+    return $t('%Y6');
+});
 
 // Make sure the url is overriden
 setUrl(new ReactiveUrl({ url: 'order/' + (order.value?.id ?? props.orderId) }), 'Bestelling ' + (order.value?.number ?? ''));

--- a/frontend/shared/components/src/navigation/LegalFooter.vue
+++ b/frontend/shared/components/src/navigation/LegalFooter.vue
@@ -31,8 +31,7 @@
             </aside>
             <div v-if="STAMHOOFD.platformName !== 'stamhoofd'" class="style-wysiwyg gray no-underline-links" v-html="platform.config.shopFooterText.html" />
             <div v-else>
-                <a v-if="hasTickets" :href="'https://'+ LocalizedDomains.marketing +'?utm_medium=webshop'">{{ $t('%Y3') }} <Logo /></a>
-                <a v-else-if="isWebshop" :href="'https://'+ LocalizedDomains.marketing +'?utm_medium=webshop'">{{ $t('%gB') }} <Logo /></a>
+                <a v-if="isWebshop" :href="'https://'+ LocalizedDomains.marketing +'?utm_medium=webshop'">{{ $t('Gemaakt met') }} <Logo /></a>
                 <a v-else :href="'https://'+ LocalizedDomains.marketing +'/ledenadministratie?utm_medium=ledenportaal'">{{ $t('%XC') }} <Logo /></a>
             </div>
         </div>
@@ -41,7 +40,7 @@
 
 <script lang="ts" setup>
 import type { Company, Organization, Webshop, WebshopPreview } from '@stamhoofd/structures';
-import { LanguageHelper, WebshopTicketType } from '@stamhoofd/structures';
+import { LanguageHelper } from '@stamhoofd/structures';
 
 import { useContext } from '#hooks/useContext.ts';
 import { usePlatform } from '#hooks/usePlatform.ts';
@@ -90,8 +89,6 @@ const privacyUrl = computed(() => {
 });
 
 const policies = computed(() => props.webshop?.meta.policies ?? []);
-
-const hasTickets = computed(() => props.webshop?.meta.ticketType === WebshopTicketType.Tickets);
 
 const isWebshop = computed(() => !!props.webshop);
 const { hasLanguages, switchLanguage } = useSwitchLanguage();

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -110,7 +110,8 @@
             <FieldBox v-for="field in cartItem.product.customFields" :key="field.id" :field="field" :answers="cartItem.fieldAnswers" :error-box="errors.errorBox" />
 
             <template v-if="canOrder && canSelectAmount">
-                <hr><h2>{{ $t('%M4') }}</h2>
+                <hr>
+                <h2>{{ $t('%M4') }}</h2>
 
                 <STInputBox class="max">
                     <NumberInput v-model="cartItem.amount" :suffix="suffix" :suffix-singular="suffixSingular" :max="maximumRemaining" :min="1" :stepper="true" data-testid="amount-number-input" />

--- a/frontend/shared/components/src/views/ProductBox.vue
+++ b/frontend/shared/components/src/views/ProductBox.vue
@@ -1,5 +1,5 @@
 <template>
-    <article class="product-box" :class="{ selected: count > 0}" data-testid="product-box" @click="onClicked">
+    <article class="product-box" :class="{ selected: count > 0, 'show-count': product.allowMultiple}" data-testid="product-box" @click="onClicked">
         <div class="left" />
         <div class="content">
             <div>
@@ -359,7 +359,7 @@ function formatDateRange(dateRange: ProductDateRange) {
         position: relative;
     }
 
-    &.selected {
+    &.selected.show-count {
         > .content > div {
             > h3 {
                 transform: translateX(30px);

--- a/shared/structures/src/webshops/WebshopMetaData.ts
+++ b/shared/structures/src/webshops/WebshopMetaData.ts
@@ -405,6 +405,33 @@ export enum WebshopAuthType {
     Required = 'Required',
 }
 
+export class WebshopCrowdfunding extends AutoEncoder {
+    /**
+     * NOTE: We store an integer of the price up to 4 digits after the comma.
+     * 1 euro = 10000.
+     */
+    @field({ decoder: IntegerDecoder, nullable: true })
+    goalAmount: number | null = null;
+
+    /**
+     * Cached sum of the paid amounts (pricePaid) of all balance items of this webshop.
+     *
+     * NOTE: We store an integer of the price up to 4 digits after the comma.
+     * 1 euro = 10000.
+     */
+    @field({ decoder: IntegerDecoder })
+    progressAmount = 0;
+
+    /**
+     * Cached sum of the pending payment amounts (pricePending) of all balance items of this webshop.
+     *
+     * NOTE: We store an integer of the price up to 4 digits after the comma.
+     * 1 euro = 10000.
+     */
+    @field({ decoder: IntegerDecoder })
+    pendingAmount = 0;
+}
+
 export class WebshopMetaData extends AutoEncoder {
     @field({ decoder: StringDecoder })
     name = '';
@@ -622,6 +649,13 @@ export class WebshopMetaData extends AutoEncoder {
      */
     @field({ decoder: new EnumDecoder(Language), version: 404 })
     defaultLanguage: Language = Language.Dutch;
+
+    /**
+     * Enables crowdfunding: publicly shows the (goal and) progress of the total revenue of this webshop.
+     * When null, the cached amounts are not calculated or updated.
+     */
+    @field({ decoder: WebshopCrowdfunding, nullable: true, ...NextVersion })
+    crowdfunding: WebshopCrowdfunding | null = null;
 
     /**
      * Returns whether the webshop is event/ticketing based - regardless whether scanners are used or not


### PR DESCRIPTION
Adds a minimal crowdfunding feature to webshops: a nullable `crowdfunding` structure on `WebshopMetaData` (`goalAmount` + cached `progressAmount`/`pendingAmount`, 4-decimal price units) that publicly shows fundraising progress when enabled.

**Backend**
- `WebshopCrowdfundingService` recalculates the cached amounts with one SQL sum over the order balance items (status `Due` only), serialized through the `webshop-stock/` queue and throttled to one update per webshop per 10s (1s in development).
- Wired into `BalanceItemService.scheduleUpdates`, so order placement, payment success/failure and order cancellation all update the amounts.
- `PlaceOrderEndpoint` / `PatchWebshopOrdersEndpoint` now run `updatePaidAndPending` after creating order balance items so unconfirmed transfer/point-of-sale payments count as pending. Patching the crowdfunding settings (e.g. enabling it) triggers an immediate recalculation so existing paid orders count right away.

**Frontend**
- Progress bar on the webshop, settings view in the dashboard (donation-type webshops get a todo suggestion), and order view titles per webshop type.

**Gotchas**
- `pendingAmount` deliberately excludes online payments: their balance item stays hidden until the payment succeeds. It includes payments in `Created` state (Stamhoofd's `pricePending` semantics), so an unconfirmed transfer counts until it's marked paid/failed.
- Canceling an order removes its paid amount from the progress (balance items become `Canceled`).

**Still to do (follow-up)**: Playwright happy-path test for the crowdfunding bar + settings view.

Covered by 14 backend tests (unit + endpoint lifecycle: online pending→paid/failed via mocked Stripe, transfer paid/failed, admin-created orders, cancellation, enable-recalculation). Full api suite green; vue-tsc clean for webshop + dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789215620&installation_model_id=423362&pr_number=743&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F743&signature=2a657f667e6cf4eff903089d5e87b5a8a19e92d51d491e018f201b22630dfc31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->