### PR TITLE
Show a proper empty state when a period has no groups or categories

### DIFF
--- a/frontend/shared/components/src/admins/EditResourcePermissionsView.vue
+++ b/frontend/shared/components/src/admins/EditResourcePermissionsView.vue
@@ -17,7 +17,7 @@
         </div>
 
         <p v-if="filteredResources.length === 0" class="info-box">
-            {{ $t('%1AX') }}
+            {{ emptyText }}
         </p>
         <STList v-else>
             <ResourcePermissionRow v-for="resource in filteredResources" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="configurableAccessRights" type="resource" @patch:role="addPatch" />
@@ -82,6 +82,18 @@ const filteredResources = computed(() => {
         return resources.value;
     }
     return resources.value.filter(r => r.name.toLowerCase().includes(query));
+});
+
+const emptyText = computed(() => {
+    if (searchQuery.value) {
+        return $t('%1AX');
+    }
+
+    if (props.type === PermissionsResourceType.Groups) {
+        return $t('Er zijn geen inschrijvingsgroepen in deze periode.');
+    }
+
+    return $t('Er zijn geen inschrijvingscategorieën in deze periode.');
 });
 
 function blurFocus() {

--- a/frontend/shared/components/src/admins/EditResourcePermissionsView.vue
+++ b/frontend/shared/components/src/admins/EditResourcePermissionsView.vue
@@ -1,0 +1,106 @@
+<template>
+    <SaveView :title="title" :disabled="!hasChanges" :save-text="$t('Opslaan')" @save="save">
+        <h1>{{ title }}</h1>
+
+        <div class="input-with-buttons">
+            <div>
+                <form novalidate class="input-icon-container icon search small gray" @submit.prevent="blurFocus">
+                    <input v-model="searchQuery" class="input" name="search" type="search" inputmode="search" enterkeyhint="search" autocorrect="off" autocomplete="off" :spellcheck="false" autocapitalize="off" :placeholder="$t(`%KC`)">
+                </form>
+            </div>
+            <div>
+                <button type="button" class="button text" @click="switchPeriod">
+                    <span>{{ period.period.name }}</span>
+                    <span class="icon arrow-down-small" />
+                </button>
+            </div>
+        </div>
+
+        <p v-if="filteredResources.length === 0" class="info-box">
+            {{ $t('%1AX') }}
+        </p>
+        <STList v-else>
+            <ResourcePermissionRow v-for="resource in filteredResources" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="configurableAccessRights" type="resource" @patch:role="addPatch" />
+        </STList>
+    </SaveView>
+</template>
+
+<script setup lang="ts">
+import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
+import { usePop } from '@simonbackx/vue-app-navigation';
+import { usePatch } from '#hooks/usePatch.ts';
+import { CenteredMessage } from '#overlays/CenteredMessage.ts';
+import { useSwitchablePeriod } from '#hooks/useSwitchablePeriod.ts';
+import type { AccessRight, PermissionRoleDetailed, PermissionRoleForResponsibility } from '@stamhoofd/structures';
+import { getGroupTypeName, GroupType, PermissionsResourceType } from '@stamhoofd/structures';
+import { computed, ref } from 'vue';
+import ResourcePermissionRow from './components/ResourcePermissionRow.vue';
+
+const props = withDefaults(
+    defineProps<{
+        title: string;
+        role: PermissionRoleDetailed | PermissionRoleForResponsibility;
+        inheritedRoles?: (PermissionRoleDetailed | PermissionRoleForResponsibility)[];
+        type: PermissionsResourceType.Groups | PermissionsResourceType.GroupCategories;
+        configurableAccessRights?: AccessRight[] | null;
+        saveHandler: (patch: AutoEncoderPatchType<PermissionRoleDetailed | PermissionRoleForResponsibility>) => void;
+    }>(), {
+        inheritedRoles: () => [],
+        configurableAccessRights: null,
+    },
+);
+
+const pop = usePop();
+const { patched, addPatch, patch, hasChanges } = usePatch(props.role);
+const { period, switchPeriod } = useSwitchablePeriod();
+
+const searchQuery = ref('');
+
+const resources = computed(() => {
+    if (props.type === PermissionsResourceType.Groups) {
+        return [
+            ...period.value.adminCategoryTree.getAllGroups(),
+            ...period.value.waitingLists,
+        ].map(group => ({
+            id: group.id,
+            name: group.settings.getNameWithPeriod(),
+            type: props.type,
+            description: group.type === GroupType.WaitingList ? getGroupTypeName(group.type) : undefined,
+        }));
+    }
+
+    return period.value.adminCategoryTree.getAllCategories().map(category => ({
+        id: category.id,
+        name: category.getName(period.value) + ' (' + period.value.period.nameShort + ')',
+        type: props.type,
+    }));
+});
+
+const filteredResources = computed(() => {
+    const query = searchQuery.value.toLowerCase().trim();
+    if (!query) {
+        return resources.value;
+    }
+    return resources.value.filter(r => r.name.toLowerCase().includes(query));
+});
+
+function blurFocus() {
+    (document.activeElement as HTMLElement)?.blur();
+}
+
+async function save() {
+    props.saveHandler(patch.value);
+    await pop({ force: true });
+}
+
+const shouldNavigateAway = async () => {
+    if (!hasChanges.value) {
+        return true;
+    }
+    return await CenteredMessage.confirm($t(`%A0`), $t(`%4X`));
+};
+
+defineExpose({
+    shouldNavigateAway,
+});
+</script>

--- a/frontend/shared/components/src/admins/EditRoleView.vue
+++ b/frontend/shared/components/src/admins/EditRoleView.vue
@@ -92,7 +92,7 @@
                 <p>{{ $t('%Z6') }}</p>
 
                 <STList>
-                    <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('Alle categorieën'), type: PermissionsResourceType.GroupCategories }" :configurable-access-rights="[AccessRight.OrganizationCreateGroups]" type="resource" @patch:role="addPatch" />
+                    <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('Alle categorieën'), type: PermissionsResourceType.GroupCategories }" :configurable-access-rights="[AccessRight.OrganizationCreateGroups]" type="resource" @patch:role="patchAllCategories" />
 
                     <ResourcePermissionRow v-for="resource in categoryResources" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="[AccessRight.OrganizationCreateGroups]" type="resource" @patch:role="addPatch" />
                 </STList>
@@ -108,7 +108,7 @@
 
                 <Spinner v-if="loadingGroups" />
                 <STList v-else>
-                    <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('%L8'), type: PermissionsResourceType.Groups }" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" @patch:role="addPatch" />
+                    <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('%L8'), type: PermissionsResourceType.Groups }" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" @patch:role="patchAllGroups" />
 
                     <ResourcePermissionRow v-for="resource in groupResources" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" @patch:role="addPatch" />
                 </STList>
@@ -210,6 +210,7 @@
 
 <script setup lang="ts">
 import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
+import { PatchMap } from '@simonbackx/simple-encoding';
 import { SimpleError } from '@simonbackx/simple-errors';
 import { ComponentWithProperties, NavigationController, usePop, usePresent } from '@simonbackx/vue-app-navigation';
 import { CenteredMessage } from '#overlays/CenteredMessage.ts';
@@ -272,7 +273,7 @@ const title = computed(() => {
 const { sortedAdmins, loading, getUnloadedPermissions } = useAdmins();
 const organization = useOrganization();
 const platform = usePlatform();
-const { patched, addPatch, hasChanges, patch } = usePatch(props.role);
+const { patched, addPatch, createPatch, hasChanges, patch } = usePatch(props.role);
 const getGroupsById = useGetGroupsById();
 const webshops: Ref<WebshopPreview[]> = computed(() => organization.value?.webshops ?? []);
 const tags = computed(() => platform.value.config.tags);
@@ -529,6 +530,60 @@ const lockedMinimumLevel = computed(() => {
 
 const isLevelLocked = (level: PermissionLevel) => getPermissionLevelNumber(level) < getPermissionLevelNumber(lockedMinimumLevel.value);
 
+/**
+ * Delete the resources that no longer add anything on top of the base permission or the row for all resources
+ */
+function pruneRedundantResources(type: PermissionsResourceType.Groups | PermissionsResourceType.GroupCategories) {
+    const resources = patched.value.resources.get(type);
+    if (!resources) {
+        return;
+    }
+
+    // What is granted for every resource of this type, without the row for all resources itself
+    const coverage = ResourcePermissions.create({ level: patched.value.level });
+
+    for (const role of props.inheritedRoles) {
+        const all = role.getMergedResourcePermissions(type, '');
+        if (all) {
+            coverage.add(all);
+        }
+    }
+
+    const subPatch = new PatchMap<string, AutoEncoderPatchType<ResourcePermissions> | ResourcePermissions | null>();
+
+    const all = resources.get('');
+    if (all) {
+        if (all.isCoveredBy(coverage)) {
+            subPatch.set('', null);
+        }
+        coverage.add(all);
+    }
+
+    for (const [id, resourcePermissions] of resources) {
+        if (id !== '' && resourcePermissions.isCoveredBy(coverage)) {
+            subPatch.set(id, null);
+        }
+    }
+
+    if (subPatch.size === 0) {
+        return;
+    }
+
+    const patch = createPatch();
+    patch.resources!.set(type, subPatch);
+    addPatch(patch);
+}
+
+function patchAllGroups(patch: AutoEncoderPatchType<PermissionRoleDetailed | PermissionRoleForResponsibility>) {
+    addPatch(patch);
+    pruneRedundantResources(PermissionsResourceType.Groups);
+}
+
+function patchAllCategories(patch: AutoEncoderPatchType<PermissionRoleDetailed | PermissionRoleForResponsibility>) {
+    addPatch(patch);
+    pruneRedundantResources(PermissionsResourceType.GroupCategories);
+}
+
 const basePermission = computed({
     get: () => maximumPermissionlevel(lockedMinimumLevel.value, patched.value.level),
     set: (level) => {
@@ -536,6 +591,8 @@ const basePermission = computed({
             return;
         }
         addPatch({ level });
+        pruneRedundantResources(PermissionsResourceType.Groups);
+        pruneRedundantResources(PermissionsResourceType.GroupCategories);
     },
 });
 

--- a/frontend/shared/components/src/admins/EditRoleView.vue
+++ b/frontend/shared/components/src/admins/EditRoleView.vue
@@ -92,6 +92,13 @@
             </CategorizedBox>
 
             <CategorizedBox v-if="showGroupsBox" icon="group" :title="$t('%Z7')">
+                <template v-if="canAddGroups" #buttons>
+                    <button class="button text only-icon-smartphone" type="button" @click="addGroups">
+                        <span class="icon add" />
+                        <span>{{ $t('Meer toevoegen') }}</span>
+                    </button>
+                </template>
+
                 <Spinner v-if="loadingGroups" />
                 <STList v-else>
                     <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('%L8'), type: PermissionsResourceType.Groups }" :configurable-access-rights="[AccessRight.EventWrite]" type="resource" @patch:role="addPatch" />
@@ -197,7 +204,7 @@
 <script setup lang="ts">
 import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { SimpleError } from '@simonbackx/simple-errors';
-import { usePop } from '@simonbackx/vue-app-navigation';
+import { ComponentWithProperties, NavigationController, usePop, usePresent } from '@simonbackx/vue-app-navigation';
 import { CenteredMessage } from '#overlays/CenteredMessage.ts';
 import { ErrorBox } from '#errors/ErrorBox.ts';
 import { useErrors } from '#errors/useErrors.ts';
@@ -206,6 +213,7 @@ import { useAuth } from '#hooks/useAuth.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import { usePatch } from '#hooks/usePatch.ts';
 import { usePlatform } from '#hooks/usePlatform.ts';
+import { AsyncComponent } from '#containers/AsyncComponent.ts';
 import CategorizedBox from '#layout/categorized-view/CategorizedBox.vue';
 import CategorizedView from '#layout/categorized-view/CategorizedView.vue';
 import Spinner from '#Spinner.vue';
@@ -243,6 +251,7 @@ const props = withDefaults(
 const app = useAppContext();
 const enableWebshopModule = computed(() => (organization.value?.meta?.packages.useWebshops ?? false));
 const pop = usePop();
+const present = usePresent();
 const isForResponsibility = props.role instanceof PermissionRoleForResponsibility;
 const canDelete = !props.isNew && !!props.deleteHandler;
 
@@ -373,6 +382,29 @@ const groupResources = computed(() => {
     rows.sort((a, b) => Sorter.byStringValue(a.name, b.name));
     return rows;
 });
+
+const canAddGroups = computed(() => !!organization.value && maximumPermissionlevel(
+    basePermission.value,
+    patched.value.resources.get(PermissionsResourceType.Groups)?.get('')?.level ?? PermissionLevel.None,
+) !== PermissionLevel.Full);
+
+async function addGroups() {
+    await present({
+        components: [
+            new ComponentWithProperties(NavigationController, {
+                root: AsyncComponent(() => import('./EditResourcePermissionsView.vue'), {
+                    title: $t('Inschrijvingsgroepen'),
+                    role: patched.value,
+                    inheritedRoles: props.inheritedRoles,
+                    type: PermissionsResourceType.Groups,
+                    configurableAccessRights: [AccessRight.EventWrite],
+                    saveHandler: addPatch,
+                }),
+            }),
+        ],
+        modalDisplayStyle: 'popup',
+    });
+}
 
 const showGroupsBox = computed(() => organization.value?.meta?.packages.useMembers || !!patched.value.resources.get(PermissionsResourceType.Groups)?.size || configuredGroupIds.value.length > 0);
 

--- a/frontend/shared/components/src/admins/EditRoleView.vue
+++ b/frontend/shared/components/src/admins/EditRoleView.vue
@@ -81,13 +81,20 @@
                 </STList>
             </CategorizedBox>
 
-            <CategorizedBox v-if="categories.length" icon="folder" :title="$t('%Z5')">
+            <CategorizedBox v-if="showCategoriesBox" icon="folder" :title="$t('%Z5')">
+                <template v-if="organization" #buttons>
+                    <button class="button text only-icon-smartphone" type="button" @click="addCategories">
+                        <span class="icon add" />
+                        <span>{{ $t('Meer toevoegen') }}</span>
+                    </button>
+                </template>
+
                 <p>{{ $t('%Z6') }}</p>
 
                 <STList>
-                    <ResourcePermissionRow v-for="category in categories" :key="category.id" :role="patched" :inherited-roles="inheritedRoles" :resource="{id: category.id, name: category.settings.name, type: PermissionsResourceType.GroupCategories }" :configurable-access-rights="[AccessRight.OrganizationCreateGroups]" type="resource" @patch:role="addPatch" />
+                    <ResourcePermissionRow :role="patched" :inherited-roles="inheritedRoles" :resource="{id: '', name: $t('Alle categorieën'), type: PermissionsResourceType.GroupCategories }" :configurable-access-rights="[AccessRight.OrganizationCreateGroups]" type="resource" @patch:role="addPatch" />
 
-                    <ResourcePermissionRow v-for="resource in getUnlistedResources(PermissionsResourceType.GroupCategories, patched, categories)" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="[AccessRight.OrganizationCreateGroups]" type="resource" :unlisted="true" @patch:role="addPatch" />
+                    <ResourcePermissionRow v-for="resource in categoryResources" :key="resource.id" :role="patched" :inherited-roles="inheritedRoles" :resource="resource" :configurable-access-rights="[AccessRight.OrganizationCreateGroups]" type="resource" @patch:role="addPatch" />
                 </STList>
             </CategorizedBox>
 
@@ -268,7 +275,6 @@ const platform = usePlatform();
 const { patched, addPatch, hasChanges, patch } = usePatch(props.role);
 const getGroupsById = useGetGroupsById();
 const webshops: Ref<WebshopPreview[]> = computed(() => organization.value?.webshops ?? []);
-const categories: Ref<GroupCategory[]> = computed(() => organization.value?.getCategoryTree({ permissions: auth.permissions }).categories ?? []);
 const tags = computed(() => platform.value.config.tags);
 const recordCategories = computed(() => {
     const base = (organization.value?.meta.recordsConfiguration.recordCategories?.slice() ?? []).map(r => ({
@@ -341,11 +347,11 @@ watch(configuredGroupIds, async (ids) => {
     loadingGroups.value = false;
 }, { immediate: true });
 
-function getGroupsCoverage() {
+function getResourceCoverage(type: PermissionsResourceType) {
     const coverage = ResourcePermissions.create({});
 
     for (const role of [patched.value, ...props.inheritedRoles]) {
-        const all = role.getMergedResourcePermissions(PermissionsResourceType.Groups, '');
+        const all = role.getMergedResourcePermissions(type, '');
         if (all) {
             coverage.add(all);
         }
@@ -354,11 +360,11 @@ function getGroupsCoverage() {
     return coverage;
 }
 
-function groupAddsAccess(id: string) {
-    const coverage = getGroupsCoverage();
+function resourceAddsAccess(type: PermissionsResourceType, id: string) {
+    const coverage = getResourceCoverage(type);
 
     return [patched.value, ...props.inheritedRoles].some((role) => {
-        const resource = role.resources.get(PermissionsResourceType.Groups)?.get(id);
+        const resource = role.resources.get(type)?.get(id);
         return !!resource && !resource.isCoveredBy(coverage);
     });
 }
@@ -368,7 +374,7 @@ const groupResources = computed(() => {
 
     for (const id of configuredGroupIds.value) {
         const group = resolvedGroups.value.get(id);
-        if (!group || !groupAddsAccess(id)) {
+        if (!group || !resourceAddsAccess(PermissionsResourceType.Groups, id)) {
             continue;
         }
 
@@ -381,6 +387,26 @@ const groupResources = computed(() => {
 
     rows.sort((a, b) => Sorter.byStringValue(a.name, b.name));
     return rows;
+});
+
+// Categories are not resolved: they are rendered with the name cached in the role
+const categoryResources = computed(() => {
+    const rows = getUnlistedResources(PermissionsResourceType.GroupCategories, patched.value, []);
+    const ids = new Set(rows.map(r => r.id));
+
+    // Categories this role only has access to through an inherited role have no entry of their own
+    for (const role of props.inheritedRoles) {
+        for (const [id, resource] of role.resources.get(PermissionsResourceType.GroupCategories) ?? []) {
+            if (id === '' || ids.has(id)) {
+                continue;
+            }
+            ids.add(id);
+            rows.push({ id, name: resource.resourceName, type: PermissionsResourceType.GroupCategories });
+        }
+    }
+
+    rows.sort((a, b) => Sorter.byStringValue(a.name, b.name));
+    return rows.filter(resource => resourceAddsAccess(PermissionsResourceType.GroupCategories, resource.id));
 });
 
 const canAddGroups = computed(() => !!organization.value && maximumPermissionlevel(
@@ -406,7 +432,27 @@ async function addGroups() {
     });
 }
 
+async function addCategories() {
+    await present({
+        components: [
+            new ComponentWithProperties(NavigationController, {
+                root: AsyncComponent(() => import('./EditResourcePermissionsView.vue'), {
+                    title: $t('Inschrijvingscategorieën'),
+                    role: patched.value,
+                    inheritedRoles: props.inheritedRoles,
+                    type: PermissionsResourceType.GroupCategories,
+                    configurableAccessRights: [AccessRight.OrganizationCreateGroups],
+                    saveHandler: addPatch,
+                }),
+            }),
+        ],
+        modalDisplayStyle: 'popup',
+    });
+}
+
 const showGroupsBox = computed(() => organization.value?.meta?.packages.useMembers || !!patched.value.resources.get(PermissionsResourceType.Groups)?.size || configuredGroupIds.value.length > 0);
+
+const showCategoriesBox = computed(() => organization.value?.meta?.packages.useMembers || !!patched.value.resources.get(PermissionsResourceType.GroupCategories)?.size);
 
 const save = async () => {
     if (saving.value || deleting.value) {


### PR DESCRIPTION
Het keuzescherm toonde "Geen zoekresultaten" bij een periode die gewoon geen groepen/categorieën heeft → maakt nu onderscheid tussen een leeg zoekresultaat en een lege periode.