### PR TITLE
Let roles reach groups of any period through explicit grants

### DIFF
--- a/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/registration-periods/PatchOrganizationRegistrationPeriodsEndpoint.ts
@@ -127,7 +127,7 @@ export class PatchOrganizationRegistrationPeriodsEndpoint extends Endpoint<Param
                                 continue;
                             }
 
-                            if (!await Context.auth.canCreateGroupInCategory(organization.id, category)) {
+                            if (!await Context.auth.canCreateGroupInCategory(organization.id, category, organizationPeriod)) {
                                 throw Context.auth.error($t(`%Ez`));
                             }
 

--- a/backend/app/api/src/helpers/AdminPermissionChecker.test.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.test.ts
@@ -1,0 +1,139 @@
+import type { Organization, RegistrationPeriod, User } from '@stamhoofd/models';
+import { GroupFactory, OrganizationFactory, OrganizationRegistrationPeriodFactory, Platform, RegistrationPeriodFactory, UserFactory } from '@stamhoofd/models';
+import { GroupCategory, GroupCategorySettings, OrganizationRegistrationPeriodSettings, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { v4 as uuidv4 } from 'uuid';
+import { AdminPermissionChecker } from './AdminPermissionChecker.js';
+
+describe('AdminPermissionChecker.canAccessGroup', () => {
+    let previousPeriod: RegistrationPeriod;
+    let currentPeriod: RegistrationPeriod;
+
+    beforeEach(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+
+        previousPeriod = await new RegistrationPeriodFactory({
+            startDate: new Date(2023, 0, 1),
+            endDate: new Date(2023, 11, 31),
+        }).create();
+
+        currentPeriod = await new RegistrationPeriodFactory({
+            startDate: new Date(2024, 0, 1),
+            endDate: new Date(2024, 11, 31),
+        }).create();
+    });
+
+    /**
+     * An organization that already moved on to currentPeriod, with an admin whose only permissions come
+     * from a role. The role is returned empty so the test can grant it what it needs.
+     */
+    async function createOrganizationWithRole(permissions?: Partial<{ level: PermissionLevel }>) {
+        const resources = new Map<PermissionsResourceType, Map<string, ResourcePermissions>>();
+        const role = PermissionRoleDetailed.create({ name: 'Test Role', resources, level: permissions?.level ?? PermissionLevel.None });
+
+        const organization = await new OrganizationFactory({ period: currentPeriod, roles: [role] }).create();
+
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({
+                level: PermissionLevel.None,
+                roles: [role],
+            }),
+        }).create();
+
+        return { organization, user, resources };
+    }
+
+    async function createChecker(user: User, organization: Organization) {
+        return new AdminPermissionChecker(user, await Platform.getSharedPrivateStruct(), organization);
+    }
+
+    test('A grant on a specific group also applies outside the period the organization uses', async () => {
+        const { organization, user, resources } = await createOrganizationWithRole();
+
+        const group = await new GroupFactory({ organization, period: previousPeriod }).create();
+        const otherGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+        resources.set(PermissionsResourceType.Groups, new Map([[
+            group.id,
+            ResourcePermissions.create({ level: PermissionLevel.Read }),
+        ]]));
+        await organization.save();
+
+        const checker = await createChecker(user, organization);
+
+        expect(await checker.canAccessGroup(group)).toBe(true);
+        expect(await checker.canAccessGroup(otherGroup)).toBe(false);
+    });
+
+    test('A grant on a specific category is resolved in the period the group belongs to', async () => {
+        const { organization, user, resources } = await createOrganizationWithRole();
+
+        const group = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+        // Categories are period specific: this category only exists in the period of the group
+        const categoryId = uuidv4();
+        const organizationPeriod = await new OrganizationRegistrationPeriodFactory({ organization, period: previousPeriod }).create();
+        organizationPeriod.settings = OrganizationRegistrationPeriodSettings.create({
+            categories: [
+                GroupCategory.create({
+                    id: categoryId,
+                    settings: GroupCategorySettings.create({ name: 'Kapoenen' }),
+                    groupIds: [group.id],
+                }),
+            ],
+            rootCategoryId: categoryId,
+        });
+        await organizationPeriod.save();
+
+        resources.set(PermissionsResourceType.GroupCategories, new Map([[
+            categoryId,
+            ResourcePermissions.create({ level: PermissionLevel.Read }),
+        ]]));
+        await organization.save();
+
+        const checker = await createChecker(user, organization);
+
+        expect(await checker.canAccessGroup(group)).toBe(true);
+    });
+
+    test('Read access for the whole organization stops at the period the organization uses', async () => {
+        const { organization, user } = await createOrganizationWithRole({ level: PermissionLevel.Read });
+
+        const currentGroup = await new GroupFactory({ organization, period: currentPeriod }).create();
+        const previousGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+        const checker = await createChecker(user, organization);
+
+        expect(await checker.canAccessGroup(currentGroup)).toBe(true);
+        expect(await checker.canAccessGroup(previousGroup)).toBe(false);
+    });
+
+    test('The all groups wildcard stops at the period the organization uses', async () => {
+        const { organization, user, resources } = await createOrganizationWithRole();
+
+        const currentGroup = await new GroupFactory({ organization, period: currentPeriod }).create();
+        const previousGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+        resources.set(PermissionsResourceType.Groups, new Map([[
+            '',
+            ResourcePermissions.create({ level: PermissionLevel.Read }),
+        ]]));
+        await organization.save();
+
+        const checker = await createChecker(user, organization);
+
+        expect(await checker.canAccessGroup(currentGroup)).toBe(true);
+        expect(await checker.canAccessGroup(previousGroup)).toBe(false);
+    });
+
+    test('Full access reaches every period', async () => {
+        const { organization, user } = await createOrganizationWithRole({ level: PermissionLevel.Full });
+
+        const previousGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+        const checker = await createChecker(user, organization);
+
+        expect(await checker.canAccessGroup(previousGroup)).toBe(true);
+    });
+});

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -340,7 +340,7 @@ export class AdminPermissionChecker {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+            const organizationPeriod = await this.getOrganizationPeriod(organization, group.periodId);
             const parentCategories = organizationPeriod ? group.getParentCategories(organizationPeriod.settings.categories) : [];
             for (const category of parentCategories) {
                 if (organizationPermissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -309,19 +309,24 @@ export class AdminPermissionChecker {
             // return false;
         }
 
-        if (!await this.canAccessGroupsInPeriod(group.periodId, group.organizationId)) {
-            return false;
-        }
         const organization = await this.getOrganization(group.organizationId);
 
         if (group.deletedAt || group.status === GroupStatus.Archived) {
             return await this.canAccessArchivedGroups(group.organizationId);
         }
 
-        const organizationPermissions = await this.getOrganizationPermissions(group.organizationId);
+        let organizationPermissions = await this.getOrganizationPermissions(group.organizationId);
 
         if (!organizationPermissions) {
             return false;
+        }
+
+        const isUsedPeriod = await this.canAccessGroupsInPeriod(group.periodId, group.organizationId);
+
+        if (!isUsedPeriod) {
+            // Outside the period the organization is using, only grants that name this group or one of
+            // its categories still apply
+            organizationPermissions = organizationPermissions.onlyExplicitResources();
         }
 
         // Check global level permissions for this user
@@ -329,7 +334,7 @@ export class AdminPermissionChecker {
             return true;
         }
 
-        if (group.type === GroupType.EventRegistration) {
+        if (isUsedPeriod && group.type === GroupType.EventRegistration) {
             // Check if we can access the event
             const event = await Event.select().where('groupId', group.id).first(false);
 
@@ -349,7 +354,7 @@ export class AdminPermissionChecker {
             }
         }
 
-        if (group.type === GroupType.WaitingList) {
+        if (isUsedPeriod && group.type === GroupType.WaitingList) {
             // Check if this is a waiting list for an event
             const parentGroup = await Group.select()
                 .where('type', GroupType.EventRegistration)

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -523,7 +523,6 @@ export class AdminPermissionChecker {
         }
 
         if (organizationPermissions.hasAccess(PermissionLevel.Full)) {
-            // Only full permissions; because non-full doesn't have access to other periods
             return true;
         }
 
@@ -537,16 +536,6 @@ export class AdminPermissionChecker {
             // No full access: cannot access deactivated registrations
             if (permissionLevel !== PermissionLevel.Read) {
                 // Not allowed to edit registrations that are deleted
-                return false;
-            }
-        }
-
-        const organization = await this.getOrganization(registration.organizationId);
-
-        if (registration.periodId !== organization.periodId) {
-            if (STAMHOOFD.userMode === 'organization' || registration.periodId !== this.platform.period.id) {
-                // We already checked for full permissions - and we don't have full permissions
-                // so that also means no permissions for registrations in other periods
                 return false;
             }
         }

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -1260,11 +1260,15 @@ export class AdminPermissionChecker {
         return true;
     }
 
-    async canCreateGroupInCategory(organizationId: string, category: GroupCategory) {
-        const organizationPermissions = await this.getOrganizationPermissions(organizationId);
+    async canCreateGroupInCategory(organizationId: string, category: GroupCategory, organizationPeriod: OrganizationRegistrationPeriod) {
+        let organizationPermissions = await this.getOrganizationPermissions(organizationId);
 
         if (!organizationPermissions) {
             return false;
+        }
+
+        if (!await this.canAccessGroupsInPeriod(organizationPeriod.periodId, organizationId)) {
+            organizationPermissions = organizationPermissions.onlyExplicitResources();
         }
 
         if (organizationPermissions.hasResourceAccessRight(PermissionsResourceType.GroupCategories, category.id, AccessRight.OrganizationCreateGroups)) {
@@ -1272,9 +1276,7 @@ export class AdminPermissionChecker {
         }
 
         // Check parents
-        const organization = await this.getOrganization(organizationId);
-        const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
-        const parentCategories = organizationPeriod ? category.getParentCategories(organizationPeriod.settings.categories) : [];
+        const parentCategories = category.getParentCategories(organizationPeriod.settings.categories);
 
         for (const parentCategory of parentCategories) {
             if (organizationPermissions.hasResourceAccessRight(PermissionsResourceType.GroupCategories, parentCategory.id, AccessRight.OrganizationCreateGroups)) {

--- a/backend/app/api/src/helpers/AdminPermissionChecker.ts
+++ b/backend/app/api/src/helpers/AdminPermissionChecker.ts
@@ -1,8 +1,8 @@
 import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { PatchMap } from '@simonbackx/simple-encoding';
 import { isSimpleError, isSimpleErrors, SimpleError } from '@simonbackx/simple-errors';
-import type { BalanceItem, Document, Email, EmailTemplate, MemberWithUsers, MemberWithUsersAndRegistrations, MemberWithUsersRegistrationsAndGroups, Order, OrganizationRegistrationPeriod, User } from '@stamhoofd/models';
-import { CachedBalance, Event, EventNotification, Group, Member, MemberPlatformMembership, Organization, Payment, Registration, Webshop } from '@stamhoofd/models';
+import type { BalanceItem, Document, Email, EmailTemplate, MemberWithUsers, MemberWithUsersAndRegistrations, MemberWithUsersRegistrationsAndGroups, Order, User } from '@stamhoofd/models';
+import { CachedBalance, Event, EventNotification, Group, Member, MemberPlatformMembership, Organization, OrganizationRegistrationPeriod, Payment, Registration, Webshop } from '@stamhoofd/models';
 import type { GroupCategory, MemberWithRegistrationsBlob, Platform as PlatformStruct, RecordAnswer, RecordSettings, ResourcePermissions } from '@stamhoofd/structures';
 import { AccessRight, EmailTemplate as EmailTemplateStruct, EventPermissionChecker, FinancialSupportSettings, GroupStatus, GroupType, PermissionLevel, PermissionsResourceType, ReceivableBalanceType, UitpasNumberDetails, UitpasSocialTariff, UitpasSocialTariffStatus } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
@@ -28,6 +28,7 @@ export class AdminPermissionChecker {
     organizationCache: Map<string, Organization | Promise<Organization | undefined>> = new Map();
     groupsCache: Map<string, Group | null | Promise<Group | null>> = new Map();
     webshopsCache: Map<string, Webshop | null | Promise<Webshop | null>> = new Map();
+    organizationPeriodsCache: Map<string, OrganizationRegistrationPeriod | null | Promise<OrganizationRegistrationPeriod | null>> = new Map();
 
     constructor(user: User, platform: PlatformStruct, organization?: Organization) {
         this.user = user;
@@ -154,9 +155,28 @@ export class AdminPermissionChecker {
         }
     }
 
-    async getOrganizationCurrentPeriod(id: string | Organization): Promise<OrganizationRegistrationPeriod> {
+    async getOrganizationPeriod(id: string | Organization, periodId: string): Promise<OrganizationRegistrationPeriod | null> {
         const organization = await this.getOrganization(id);
-        return await organization.getPeriod();
+
+        if (periodId === organization.periodId) {
+            return await organization.getPeriod();
+        }
+
+        const key = organization.id + '-' + periodId;
+        const cache = this.organizationPeriodsCache.get(key);
+        if (cache !== undefined) {
+            return await cache;
+        }
+
+        const promise = OrganizationRegistrationPeriod.select()
+            .where('organizationId', organization.id)
+            .where('periodId', periodId)
+            .first(false);
+
+        this.organizationPeriodsCache.set(key, promise);
+        const organizationPeriod = await promise;
+        this.organizationPeriodsCache.set(key, organizationPeriod);
+        return organizationPeriod;
     }
 
     error(humanOrData?: string | { message: string; human?: string }): SimpleError {
@@ -320,8 +340,8 @@ export class AdminPermissionChecker {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const organizationPeriod = await this.getOrganizationCurrentPeriod(organization);
-            const parentCategories = group.getParentCategories(organizationPeriod.settings.categories);
+            const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+            const parentCategories = organizationPeriod ? group.getParentCategories(organizationPeriod.settings.categories) : [];
             for (const category of parentCategories) {
                 if (organizationPermissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {
                     return true;
@@ -1259,8 +1279,8 @@ export class AdminPermissionChecker {
 
         // Check parents
         const organization = await this.getOrganization(organizationId);
-        const organizationPeriod = await this.getOrganizationCurrentPeriod(organization);
-        const parentCategories = category.getParentCategories(organizationPeriod.settings.categories);
+        const organizationPeriod = await this.getOrganizationPeriod(organization, organization.periodId);
+        const parentCategories = organizationPeriod ? category.getParentCategories(organizationPeriod.settings.categories) : [];
 
         for (const parentCategory of parentCategories) {
             if (organizationPermissions.hasResourceAccessRight(PermissionsResourceType.GroupCategories, parentCategory.id, AccessRight.OrganizationCreateGroups)) {


### PR DESCRIPTION
Een rol kan een specifieke groep of categorie toegekend krijgen in eender welk werkjaar. Group- en category-ids zijn werkjaar-specifiek, dus het id pint het werkjaar vast.

Blijft beperkt tot het werkjaar in gebruik: base `level` read/write, `Alle leden` en `Alle inschrijvingscategorieën` (de `''` wildcards) en hun toegangsrechten. Full access blijft alle werkjaren zien.

- `canAccessGroup`: buiten het werkjaar in gebruik → `onlyExplicitResources()`. De event- en wachtlijst-fallbacks vallen daar weg: die leiden toegang af uit event-rechten, niet uit een grant op de groep zelf.
- `canAccessRegistration`: eigen werkjaar-check weg → de groep beslist.
- `canCreateGroupInCategory(orgId, category, organizationPeriod)`: categorieën van het gepatchte werkjaar i.p.v. het huidige, en dezelfde wildcard-regel.
- `getOrganizationCurrentPeriod(org)` → `getOrganizationPeriod(org, periodId)` met cache: parent categories worden opgezocht in het werkjaar van de groep zelf. `getParentCategories` matcht op `category.groupIds.includes(group.id)`, dus een groep van 24-25 zit nooit in de categories van 25-26.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858120&installation_model_id=423362&pr_number=832&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F832&signature=f8e478d86ebe1ae7422ef2a48b288c025087470881552f825436264635922610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
