### PR TITLE
✨ Allow roles to access groups of any period in the frontend

### DIFF
--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
@@ -398,6 +398,73 @@ describe('Endpoint.GetMembersEndpoint', () => {
             ]);
         });
 
+        test('User can fetch members of previous period if has group access', async () => {
+            // Setup
+            const role = PermissionRoleDetailed.create({
+                name: 'Test Role',
+                accessRights: [],
+            });
+
+            const resources = new Map();
+
+            const previousPeriod = await new RegistrationPeriodFactory({
+                startDate: new Date(2022, 0, 1),
+                endDate: new Date(2022, 11, 31),
+            }).create();
+
+            // The organization already moved on to period
+            const organization = await new OrganizationFactory({ period, roles: [role] })
+                .create();
+
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({
+                    level: PermissionLevel.None,
+                    roles: [
+                        role,
+                    ],
+                    resources,
+                }),
+            })
+                .create();
+
+            const token = await SessionService.createSession(user);
+            const member1 = await new MemberFactory({ }).create();
+            const member2 = await new MemberFactory({ }).create();
+            const previousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+            const otherPreviousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+            resources.set(
+                PermissionsResourceType.Groups, new Map([[
+                    previousPeriodGroup.id,
+                    ResourcePermissions.create({
+                        level: PermissionLevel.Read,
+                    }),
+                ]]),
+            );
+
+            await user.save();
+
+            await new RegistrationFactory({ member: member1, group: previousPeriodGroup }).create();
+            await new RegistrationFactory({ member: member2, group: otherPreviousPeriodGroup }).create();
+
+            const request = Request.get({
+                path: baseUrl,
+                host: organization.getApiHost(),
+                query: new LimitedFilteredRequest({
+                    limit: 10,
+                }),
+                headers: {
+                    authorization: 'Bearer ' + token.accessToken,
+                },
+            });
+            const response = await testServer.test(endpoint, request);
+            expect(response.status).toBe(200);
+            expect(response.body.results.members).toIncludeSameMembers([
+                expect.objectContaining({ id: member1.id }),
+            ]);
+        });
+
         test('Not allowed: Cannot fetch all members if no permissions for a single group', async () => {
             // Same test, but without giving the user permissions to read the group
             // Setup

--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
@@ -75,29 +75,17 @@ export class GetMembersEndpoint extends Endpoint<Params, Query, Body, ResponseBo
             } else {
                 // Add organization scope filter
                 if (await Context.auth.canAccessAllMembers(organization.id, permissionLevel)) {
-                    if (await Context.auth.hasFullAccess(organization.id, permissionLevel)) {
-                        // Can access full history for now
-                        scopeFilter = {
-                            registrations: {
-                                $elemMatch: {
-                                    organizationId: organization.id,
-                                },
+                    scopeFilter = {
+                        registrations: {
+                            $elemMatch: {
+                                organizationId: organization.id,
                             },
-                        };
-                    } else {
-                        // Can only access current period
-                        scopeFilter = {
-                            registrations: {
-                                $elemMatch: {
-                                    organizationId: organization.id,
-                                    periodId: organization.periodId,
-                                },
-                            },
-                        };
-                    }
+                        },
+                    };
                 } else {
-                    // Check which normal membership groups we have access to and filter on those
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.WaitingList]);
+                    // Check which normal membership groups we have access to and filter on those.
+                    // Groups of all periods are checked: access to a group is not limited to the current period.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.WaitingList]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 

--- a/backend/app/api/src/endpoints/global/registration/GetRegistrationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration/GetRegistrationsEndpoint.ts
@@ -97,33 +97,19 @@ export class GetRegistrationsEndpoint extends Endpoint<Params, Query, Body, Resp
             if (organization) {
                 // Add organization scope filter
                 if (await Context.auth.canAccessAllMembers(organization.id, permissionLevel)) {
-                    if (await Context.auth.hasFullAccess(organization.id, permissionLevel)) {
-                        // Can access full history for now
-                        scopeFilter = {
-                            member: {
-                                registrations: {
-                                    $elemMatch: {
-                                        organizationId: organization.id,
-                                    },
+                    scopeFilter = {
+                        member: {
+                            registrations: {
+                                $elemMatch: {
+                                    organizationId: organization.id,
                                 },
                             },
-                        };
-                    } else {
-                        // Can only access current period
-                        scopeFilter = {
-                            member: {
-                                registrations: {
-                                    $elemMatch: {
-                                        organizationId: organization.id,
-                                        periodId: organization.periodId,
-                                    },
-                                },
-                            },
-                        };
-                    }
+                        },
+                    };
                 } else {
-                    // Check which normal membership groups we have access to and filter on those
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.WaitingList]);
+                    // Check which normal membership groups we have access to and filter on those.
+                    // Groups of all periods are checked: access to a group is not limited to the current period.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.WaitingList]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/MoveRegistrationPeriods.test.ts
@@ -169,7 +169,8 @@ describe('Endpoint.PatchOrganizationRegistrationPeriodsEndpoint.MoveRegistration
             body.addPatch(periodPatch);
 
             await expect(patchOrganizationRegistrationPeriods({ patch: body, organization, token: allGroupsToken })).rejects.toThrow(STExpect.simpleError({
-                code: 'permission_denied',
+                code: 'locked_period',
+                message: 'This period is locked',
             }));
         });
 

--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
@@ -127,7 +127,7 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
                                 continue;
                             }
 
-                            if (!await Context.auth.canCreateGroupInCategory(organization.id, category)) {
+                            if (!await Context.auth.canCreateGroupInCategory(organization.id, category, organizationPeriod.settings.categories)) {
                                 throw Context.auth.error($t(`%Ez`));
                             }
 

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -1256,7 +1256,7 @@ export class AdminPermissionChecker {
         return true;
     }
 
-    async canCreateGroupInCategory(organizationId: string, category: GroupCategory) {
+    async canCreateGroupInCategory(organizationId: string, category: GroupCategory, allCategories: GroupCategory[]) {
         const organizationPermissions = await this.getOrganizationPermissions(organizationId);
 
         if (!organizationPermissions) {
@@ -1268,9 +1268,7 @@ export class AdminPermissionChecker {
         }
 
         // Check parents
-        const organization = await this.getOrganization(organizationId);
-        const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
-        const parentCategories = organizationPeriod ? category.getParentCategories(organizationPeriod.settings.categories) : [];
+        const parentCategories = category.getParentCategories(allCategories);
 
         for (const parentCategory of parentCategories) {
             if (organizationPermissions.hasResourceAccessRight(PermissionsResourceType.GroupCategories, parentCategory.id, AccessRight.OrganizationCreateGroups)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -1,8 +1,8 @@
 import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { PatchMap } from '@simonbackx/simple-encoding';
 import { isSimpleError, isSimpleErrors, SimpleError } from '@simonbackx/simple-errors';
-import type { BalanceItem, Document, Email, EmailTemplate, MemberWithUsers, MemberWithUsersAndRegistrations, MemberWithUsersRegistrationsAndGroups, Order, OrganizationRegistrationPeriod, User } from '@stamhoofd/models';
-import { CachedBalance, Event, EventNotification, Group, Member, MemberPlatformMembership, Organization, Payment, Registration, Webshop } from '@stamhoofd/models';
+import type { BalanceItem, Document, Email, EmailTemplate, MemberWithUsers, MemberWithUsersAndRegistrations, MemberWithUsersRegistrationsAndGroups, Order, User } from '@stamhoofd/models';
+import { CachedBalance, Event, EventNotification, Group, Member, MemberPlatformMembership, Organization, OrganizationRegistrationPeriod, Payment, Registration, Webshop } from '@stamhoofd/models';
 import type { GroupCategory, MemberWithRegistrationsBlob, Platform as PlatformStruct, RecordAnswer, RecordSettings, ResourcePermissions } from '@stamhoofd/structures';
 import { AccessRight, EmailTemplate as EmailTemplateStruct, EventPermissionChecker, FinancialSupportSettings, GroupStatus, GroupType, PermissionLevel, PermissionsResourceType, ReceivableBalanceType, UitpasNumberDetails, UitpasSocialTariff, UitpasSocialTariffStatus } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
@@ -28,6 +28,7 @@ export class AdminPermissionChecker {
     organizationCache: Map<string, Organization | Promise<Organization | undefined>> = new Map();
     groupsCache: Map<string, Group | null | Promise<Group | null>> = new Map();
     webshopsCache: Map<string, Webshop | null | Promise<Webshop | null>> = new Map();
+    organizationPeriodsCache: Map<string, OrganizationRegistrationPeriod | null | Promise<OrganizationRegistrationPeriod | null>> = new Map();
 
     constructor(user: User, platform: PlatformStruct, organization?: Organization) {
         this.user = user;
@@ -154,9 +155,32 @@ export class AdminPermissionChecker {
         }
     }
 
-    async getOrganizationCurrentPeriod(id: string | Organization): Promise<OrganizationRegistrationPeriod> {
+    /**
+     * The settings (and thus the categories) of a period are period specific: a group can only be found back
+     * in the categories of the period it belongs to.
+     */
+    async getOrganizationPeriod(id: string | Organization, periodId: string): Promise<OrganizationRegistrationPeriod | null> {
         const organization = await this.getOrganization(id);
-        return await organization.getPeriod();
+
+        if (periodId === organization.periodId) {
+            return await organization.getPeriod();
+        }
+
+        const key = organization.id + '-' + periodId;
+        const cache = this.organizationPeriodsCache.get(key);
+        if (cache !== undefined) {
+            return await cache;
+        }
+
+        const promise = OrganizationRegistrationPeriod.select()
+            .where('organizationId', organization.id)
+            .where('periodId', periodId)
+            .first(false);
+
+        this.organizationPeriodsCache.set(key, promise);
+        const organizationPeriod = await promise;
+        this.organizationPeriodsCache.set(key, organizationPeriod);
+        return organizationPeriod;
     }
 
     error(humanOrData?: string | { message: string; human?: string }): SimpleError {
@@ -317,8 +341,8 @@ export class AdminPermissionChecker {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const organizationPeriod = await this.getOrganizationCurrentPeriod(organization);
-            const parentCategories = group.getParentCategories(organizationPeriod.settings.categories);
+            const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+            const parentCategories = organizationPeriod ? group.getParentCategories(organizationPeriod.settings.categories) : [];
             for (const category of parentCategories) {
                 if (organizationPermissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {
                     return true;
@@ -1245,8 +1269,8 @@ export class AdminPermissionChecker {
 
         // Check parents
         const organization = await this.getOrganization(organizationId);
-        const organizationPeriod = await this.getOrganizationCurrentPeriod(organization);
-        const parentCategories = category.getParentCategories(organizationPeriod.settings.categories);
+        const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+        const parentCategories = organizationPeriod ? category.getParentCategories(organizationPeriod.settings.categories) : [];
 
         for (const parentCategory of parentCategories) {
             if (organizationPermissions.hasResourceAccessRight(PermissionsResourceType.GroupCategories, parentCategory.id, AccessRight.OrganizationCreateGroups)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -495,7 +495,6 @@ export class AdminPermissionChecker {
         }
 
         if (organizationPermissions.hasAccess(PermissionLevel.Full)) {
-            // Only full permissions; because non-full doesn't have access to other periods
             return true;
         }
 
@@ -509,16 +508,6 @@ export class AdminPermissionChecker {
             // No full access: cannot access deactivated registrations
             if (permissionLevel !== PermissionLevel.Read) {
                 // Not allowed to edit registrations that are deleted
-                return false;
-            }
-        }
-
-        const organization = await this.getOrganization(registration.organizationId);
-
-        if (registration.periodId !== organization.periodId) {
-            if (STAMHOOFD.userMode === 'organization' || registration.periodId !== this.platform.period.id) {
-                // We already checked for full permissions - and we don't have full permissions
-                // so that also means no permissions for registrations in other periods
                 return false;
             }
         }

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -341,7 +341,7 @@ export class AdminPermissionChecker {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+            const organizationPeriod = await this.getOrganizationPeriod(organization, group.periodId);
             const parentCategories = organizationPeriod ? group.getParentCategories(organizationPeriod.settings.categories) : [];
             for (const category of parentCategories) {
                 if (organizationPermissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -289,9 +289,6 @@ export class AdminPermissionChecker {
             // return false;
         }
 
-        if (!await this.canAccessGroupsInPeriod(group.periodId, group.organizationId)) {
-            return false;
-        }
         const organization = await this.getOrganization(group.organizationId);
 
         if (group.deletedAt || group.status === GroupStatus.Archived) {

--- a/frontend/app/dashboard/src/views/dashboard/groups/GroupOverview.vue
+++ b/frontend/app/dashboard/src/views/dashboard/groups/GroupOverview.vue
@@ -240,7 +240,7 @@ const title = computed(() => props.group.settings.name.toString());
 const isArchive = computed(() => props.group.status === GroupStatus.Archived);
 const isOpen = computed(() => !props.group.closed);
 const auth = useAuth();
-const hasFullPermissions = computed(() => auth.canAccessGroup(props.group, PermissionLevel.Full));
+const hasFullPermissions = computed(() => auth.canAccessGroup(props.group, PermissionLevel.Full, undefined, props.period));
 const organizationManager = useOrganizationManager();
 const organization = useOrganization();
 const navigationController = useNavigationController();

--- a/frontend/app/dashboard/src/views/members/useGroupActions.ts
+++ b/frontend/app/dashboard/src/views/members/useGroupActions.ts
@@ -32,7 +32,7 @@ export function useGroupActions(saveHandler?: (patch: PatchableArrayAutoEncoder<
         periods?: OrganizationRegistrationPeriod[];
     }) {
         const canManage = auth.hasFullAccess();
-        const canEdit = canManage || auth.canAccessGroup(props.group, PermissionLevel.Write);
+        const canEdit = canManage || auth.canAccessGroup(props.group, PermissionLevel.Write, undefined, props.period);
 
         function getParentCategory() {
             return props.group.getParentCategories(props.period.settings.categories)[0];

--- a/frontend/shared/components/src/members/MembersTableView.vue
+++ b/frontend/shared/components/src/members/MembersTableView.vue
@@ -287,7 +287,7 @@ const isLimitedGroup = computed(() => {
     if (organization.value && props.group.organizationId !== organization.value.id) {
         return true;
     }
-    if (!auth.canAccessGroup(props.group)) {
+    if (!auth.canAccessGroup(props.group, undefined, undefined, organizationRegistrationPeriod.value)) {
         return true;
     }
     return false;

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -376,6 +376,23 @@ export class ContextPermissions {
         return !!this.permissions && !this.permissions.isEmpty;
     }
 
+    /**
+     * Group and category permissions are period specific, so a role only reaches the periods it was
+     * granted groups in.
+     */
+    hasSomeAccessInPeriod(period: OrganizationRegistrationPeriod): boolean {
+        if (this.hasFullAccess()) {
+            return true;
+        }
+
+        const permissions = this.permissions;
+        if (!permissions) {
+            return false;
+        }
+
+        return period.getCategoryTree({ permissions }).getAllGroups().length > 0;
+    }
+
     hasPlatformFullAccess(): boolean {
         return !!this.platformPermissions && !!this.platformPermissions.hasFullAccess();
     }

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -163,14 +163,6 @@ export class ContextPermissions {
             return this.hasFullPlatformAccess();
         }
 
-        if (group.periodId !== organization.period.period.id) {
-            if (STAMHOOFD.userMode === 'organization' || group.periodId !== this.platform.period.id) {
-                if (!this.hasFullAccess()) {
-                    return false;
-                }
-            }
-        }
-
         const permissions = this.getPermissionsForOrganization(organization);
         if (!permissions) {
             return false;

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -1,4 +1,4 @@
-import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationTag, PaymentGeneral, Permissions, Platform, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
+import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationRegistrationPeriod, OrganizationTag, PaymentGeneral, Permissions, Platform, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
 import { AccessRight, EventPermissionChecker, GroupType, PermissionLevel, PermissionsResourceType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { toRaw, unref } from 'vue';
@@ -154,7 +154,7 @@ export class ContextPermissions {
         return this.hasAccessRight(AccessRight.ManageEmailTemplates);
     }
 
-    canAccessGroup(group: Group, permissionLevel: PermissionLevel = PermissionLevel.Read, organization?: Organization | null) {
+    canAccessGroup(group: Group, permissionLevel: PermissionLevel = PermissionLevel.Read, organization?: Organization | null, organizationPeriod?: OrganizationRegistrationPeriod | null) {
         if (organization === undefined || (organization === null && this.organization)) {
             organization = this.organization;
         }
@@ -172,9 +172,11 @@ export class ContextPermissions {
             return true;
         }
 
-        // Check parent categories
+        // Check parent categories. Categories are period specific: only the period the group belongs to
+        // can resolve its parents, so pass it when it is not the period the organization is using.
         if (group.type === GroupType.Membership) {
-            const parentCategories = group.getParentCategories(organization.period.settings.categories);
+            const period = organizationPeriod ?? (group.periodId === organization.period.period.id ? organization.period : null);
+            const parentCategories = period ? group.getParentCategories(period.settings.categories) : [];
             for (const category of parentCategories) {
                 if (permissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {
                     return true;


### PR DESCRIPTION
Spiegel van #798 en #799 in `ContextPermissions`, plus de helper die #802 nodig heeft. Moet identiek blijven aan de backend, anders verbergt de UI wat de API wel toelaat.

**1 — werkjaar-gate uit `canAccessGroup`**

**2 — categories uit het werkjaar van de groep**
- `canAccessGroup(group, level, organization, organizationPeriod?)`
- niets meegegeven én groep zit niet in het huidige werkjaar → geen parent categories, i.p.v. de verkeerde lijst doorzoeken
- call sites die het werkjaar al bij de hand hebben geven het mee: `GroupOverview`, `useGroupActions`, `MembersTableView`
- group-id grants werken sowieso, enkel category-grants hebben het werkjaar nodig

**3 — `hasSomeAccessInPeriod(period)`**
- full access → true
- geen permissions → false
- anders → `period.getCategoryTree({ permissions }).getAllGroups().length > 0`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790342806&installation_model_id=423362&pr_number=801&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F801&signature=99cd59e2c925dd27f0362f71effcb2be8923ad47579ee1c4cea8c5dc8d5b780b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
