### PR TITLE
Allow roles to access groups and registrations of any period

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
@@ -169,7 +169,8 @@ describe('Endpoint.PatchOrganizationRegistrationPeriodsEndpoint.MoveRegistration
             body.addPatch(periodPatch);
 
             await expect(patchOrganizationRegistrationPeriods({ patch: body, organization, token: allGroupsToken })).rejects.toThrow(STExpect.simpleError({
-                code: 'permission_denied',
+                code: 'locked_period',
+                message: 'This period is locked',
             }));
         });
 

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -495,7 +495,6 @@ export class AdminPermissionChecker {
         }
 
         if (organizationPermissions.hasAccess(PermissionLevel.Full)) {
-            // Only full permissions; because non-full doesn't have access to other periods
             return true;
         }
 
@@ -509,16 +508,6 @@ export class AdminPermissionChecker {
             // No full access: cannot access deactivated registrations
             if (permissionLevel !== PermissionLevel.Read) {
                 // Not allowed to edit registrations that are deleted
-                return false;
-            }
-        }
-
-        const organization = await this.getOrganization(registration.organizationId);
-
-        if (registration.periodId !== organization.periodId) {
-            if (STAMHOOFD.userMode === 'organization' || registration.periodId !== this.platform.period.id) {
-                // We already checked for full permissions - and we don't have full permissions
-                // so that also means no permissions for registrations in other periods
                 return false;
             }
         }

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -289,9 +289,6 @@ export class AdminPermissionChecker {
             // return false;
         }
 
-        if (!await this.canAccessGroupsInPeriod(group.periodId, group.organizationId)) {
-            return false;
-        }
         const organization = await this.getOrganization(group.organizationId);
 
         if (group.deletedAt || group.status === GroupStatus.Archived) {

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -163,14 +163,6 @@ export class ContextPermissions {
             return this.hasFullPlatformAccess();
         }
 
-        if (group.periodId !== organization.period.period.id) {
-            if (STAMHOOFD.userMode === 'organization' || group.periodId !== this.platform.period.id) {
-                if (!this.hasFullAccess()) {
-                    return false;
-                }
-            }
-        }
-
         const permissions = this.getPermissionsForOrganization(organization);
         if (!permissions) {
             return false;


### PR DESCRIPTION
`canAccessGroup` (in frontend en backend) en `canAccessRegistration` keken eerst naar het werkjaar. Als dit niet het huidige werkjaar was, konden enkel full-admins toegang krijgen. Deze PR lost dit op door te kijken of men toegang heeft tot de specifieke groep.

Wijziging in een test: "Moving group FROM locked period should fail as normal admin": die admin heeft nu wel toegang tot de groep, dus faalt de request op `locked_period` i.p.v. `permission_denied`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790342793&installation_model_id=423362&pr_number=798&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F798&signature=b270b31d96b22b337ba403eb0db53892591f5227b966cd798306aa2c6437b16c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
