### PR TITLE
Include groups of every period when scoping member and registration lists

### DIFF
--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.test.ts
@@ -399,6 +399,73 @@ describe('Endpoint.GetMembersEndpoint', () => {
             ]);
         });
 
+        test('User can fetch members of previous period if has group access', async () => {
+            // Setup
+            const role = PermissionRoleDetailed.create({
+                name: 'Test Role',
+                accessRights: [],
+            });
+
+            const resources = new Map();
+
+            const previousPeriod = await new RegistrationPeriodFactory({
+                startDate: new Date(2022, 0, 1),
+                endDate: new Date(2022, 11, 31),
+            }).create();
+
+            // The organization already moved on to period
+            const organization = await new OrganizationFactory({ period, roles: [role] })
+                .create();
+
+            const user = await new UserFactory({
+                organization,
+                permissions: Permissions.create({
+                    level: PermissionLevel.None,
+                    roles: [
+                        role,
+                    ],
+                    resources,
+                }),
+            })
+                .create();
+
+            const token = await SessionService.createSession(user);
+            const member1 = await new MemberFactory({ }).create();
+            const member2 = await new MemberFactory({ }).create();
+            const previousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+            const otherPreviousPeriodGroup = await new GroupFactory({ organization, period: previousPeriod }).create();
+
+            resources.set(
+                PermissionsResourceType.Groups, new Map([[
+                    previousPeriodGroup.id,
+                    ResourcePermissions.create({
+                        level: PermissionLevel.Read,
+                    }),
+                ]]),
+            );
+
+            await user.save();
+
+            await new RegistrationFactory({ member: member1, group: previousPeriodGroup }).create();
+            await new RegistrationFactory({ member: member2, group: otherPreviousPeriodGroup }).create();
+
+            const request = Request.get({
+                path: baseUrl,
+                host: organization.getApiHost(),
+                query: new LimitedFilteredRequest({
+                    limit: 10,
+                }),
+                headers: {
+                    authorization: 'Bearer ' + token.accessToken,
+                },
+            });
+            const response = await testServer.test(endpoint, request);
+            expect(response.status).toBe(200);
+            expect(response.body.results.members).toIncludeSameMembers([
+                expect.objectContaining({ id: member1.id }),
+            ]);
+        });
+
         test('Not allowed: Cannot fetch all members if no permissions for a single group', async () => {
             // Same test, but without giving the user permissions to read the group
             // Setup

--- a/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/members/GetMembersEndpoint.ts
@@ -96,8 +96,9 @@ export class GetMembersEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                         };
                     }
                 } else {
-                    // Check which normal membership groups we have access to and filter on those
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.WaitingList]);
+                    // Check which groups we have access to and filter on those. Groups of every period are
+                    // checked: a role can be granted a group of a period the organization already left.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.WaitingList]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 

--- a/backend/app/api/src/endpoints/global/registration-invitations/GetRegistrationInvitationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration-invitations/GetRegistrationInvitationsEndpoint.ts
@@ -94,7 +94,9 @@ export class GetRegistrationInvitationsEndpoint extends Endpoint<Params, Query, 
                         };
                     }
                 } else {
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.EventRegistration]);
+                    // Groups of every period are checked: a role can be granted a group of a period the
+                    // organization already left.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.EventRegistration]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 

--- a/backend/app/api/src/endpoints/global/registration/GetRegistrationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration/GetRegistrationsEndpoint.ts
@@ -122,8 +122,9 @@ export class GetRegistrationsEndpoint extends Endpoint<Params, Query, Body, Resp
                         };
                     }
                 } else {
-                    // Check which normal membership groups we have access to and filter on those
-                    const groups = await Group.getAll(organization.id, organization.periodId, true, [GroupType.Membership, GroupType.WaitingList]);
+                    // Check which groups we have access to and filter on those. Groups of every period are
+                    // checked: a role can be granted a group of a period the organization already left.
+                    const groups = await Group.getAll(organization.id, null, true, [GroupType.Membership, GroupType.WaitingList]);
                     Context.auth.cacheGroups(groups);
                     const groupIds: string[] = [];
 


### PR DESCRIPTION
`GetMembersEndpoint`, `GetRegistrationsEndpoint` en `GetRegistrationInvitationsEndpoint` bouwen hun scope filter uit de groepen waar je toegang tot hebt, maar zochten enkel in het huidige werkjaar → een expliciete grant op een groep van een vorig werkjaar werd nooit gevonden.

`Group.getAll(organization.id, null, ...)` → alle werkjaren. De andere takken (full → alle werkjaren, wildcard/level → huidig werkjaar) blijven zoals ze waren.

Kost: 1 query voor alle groepen van alle werkjaren + `canAccessGroup` per groep (categories per werkjaar gecached).

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858125&installation_model_id=423362&pr_number=833&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F833&signature=0d151097fcc04a054c5ced31c8e26c0631c314ed4f88b37d0c3707b3d4e931e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
