### PR TITLE
✨ Add PeriodAccessHelper to check whether a role can open a period

### DIFF
--- a/shared/structures/src/helpers/PeriodAccessHelper.test.ts
+++ b/shared/structures/src/helpers/PeriodAccessHelper.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest';
+import { Group } from '../Group.js';
+import { GroupCategory, GroupCategorySettings } from '../GroupCategory.js';
+import { LoadedPermissions } from '../LoadedPermissions.js';
+import { PermissionLevel } from '../PermissionLevel.js';
+import { PermissionRoleDetailed } from '../PermissionRole.js';
+import { PermissionsResourceType } from '../PermissionsResourceType.js';
+import { OrganizationRegistrationPeriod, RegistrationPeriod } from '../RegistrationPeriod.js';
+import { ResourcePermissions } from '../ResourcePermissions.js';
+import { PeriodAccessHelper } from './PeriodAccessHelper.js';
+
+describe('PeriodAccessHelper.isPeriodAccessible', () => {
+    function createPeriod() {
+        const group = Group.create({ periodId: 'period-1' });
+        const category = GroupCategory.create({
+            settings: GroupCategorySettings.create({ name: 'Kapoenen' }),
+            groupIds: [group.id],
+        });
+
+        const period = OrganizationRegistrationPeriod.create({
+            period: RegistrationPeriod.create({}),
+            groups: [group],
+        });
+        period.settings.categories = [category];
+        period.settings.rootCategoryId = category.id;
+
+        return { period, group };
+    }
+
+    function createRolePermissions(resources: Map<PermissionsResourceType, Map<string, ResourcePermissions>>) {
+        return LoadedPermissions.fromRole(PermissionRoleDetailed.create({ name: 'Test Role', resources }));
+    }
+
+    test('Without permissions no period is accessible', () => {
+        const { period } = createPeriod();
+
+        expect(PeriodAccessHelper.isPeriodAccessible(period, null)).toBe(false);
+    });
+
+    test('A full admin can access every period', () => {
+        const { period } = createPeriod();
+        const permissions = LoadedPermissions.create({ level: PermissionLevel.Full });
+
+        expect(PeriodAccessHelper.isPeriodAccessible(period, permissions)).toBe(true);
+    });
+
+    test('A role that was granted a group of the period can access it', () => {
+        const { period, group } = createPeriod();
+        const permissions = createRolePermissions(new Map([[
+            PermissionsResourceType.Groups,
+            new Map([[group.id, ResourcePermissions.create({ level: PermissionLevel.Read })]]),
+        ]]));
+
+        expect(PeriodAccessHelper.isPeriodAccessible(period, permissions)).toBe(true);
+    });
+
+    test('A role that was only granted a group of another period cannot access it', () => {
+        const { period } = createPeriod();
+        const permissions = createRolePermissions(new Map([[
+            PermissionsResourceType.Groups,
+            new Map([['a-group-of-another-period', ResourcePermissions.create({ level: PermissionLevel.Read })]]),
+        ]]));
+
+        expect(PeriodAccessHelper.isPeriodAccessible(period, permissions)).toBe(false);
+    });
+});

--- a/shared/structures/src/helpers/PeriodAccessHelper.ts
+++ b/shared/structures/src/helpers/PeriodAccessHelper.ts
@@ -1,0 +1,20 @@
+import type { LoadedPermissions } from '../LoadedPermissions.js';
+import type { OrganizationRegistrationPeriod } from '../RegistrationPeriod.js';
+
+export class PeriodAccessHelper {
+    /**
+     * Whether an admin can open a given period: group and category permissions are period specific,
+     * so a role only reaches the periods it was granted groups in.
+     */
+    static isPeriodAccessible(period: OrganizationRegistrationPeriod, permissions: LoadedPermissions | null): boolean {
+        if (!permissions) {
+            return false;
+        }
+
+        if (permissions.hasFullAccess()) {
+            return true;
+        }
+
+        return period.getCategoryTree({ permissions }).getAllGroups().length > 0;
+    }
+}


### PR DESCRIPTION
`PeriodAccessHelper.isPeriodAccessible(period, permissions)`

- geen permissions → false
- full access → true
- anders → `period.getCategoryTree({ permissions }).getAllGroups().length > 0`

Pure functie + unit test (4 gevallen) zodat de regel niet in een `.vue` zit. Staat bij de andere helpers in `shared/structures/src/helpers/`; geen AutoEncoder velden geraakt, dus geen versioning.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335223&installation_model_id=423362&pr_number=795&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F795&signature=2968a969376348095c3010e28158a57783d3c15930c457145c34a8a76994d841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
