### PR TITLE
🎨 Added featureflag to always enable fiscal documents

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/documents/EditDocumentTemplateView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/documents/EditDocumentTemplateView.vue
@@ -160,6 +160,7 @@ import NumberInputBox from '@stamhoofd/components/inputs/NumberInputBox.vue';
 
 import { fiscal } from './definitions/fiscal';
 import { participation } from './definitions/participation';
+import { useFeatureFlag } from '@stamhoofd/components/hooks/useFeatureFlag.ts';
 
 const props = withDefaults(defineProps<{
     isNew: boolean;
@@ -186,6 +187,7 @@ const fiscalDocumentYearHelper = new FiscalDocumentYearHelper();
 const recordAnswers = computed(() => {
     return patchedDocument.value.getRecordAnswers();
 });
+const getFeatureFlag = useFeatureFlag();
 
 function calculateHasBeenExported() {
     const allowedIds = new Set<string>();
@@ -349,6 +351,8 @@ function validateYearSync(value: number = year.value): SimpleError | null {
     const isFiscal = editingType.value === fiscal.type;
 
     if (isFiscal) {
+        if (getFeatureFlag('fiscal-document-always')) return null;
+
         if (value === fiscalDocumentYearHelper.year && !fiscalDocumentYearHelper.canCreateFiscalDocumentForCurrentYear) {
             return new SimpleError({
                 code: 'invalid_year',

--- a/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
@@ -247,6 +247,18 @@
                         {{ $t('%Zl0') }}
                     </p>
                 </STListItem>
+
+                <STListItem :selectable="true" element-name="label" data-testid="fiscal-document-no-timelimit">
+                    <template #left>
+                        <Checkbox :model-value="getFeatureFlag('fiscal-document-always')" @update:model-value="setFeatureFlag('fiscal-document-always', !!$event)" />
+                    </template>
+                    <h3 class="style-title-list">
+                        {{ $t('Fiscale documenten op elk moment aanmaken') }}
+                    </h3>
+                    <p class="style-description-small">
+                        {{ $t('Fiscale documenten kunnen op elk moment worden aangemaakt') }}
+                    </p>
+                </STListItem>
             </STList>
 
             <hr><button class="button text" type="button" @click="applyDiscountCode">

--- a/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/LabsView.vue
@@ -248,17 +248,19 @@
                     </p>
                 </STListItem>
 
-                <STListItem :selectable="true" element-name="label" data-testid="fiscal-document-no-timelimit">
-                    <template #left>
-                        <Checkbox :model-value="getFeatureFlag('fiscal-document-always')" @update:model-value="setFeatureFlag('fiscal-document-always', !!$event)" />
-                    </template>
-                    <h3 class="style-title-list">
-                        {{ $t('Fiscale documenten op elk moment aanmaken') }}
-                    </h3>
-                    <p class="style-description-small">
-                        {{ $t('Fiscale documenten kunnen op elk moment worden aangemaakt') }}
-                    </p>
-                </STListItem>
+                <template v-if="STAMHOOFD.environment === 'development' || STAMHOOFD.environment === 'staging'">
+                    <STListItem :selectable="true" element-name="label" data-testid="fiscal-document-no-timelimit">
+                        <template #left>
+                            <Checkbox :model-value="getFeatureFlag('fiscal-document-always')" @update:model-value="setFeatureFlag('fiscal-document-always', !!$event)" />
+                        </template>
+                        <h3 class="style-title-list">
+                            {{ $t('Fiscale documenten op elk moment aanmaken') }}
+                        </h3>
+                        <p class="style-description-small">
+                            {{ $t('Fiscale documenten kunnen op elk moment worden aangemaakt') }}
+                        </p>
+                    </STListItem>
+                </template>
             </STList>
 
             <hr><button class="button text" type="button" @click="applyDiscountCode">


### PR DESCRIPTION
Fixes STA-1362

Heb het momenteel met een feature-flag gedaan. Deze is enkel zichtbaar in development of staging.
Goed idee?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790261404&installation_model_id=423362&pr_number=773&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F773&signature=1ee5d078c4abc473273dcf1e81de27855c84cc9b69bdd90a88f31e9c14d8ff27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->