### PR TITLE
🐛 Render title when only one category

### DIFF
--- a/frontend/shared/components/src/layout/categorized-view/CategorizedView.vue
+++ b/frontend/shared/components/src/layout/categorized-view/CategorizedView.vue
@@ -37,14 +37,14 @@
                 <template #buttons>
                     <slot name="buttons" />
                 </template>
-                <header v-if="!columnsEnabled && isEnabled" class="container">
+                <header v-if="!columnsEnabled || !isEnabled" class="container">
                     <slot name="title">
                         <h1>
                             {{ title }}
                         </h1>
                     </slot>
                     <div class="inline-seeker-box">
-                        <STList>
+                        <STList v-if="isEnabled">
                             <STListItem v-for="(category, index) of categories" :key="index" :selectable="true" class="" @click="scrollToCategory(category)">
                                 <template #left>
                                     <span :class="'icon ' + category.icon.value" />
@@ -118,6 +118,11 @@ const canDelete = computed(() => {
 });
 
 function updateVisible() {
+    if (!isEnabled.value) {
+        visibleCategories.value = [];
+        return;
+    }
+
     // Prevent multiple updates in the same frame
     if (tick) {
         return;
@@ -237,8 +242,12 @@ onMounted(() => {
     updateVisible();
 });
 
-useScrollListener(scrollElement, () => {
+useScrollListener(computed(() => isEnabled.value ? scrollElement.value : null), () => {
     throttledUpdateVisible();
+});
+
+watch(isEnabled, () => {
+    updateVisible();
 });
 
 function updateSeeker() {


### PR DESCRIPTION
vroeger: ALS slechts 1 categorie -> geen summary kolom links -> geen titel

<img width="769" height="1165" alt="Screenshot 2026-08-25 at 13 51 08" src="https://github.com/user-attachments/assets/4117c941-7cb9-42fd-a754-df7c97fc6427" />


nu: ALS geen summary kolom -> toon toch titel

<img width="794" height="975" alt="Screenshot 2026-08-25 at 12 40 55" src="https://github.com/user-attachments/assets/12da2b8b-44e8-4e4e-b279-a1ca6def3264" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790246483&installation_model_id=423362&pr_number=766&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F766&signature=39119a20a7b66aa01e36864f547f522907e318af7a78221626fe519887692f0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->