### PR TITLE
🐛 Resolve group parent categories against the period of the group

### DIFF
--- a/backend/app/api/src/helpers/AdminPermissionChecker.test.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.test.ts
@@ -1,0 +1,83 @@
+import type { Organization, RegistrationPeriod, User } from '@stamhoofd/models';
+import { GroupFactory, OrganizationFactory, OrganizationRegistrationPeriodFactory, Platform, RegistrationPeriodFactory, UserFactory } from '@stamhoofd/models';
+import { GroupCategory, GroupCategorySettings, OrganizationRegistrationPeriodSettings, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { v4 as uuidv4 } from 'uuid';
+import { AdminPermissionChecker } from './AdminPermissionChecker.js';
+
+describe('AdminPermissionChecker', () => {
+    let previousPeriod: RegistrationPeriod;
+    let currentPeriod: RegistrationPeriod;
+
+    beforeEach(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+
+        previousPeriod = await new RegistrationPeriodFactory({
+            startDate: new Date(2023, 0, 1),
+            endDate: new Date(2023, 11, 31),
+        }).create();
+
+        currentPeriod = await new RegistrationPeriodFactory({
+            startDate: new Date(2024, 0, 1),
+            endDate: new Date(2024, 11, 31),
+        }).create();
+    });
+
+    /**
+     * An organization that already moved on to currentPeriod, with an admin whose only permissions come
+     * from a role. The role is returned empty so the test can grant it resources it needs to reference.
+     */
+    async function createOrganizationWithRole() {
+        const resources = new Map<PermissionsResourceType, Map<string, ResourcePermissions>>();
+        const role = PermissionRoleDetailed.create({ name: 'Test Role', resources });
+
+        const organization = await new OrganizationFactory({ period: currentPeriod, roles: [role] }).create();
+
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({
+                level: PermissionLevel.None,
+                roles: [role],
+            }),
+        }).create();
+
+        return { organization, user, resources };
+    }
+
+    async function createChecker(user: User, organization: Organization) {
+        return new AdminPermissionChecker(user, await Platform.getSharedPrivateStruct(), organization);
+    }
+
+    test('A category grant is resolved against the categories of the period the group belongs to', async () => {
+        const { organization, user, resources } = await createOrganizationWithRole();
+
+        const group = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+        // Categories are period specific: this category only exists in the period the group belongs to
+        const categoryId = uuidv4();
+        const organizationPeriod = await new OrganizationRegistrationPeriodFactory({ organization, period: previousPeriod }).create();
+        organizationPeriod.settings = OrganizationRegistrationPeriodSettings.create({
+            categories: [
+                GroupCategory.create({
+                    id: categoryId,
+                    settings: GroupCategorySettings.create({ name: 'Kapoenen' }),
+                    groupIds: [group.id],
+                }),
+            ],
+            rootCategoryId: categoryId,
+        });
+        await organizationPeriod.save();
+
+        resources.set(
+            PermissionsResourceType.GroupCategories, new Map([[
+                categoryId,
+                ResourcePermissions.create({ level: PermissionLevel.Read }),
+            ]]),
+        );
+        await organization.save();
+
+        const checker = await createChecker(user, organization);
+
+        expect(await checker.canAccessGroup(group)).toBe(true);
+    });
+});

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -341,7 +341,7 @@ export class AdminPermissionChecker {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+            const organizationPeriod = await this.getOrganizationPeriod(organization, group.periodId);
             const parentCategories = organizationPeriod ? group.getParentCategories(organizationPeriod.settings.categories) : [];
             for (const category of parentCategories) {
                 if (organizationPermissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {


### PR DESCRIPTION
`canAccessGroup` zocht de parent categories in het huidige werkjaar van de organisatie.

Probleem: `getParentCategories` matcht op `category.groupIds.includes(group.id)` en category ids zijn werkjaar-specifiek → een groep van 24-25 zit nooit in de categories van 25-26 → lookup geeft `[]` → elke category-grant faalt stil buiten het huidige werkjaar. Stil, want het leest als "geen toegang", niet als een fout.

- → `getOrganizationPeriod(group.organizationId, group.periodId)`
- werkjaar niet gevonden → geen parent categories

Test: category-grant in een vorig werkjaar geeft toegang.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335190&installation_model_id=423362&pr_number=788&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F788&signature=de50bcdada0bafa19ebae804b9809861568c868910ae606a32782aaa67a1d1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
