### PR TITLE
Keep event groups restricted to the current period in ContextPermissions

### DIFF
--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -163,6 +163,17 @@ export class ContextPermissions {
         return getCachedOrganizationPeriods(organization.id)?.organizationPeriods.find(p => p.period.id === group.periodId) ?? null;
     }
 
+    canAccessGroupsInPeriod(periodId: string, organization: Organization) {
+        if (periodId !== organization.period.period.id) {
+            if (STAMHOOFD.userMode === 'organization' || periodId !== this.platform.period.id) {
+                if (!this.hasFullAccess()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     canAccessGroup(group: Group, permissionLevel: PermissionLevel = PermissionLevel.Read, organization?: Organization | null, organizationPeriod?: OrganizationRegistrationPeriod | null) {
         if (organization === undefined || (organization === null && this.organization)) {
             organization = this.organization;
@@ -194,12 +205,12 @@ export class ContextPermissions {
 
         if (group.type === GroupType.EventRegistration && group.event && group.event.organizationId === organization.id) {
             // we'll need to check the event permissions
-            return this.canWriteEventForOrganization(group.event, organization);
+            return this.canAccessGroupsInPeriod(group.periodId, organization) && this.canWriteEventForOrganization(group.event, organization);
         }
 
         if (group.type === GroupType.WaitingList && group.parentGroup && group.parentGroup.type === GroupType.EventRegistration && group.parentGroup.event && group.parentGroup.event.organizationId === organization.id) {
             // we'll need to check the event permissions
-            return this.canWriteEventForOrganization(group.parentGroup.event, organization);
+            return this.canAccessGroupsInPeriod(group.periodId, organization) && this.canWriteEventForOrganization(group.parentGroup.event, organization);
         }
 
         return false;


### PR DESCRIPTION
De frontend had geen aparte check voor events in een bepaalde periode. De if/else bovenaan canAccessGroup dekte vroeger ook event-inschrijvingsgroepen af, maar werd verwijderd in PR [#798](https://github.com/stamhoofd/stamhoofd/pull/798).

canAccessGroupsInPeriod(periodId, organization) toegevoegd aan ContextPermissions
Deze check toegepast op de twee event-takken van canAccessGroup

Vroeger werd dit nergens in de frontend gecontroleerd. Een event met een startdatum buiten het huidige werkjaar werd daardoor pas door de backend geweigerd (403).

Nu is de frontend-check in lijn met de backend.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335208&installation_model_id=423362&pr_number=792&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F792&signature=cbd443733ab11c384ae35116fee27fc95a8265bc3d7c8780db1f598a592b3b9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
