### PR TITLE
Add onlyExplicitResources to LoadedPermissions

### DIFF
--- a/shared/structures/src/LoadedPermissions.test.ts
+++ b/shared/structures/src/LoadedPermissions.test.ts
@@ -9,6 +9,45 @@ import { PermissionsResourceType } from './PermissionsResourceType.js';
 import { ResourcePermissions } from './ResourcePermissions.js';
 
 describe('Unit.LoadedPermissions', () => {
+    describe('onlyExplicitResources', () => {
+        function createPermissions() {
+            return LoadedPermissions.create({
+                level: PermissionLevel.Write,
+                accessRights: [AccessRight.OrganizationCreateGroups],
+                resources: new Map([[
+                    PermissionsResourceType.Groups,
+                    new Map([
+                        ['', LoadedPermissions.fromResource(ResourcePermissions.create({ level: PermissionLevel.Write }))],
+                        ['group-1', LoadedPermissions.fromResource(ResourcePermissions.create({ level: PermissionLevel.Read }))],
+                    ]),
+                ]]),
+            });
+        }
+
+        test('Keeps grants that name a specific resource', () => {
+            const permissions = createPermissions().onlyExplicitResources();
+
+            expect(permissions.hasResourceAccess(PermissionsResourceType.Groups, 'group-1', PermissionLevel.Read)).toBe(true);
+        });
+
+        test('Drops the base level, the wildcard and the organization access rights', () => {
+            const permissions = createPermissions().onlyExplicitResources();
+
+            expect(permissions.hasAccess(PermissionLevel.Read)).toBe(false);
+            expect(permissions.hasAccessRight(AccessRight.OrganizationCreateGroups)).toBe(false);
+            expect(permissions.hasResourceAccess(PermissionsResourceType.Groups, 'group-2', PermissionLevel.Read)).toBe(false);
+            expect(permissions.hasResourceAccess(PermissionsResourceType.Groups, 'group-1', PermissionLevel.Write)).toBe(false);
+        });
+
+        test('Does not alter the original permissions', () => {
+            const original = createPermissions();
+            original.onlyExplicitResources();
+
+            expect(original.hasAccess(PermissionLevel.Write)).toBe(true);
+            expect(original.hasResourceAccess(PermissionsResourceType.Groups, 'group-2', PermissionLevel.Write)).toBe(true);
+        });
+    });
+
     describe('LoadedPermissions.from', () => {
         test('[Regression] Does not alter the original responsibilities', () => {
             const allTags = ResourcePermissions.create({

--- a/shared/structures/src/LoadedPermissions.ts
+++ b/shared/structures/src/LoadedPermissions.ts
@@ -191,6 +191,34 @@ export class LoadedPermissions {
         return false;
     }
 
+    /**
+     * The permissions that keep applying outside the period the organization is currently using: only
+     * grants that name a specific resource. The base level, the '' wildcards and the access rights that
+     * were granted for the whole organization are dropped.
+     */
+    onlyExplicitResources(): LoadedPermissions {
+        const permissions = LoadedPermissions.create({
+            level: PermissionLevel.None,
+            accessRights: [],
+            resources: new Map(),
+        });
+
+        for (const [type, resources] of this.resources) {
+            for (const [id, resource] of resources) {
+                if (id === '') {
+                    continue;
+                }
+
+                if (!permissions.resources.has(type)) {
+                    permissions.resources.set(type, new Map());
+                }
+                permissions.resources.get(type)!.set(id, resource.clone());
+            }
+        }
+
+        return permissions;
+    }
+
     hasResourceAccess(type: PermissionsResourceType, id: string, level: PermissionLevel): boolean {
         if (this.hasAccess(level)) {
             return true;


### PR DESCRIPTION
Buiten het werkjaar dat de organisatie gebruikt gelden enkel grants die een specifieke resource benoemen.

`LoadedPermissions.onlyExplicitResources()` → kopie zonder base `level`, zonder de `''` wildcards en zonder de toegangsrechten die voor de hele organisatie gelden. Wat overblijft: grants op een specifiek id.

Zo blijven alle bestaande checks (`hasResourceAccess`, `hasResourceAccessRight`, ...) ongewijzigd bruikbaar — ze worden gewoon tegen de gefilterde permissions uitgevoerd.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858115&installation_model_id=423362&pr_number=831&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F831&signature=a0290efc5f04fd0aa1f9c40835cc44ab68ab1eb536f140b1d4c18bffd6784444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
