### PR TITLE
Removed 'Openstaan bedrag' if no financial read rights

### DIFF
--- a/frontend/shared/components/src/members/MembersTableView.vue
+++ b/frontend/shared/components/src/members/MembersTableView.vue
@@ -55,7 +55,6 @@ import { useAdvancedMemberWithRegistrationsBlobUIFilterBuilders } from '../filte
 import { useRegistrationInvitationEventListener } from '#registrations/classes/useRegistrationInvitationEventListener.ts';
 import { useDirectMemberActions } from './classes/MemberActionBuilder';
 import { getMemberColumns } from '#members/helpers/getMemberColumns.ts';
-import MemberSegmentedView from './MemberSegmentedView.vue';
 
 type ObjectType = PlatformMember;
 

--- a/frontend/shared/components/src/members/classes/getSelectableWorkbook.ts
+++ b/frontend/shared/components/src/members/classes/getSelectableWorkbook.ts
@@ -128,12 +128,12 @@ export function getSelectableColumns({ platform, organization, auth, groupColumn
         }),
         // will always be 0 if organization is null
         organization !== null
-            ? new SelectableColumn({
+            ? returnNullIfNoAccessRight(new SelectableColumn({
                     id: 'outstandingBalance',
                     name: $t(`%76`),
                     description: $t('%184'),
                     enabled: false,
-                })
+                }), [AccessRight.MemberReadFinancialData])
             : null,
         new SelectableColumn({
             id: 'createdAt',

--- a/frontend/shared/components/src/members/helpers/getMemberColumns.ts
+++ b/frontend/shared/components/src/members/helpers/getMemberColumns.ts
@@ -560,21 +560,23 @@ export function getMemberColumns({ organization, dateRange, group, groups, filte
         );
     }
 
-    allColumns.push(
-        new Column<ObjectType, number>({
-            name: $t(`%76`),
-            description: $t('%184'),
-            allowSorting: false,
-            getValue: v => v.member.balances.reduce((sum, r) => sum + (r.amountOpen), 0),
-            format: (outstandingBalance) => {
-                return Formatter.price(outstandingBalance);
-            },
-            getStyle: v => v === 0 ? 'gray' : (v < 0 ? 'negative' : ''),
-            minimumWidth: 70,
-            recommendedWidth: 200,
-            enabled: false,
-        }),
-    );
+    if (financialRead) {
+        allColumns.push(
+            new Column<ObjectType, number>({
+                name: $t(`%76`),
+                description: $t('%184'),
+                allowSorting: false,
+                getValue: v => v.member.balances.reduce((sum, r) => sum + (r.amountOpen), 0),
+                format: (outstandingBalance) => {
+                    return Formatter.price(outstandingBalance);
+                },
+                getStyle: v => v === 0 ? 'gray' : (v < 0 ? 'negative' : ''),
+                minimumWidth: 70,
+                recommendedWidth: 200,
+                enabled: false,
+            }),
+        );
+    }
 
     if (category) {
         allColumns.push(

--- a/frontend/shared/components/src/members/helpers/getRegistrationColumns.ts
+++ b/frontend/shared/components/src/members/helpers/getRegistrationColumns.ts
@@ -514,7 +514,7 @@ export function getRegistrationColumns({ platform, organization, dateRange, grou
         );
     }
 
-    if (organization !== null) {
+    if (organization !== null && financialRead) {
         allColumns.push(
             new Column<ObjectType, number>({
                 id: 'memberCachedBalance.amountOpen',

--- a/frontend/shared/components/src/registrations/classes/getSelectableWorkbook.ts
+++ b/frontend/shared/components/src/registrations/classes/getSelectableWorkbook.ts
@@ -218,12 +218,12 @@ export function getSelectableWorkbook(platform: Platform, organization: Organiza
             : [],
         // will always be 0 if organization is null
         organization !== null
-            ? new SelectableColumn({
+            ? returnNullIfNoAccessRight(new SelectableColumn({
                     id: 'outstandingBalance',
                     name: $t(`%76`),
                     description: $t('%184'),
                     enabled: false,
-                })
+                }), [AccessRight.MemberReadFinancialData])
             : null,
         // price
         new SelectableColumn({


### PR DESCRIPTION
Fixes #STA-1262

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789638965&installation_model_id=423362&pr_number=750&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F750&signature=b42c2a8ebd608d10a0650a5e1a926f31b8b95709fa35f003573311b5d554b7dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->