### PR TITLE
Resolve group permissions of any period in EditRoleView

### DIFF
--- a/frontend/shared/components/src/admins/EditRoleView.vue
+++ b/frontend/shared/components/src/admins/EditRoleView.vue
@@ -91,12 +91,12 @@
                 </STList>
             </CategorizedBox>
 
-            <CategorizedBox v-if="enableMemberModule && groups.length" icon="group" :title="$t('%Z7')">
-                <STList>
-                    <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('%L8'), type: PermissionsResourceType.Groups }" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" @patch:role="addPatch" />
-                    <ResourcePermissionRow v-for="group in groups" :key="group.id" :role="patched" :inherited-roles="inheritedRoles" :resource="{id: group.id, name: group.settings.name + ' ('+(group.settings.period?.nameShort ?? '?')+')', type: PermissionsResourceType.Groups }" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" @patch:role="addPatch" />
+            <CategorizedBox v-if="showGroupsBox" icon="group" :title="$t('%Z7')">
+                <Spinner v-if="loadingGroups" />
+                <STList v-else>
+                    <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('%L8'), description: $t('Enkel de huidige periode'), type: PermissionsResourceType.Groups }" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" @patch:role="addPatch" />
 
-                    <ResourcePermissionRow v-for="resource in getUnlistedResources(PermissionsResourceType.Groups, patched, groups)" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" :unlisted="true" @patch:role="addPatch" />
+                    <ResourcePermissionRow v-for="resource in groupResources" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" :ignore-general-access="true" @patch:role="addPatch" />
                 </STList>
             </CategorizedBox>
 
@@ -210,12 +210,15 @@ import CategorizedBox from '#layout/categorized-view/CategorizedBox.vue';
 import CategorizedView from '#layout/categorized-view/CategorizedView.vue';
 import Spinner from '#Spinner.vue';
 import type { Group, GroupCategory, PermissionRoleDetailed, User, WebshopPreview } from '@stamhoofd/structures';
-import { AccessRight, getPermissionLevelNumber, getUnlistedResources, maximumPermissionlevel, PermissionLevel, PermissionRoleForResponsibility, PermissionsResourceType, getPermissionLevelName } from '@stamhoofd/structures';
+import { AccessRight, getPermissionLevelName, getPermissionLevelNumber, getUnlistedResources, maximumPermissionlevel, PermissionLevel, PermissionRoleForResponsibility, PermissionsResourceType } from '@stamhoofd/structures';
+import { Sorter } from '@stamhoofd/utility';
+import { useGetGroupsById } from '@stamhoofd/networking/hooks/useGetGroups';
 import type { Ref } from 'vue';
-import { computed, ref } from 'vue';
+import { computed, ref, shallowRef, watch } from 'vue';
 import AccessRightPermissionRow from './components/AccessRightPermissionRow.vue';
 import ResourcePermissionRow from './components/ResourcePermissionRow.vue';
 import { useAdmins } from './hooks/useAdmins';
+import { Toast } from '#overlays/Toast.ts';
 
 const errors = useErrors();
 const auth = useAuth();
@@ -239,7 +242,6 @@ const props = withDefaults(
 
 const app = useAppContext();
 const enableWebshopModule = computed(() => (organization.value?.meta?.packages.useWebshops ?? false));
-const enableMemberModule = computed(() => organization.value?.meta?.packages.useMembers ?? false);
 const pop = usePop();
 const isForResponsibility = props.role instanceof PermissionRoleForResponsibility;
 const canDelete = !props.isNew && !!props.deleteHandler;
@@ -255,10 +257,7 @@ const { sortedAdmins, loading, getUnloadedPermissions } = useAdmins();
 const organization = useOrganization();
 const platform = usePlatform();
 const { patched, addPatch, hasChanges, patch } = usePatch(props.role);
-const groups: Ref<Group[]> = computed(() => [
-    ...(organization.value?.adminAvailableGroups ?? []),
-    ...(organization.value?.period.waitingLists ?? []),
-]);
+const getGroupsById = useGetGroupsById();
 const webshops: Ref<WebshopPreview[]> = computed(() => organization.value?.webshops ?? []);
 const categories: Ref<GroupCategory[]> = computed(() => organization.value?.getCategoryTree({ permissions: auth.permissions }).categories ?? []);
 const tags = computed(() => platform.value.config.tags);
@@ -284,6 +283,76 @@ const senders = computed(() => {
     }
     return platform.value.privateConfig?.emails ?? [];
 });
+
+const configuredGroupIds = computed(() => {
+    const ids = new Set<string>();
+
+    for (const role of [patched.value, ...props.inheritedRoles]) {
+        for (const id of role.resources.get(PermissionsResourceType.Groups)?.keys() ?? []) {
+            if (id !== '') {
+                ids.add(id);
+            }
+        }
+    }
+
+    return [...ids];
+});
+
+const loadingGroups = ref(false);
+const resolvedGroups = shallowRef(new Map<string, Group>());
+
+const missingGroupIds = shallowRef(new Set<string>());
+
+watch(configuredGroupIds, async (ids) => {
+    const unknownIds = ids.filter(id => !resolvedGroups.value.has(id) && !missingGroupIds.value.has(id));
+    if (unknownIds.length === 0) {
+        return;
+    }
+
+    loadingGroups.value = true;
+    try {
+        const groups = await getGroupsById(unknownIds);
+
+        const resolved = new Map(resolvedGroups.value);
+        for (const group of groups) {
+            resolved.set(group.id, group);
+        }
+        resolvedGroups.value = resolved;
+
+        const missing = new Set(missingGroupIds.value);
+        for (const id of unknownIds) {
+            if (!resolved.has(id)) {
+                missing.add(id);
+            }
+        }
+        missingGroupIds.value = missing;
+    } catch (e) {
+        Toast.fromError(e).show();
+    }
+    loadingGroups.value = false;
+}, { immediate: true });
+
+const groupResources = computed(() => {
+    const rows: { id: string; name: string; type: PermissionsResourceType }[] = [];
+
+    for (const id of configuredGroupIds.value) {
+        const group = resolvedGroups.value.get(id);
+        if (!group) {
+            continue;
+        }
+
+        rows.push({
+            id,
+            name: group.settings.getNameWithPeriod(),
+            type: PermissionsResourceType.Groups,
+        });
+    }
+
+    rows.sort((a, b) => Sorter.byStringValue(a.name, b.name));
+    return rows;
+});
+
+const showGroupsBox = computed(() => organization.value?.meta?.packages.useMembers || !!patched.value.resources.get(PermissionsResourceType.Groups)?.size || configuredGroupIds.value.length > 0);
 
 const save = async () => {
     if (saving.value || deleting.value) {

--- a/frontend/shared/components/src/admins/components/ResourcePermissionRow.vue
+++ b/frontend/shared/components/src/admins/components/ResourcePermissionRow.vue
@@ -57,6 +57,11 @@ const props = withDefaults(defineProps<{
     configurableAccessRights?: AccessRight[] | null;
     configurablePermissionLevels?: PermissionLevel[] | null;
     unlisted?: boolean;
+
+    /**
+     * The general access of a role is limited to the current period, so it doesn't apply to a resource of another period
+     */
+    ignoreGeneralAccess?: boolean;
     defaultLevel?: PermissionLevel | null;
     defaultAccessRights?: AccessRight[] | null;
 }>(), {
@@ -66,6 +71,7 @@ const props = withDefaults(defineProps<{
     defaultLevel: null,
     defaultAccessRights: null,
     unlisted: false,
+    ignoreGeneralAccess: false,
 });
 
 const configurableAccessRights = props.configurableAccessRights ?? getConfigurableAccessRightsForResourceType(props.resource.type);
@@ -89,22 +95,28 @@ const isMe = computed(() => {
 const resourcePermissions = computed(() => role.value.resources.get(props.resource.type)?.get(props.resource.id));
 
 const lockedMinimumLevel = computed(() => {
-    const a = props.role.level;
-    const b = props.resource.id !== '' ? (role.value.resources.get(props.resource.type)?.get('')?.level ?? PermissionLevel.None) : PermissionLevel.None;
+    const arr: PermissionLevel[] = [];
 
-    const arr = [a, b];
+    if (!props.ignoreGeneralAccess) {
+        arr.push(props.role.level);
+        arr.push(props.resource.id !== '' ? (role.value.resources.get(props.resource.type)?.get('')?.level ?? PermissionLevel.None) : PermissionLevel.None);
+    }
 
     for (const role of props.inheritedRoles) {
-        const c = role.level;
-        const d = role.resources.get(props.resource.type)?.get('')?.level ?? PermissionLevel.None;
-        const e = props.resource.id !== '' ? (role.resources.get(props.resource.type)?.get(props.resource.id)?.level ?? PermissionLevel.None) : PermissionLevel.None;
-        arr.push(c, d, e);
+        if (!props.ignoreGeneralAccess) {
+            arr.push(role.level);
+            arr.push(role.resources.get(props.resource.type)?.get('')?.level ?? PermissionLevel.None);
+        }
+        arr.push(props.resource.id !== '' ? (role.resources.get(props.resource.type)?.get(props.resource.id)?.level ?? PermissionLevel.None) : PermissionLevel.None);
     }
 
     return maximumPermissionlevel(...arr);
 });
 
 const lockedAccessRights = computed(() => {
+    if (props.ignoreGeneralAccess) {
+        return [];
+    }
     const accessRights = props.resource.id !== '' ? (role.value.resources.get(props.resource.type)?.get('')?.accessRights ?? []) : [];
     return accessRights;
 });

--- a/shared/structures/src/GroupSettings.ts
+++ b/shared/structures/src/GroupSettings.ts
@@ -969,6 +969,13 @@ export class GroupSettings extends AutoEncoder {
         return Formatter.firstLetters(this.name, maxLength);
     }
 
+    getNameWithPeriod(): string {
+        if (!this.period) {
+            return this.name.toString();
+        }
+        return this.name.toString() + ' (' + this.period.nameShort + ')';
+    }
+
     getFilteredPrices(options?: { admin?: boolean; date?: Date }) {
         if (options?.admin) {
             return [...this.prices];


### PR DESCRIPTION
Bij het instellen van een rol stond bij "Individuele inschrijvingsgroepen":
vroeger: álle groepen van de huidige periode
nu: enkel de groepen die in de rol staan of via een andere rol geërfd worden

We doen dit "slim":  als het base level hoger is of je hebt bvb toegang tot alle groepen, dan tonen we individuele groepen niet.