### PR TITLE
✨ Allow roles to access groups of any period in ContextPermissions

### DIFF
--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
@@ -398,6 +398,73 @@ describe('Endpoint.GetMembersEndpoint', () => {
             ]);
         });
 
+        test('Allowed: Can fetch members of a group of a period the organization already left', async () => {
+            // Setup
+            const role = PermissionRoleDetailed.create({
+                name: 'Test Role',
+                accessRights: [],
+            });
+
+            const resources = new Map();
+
+            const previousPeriod = await new RegistrationPeriodFactory({
+                startDate: new Date(2022, 0, 1),
+                endDate: new Date(2022, 11, 31),
+            }).create();
+
+            // The organization already moved on to period
+            const organization = await new OrganizationFactory({ period, roles: [role] })
+                .create();
+
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({
+                    level: PermissionLevel.None,
+                    roles: [
+                        role,
+                    ],
+                    resources,
+                }),
+            })
+                .create();
+
+            const token = await SessionService.createSession(user);
+            const member1 = await new MemberFactory({ }).create();
+            const member2 = await new MemberFactory({ }).create();
+            const previousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+            const otherPreviousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+            resources.set(
+                PermissionsResourceType.Groups, new Map([[
+                    previousPeriodGroup.id,
+                    ResourcePermissions.create({
+                        level: PermissionLevel.Read,
+                    }),
+                ]]),
+            );
+
+            await user.save();
+
+            await new RegistrationFactory({ member: member1, group: previousPeriodGroup }).create();
+            await new RegistrationFactory({ member: member2, group: otherPreviousPeriodGroup }).create();
+
+            const request = Request.get({
+                path: baseUrl,
+                host: organization.getApiHost(),
+                query: new LimitedFilteredRequest({
+                    limit: 10,
+                }),
+                headers: {
+                    authorization: 'Bearer ' + token.accessToken,
+                },
+            });
+            const response = await testServer.test(endpoint, request);
+            expect(response.status).toBe(200);
+            expect(response.body.results.members).toIncludeSameMembers([
+                expect.objectContaining({ id: member1.id }),
+            ]);
+        });
+
         test('Not allowed: Cannot fetch all members if no permissions for a single group', async () => {
             // Same test, but without giving the user permissions to read the group
             // Setup

--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
@@ -75,29 +75,17 @@ export class GetMembersEndpoint extends Endpoint<Params, Query, Body, ResponseBo
             } else {
                 // Add organization scope filter
                 if (await Context.auth.canAccessAllMembers(organization.id, permissionLevel)) {
-                    if (await Context.auth.hasFullAccess(organization.id, permissionLevel)) {
-                        // Can access full history for now
-                        scopeFilter = {
-                            registrations: {
-                                $elemMatch: {
-                                    organizationId: organization.id,
-                                },
+                    scopeFilter = {
+                        registrations: {
+                            $elemMatch: {
+                                organizationId: organization.id,
                             },
-                        };
-                    } else {
-                        // Can only access current period
-                        scopeFilter = {
-                            registrations: {
-                                $elemMatch: {
-                                    organizationId: organization.id,
-                                    periodId: organization.periodId,
-                                },
-                            },
-                        };
-                    }
+                        },
+                    };
                 } else {
-                    // Check which normal membership groups we have access to and filter on those
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.WaitingList]);
+                    // Check which normal membership groups we have access to and filter on those.
+                    // Groups of all periods are checked: access to a group is not limited to the current period.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.WaitingList]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 

--- a/backend/app/api/src/endpoints/global/registration/GetRegistrationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration/GetRegistrationsEndpoint.ts
@@ -97,33 +97,19 @@ export class GetRegistrationsEndpoint extends Endpoint<Params, Query, Body, Resp
             if (organization) {
                 // Add organization scope filter
                 if (await Context.auth.canAccessAllMembers(organization.id, permissionLevel)) {
-                    if (await Context.auth.hasFullAccess(organization.id, permissionLevel)) {
-                        // Can access full history for now
-                        scopeFilter = {
-                            member: {
-                                registrations: {
-                                    $elemMatch: {
-                                        organizationId: organization.id,
-                                    },
+                    scopeFilter = {
+                        member: {
+                            registrations: {
+                                $elemMatch: {
+                                    organizationId: organization.id,
                                 },
                             },
-                        };
-                    } else {
-                        // Can only access current period
-                        scopeFilter = {
-                            member: {
-                                registrations: {
-                                    $elemMatch: {
-                                        organizationId: organization.id,
-                                        periodId: organization.periodId,
-                                    },
-                                },
-                            },
-                        };
-                    }
+                        },
+                    };
                 } else {
-                    // Check which normal membership groups we have access to and filter on those
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.WaitingList]);
+                    // Check which normal membership groups we have access to and filter on those.
+                    // Groups of all periods are checked: access to a group is not limited to the current period.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.WaitingList]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
@@ -169,7 +169,8 @@ describe('Endpoint.PatchOrganizationRegistrationPeriodsEndpoint.MoveRegistration
             body.addPatch(periodPatch);
 
             await expect(patchOrganizationRegistrationPeriods({ patch: body, organization, token: allGroupsToken })).rejects.toThrow(STExpect.simpleError({
-                code: 'permission_denied',
+                code: 'locked_period',
+                message: 'This period is locked',
             }));
         });
 

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
@@ -127,7 +127,7 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
                                 continue;
                             }
 
-                            if (!await Context.auth.canCreateGroupInCategory(organization.id, category)) {
+                            if (!await Context.auth.canCreateGroupInCategory(organization.id, category, organizationPeriod.settings.categories)) {
                                 throw Context.auth.error($t(`%Ez`));
                             }
 

--- a/backend/app/api/src/helpers/AdminPermissionChecker.test.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.test.ts
@@ -1,0 +1,83 @@
+import type { Organization, RegistrationPeriod, User } from '@stamhoofd/models';
+import { GroupFactory, OrganizationFactory, OrganizationRegistrationPeriodFactory, Platform, RegistrationPeriodFactory, UserFactory } from '@stamhoofd/models';
+import { GroupCategory, GroupCategorySettings, OrganizationRegistrationPeriodSettings, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { v4 as uuidv4 } from 'uuid';
+import { AdminPermissionChecker } from './AdminPermissionChecker.js';
+
+describe('AdminPermissionChecker', () => {
+    let previousPeriod: RegistrationPeriod;
+    let currentPeriod: RegistrationPeriod;
+
+    beforeEach(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+
+        previousPeriod = await new RegistrationPeriodFactory({
+            startDate: new Date(2023, 0, 1),
+            endDate: new Date(2023, 11, 31),
+        }).create();
+
+        currentPeriod = await new RegistrationPeriodFactory({
+            startDate: new Date(2024, 0, 1),
+            endDate: new Date(2024, 11, 31),
+        }).create();
+    });
+
+    /**
+     * An organization that already moved on to currentPeriod, with an admin whose only permissions come
+     * from a role. The role is returned empty so the test can grant it resources it needs to reference.
+     */
+    async function createOrganizationWithRole() {
+        const resources = new Map<PermissionsResourceType, Map<string, ResourcePermissions>>();
+        const role = PermissionRoleDetailed.create({ name: 'Test Role', resources });
+
+        const organization = await new OrganizationFactory({ period: currentPeriod, roles: [role] }).create();
+
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({
+                level: PermissionLevel.None,
+                roles: [role],
+            }),
+        }).create();
+
+        return { organization, user, resources };
+    }
+
+    async function createChecker(user: User, organization: Organization) {
+        return new AdminPermissionChecker(user, await Platform.getSharedPrivateStruct(), organization);
+    }
+
+    test('A category grant is resolved against the categories of the period the group belongs to', async () => {
+        const { organization, user, resources } = await createOrganizationWithRole();
+
+        const group = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+        // Categories are period specific: this category only exists in the period the group belongs to
+        const categoryId = uuidv4();
+        const organizationPeriod = await new OrganizationRegistrationPeriodFactory({ organization, period: previousPeriod }).create();
+        organizationPeriod.settings = OrganizationRegistrationPeriodSettings.create({
+            categories: [
+                GroupCategory.create({
+                    id: categoryId,
+                    settings: GroupCategorySettings.create({ name: 'Kapoenen' }),
+                    groupIds: [group.id],
+                }),
+            ],
+            rootCategoryId: categoryId,
+        });
+        await organizationPeriod.save();
+
+        resources.set(
+            PermissionsResourceType.GroupCategories, new Map([[
+                categoryId,
+                ResourcePermissions.create({ level: PermissionLevel.Read }),
+            ]]),
+        );
+        await organization.save();
+
+        const checker = await createChecker(user, organization);
+
+        expect(await checker.canAccessGroup(group)).toBe(true);
+    });
+});

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -1256,7 +1256,7 @@ export class AdminPermissionChecker {
         return true;
     }
 
-    async canCreateGroupInCategory(organizationId: string, category: GroupCategory) {
+    async canCreateGroupInCategory(organizationId: string, category: GroupCategory, allCategories: GroupCategory[]) {
         const organizationPermissions = await this.getOrganizationPermissions(organizationId);
 
         if (!organizationPermissions) {
@@ -1268,9 +1268,7 @@ export class AdminPermissionChecker {
         }
 
         // Check parents
-        const organization = await this.getOrganization(organizationId);
-        const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
-        const parentCategories = organizationPeriod ? category.getParentCategories(organizationPeriod.settings.categories) : [];
+        const parentCategories = category.getParentCategories(allCategories);
 
         for (const parentCategory of parentCategories) {
             if (organizationPermissions.hasResourceAccessRight(PermissionsResourceType.GroupCategories, parentCategory.id, AccessRight.OrganizationCreateGroups)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -1,8 +1,8 @@
 import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { PatchMap } from '@simonbackx/simple-encoding';
 import { isSimpleError, isSimpleErrors, SimpleError } from '@simonbackx/simple-errors';
-import type { BalanceItem, Document, Email, EmailTemplate, MemberWithUsers, MemberWithUsersAndRegistrations, MemberWithUsersRegistrationsAndGroups, Order, OrganizationRegistrationPeriod, User } from '@stamhoofd/models';
-import { CachedBalance, Event, EventNotification, Group, Member, MemberPlatformMembership, Organization, Payment, Registration, Webshop } from '@stamhoofd/models';
+import type { BalanceItem, Document, Email, EmailTemplate, MemberWithUsers, MemberWithUsersAndRegistrations, MemberWithUsersRegistrationsAndGroups, Order, User } from '@stamhoofd/models';
+import { CachedBalance, Event, EventNotification, Group, Member, MemberPlatformMembership, Organization, OrganizationRegistrationPeriod, Payment, Registration, Webshop } from '@stamhoofd/models';
 import type { GroupCategory, MemberWithRegistrationsBlob, Platform as PlatformStruct, RecordAnswer, RecordSettings, ResourcePermissions } from '@stamhoofd/structures';
 import { AccessRight, EmailTemplate as EmailTemplateStruct, EventPermissionChecker, FinancialSupportSettings, GroupStatus, GroupType, PermissionLevel, PermissionsResourceType, ReceivableBalanceType, UitpasNumberDetails, UitpasSocialTariff, UitpasSocialTariffStatus } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
@@ -28,6 +28,7 @@ export class AdminPermissionChecker {
     organizationCache: Map<string, Organization | Promise<Organization | undefined>> = new Map();
     groupsCache: Map<string, Group | null | Promise<Group | null>> = new Map();
     webshopsCache: Map<string, Webshop | null | Promise<Webshop | null>> = new Map();
+    organizationPeriodsCache: Map<string, OrganizationRegistrationPeriod | null | Promise<OrganizationRegistrationPeriod | null>> = new Map();
 
     constructor(user: User, platform: PlatformStruct, organization?: Organization) {
         this.user = user;
@@ -154,9 +155,32 @@ export class AdminPermissionChecker {
         }
     }
 
-    async getOrganizationCurrentPeriod(id: string | Organization): Promise<OrganizationRegistrationPeriod> {
+    /**
+     * The settings (and thus the categories) of a period are period specific: a group can only be found back
+     * in the categories of the period it belongs to.
+     */
+    async getOrganizationPeriod(id: string | Organization, periodId: string): Promise<OrganizationRegistrationPeriod | null> {
         const organization = await this.getOrganization(id);
-        return await organization.getPeriod();
+
+        if (periodId === organization.periodId) {
+            return await organization.getPeriod();
+        }
+
+        const key = organization.id + '-' + periodId;
+        const cache = this.organizationPeriodsCache.get(key);
+        if (cache !== undefined) {
+            return await cache;
+        }
+
+        const promise = OrganizationRegistrationPeriod.select()
+            .where('organizationId', organization.id)
+            .where('periodId', periodId)
+            .first(false);
+
+        this.organizationPeriodsCache.set(key, promise);
+        const organizationPeriod = await promise;
+        this.organizationPeriodsCache.set(key, organizationPeriod);
+        return organizationPeriod;
     }
 
     error(humanOrData?: string | { message: string; human?: string }): SimpleError {
@@ -317,8 +341,8 @@ export class AdminPermissionChecker {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const organizationPeriod = await this.getOrganizationCurrentPeriod(organization);
-            const parentCategories = group.getParentCategories(organizationPeriod.settings.categories);
+            const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+            const parentCategories = organizationPeriod ? group.getParentCategories(organizationPeriod.settings.categories) : [];
             for (const category of parentCategories) {
                 if (organizationPermissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {
                     return true;
@@ -1245,8 +1269,8 @@ export class AdminPermissionChecker {
 
         // Check parents
         const organization = await this.getOrganization(organizationId);
-        const organizationPeriod = await this.getOrganizationCurrentPeriod(organization);
-        const parentCategories = category.getParentCategories(organizationPeriod.settings.categories);
+        const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+        const parentCategories = organizationPeriod ? category.getParentCategories(organizationPeriod.settings.categories) : [];
 
         for (const parentCategory of parentCategories) {
             if (organizationPermissions.hasResourceAccessRight(PermissionsResourceType.GroupCategories, parentCategory.id, AccessRight.OrganizationCreateGroups)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -495,7 +495,6 @@ export class AdminPermissionChecker {
         }
 
         if (organizationPermissions.hasAccess(PermissionLevel.Full)) {
-            // Only full permissions; because non-full doesn't have access to other periods
             return true;
         }
 
@@ -509,16 +508,6 @@ export class AdminPermissionChecker {
             // No full access: cannot access deactivated registrations
             if (permissionLevel !== PermissionLevel.Read) {
                 // Not allowed to edit registrations that are deleted
-                return false;
-            }
-        }
-
-        const organization = await this.getOrganization(registration.organizationId);
-
-        if (registration.periodId !== organization.periodId) {
-            if (STAMHOOFD.userMode === 'organization' || registration.periodId !== this.platform.period.id) {
-                // We already checked for full permissions - and we don't have full permissions
-                // so that also means no permissions for registrations in other periods
                 return false;
             }
         }

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -341,7 +341,7 @@ export class AdminPermissionChecker {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+            const organizationPeriod = await this.getOrganizationPeriod(organization, group.periodId);
             const parentCategories = organizationPeriod ? group.getParentCategories(organizationPeriod.settings.categories) : [];
             for (const category of parentCategories) {
                 if (organizationPermissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -289,9 +289,6 @@ export class AdminPermissionChecker {
             // return false;
         }
 
-        if (!await this.canAccessGroupsInPeriod(group.periodId, group.organizationId)) {
-            return false;
-        }
         const organization = await this.getOrganization(group.organizationId);
 
         if (group.deletedAt || group.status === GroupStatus.Archived) {

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -178,14 +178,6 @@ export class ContextPermissions {
             return this.hasFullPlatformAccess();
         }
 
-        if (group.periodId !== organization.period.period.id) {
-            if (STAMHOOFD.userMode === 'organization' || group.periodId !== this.platform.period.id) {
-                if (!this.hasFullAccess()) {
-                    return false;
-                }
-            }
-        }
-
         const permissions = this.getPermissionsForOrganization(organization);
         if (!permissions) {
             return false;

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -154,6 +154,21 @@ export class ContextPermissions {
         return this.hasAccessRight(AccessRight.ManageEmailTemplates);
     }
 
+    /**
+     * Event groups live in the period of the event start date: only full admins can reach the ones outside
+     * the period that is currently being used.
+     */
+    canAccessGroupsInPeriod(periodId: string, organization: Organization) {
+        if (periodId !== organization.period.period.id) {
+            if (STAMHOOFD.userMode === 'organization' || periodId !== this.platform.period.id) {
+                if (!this.hasFullAccess()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     canAccessGroup(group: Group, permissionLevel: PermissionLevel = PermissionLevel.Read, organization?: Organization | null) {
         if (organization === undefined || (organization === null && this.organization)) {
             organization = this.organization;
@@ -192,12 +207,12 @@ export class ContextPermissions {
 
         if (group.type === GroupType.EventRegistration && group.event && group.event.organizationId === organization.id) {
             // we'll need to check the event permissions
-            return this.canWriteEventForOrganization(group.event, organization);
+            return this.canAccessGroupsInPeriod(group.periodId, organization) && this.canWriteEventForOrganization(group.event, organization);
         }
 
         if (group.type === GroupType.WaitingList && group.parentGroup && group.parentGroup.type === GroupType.EventRegistration && group.parentGroup.event && group.parentGroup.event.organizationId === organization.id) {
             // we'll need to check the event permissions
-            return this.canWriteEventForOrganization(group.parentGroup.event, organization);
+            return this.canAccessGroupsInPeriod(group.periodId, organization) && this.canWriteEventForOrganization(group.parentGroup.event, organization);
         }
 
         return false;


### PR DESCRIPTION
Spiegel van #785: werkjaar-gate uit `ContextPermissions.canAccessGroup`.

Moet identiek blijven aan de backend, anders verbergt de UI wat de API wel toelaat.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335212&installation_model_id=423362&pr_number=793&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F793&signature=0cbcb2e0374aa27a285ac0d99fa1c145d1cf9c3e5fadac269b3189199a910c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
