### PR TITLE
🐛 Resolve group parent categories against the period of the group in ContextPermissions

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupOverview.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupOverview.vue
@@ -240,7 +240,7 @@ const title = computed(() => props.group.settings.name.toString());
 const isArchive = computed(() => props.group.status === GroupStatus.Archived);
 const isOpen = computed(() => !props.group.closed);
 const auth = useAuth();
-const hasFullPermissions = computed(() => auth.canAccessGroup(props.group, PermissionLevel.Full));
+const hasFullPermissions = computed(() => auth.canAccessGroup(props.group, PermissionLevel.Full, undefined, props.period));
 const organizationManager = useOrganizationManager();
 const organization = useOrganization();
 const navigationController = useNavigationController();

--- a/frontend/app/dashboard/src/views/members/useGroupActions.ts
+++ b/frontend/app/dashboard/src/views/members/useGroupActions.ts
@@ -32,7 +32,7 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
         periods?: OrganizationRegistrationPeriod[];
     }) {
         const canManage = auth.hasFullAccess();
-        const canEdit = canManage || auth.canAccessGroup(props.group, PermissionLevel.Write);
+        const canEdit = canManage || auth.canAccessGroup(props.group, PermissionLevel.Write, undefined, props.period);
 
         function getParentCategory() {
             return props.group.getParentCategories(props.period.settings.categories)[0];

--- a/frontend/shared/components/src/members/MembersTableView.vue
+++ b/frontend/shared/components/src/members/MembersTableView.vue
@@ -287,7 +287,7 @@ const isLimitedGroup = computed(() => {
     if (organization.value && props.group.organizationId !== organization.value.id) {
         return true;
     }
-    if (!auth.canAccessGroup(props.group)) {
+    if (!auth.canAccessGroup(props.group, undefined, undefined, organizationRegistrationPeriod.value)) {
         return true;
     }
     return false;

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -1,4 +1,4 @@
-import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationTag, PaymentGeneral, Permissions, Platform, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
+import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationRegistrationPeriod, OrganizationTag, PaymentGeneral, Permissions, Platform, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
 import { AccessRight, EventPermissionChecker, GroupType, PermissionLevel, PermissionsResourceType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { toRaw, unref } from 'vue';
@@ -169,7 +169,7 @@ export class ContextPermissions {
         return true;
     }
 
-    canAccessGroup(group: Group, permissionLevel: PermissionLevel = PermissionLevel.Read, organization?: Organization | null) {
+    canAccessGroup(group: Group, permissionLevel: PermissionLevel = PermissionLevel.Read, organization?: Organization | null, organizationPeriod?: OrganizationRegistrationPeriod | null) {
         if (organization === undefined || (organization === null && this.organization)) {
             organization = this.organization;
         }
@@ -187,9 +187,11 @@ export class ContextPermissions {
             return true;
         }
 
-        // Check parent categories
+        // Check parent categories. Categories are period specific: only the period the group belongs to
+        // can resolve its parents, so pass it when it is not the period the organization is using.
         if (group.type === GroupType.Membership) {
-            const parentCategories = group.getParentCategories(organization.period.settings.categories);
+            const period = organizationPeriod ?? (group.periodId === organization.period.period.id ? organization.period : null);
+            const parentCategories = period ? group.getParentCategories(period.settings.categories) : [];
             for (const category of parentCategories) {
                 if (permissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {
                     return true;


### PR DESCRIPTION
Spiegel van #788.

- `canAccessGroup(group, level, organization, organizationPeriod?)`
- categories komen uit het meegegeven werkjaar; niets meegegeven én groep zit niet in het huidige werkjaar → geen parent categories, i.p.v. de verkeerde lijst doorzoeken
- call sites die het werkjaar al bij de hand hebben geven het mee: `GroupOverview`, `useGroupActions`, `MembersTableView`

Group-id grants werken sowieso, enkel category-grants hebben het werkjaar nodig.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335218&installation_model_id=423362&pr_number=794&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F794&signature=06d4fb2e9940f38f6797e2ba321da0bab8fccf6379020ad6d934b0ec75a289c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
