### PR TITLE
Don't show 'saldoverrekening' when only payment is deferred

### DIFF
--- a/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
+++ b/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
@@ -259,7 +259,7 @@ const refundableOnlinePayments = computed(() => {
 
 const showBalanceSettelment = computed(() => {
     const hasOnlyDeferredPayments = !detailedItem.value?.filteredBalanceItems
-        .some(b => b.dueAt < new Date());
+        .some(b => b.dueAt && b.dueAt < new Date());
 
     return detailedItem.value?.amountOpen === 0 && detailedItem.value?.filteredBalanceItems.length
         && !hasOnlyDeferredPayments;

--- a/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
+++ b/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
@@ -95,7 +95,7 @@
                     </template>
                 </STListItem>
 
-                <STListItem v-if="detailedItem.amountOpen === 0 && detailedItem.filteredBalanceItems.length" :selectable="true" element-name="button" class="theme-secundary" @click="createPayment(PaymentType.Reallocation)">
+                <STListItem v-if="showBalanceSettelment" :selectable="true" element-name="button" class="theme-secundary" @click="createPayment(PaymentType.Reallocation)">
                     <template #left>
                         <IconContainer icon="wand">
                             <template #aside>
@@ -255,6 +255,14 @@ const refundableOnlinePayments = computed(() => {
     return detailedItem.value?.payments
         .filter(p => p.provider === PaymentProvider.Mollie && p.type === PaymentType.Payment && p.isSucceeded && p.price + p.refundedAmount + p.pendingRefundAmount > 0)
         .sort((a, b) => Sorter.byDateValue(a.paidAt ?? a.createdAt, b.paidAt ?? b.createdAt)) ?? [];
+});
+
+const showBalanceSettelment = computed(() => {
+    const hasOnlyDeferredPayments = !detailedItem.value?.balanceItems
+        .some(b => b.dueAt < new Date());
+
+    return detailedItem.value?.amountOpen === 0 && detailedItem.value?.filteredBalanceItems.length
+        && !hasOnlyDeferredPayments;
 });
 
 // Load detailed item

--- a/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
+++ b/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
@@ -258,7 +258,7 @@ const refundableOnlinePayments = computed(() => {
 });
 
 const showBalanceSettelment = computed(() => {
-    const hasOnlyDeferredPayments = !detailedItem.value?.balanceItems
+    const hasOnlyDeferredPayments = !detailedItem.value?.filteredBalanceItems
         .some(b => b.dueAt < new Date());
 
     return detailedItem.value?.amountOpen === 0 && detailedItem.value?.filteredBalanceItems.length


### PR DESCRIPTION
Fixes #STA-1305

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789570862&installation_model_id=423362&pr_number=747&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F747&signature=6087c5bb381e1df61499300af11a3ee5a6297f4f38ff06e617cd1c37e518f538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->