### PR TITLE
Added redirects for platform-admin and search others to custom domains

### DIFF
--- a/frontend/app/web-app/src/RouterAppView.vue
+++ b/frontend/app/web-app/src/RouterAppView.vue
@@ -5,12 +5,12 @@
 <script lang="ts" setup>
 import { SimpleError } from '@simonbackx/simple-errors';
 import { ComponentWithProperties, defineRoute, UrlHelper, useNavigate } from '@simonbackx/vue-app-navigation';
+import { AsyncComponent } from '@stamhoofd/components/containers/AsyncComponent.ts';
 import LoadingView from '@stamhoofd/components/containers/LoadingView.vue';
 import { provideAppNavigate } from '@stamhoofd/components/hooks/useAppNavigate';
 import { AppManager } from '@stamhoofd/networking/AppManager';
 import type { Organization } from '@stamhoofd/structures';
 import { AppRoute } from '@stamhoofd/structures';
-import type { Language } from '@stamhoofd/types/Language';
 import { Formatter } from '@stamhoofd/utility';
 import { domainToOrganization, idToOrganization, uriToOrganization } from './organizationLoaders';
 import { wrap } from './wrapAndReplace';
@@ -96,6 +96,16 @@ if (isDashboardDomain) {
         url: 'platform',
         component: async () => {
             return await loadAdmin();
+        },
+    });
+} else if (orgInDomain) {
+    defineRoute({
+        name: AppRoute.Admin,
+        url: 'platform',
+        component: async () => {
+            return AsyncComponent(() => import('@stamhoofd/components/auth/RedirectView.vue'), {
+                location: `https://${STAMHOOFD.domains.dashboard}/platform`,
+            });
         },
     });
 }
@@ -274,6 +284,18 @@ if (orgInDomain) {
         replace: 100,
         component: async () => {
             return await loadAuto(await orgInDomain());
+        },
+    });
+    defineRoute({
+        name: AppRoute.UnscopedAuto,
+        url: '',
+        isDefault: {},
+        force: true,
+        replace: 100,
+        component: async () => {
+            return AsyncComponent(() => import('@stamhoofd/components/auth/RedirectView.vue'), {
+                location: `https://${STAMHOOFD.domains.dashboard}`,
+            });
         },
     });
 } else {

--- a/frontend/shared/components/src/context/OrganizationAppSelector.vue
+++ b/frontend/shared/components/src/context/OrganizationAppSelector.vue
@@ -54,7 +54,7 @@
                     </template>
 
                     <h1 class="style-title-list">
-                        {{ $t('%a3') }}
+                        {{ $t('Andere vereniging zoeken') }}
                     </h1>
                 </STListItem>
             </STList>
@@ -63,7 +63,7 @@
                 <hr v-if="currentOptions.length || otherOptions.length">
                 <button class="button text" type="button" data-testid="app-switcher-search-others" @click="searchOrganizations">
                     <span class="icon search" />
-                    <span>{{ $t('%a3') }}</span>
+                    <span>{{ $t('Andere vereniging zoeken') }}</span>
                 </button>
             </template>
         </main>
@@ -107,7 +107,6 @@ function isCurrentOption(o: Option) {
     // Current option = logged in with the same user
     return (!organization.value || !o.organization || (organization.value && o.organization?.id === organization.value.id)) && user.value && o.context.user?.id === user.value.id;
 }
-
 const currentOptions = computed(() => {
     const list = options.value.filter(o => isCurrentOption(o));
     if (list.length >= 1) {

--- a/tests/playwright/src/tests/routing.spec.ts
+++ b/tests/playwright/src/tests/routing.spec.ts
@@ -1218,6 +1218,8 @@ test.describe('Routing on page load @routing', () => {
     });
 
     [true, false].forEach((useRegisterDomain) => {
+        const originalDomain = WorkerData.urls.dashboard;
+
         test.describe(useRegisterDomain ? 'Organization mode on custom domain' : 'Organization mode on default register domain', () => {
             let organization!: Organization;
             let domain!: string;
@@ -1252,12 +1254,12 @@ test.describe('Routing on page load @routing', () => {
                     await loginAs({ user, page });
                 });
 
-                test('/platform/instellingen redirects to /beheerders/leden/instellingen', async ({ page }) => {
+                test('/platform redirects to default dashboard domain /platform/start', async ({ page }) => {
                     await testRoute({
                         page,
                         user,
-                        url: domain + '/platform/instellingen',
-                        expectedUrl: domain + '/nl-BE/beheerders/leden/instellingen',
+                        url: domain + '/platform',
+                        expectedUrl: originalDomain + '/nl-BE/platform/start',
                         expectedScope,
                         expectedLocator: '[data-testid="members-menu"]',
                         expectedTopLeft: {

--- a/tests/playwright/src/tests/routing.spec.ts
+++ b/tests/playwright/src/tests/routing.spec.ts
@@ -181,6 +181,13 @@ async function testRoute({ page, ...spec }: {
     }
 }
 
+async function clickSearchOtherOrganizations({ page, expectedUrl }: { page: Page; expectedUrl: string }) {
+    await page.getByTestId('app-switcher-search-others').click();
+    await expect(page).toHaveURL(expectedUrl, { timeout: 5_000 });
+    await expect(page.getByTestId('organization-selection-view')).toBeVisible();
+    await checkScopedTo({ page, organization: null });
+}
+
 test.describe('Routing on page load @routing', () => {
     /**
      * Default if not set.
@@ -844,6 +851,26 @@ test.describe('Routing on page load @routing', () => {
                 });
             });
 
+            test("clicking 'Andere vereniging zoeken' shows the organization overview without leaving the dashboard domain", async ({ page }) => {
+                await testRoute({
+                    page,
+                    user,
+                    url: domain + '/platform/instellingen',
+                    expectedUrl: domain + '/nl-BE/platform/instellingen',
+                    expectedScope: null,
+                    expectedLocator: '#settings-view',
+                    expectedTopLeft: {
+                        options: [adminOption, otherOrgOptions(membershipOrganization)],
+                        includeSearchOthers: true,
+                    },
+                });
+
+                await clickSearchOtherOrganizations({
+                    page,
+                    expectedUrl: domain + '/nl-BE',
+                });
+            });
+
             test('/beheerders/<uri>/instellingen', async ({ page }) => {
                 const organization = await createOrganization();
 
@@ -1281,6 +1308,26 @@ test.describe('Routing on page load @routing', () => {
                             options: [adminOption, scopedMemberPortalOption(organization), dashboardOption(organization), otherOrgOptions(membershipOrganization)],
                             includeSearchOthers: true,
                         },
+                    });
+                });
+
+                test("clicking 'Andere vereniging zoeken' redirects to the organization overview on the dashboard domain", async ({ page }) => {
+                    await testRoute({
+                        page,
+                        user,
+                        url: domain + '/beheerders/instellingen',
+                        expectedUrl: domain + '/nl-BE/beheerders/instellingen',
+                        expectedScope,
+                        expectedLocator: '#settings-view',
+                        expectedTopLeft: {
+                            options: [adminOption, scopedMemberPortalOption(organization), dashboardOption(organization), otherOrgOptions(membershipOrganization)],
+                            includeSearchOthers: true,
+                        },
+                    });
+
+                    await clickSearchOtherOrganizations({
+                        page,
+                        expectedUrl: originalDomain + '/nl-BE',
                     });
                 });
 

--- a/tests/playwright/src/tests/routing.spec.ts
+++ b/tests/playwright/src/tests/routing.spec.ts
@@ -181,13 +181,6 @@ async function testRoute({ page, ...spec }: {
     }
 }
 
-async function clickSearchOtherOrganizations({ page, expectedUrl }: { page: Page; expectedUrl: string }) {
-    await page.getByTestId('app-switcher-search-others').click();
-    await expect(page).toHaveURL(expectedUrl, { timeout: 5_000 });
-    await expect(page.getByTestId('organization-selection-view')).toBeVisible();
-    await checkScopedTo({ page, organization: null });
-}
-
 test.describe('Routing on page load @routing', () => {
     /**
      * Default if not set.
@@ -851,26 +844,6 @@ test.describe('Routing on page load @routing', () => {
                 });
             });
 
-            test("clicking 'Andere vereniging zoeken' shows the organization overview without leaving the dashboard domain", async ({ page }) => {
-                await testRoute({
-                    page,
-                    user,
-                    url: domain + '/platform/instellingen',
-                    expectedUrl: domain + '/nl-BE/platform/instellingen',
-                    expectedScope: null,
-                    expectedLocator: '#settings-view',
-                    expectedTopLeft: {
-                        options: [adminOption, otherOrgOptions(membershipOrganization)],
-                        includeSearchOthers: true,
-                    },
-                });
-
-                await clickSearchOtherOrganizations({
-                    page,
-                    expectedUrl: domain + '/nl-BE',
-                });
-            });
-
             test('/beheerders/<uri>/instellingen', async ({ page }) => {
                 const organization = await createOrganization();
 
@@ -1287,13 +1260,36 @@ test.describe('Routing on page load @routing', () => {
                         user,
                         url: domain + '/platform',
                         expectedUrl: originalDomain + '/nl-BE/platform/start',
+                        expectedScope: null,
+                        expectedLocator: '[data-testid="platform-start-view"]',
+                        expectedTopLeft: {
+                            options: [adminOption, otherOrgOptions(membershipOrganization)],
+                            includeSearchOthers: true,
+                        },
+                    });
+                });
+
+                test('Searching other organizations goes to default dashboard domain', async ({ page }) => {
+                    await testRoute({
+                        page,
+                        user,
+                        url: domain + '/beheerders/instellingen',
+                        expectedUrl: domain + '/nl-BE/beheerders/instellingen',
                         expectedScope,
-                        expectedLocator: '[data-testid="members-menu"]',
+                        expectedLocator: '#settings-view',
                         expectedTopLeft: {
                             options: [adminOption, scopedMemberPortalOption(organization), dashboardOption(organization), otherOrgOptions(membershipOrganization)],
                             includeSearchOthers: true,
                         },
                     });
+
+                    const selector = page.locator('.organization-app-switcher');
+                    await expect(selector).toBeVisible();
+
+                    const switchLocator = selector.locator(`[data-testid='app-switcher-search-others']`);
+                    await switchLocator.click();
+
+                    await expect(page).toHaveURL(originalDomain + '/nl-BE', { timeout: 5_000 });
                 });
 
                 test('/beheerders/instellingen', async ({ page }) => {
@@ -1308,26 +1304,6 @@ test.describe('Routing on page load @routing', () => {
                             options: [adminOption, scopedMemberPortalOption(organization), dashboardOption(organization), otherOrgOptions(membershipOrganization)],
                             includeSearchOthers: true,
                         },
-                    });
-                });
-
-                test("clicking 'Andere vereniging zoeken' redirects to the organization overview on the dashboard domain", async ({ page }) => {
-                    await testRoute({
-                        page,
-                        user,
-                        url: domain + '/beheerders/instellingen',
-                        expectedUrl: domain + '/nl-BE/beheerders/instellingen',
-                        expectedScope,
-                        expectedLocator: '#settings-view',
-                        expectedTopLeft: {
-                            options: [adminOption, scopedMemberPortalOption(organization), dashboardOption(organization), otherOrgOptions(membershipOrganization)],
-                            includeSearchOthers: true,
-                        },
-                    });
-
-                    await clickSearchOtherOrganizations({
-                        page,
-                        expectedUrl: originalDomain + '/nl-BE',
                     });
                 });
 


### PR DESCRIPTION
Fixes #STA-1203

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789632845&installation_model_id=423362&pr_number=748&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F748&signature=33f77cebf336e8c2f6adf5b2bc076dd3e0c3e94a2a986a9c000e860e1fca89ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->