### PR TITLE
✨ Include groups of all periods in the members list scope filter

### DIFF
--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
@@ -398,6 +398,73 @@ describe('Endpoint.GetMembersEndpoint', () => {
             ]);
         });
 
+        test('Allowed: Can fetch members of a group of a period the organization already left', async () => {
+            // Setup
+            const role = PermissionRoleDetailed.create({
+                name: 'Test Role',
+                accessRights: [],
+            });
+
+            const resources = new Map();
+
+            const previousPeriod = await new RegistrationPeriodFactory({
+                startDate: new Date(2022, 0, 1),
+                endDate: new Date(2022, 11, 31),
+            }).create();
+
+            // The organization already moved on to period
+            const organization = await new OrganizationFactory({ period, roles: [role] })
+                .create();
+
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({
+                    level: PermissionLevel.None,
+                    roles: [
+                        role,
+                    ],
+                    resources,
+                }),
+            })
+                .create();
+
+            const token = await SessionService.createSession(user);
+            const member1 = await new MemberFactory({ }).create();
+            const member2 = await new MemberFactory({ }).create();
+            const previousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+            const otherPreviousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+            resources.set(
+                PermissionsResourceType.Groups, new Map([[
+                    previousPeriodGroup.id,
+                    ResourcePermissions.create({
+                        level: PermissionLevel.Read,
+                    }),
+                ]]),
+            );
+
+            await user.save();
+
+            await new RegistrationFactory({ member: member1, group: previousPeriodGroup }).create();
+            await new RegistrationFactory({ member: member2, group: otherPreviousPeriodGroup }).create();
+
+            const request = Request.get({
+                path: baseUrl,
+                host: organization.getApiHost(),
+                query: new LimitedFilteredRequest({
+                    limit: 10,
+                }),
+                headers: {
+                    authorization: 'Bearer ' + token.accessToken,
+                },
+            });
+            const response = await testServer.test(endpoint, request);
+            expect(response.status).toBe(200);
+            expect(response.body.results.members).toIncludeSameMembers([
+                expect.objectContaining({ id: member1.id }),
+            ]);
+        });
+
         test('Not allowed: Cannot fetch all members if no permissions for a single group', async () => {
             // Same test, but without giving the user permissions to read the group
             // Setup

--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
@@ -75,29 +75,17 @@ export class GetMembersEndpoint extends Endpoint<Params, Query, Body, ResponseBo
             } else {
                 // Add organization scope filter
                 if (await Context.auth.canAccessAllMembers(organization.id, permissionLevel)) {
-                    if (await Context.auth.hasFullAccess(organization.id, permissionLevel)) {
-                        // Can access full history for now
-                        scopeFilter = {
-                            registrations: {
-                                $elemMatch: {
-                                    organizationId: organization.id,
-                                },
+                    scopeFilter = {
+                        registrations: {
+                            $elemMatch: {
+                                organizationId: organization.id,
                             },
-                        };
-                    } else {
-                        // Can only access current period
-                        scopeFilter = {
-                            registrations: {
-                                $elemMatch: {
-                                    organizationId: organization.id,
-                                    periodId: organization.periodId,
-                                },
-                            },
-                        };
-                    }
+                        },
+                    };
                 } else {
-                    // Check which normal membership groups we have access to and filter on those
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.WaitingList]);
+                    // Check which normal membership groups we have access to and filter on those.
+                    // Groups of all periods are checked: access to a group is not limited to the current period.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.WaitingList]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 


### PR DESCRIPTION
`GetMembersEndpoint.buildQuery` pinde niet-full admins twee keer vast op het huidige werkjaar.

- de 2 `canAccessAllMembers` takken vallen samen → de `periodId` clause was hun enige verschil
- kandidaat-groepen uit alle werkjaren: `Group.getAll(organization.id, null, ...)`

Test: lijst zonder filter geeft de leden van een toegekende groep uit een vorig werkjaar, en niet die van een niet-toegekende groep.

Kost: 1 query voor alle groepen van alle werkjaren + `canAccessGroup` per groep (categories per werkjaar gecached) → groeit met het aantal jaren. Alternatief indien nodig: kandidaten afleiden uit de resource map van de rol i.p.v. scannen.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335200&installation_model_id=423362&pr_number=790&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F790&signature=d7ca9a4a9c887a627736d31e2d38f9a09e7c913794a61e1618a576d375a00635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
