### PR TITLE
Remove group and category permissions that no longer add access rights

### DIFF
--- a/shared/structures/src/PermissionRole.ts
+++ b/shared/structures/src/PermissionRole.ts
@@ -80,6 +80,19 @@ export class PermissionRoleDetailed extends PermissionRole {
         if (this.level === PermissionLevel.Full) {
             this.accessRights = [];
             this.resources = new Map();
+            return;
+        }
+
+        for (const [type, resources] of this.resources) {
+            for (const [id, resource] of resources) {
+                if (resource.isEmpty) {
+                    resources.delete(id);
+                }
+            }
+
+            if (resources.size === 0) {
+                this.resources.delete(type);
+            }
         }
     }
 


### PR DESCRIPTION
"Alle leden" of het basisniveau verhoogd → items die niets extra geven worden verwijderd.

overbodig = niveau ≤ dekkend niveau && elk toegangsrecht ∈ dekking (expliciet, of automatisch toegekend door het dekkende niveau)