### PR TITLE
Include the period in the cached resource name written by the backend

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
@@ -732,7 +732,7 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
                 throw new Error('Unexpected missing permissions');
             }
             const resourcePermissions = ResourcePermissions.create({
-                resourceName: model.settings.name.toString(),
+                resourceName: model.settings.getNameWithPeriod(),
                 level: PermissionLevel.Full,
             });
             const patch = resourcePermissions.createInsertPatch(PermissionsResourceType.Groups, model.id, organizationPermissions);


### PR DESCRIPTION
De backend schreef de periode niet mee in `ResourcePermissions.resourceName` → groepen met dezelfde naam uit verschillende periodes waren niet te onderscheiden.

`PatchOrganizationRegistrationPeriodsEndpoint`: de auteur die een groep aanmaakt zonder er toegang toe te hebben, krijgt nu een naam mét periode via `GroupSettings.getNameWithPeriod()` (toegevoegd in #774).