### PR TITLE
Unify the two registration period caches

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/settings/modules/members/RegistrationPeriodSelector.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/modules/members/RegistrationPeriodSelector.vue
@@ -13,30 +13,26 @@
 
 <script setup lang="ts">
 import Dropdown from '@stamhoofd/components/inputs/Dropdown.vue';
-import { useOrganizationManager } from '@stamhoofd/networking/OrganizationManager';
-import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
+import { useRequiredOrganization } from '@stamhoofd/components/hooks/useOrganization';
+import { useFetchOrganizationRegistrationPeriods } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
 import type { OrganizationRegistrationPeriod } from '@stamhoofd/structures';
-import { computed } from 'vue';
+import type { Ref } from 'vue';
+import { computed, ref } from 'vue';
 const props = withDefaults(defineProps<{ modelValue: OrganizationRegistrationPeriod; shouldDisableLockedPeriods?: boolean }>(), {
     shouldDisableLockedPeriods: false,
 });
 
 const emit = defineEmits<{ (e: 'update:modelValue', value: OrganizationRegistrationPeriod | null): void }>();
 
-const organizationManager = useOrganizationManager();
-const owner = useRequestOwner();
+const organization = useRequiredOrganization();
+const fetchPeriods = useFetchOrganizationRegistrationPeriods();
+const fetchedPeriods = ref(null) as Ref<OrganizationRegistrationPeriod[] | null>;
 
-// Load groups
-organizationManager.value.loadPeriods(false, false, owner).catch(console.error);
+fetchPeriods({ shouldRetry: false }).then((list) => {
+    fetchedPeriods.value = list.organizationPeriods;
+}).catch(console.error);
 
-const periods = computed(() => {
-    const periods = organizationManager.value.organization.periods?.organizationPeriods;
-    if (periods === undefined) {
-        return [organizationManager.value.organization.period];
-    }
-
-    return [...periods];
-});
+const periods = computed(() => fetchedPeriods.value ?? [organization.value.period]);
 
 const isSinglePeriod = computed(() => periods.value.length === 1);
 

--- a/frontend/app/dashboard/src/views/onboarding/OnboardingRegistrationPeriodView.vue
+++ b/frontend/app/dashboard/src/views/onboarding/OnboardingRegistrationPeriodView.vue
@@ -107,7 +107,7 @@ import { RegistrationPeriod } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { computed, ref, watch } from 'vue';
 import type { OnboardingStepProps } from './useMemberAdministrationOnboarding';
-import { clearOrganizationPeriodsCache } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
+import { clearOrganizationPeriodsCache } from '@stamhoofd/networking/organizationPeriodsCache';
 import { clearRegistrationPeriodsCache } from '@stamhoofd/networking/hooks/useFetchRegistrationPeriods';
 
 type ConfigType = 'year' | 'semester' | 'custom';

--- a/frontend/shared/components/src/inputs/GroupsInput.vue
+++ b/frontend/shared/components/src/inputs/GroupsInput.vue
@@ -31,8 +31,7 @@
 import LoadingBoxTransition from '#containers/LoadingBoxTransition.vue';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import { usePlatform } from '#hooks/usePlatform.ts';
-import { useOrganizationManager } from '@stamhoofd/networking/OrganizationManager';
-import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
+import { useFetchOrganizationRegistrationPeriods } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
 import { GroupType, NamedObject, RegistrationPeriodList } from '@stamhoofd/structures';
 import type { Ref} from 'vue';
 import { computed, ref, watch, watchEffect } from 'vue';
@@ -50,8 +49,7 @@ const props = withDefaults(
 
 const model = defineModel<NamedObject[] | null>({ required: true });
 const organization = useOrganization();
-const organizationManager = useOrganizationManager();
-const owner = useRequestOwner();
+const fetchPeriods = useFetchOrganizationRegistrationPeriods();
 const platform = usePlatform();
 
 const lastCachedValue = ref<NamedObject[] | null>(null);
@@ -130,7 +128,7 @@ watch(enabledOptions, (options) => {
     }
 }, { immediate: true });
 
-organizationManager.value.loadPeriods(false, true, owner).then((p) => {
+fetchPeriods({ shouldRetry: true }).then((p) => {
     periods.value = p;
     loading.value = false;
 }).catch(console.error);

--- a/frontend/shared/components/src/members/MembersTableView.vue
+++ b/frontend/shared/components/src/members/MembersTableView.vue
@@ -55,6 +55,7 @@ import { useAdvancedMemberWithRegistrationsBlobUIFilterBuilders } from '../filte
 import { useRegistrationInvitationEventListener } from '#registrations/classes/useRegistrationInvitationEventListener.ts';
 import { useDirectMemberActions } from './classes/MemberActionBuilder';
 import { getMemberColumns } from '#members/helpers/getMemberColumns.ts';
+import { useOrganizationRegistrationPeriod } from '@stamhoofd/networking/hooks/useOrganizationRegistrationPeriod';
 
 type ObjectType = PlatformMember;
 
@@ -129,11 +130,7 @@ const defaultFilter = isPlatform && app === 'admin' && !props.group && !props.cu
         }
     : null;
 
-const organizationRegistrationPeriod = computed(() => {
-    const periodId = filterPeriodId;
-
-    return organization.value?.periods?.organizationPeriods?.find(p => p.period.id === periodId);
-});
+const organizationRegistrationPeriod = useOrganizationRegistrationPeriod(filterPeriodId);
 
 useGlobalEventListener('members-deleted', async () => {
     tableObjectFetcher.reset(true, true);

--- a/frontend/shared/components/src/members/helpers/updateContextFromMembersBlob.ts
+++ b/frontend/shared/components/src/members/helpers/updateContextFromMembersBlob.ts
@@ -1,6 +1,6 @@
 import type { SessionContext } from '@stamhoofd/networking/SessionContext';
 import type { MembersBlob, OrganizationRegistrationPeriod } from '@stamhoofd/structures';
-import { getCachedOrganizationPeriods } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
+import { getCachedOrganizationPeriods } from '@stamhoofd/networking/organizationPeriodsCache';
 
 /**
  * Call this method when we receive a fresh blob from the backend.

--- a/frontend/shared/components/src/members/helpers/updateContextFromMembersBlob.ts
+++ b/frontend/shared/components/src/members/helpers/updateContextFromMembersBlob.ts
@@ -1,5 +1,6 @@
 import type { SessionContext } from '@stamhoofd/networking/SessionContext';
 import type { MembersBlob, OrganizationRegistrationPeriod } from '@stamhoofd/structures';
+import { getCachedOrganizationPeriods } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
 
 /**
  * Call this method when we receive a fresh blob from the backend.
@@ -55,7 +56,7 @@ export function updateContextFromMembersBlob(context: SessionContext, blob: Memb
                     let period: OrganizationRegistrationPeriod | undefined = context.organization.period;
 
                     if (context.organization.period.period.id !== periodId) {
-                        period = context.organization.periods?.organizationPeriods.find(p => p.period.id === periodId);
+                        period = getCachedOrganizationPeriods(context.organization.id)?.organizationPeriods.find(p => p.period.id === periodId);
                     }
 
                     const originalGroup = period?.groups.find(g => g.id === registration.groupId) ?? period?.waitingLists.find(g => g.id === registration.groupId);

--- a/frontend/shared/components/src/organizations/usePatchOrganization.ts
+++ b/frontend/shared/components/src/organizations/usePatchOrganization.ts
@@ -5,6 +5,7 @@ import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import { Organization } from '@stamhoofd/structures';
 import { GlobalEventBus } from '../EventBus';
 import { useContext } from '../hooks/useContext';
+import { clearOrganizationPeriodsCache } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
 
 export function usePatchOrganization() {
     const organization = useOrganization();
@@ -35,7 +36,7 @@ export function usePatchOrganization() {
 
         if (patch.period) {
             // Clear cached periods
-            organization.value.periods = undefined;
+            clearOrganizationPeriodsCache();
         }
 
         await GlobalEventBus.sendEvent('organization-updated', organization.value);

--- a/frontend/shared/components/src/organizations/usePatchOrganization.ts
+++ b/frontend/shared/components/src/organizations/usePatchOrganization.ts
@@ -5,7 +5,7 @@ import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import { Organization } from '@stamhoofd/structures';
 import { GlobalEventBus } from '../EventBus';
 import { useContext } from '../hooks/useContext';
-import { clearOrganizationPeriodsCache } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
+import { clearOrganizationPeriodsCache } from '@stamhoofd/networking/organizationPeriodsCache';
 
 export function usePatchOrganization() {
     const organization = useOrganization();

--- a/frontend/shared/components/src/periods/EditRegistrationPeriodsView.vue
+++ b/frontend/shared/components/src/periods/EditRegistrationPeriodsView.vue
@@ -62,7 +62,7 @@ import type { AutoEncoderPatchType, Decoder, PatchableArrayAutoEncoder } from '@
 import { ArrayDecoder, PatchableArray } from '@simonbackx/simple-encoding';
 import { ComponentWithProperties, usePop, usePresent } from '@simonbackx/vue-app-navigation';
 import { AsyncComponent } from '#containers/AsyncComponent.ts';
-import { clearOrganizationPeriodsCache } from '@stamhoofd/networking/hooks/useFetchOrganizationRegistrationPeriods';
+import { clearOrganizationPeriodsCache } from '@stamhoofd/networking/organizationPeriodsCache';
 import { clearRegistrationPeriodsCache, useFetchRegistrationPeriods } from '@stamhoofd/networking/hooks/useFetchRegistrationPeriods';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import { Organization, RegistrationPeriod } from '@stamhoofd/structures';

--- a/frontend/shared/components/src/registrations/RegistrationsTableView.vue
+++ b/frontend/shared/components/src/registrations/RegistrationsTableView.vue
@@ -59,6 +59,7 @@ import { useRegistrationsObjectFetcher } from '../fetchers/useRegistrationsObjec
 import { useAdvancedRegistrationWithMemberUIFilterBuilders } from '../filters/filter-builders/registrations-with-member';
 import { getRegistrationColumns } from '../members/helpers/getRegistrationColumns';
 import { useDirectRegistrationActions } from './classes/RegistrationActionBuilder';
+import { useOrganizationRegistrationPeriod } from '@stamhoofd/networking/hooks/useOrganizationRegistrationPeriod';
 
 type ObjectType = PlatformRegistration;
 
@@ -182,11 +183,7 @@ function getDefaultFilter(): StamhoofdFilter {
     return null;
 }
 
-const organizationRegistrationPeriod = computed(() => {
-    const periodId = filterPeriodId;
-
-    return props.organization?.periods?.organizationPeriods?.find(p => p.period.id === periodId);
-});
+const organizationRegistrationPeriod = useOrganizationRegistrationPeriod(filterPeriodId, { organization: computed(() => props.organization) });
 
 useGlobalEventListener('members-deleted', async () => {
     tableObjectFetcher.reset(true, true);

--- a/frontend/shared/networking/src/OrganizationManager.ts
+++ b/frontend/shared/networking/src/OrganizationManager.ts
@@ -2,12 +2,12 @@ import type { AutoEncoderPatchType, Decoder } from '@simonbackx/simple-encoding'
 import { ArrayDecoder, deepSetArray } from '@simonbackx/simple-encoding';
 import { SimpleError } from '@simonbackx/simple-errors';
 import { GlobalEventBus } from '@stamhoofd/components/EventBus';
-import { Group, LimitedFilteredRequest, Organization, OrganizationAdmins, OrganizationRegistrationPeriod, PaginatedResponseDecoder, RegistrationPeriod, RegistrationPeriodList, SortItemDirection } from '@stamhoofd/structures';
-import { Sorter } from '@stamhoofd/utility';
+import { Group, Organization, OrganizationAdmins } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { inject, toRef } from 'vue';
 import type { SessionContext } from './SessionContext';
 import { SessionManager } from './SessionManager';
+import { clearOrganizationPeriodsCache } from './hooks/useFetchOrganizationRegistrationPeriods.js';
 
 export function useOrganizationManager(): Ref<OrganizationManager> {
     return toRef(inject<OrganizationManager>('$organizationManager')) as any as Ref<OrganizationManager>;
@@ -82,7 +82,7 @@ export class OrganizationManager {
 
         if (patch.period) {
             // Clear cached periods
-            this.$context.organization.periods = undefined;
+            clearOrganizationPeriodsCache();
 
             // There is something fishy going on with the period that doesn't get set using deepSet (updateOrganization) - can't explain why atm
             // this fixes it for now
@@ -97,101 +97,6 @@ export class OrganizationManager {
         this.save().catch(console.error);
 
         await GlobalEventBus.sendEvent('organization-updated', this.$context.organization);
-    }
-
-    /**
-     * @deprecated
-     * useFetchRegistrationPeriods
-     */
-    async loadPeriods(force = false, shouldRetry?: boolean, owner?: any) {
-        if (!force && this.organization.periods) {
-            return this.organization.periods;
-        }
-
-        // Load last 5 years
-        const startDate = new Date();
-        startDate.setFullYear(startDate.getFullYear() - 6);
-
-        // Improve http caching
-        startDate.setDate(1);
-        startDate.setMonth(0);
-        startDate.setHours(0, 0, 0, 0);
-
-        // Load periods
-        const periodsResponse = await this.$context.authenticatedServer.request({
-            method: 'GET',
-            path: '/registration-periods',
-            query: new LimitedFilteredRequest({
-                filter: {
-                    startDate: {
-                        $gt: startDate,
-                    },
-                },
-                limit: 10,
-                sort: [
-                    {
-                        key: 'startDate',
-                        order: SortItemDirection.DESC,
-                    },
-                    {
-                        key: 'id',
-                        order: SortItemDirection.ASC,
-                    },
-                ],
-            }),
-            decoder: new PaginatedResponseDecoder(
-                new ArrayDecoder(RegistrationPeriod as Decoder<RegistrationPeriod>),
-                LimitedFilteredRequest,
-            ),
-            owner,
-            shouldRetry: shouldRetry ?? false,
-        });
-
-        const periods = periodsResponse.data.results;
-        let organizationPeriods: OrganizationRegistrationPeriod[] = [];
-
-        if (periods.length !== 0) {
-            const response = await this.$context.authenticatedServer.request({
-                method: 'GET',
-                path: '/organization/registration-periods',
-                query: new LimitedFilteredRequest({
-                    filter: {
-                        periodId: {
-                            $in: periods.map(p => p.id),
-                        },
-                    },
-                    limit: 20,
-                    sort: [
-                        {
-                            key: 'id',
-                            order: SortItemDirection.ASC,
-                        },
-                    ],
-                }),
-                decoder: new PaginatedResponseDecoder(
-                    new ArrayDecoder(OrganizationRegistrationPeriod as Decoder<OrganizationRegistrationPeriod>),
-                    LimitedFilteredRequest,
-                ),
-                owner,
-                shouldRetry: shouldRetry ?? false,
-            });
-            organizationPeriods = response.data.results;
-        }
-
-        organizationPeriods.sort((a, b) => Sorter.byDateValue(a.period.startDate, b.period.startDate));
-
-        const list = RegistrationPeriodList.create({
-            organizationPeriods: organizationPeriods,
-            periods: periods,
-        });
-
-        if (this.organization.periods) {
-            this.organization.periods?.deepSet(list);
-        } else {
-            this.organization.periods = list;
-        }
-
-        return list;
     }
 
     async loadArchivedGroups({ owner }: { owner?: any }) {

--- a/frontend/shared/networking/src/OrganizationManager.ts
+++ b/frontend/shared/networking/src/OrganizationManager.ts
@@ -7,7 +7,7 @@ import type { Ref } from 'vue';
 import { inject, toRef } from 'vue';
 import type { SessionContext } from './SessionContext';
 import { SessionManager } from './SessionManager';
-import { clearOrganizationPeriodsCache } from './hooks/useFetchOrganizationRegistrationPeriods.js';
+import { clearOrganizationPeriodsCache } from './organizationPeriodsCache.js';
 
 export function useOrganizationManager(): Ref<OrganizationManager> {
     return toRef(inject<OrganizationManager>('$organizationManager')) as any as Ref<OrganizationManager>;

--- a/frontend/shared/networking/src/hooks/useFetchOrganizationRegistrationPeriods.ts
+++ b/frontend/shared/networking/src/hooks/useFetchOrganizationRegistrationPeriods.ts
@@ -7,13 +7,19 @@ import { LimitedFilteredRequest, OrganizationRegistrationPeriod, PaginatedRespon
 import { Sorter } from '@stamhoofd/utility';
 import { useFetchRegistrationPeriods } from './useFetchRegistrationPeriods';
 import { useRequestOwner } from './useRequestOwner';
-import { reactive } from 'vue';
+import { reactive, shallowReactive } from 'vue';
 import type { Ref } from 'vue';
 
-const periodsCache = new Map<string, RegistrationPeriodList>();
+// Reactive so a synchronous read re-evaluates once the periods are fetched. Shallow: the lists themselves
+// are made reactive when they are stored.
+const periodsCache = shallowReactive(new Map<string, unknown>()) as unknown as Map<string, RegistrationPeriodList>;
 
 export function clearOrganizationPeriodsCache() {
     periodsCache.clear();
+}
+
+export function getCachedOrganizationPeriods(organizationId: string): RegistrationPeriodList | undefined {
+    return periodsCache.get(organizationId);
 }
 
 export function useFetchOrganizationRegistrationPeriods({ organization }: { organization?: Ref<Organization> } = {}) {

--- a/frontend/shared/networking/src/hooks/useFetchOrganizationRegistrationPeriods.ts
+++ b/frontend/shared/networking/src/hooks/useFetchOrganizationRegistrationPeriods.ts
@@ -7,20 +7,9 @@ import { LimitedFilteredRequest, OrganizationRegistrationPeriod, PaginatedRespon
 import { Sorter } from '@stamhoofd/utility';
 import { useFetchRegistrationPeriods } from './useFetchRegistrationPeriods';
 import { useRequestOwner } from './useRequestOwner';
-import { reactive, shallowReactive } from 'vue';
+import { getCachedOrganizationPeriods, setCachedOrganizationPeriods } from '../organizationPeriodsCache.js';
+import { reactive } from 'vue';
 import type { Ref } from 'vue';
-
-// Reactive so a synchronous read re-evaluates once the periods are fetched. Shallow: the lists themselves
-// are made reactive when they are stored.
-const periodsCache = shallowReactive(new Map<string, unknown>()) as unknown as Map<string, RegistrationPeriodList>;
-
-export function clearOrganizationPeriodsCache() {
-    periodsCache.clear();
-}
-
-export function getCachedOrganizationPeriods(organizationId: string): RegistrationPeriodList | undefined {
-    return periodsCache.get(organizationId);
-}
 
 export function useFetchOrganizationRegistrationPeriods({ organization }: { organization?: Ref<Organization> } = {}) {
     const context = useContext();
@@ -29,7 +18,7 @@ export function useFetchOrganizationRegistrationPeriods({ organization }: { orga
     organization = organization ?? useRequiredOrganization();
 
     return async function ({ shouldRetry, force }: { shouldRetry?: boolean; force?: boolean }) {
-        const cache = periodsCache.get(organization.value.id);
+        const cache = getCachedOrganizationPeriods(organization.value.id);
         if (!force && cache) {
             return cache;
         }
@@ -83,7 +72,7 @@ export function useFetchOrganizationRegistrationPeriods({ organization }: { orga
         if (!cache) {
             // Using 'reactive' is required when the periods are not immediately used in vue and not made reactive automatically
             // it prevents issues where computed properties won't update because they are not using the reactive version of an organization period
-            periodsCache.set(organization.value.id, reactive(list) as unknown as RegistrationPeriodList);
+            setCachedOrganizationPeriods(organization.value.id, reactive(list) as unknown as RegistrationPeriodList);
         } else {
             cache.deepSet(list);
         }

--- a/frontend/shared/networking/src/hooks/useOrganizationRegistrationPeriod.ts
+++ b/frontend/shared/networking/src/hooks/useOrganizationRegistrationPeriod.ts
@@ -1,7 +1,7 @@
 import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
 import type { Organization, OrganizationRegistrationPeriod } from '@stamhoofd/structures';
-import type { MaybeRefOrGetter, Ref } from 'vue';
-import { computed, toValue, watch } from 'vue';
+import type { Ref } from 'vue';
+import { computed, watch } from 'vue';
 import { getCachedOrganizationPeriods } from '../organizationPeriodsCache.js';
 import { useFetchOrganizationRegistrationPeriods } from './useFetchOrganizationRegistrationPeriods.js';
 
@@ -9,30 +9,29 @@ import { useFetchOrganizationRegistrationPeriods } from './useFetchOrganizationR
  * The organization period a period id belongs to. The periods are only fetched when the id is not the
  * period the organization is currently using.
  */
-export function useOrganizationRegistrationPeriod(periodId: MaybeRefOrGetter<string | null | undefined>, options?: { organization?: Ref<Organization | null> }) {
+export function useOrganizationRegistrationPeriod(periodId: string | null | undefined, options?: { organization?: Ref<Organization | null> }) {
     const contextOrganization = useOrganization();
     const organization = options?.organization ?? contextOrganization;
     const fetchPeriods = useFetchOrganizationRegistrationPeriods({ organization: organization as Ref<Organization> });
 
-    watch([() => toValue(periodId), organization], ([id, org]) => {
-        if (!org || !id || org.period.period.id === id || getCachedOrganizationPeriods(org.id)) {
+    watch(organization, (org) => {
+        if (!org || !periodId || org.period.period.id === periodId || getCachedOrganizationPeriods(org.id)) {
             return;
         }
         fetchPeriods({ shouldRetry: false }).catch(console.error);
     }, { immediate: true });
 
     return computed((): OrganizationRegistrationPeriod | undefined => {
-        const id = toValue(periodId);
         const org = organization.value;
 
-        if (!org || !id) {
+        if (!org || !periodId) {
             return undefined;
         }
 
-        if (org.period.period.id === id) {
+        if (org.period.period.id === periodId) {
             return org.period;
         }
 
-        return getCachedOrganizationPeriods(org.id)?.organizationPeriods.find(p => p.period.id === id);
+        return getCachedOrganizationPeriods(org.id)?.organizationPeriods.find(p => p.period.id === periodId);
     });
 }

--- a/frontend/shared/networking/src/hooks/useOrganizationRegistrationPeriod.ts
+++ b/frontend/shared/networking/src/hooks/useOrganizationRegistrationPeriod.ts
@@ -2,7 +2,8 @@ import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts'
 import type { Organization, OrganizationRegistrationPeriod } from '@stamhoofd/structures';
 import type { MaybeRefOrGetter, Ref } from 'vue';
 import { computed, toValue, watch } from 'vue';
-import { getCachedOrganizationPeriods, useFetchOrganizationRegistrationPeriods } from './useFetchOrganizationRegistrationPeriods.js';
+import { getCachedOrganizationPeriods } from '../organizationPeriodsCache.js';
+import { useFetchOrganizationRegistrationPeriods } from './useFetchOrganizationRegistrationPeriods.js';
 
 /**
  * The organization period a period id belongs to. The periods are only fetched when the id is not the

--- a/frontend/shared/networking/src/hooks/useOrganizationRegistrationPeriod.ts
+++ b/frontend/shared/networking/src/hooks/useOrganizationRegistrationPeriod.ts
@@ -1,0 +1,37 @@
+import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
+import type { Organization, OrganizationRegistrationPeriod } from '@stamhoofd/structures';
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { computed, toValue, watch } from 'vue';
+import { getCachedOrganizationPeriods, useFetchOrganizationRegistrationPeriods } from './useFetchOrganizationRegistrationPeriods.js';
+
+/**
+ * The organization period a period id belongs to. The periods are only fetched when the id is not the
+ * period the organization is currently using.
+ */
+export function useOrganizationRegistrationPeriod(periodId: MaybeRefOrGetter<string | null | undefined>, options?: { organization?: Ref<Organization | null> }) {
+    const contextOrganization = useOrganization();
+    const organization = options?.organization ?? contextOrganization;
+    const fetchPeriods = useFetchOrganizationRegistrationPeriods({ organization: organization as Ref<Organization> });
+
+    watch([() => toValue(periodId), organization], ([id, org]) => {
+        if (!org || !id || org.period.period.id === id || getCachedOrganizationPeriods(org.id)) {
+            return;
+        }
+        fetchPeriods({ shouldRetry: false }).catch(console.error);
+    }, { immediate: true });
+
+    return computed((): OrganizationRegistrationPeriod | undefined => {
+        const id = toValue(periodId);
+        const org = organization.value;
+
+        if (!org || !id) {
+            return undefined;
+        }
+
+        if (org.period.period.id === id) {
+            return org.period;
+        }
+
+        return getCachedOrganizationPeriods(org.id)?.organizationPeriods.find(p => p.period.id === id);
+    });
+}

--- a/frontend/shared/networking/src/hooks/usePatchOrganizationPeriods.ts
+++ b/frontend/shared/networking/src/hooks/usePatchOrganizationPeriods.ts
@@ -4,7 +4,7 @@ import { useContext } from '@stamhoofd/components/hooks/useContext.ts';
 import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
 import { OrganizationRegistrationPeriod } from '@stamhoofd/structures';
 import { useRequestOwner } from './useRequestOwner';
-import { clearOrganizationPeriodsCache } from './useFetchOrganizationRegistrationPeriods.js';
+import { clearOrganizationPeriodsCache } from '../organizationPeriodsCache.js';
 
 export function usePatchOrganizationPeriods() {
     const context = useContext();

--- a/frontend/shared/networking/src/hooks/usePatchOrganizationPeriods.ts
+++ b/frontend/shared/networking/src/hooks/usePatchOrganizationPeriods.ts
@@ -4,6 +4,7 @@ import { useContext } from '@stamhoofd/components/hooks/useContext.ts';
 import { useOrganization } from '@stamhoofd/components/hooks/useOrganization.ts';
 import { OrganizationRegistrationPeriod } from '@stamhoofd/structures';
 import { useRequestOwner } from './useRequestOwner';
+import { clearOrganizationPeriodsCache } from './useFetchOrganizationRegistrationPeriods.js';
 
 export function usePatchOrganizationPeriods() {
     const context = useContext();
@@ -23,10 +24,8 @@ export function usePatchOrganizationPeriods() {
         // If current organization in scope, make sure the in-memory version is updated
         organization.value?.updatePeriods(response.data);
 
-        if (organization.value) {
-            // We need to clear because there could be new periods
-            organization.value.periods = undefined;
-        }
+        // We need to clear because there could be new periods
+        clearOrganizationPeriodsCache();
 
         if (options.periods) {
             for (const period of options.periods ?? []) {

--- a/frontend/shared/networking/src/organizationPeriodsCache.ts
+++ b/frontend/shared/networking/src/organizationPeriodsCache.ts
@@ -1,0 +1,18 @@
+import type { RegistrationPeriodList } from '@stamhoofd/structures';
+import { shallowReactive } from 'vue';
+
+// Reactive so a synchronous read re-evaluates once the periods are fetched. Shallow: the lists themselves
+// are made reactive when they are stored.
+const periodsCache = shallowReactive(new Map<string, unknown>()) as unknown as Map<string, RegistrationPeriodList>;
+
+export function clearOrganizationPeriodsCache() {
+    periodsCache.clear();
+}
+
+export function getCachedOrganizationPeriods(organizationId: string): RegistrationPeriodList | undefined {
+    return periodsCache.get(organizationId);
+}
+
+export function setCachedOrganizationPeriods(organizationId: string, list: RegistrationPeriodList) {
+    periodsCache.set(organizationId, list);
+}

--- a/frontend/shared/networking/src/organizationPeriodsCache.ts
+++ b/frontend/shared/networking/src/organizationPeriodsCache.ts
@@ -3,7 +3,7 @@ import { shallowReactive } from 'vue';
 
 // Reactive so a synchronous read re-evaluates once the periods are fetched. Shallow: the lists themselves
 // are made reactive when they are stored.
-const periodsCache = shallowReactive(new Map<string, unknown>()) as unknown as Map<string, RegistrationPeriodList>;
+const periodsCache = shallowReactive(new Map<string, RegistrationPeriodList>());
 
 export function clearOrganizationPeriodsCache() {
     periodsCache.clear();

--- a/shared/structures/src/Organization.ts
+++ b/shared/structures/src/Organization.ts
@@ -16,7 +16,6 @@ import type { RecordSettings } from './members/records/RecordSettings.js';
 import { OrganizationMetaData } from './OrganizationMetaData.js';
 import { OrganizationPrivateMetaData } from './OrganizationPrivateMetaData.js';
 import { OrganizationType } from './OrganizationType.js';
-import type { RegistrationPeriodList } from './RegistrationPeriod.js';
 import { OrganizationRegistrationPeriod, RegistrationPeriod } from './RegistrationPeriod.js';
 import { UmbrellaOrganization } from './UmbrellaOrganization.js';
 import { Webshop, WebshopPreview } from './webshops/Webshop.js';
@@ -216,12 +215,6 @@ export class Organization extends BaseOrganization implements ObjectWithRecords 
     webshops: WebshopPreview[] = [];
 
     /**
-     * @deprecated
-     * This way of caching is discouraged and unstable because it gets overriden easily using deepSet
-     */
-    periods?: RegistrationPeriodList;
-
-    /**
      * Whether internal administrators (members with responsibilities/functions) are relevant for this organization.
      * In platform mode this is always the case. In organization mode it only makes sense when the members package is used.
      */
@@ -263,13 +256,6 @@ export class Organization extends BaseOrganization implements ObjectWithRecords 
 
     updatePeriods(periods: OrganizationRegistrationPeriod[]) {
         // Update in memory
-        for (const period of this.periods?.organizationPeriods ?? []) {
-            const updated = periods.find(p => p.id === period.id);
-            if (updated) {
-                period.deepSet(updated);
-            }
-        }
-
         const updated = periods.find(p => p.id === this.period.id);
         if (updated) {
             this.period.deepSet(updated);


### PR DESCRIPTION
Er waren twee caches voor dezelfde data:
- `Organization.periods` (`@deprecated`) ← enkel geschreven door `OrganizationManager.loadPeriods()`
- module `periodsCache` in `useFetchOrganizationRegistrationPeriods`

`OrganizationManager.patch` (bij wissel van werkjaar), `usePatchOrganization` en `usePatchOrganizationPeriods` leegden enkel de eerste & lieten de tweede ongewijzigd. Vandaar dat `EditRegistrationPeriodsView` en `OnboardingRegistrationPeriodView` `clearOrganizationPeriodsCache()` manueel riepen. Dit is nu niet meer nodig

**één cache**
- `Organization.periods` + `OrganizationManager.loadPeriods()` zijn nu weg
- `RegistrationPeriodSelector` & `GroupsInput` → `useFetchOrganizationRegistrationPeriods`
- om cache te legen (zodat opnieuw gefetcht zal worden indien nodig) → `clearOrganizationPeriodsCache()`
- `periodsCache` (organisatie-id → `RegistrationPeriodList`) is `shallowReactive`: de Map-operaties zijn
  reactief zodat een synchrone lezer (computed) de UI-opnieuw bouwt zodra de cache gevuld is. De lists zelf worden
  niet gewrapt: die worden al reactive opgeslagen.

**`useOrganizationRegistrationPeriod(periodId)`**
- periodId == werkjaar van de organisatie → `organization.period`, geen fetch
- anders → cache, fetcht enkel als die leeg is
- vervangt de gedupliceerde computed in `MembersTableView` en `RegistrationsTableView`



<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790776185&installation_model_id=423362&pr_number=827&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F827&signature=d270a086a0811b6e964120286aaaaf4fdeb7659c39c17e6e2cb48ad7f2506c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
