### PR TITLE
✨ Always show the period switcher and disable periods without access

### DIFF
--- a/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
+++ b/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
@@ -34,7 +34,7 @@
 
             <GroupCategoryMenuBox :period="period" />
 
-            <div v-if="!props.period && auth.hasFullAccess()" class="container footer">
+            <div v-if="!props.period" class="container footer">
                 <hr>
 
                 <button class="st-menu-item" type="button" @click="switchPeriod">
@@ -69,6 +69,7 @@ import { Toast } from '@stamhoofd/components/overlays/Toast';
 
 import { useFetchOrganizationRegistrationPeriods } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods.ts';
 import { Organization } from '@stamhoofd/structures/Organization.js';
+import { PeriodAccessHelper } from '@stamhoofd/structures/helpers/PeriodAccessHelper.js';
 import type { OrganizationRegistrationPeriod, RegistrationPeriod, RegistrationPeriodList } from '@stamhoofd/structures/RegistrationPeriod.js';
 import { Formatter } from '@stamhoofd/utility';
 import { computed, onActivated, watch } from 'vue';
@@ -314,6 +315,23 @@ async function startPeriod(p: RegistrationPeriod) {
     });
 }
 
+function getPeriodDisabledReason(p: RegistrationPeriod, organizationPeriod: OrganizationRegistrationPeriod | undefined): string | false {
+    if (p.id === period.value.period.id) {
+        return $t('%1b0');
+    }
+
+    if (!organizationPeriod) {
+        // Choosing this period starts it
+        return hasFullAccess.value ? false : $t('Dit werkjaar is nog niet gestart');
+    }
+
+    if (!PeriodAccessHelper.isPeriodAccessible(organizationPeriod, context.value?.organizationPermissions ?? null)) {
+        return $t('Je hebt geen toegang tot dit werkjaar');
+    }
+
+    return false;
+}
+
 async function switchPeriod(event: MouseEvent) {
     let periods: RegistrationPeriodList;
     try {
@@ -325,11 +343,12 @@ async function switchPeriod(event: MouseEvent) {
 
     const menu = new ContextMenu([
         periods.periods.map((p) => {
+            const existing = periods.organizationPeriods.find(pp => pp.period.id === p.id);
+
             return new ContextMenuItem({
                 name: p.name,
-                disabled: p.id === period.value.period.id ? $t('%1b0') : false,
+                disabled: getPeriodDisabledReason(p, existing),
                 action: async () => {
-                    const existing = periods.organizationPeriods.find(pp => pp.period.id === p.id);
                     if (existing) {
                         await $navigate(Routes.Period, {
                             properties: {
@@ -344,7 +363,7 @@ async function switchPeriod(event: MouseEvent) {
             });
         }),
 
-        ...(STAMHOOFD.userMode === 'organization'
+        ...(STAMHOOFD.userMode === 'organization' && hasFullAccess.value
             ? ([
                     [
                         new ContextMenuItem({


### PR DESCRIPTION
`v-if="!props.period && auth.hasFullAccess()"` → een rol met toegang tot een ander werkjaar raakte er niet.

- `auth.hasFullAccess()` weg, `!props.period` blijft → switcher voor elke admin, nog steeds enkel op het menu van het werkjaar in gebruik
- context menu: werkjaren zonder toegang staan disabled met reden, naast de bestaande "dit werkjaar bekijk je al"
- niet-full admins: werkjaren zonder `organizationPeriod` ook disabled, want kiezen = werkjaar starten
- "nieuw werkjaar starten" / werkjaar-instellingen blijven full admin

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790335227&installation_model_id=423362&pr_number=796&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F796&signature=805ee22d1d3b3997365efde814cf8d460c6ea02536a1195f8f6187ec752a5cf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
