### PR TITLE
Handle inherited base permissions better

### DIFF
--- a/frontend/shared/components/src/admins/EditRoleView.vue
+++ b/frontend/shared/components/src/admins/EditRoleView.vue
@@ -24,39 +24,39 @@
             <p>{{ $t('%Yz') }}</p>
 
             <STList>
-                <STListItem :selectable="true" element-name="label">
+                <STListItem :selectable="!isLevelLocked(PermissionLevel.None)" :disabled="isLevelLocked(PermissionLevel.None)" element-name="label">
                     <template #left>
-                        <Radio v-model="basePermission" value="None" :disabled="lockedMinimumLevel !== PermissionLevel.None" />
+                        <Radio v-model="basePermission" :value="PermissionLevel.None" :disabled="isLevelLocked(PermissionLevel.None)" />
                     </template>
                     <h3 class="style-title-list">
                         {{ getPermissionLevelName(PermissionLevel.None) }}
                     </h3>
-                    <p v-if="basePermission === 'None'" class="style-description-small">
+                    <p v-if="basePermission === PermissionLevel.None" class="style-description-small">
                         {{ $t('%Z0') }}
                     </p>
                 </STListItem>
 
-                <STListItem v-if="basePermission === PermissionLevel.Read || auth.hasPlatformFullAccess()" :selectable="true" element-name="label">
+                <STListItem v-if="basePermission === PermissionLevel.Read || auth.hasPlatformFullAccess()" :selectable="!isLevelLocked(PermissionLevel.Read)" :disabled="isLevelLocked(PermissionLevel.Read)" element-name="label">
                     <template #left>
-                        <Radio v-model="basePermission" :value="PermissionLevel.Read" />
+                        <Radio v-model="basePermission" :value="PermissionLevel.Read" :disabled="isLevelLocked(PermissionLevel.Read)" />
                     </template>
                     <h3 class="style-title-list">
                         {{ getPermissionLevelName(PermissionLevel.Read) }}
                     </h3>
                 </STListItem>
 
-                <STListItem v-if="basePermission === PermissionLevel.Write || auth.hasPlatformFullAccess()" :selectable="true" element-name="label">
+                <STListItem v-if="basePermission === PermissionLevel.Write || auth.hasPlatformFullAccess()" :selectable="!isLevelLocked(PermissionLevel.Write)" :disabled="isLevelLocked(PermissionLevel.Write)" element-name="label">
                     <template #left>
-                        <Radio v-model="basePermission" :value="PermissionLevel.Write" />
+                        <Radio v-model="basePermission" :value="PermissionLevel.Write" :disabled="isLevelLocked(PermissionLevel.Write)" />
                     </template>
                     <h3 class="style-title-list">
                         {{ getPermissionLevelName(PermissionLevel.Write) }}
                     </h3>
                 </STListItem>
 
-                <STListItem :selectable="true" element-name="label">
+                <STListItem :selectable="!isLevelLocked(PermissionLevel.Full)" :disabled="isLevelLocked(PermissionLevel.Full)" element-name="label">
                     <template #left>
-                        <Radio v-model="basePermission" :value="PermissionLevel.Full" :disabled="lockedMinimumLevel !== PermissionLevel.None" />
+                        <Radio v-model="basePermission" :value="PermissionLevel.Full" :disabled="isLevelLocked(PermissionLevel.Full)" />
                     </template>
                     <h3 class="style-title-list">
                         {{ getPermissionLevelName(PermissionLevel.Full) }}
@@ -210,7 +210,7 @@ import CategorizedBox from '#layout/categorized-view/CategorizedBox.vue';
 import CategorizedView from '#layout/categorized-view/CategorizedView.vue';
 import Spinner from '#Spinner.vue';
 import type { Group, GroupCategory, PermissionRoleDetailed, User, WebshopPreview } from '@stamhoofd/structures';
-import { AccessRight, getUnlistedResources, maximumPermissionlevel, PermissionLevel, PermissionRoleForResponsibility, PermissionsResourceType, getPermissionLevelName } from '@stamhoofd/structures';
+import { AccessRight, getPermissionLevelNumber, getUnlistedResources, maximumPermissionlevel, PermissionLevel, PermissionRoleForResponsibility, PermissionsResourceType, getPermissionLevelName } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { computed, ref } from 'vue';
 import AccessRightPermissionRow from './components/AccessRightPermissionRow.vue';
@@ -358,9 +358,16 @@ const lockedMinimumLevel = computed(() => {
     return maximumPermissionlevel(...arr);
 });
 
+const isLevelLocked = (level: PermissionLevel) => getPermissionLevelNumber(level) < getPermissionLevelNumber(lockedMinimumLevel.value);
+
 const basePermission = computed({
     get: () => maximumPermissionlevel(lockedMinimumLevel.value, patched.value.level),
-    set: level => addPatch({ level }),
+    set: (level) => {
+        if (isLevelLocked(level)) {
+            return;
+        }
+        addPatch({ level });
+    },
 });
 
 const shouldNavigateAway = async () => {


### PR DESCRIPTION
Als je een base permission overerfde waren de opties niet altijd netjes greyed out. Soms gebeurde er ook achterliggend toch nog een patch, terwijl dit niet nodig was. Bijvoorbeeld inherited full access > klikte op "Write" > maakte een patch request aan (UI bleef op full access)).

Mijn voorstel is om :selectable en :disabled in sync te houden.

<img width="1223" height="453" alt="Screenshot 2026-08-25 at 12 53 04" src="https://github.com/user-attachments/assets/6ebbd9fb-7419-4b18-8dc2-1c2c13c95a40" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790247198&installation_model_id=423362&pr_number=770&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F770&signature=e5a8e21ad22f3b108290d277db6d7c69ef71a2446e0386cafa681fd93f2f122f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->