### PR TITLE
🐛 Fixed bug where the button for changing period was visible for non-…

### DIFF
--- a/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
+++ b/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
@@ -412,6 +412,8 @@ type Action = {
 );
 
 const canSetDefaultPeriod = computed(() => {
+    if (!auth.hasFullAccess()) return false;
+
     if (period.value.id === organization.value.period.id) {
         return false;
     }
@@ -423,6 +425,14 @@ const canSetDefaultPeriod = computed(() => {
         (period.value.period.startDate >= platform.value.period.startDate && !period.value.period.locked)
         && (!period.value.period.locked && (period.value.period.switchDate === null || period.value.period.switchDate < new Date()))
     );
+});
+
+console.table({
+    canSetDefaultPeriod: canSetDefaultPeriod.value,
+    props: props,
+    periodId: period.value.id,
+    organizationPeriodId: organization.value.period.id,
+    userMode: STAMHOOFD.userMode,
 });
 
 const patchOrganization = usePatchOrganization();

--- a/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
+++ b/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
@@ -427,14 +427,6 @@ const canSetDefaultPeriod = computed(() => {
     );
 });
 
-console.table({
-    canSetDefaultPeriod: canSetDefaultPeriod.value,
-    props: props,
-    periodId: period.value.id,
-    organizationPeriodId: organization.value.period.id,
-    userMode: STAMHOOFD.userMode,
-});
-
 const patchOrganization = usePatchOrganization();
 const pop = usePop();
 async function setDefaultPeriod() {


### PR DESCRIPTION
…admins

Fixes STA-1382

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790423925&installation_model_id=423362&pr_number=806&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F806&signature=b45f4afed72617382514b74f113e8f8e4034aafe85dda08efb2d62cec1616ffb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->