### PR TITLE
✨ Allow roles to access groups of any period

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
@@ -169,7 +169,8 @@ describe('Endpoint.PatchOrganizationRegistrationPeriodsEndpoint.MoveRegistration
             body.addPatch(periodPatch);
 
             await expect(patchOrganizationRegistrationPeriods({ patch: body, organization, token: allGroupsToken })).rejects.toThrow(STExpect.simpleError({
-                code: 'permission_denied',
+                code: 'locked_period',
+                message: 'This period is locked',
             }));
         });
 

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -289,9 +289,6 @@ export class AdminPermissionChecker {
             // return false;
         }
 
-        if (!await this.canAccessGroupsInPeriod(group.periodId, group.organizationId)) {
-            return false;
-        }
         const organization = await this.getOrganization(group.organizationId);
 
         if (group.deletedAt || group.status === GroupStatus.Archived) {


### PR DESCRIPTION
`canAccessGroup` weigerde alles buiten het huidige werkjaar → enkel full admins raakten aan een ander werkjaar.

- gate `canAccessGroupsInPeriod(...)` uit `canAccessGroup` → toegang volgt nu enkel uit de resource grants van de rol
- de methode zelf blijft: enige caller is `PatchEventsEndpoint.putEventGroup`, waar ze bepaalt in welk werkjaar een event-groep mag komen

Aangepaste test — "Moving group FROM locked period should fail as normal admin": die admin heeft nu wel toegang tot de groep, dus faalt de request op `locked_period` i.p.v. `permission_denied` (zelfde code als de zuster-test). Verplaatsen blijft geweigerd, enkel de reden verandert.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335177&installation_model_id=423362&pr_number=785&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F785&signature=19caa745999cd3a14a172ac55a5877c836e1f3a032c234d06afe41f90b456bdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
