### PR TITLE
Apply the same period rule in ContextPermissions

### DIFF
--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -1,7 +1,8 @@
-import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationTag, PaymentGeneral, Permissions, Platform, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
+import type { EmailPreview, Event, Group, GroupCategory, LoadedPermissions, Organization, OrganizationForPermissionCalculation, OrganizationRegistrationPeriod, OrganizationTag, PaymentGeneral, Permissions, Platform, PlatformMember, Registration, UserWithMembers } from '@stamhoofd/structures';
 import { AccessRight, EventPermissionChecker, GroupType, PermissionLevel, PermissionsResourceType } from '@stamhoofd/structures';
 import type { Ref } from 'vue';
 import { toRaw, unref } from 'vue';
+import { getCachedOrganizationPeriods } from './organizationPeriodsCache.js';
 
 export class ContextPermissions {
     reactiveUser: UserWithMembers | null | Ref<UserWithMembers | null>;
@@ -154,6 +155,25 @@ export class ContextPermissions {
         return this.hasAccessRight(AccessRight.ManageEmailTemplates);
     }
 
+    canAccessGroupsInPeriod(periodId: string, organization: Organization) {
+        if (periodId !== organization.period.period.id) {
+            if (STAMHOOFD.userMode === 'organization' || periodId !== this.platform.period.id) {
+                if (!this.hasFullAccess()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private getPeriodOfGroup(group: Group, organization: Organization): OrganizationRegistrationPeriod | null {
+        if (group.periodId === organization.period.period.id) {
+            return organization.period;
+        }
+
+        return getCachedOrganizationPeriods(organization.id)?.organizationPeriods.find(p => p.period.id === group.periodId) ?? null;
+    }
+
     canAccessGroup(group: Group, permissionLevel: PermissionLevel = PermissionLevel.Read, organization?: Organization | null) {
         if (organization === undefined || (organization === null && this.organization)) {
             organization = this.organization;
@@ -163,17 +183,17 @@ export class ContextPermissions {
             return this.hasFullPlatformAccess();
         }
 
-        if (group.periodId !== organization.period.period.id) {
-            if (STAMHOOFD.userMode === 'organization' || group.periodId !== this.platform.period.id) {
-                if (!this.hasFullAccess()) {
-                    return false;
-                }
-            }
-        }
-
-        const permissions = this.getPermissionsForOrganization(organization);
+        let permissions = this.getPermissionsForOrganization(organization);
         if (!permissions) {
             return false;
+        }
+
+        const isUsedPeriod = this.canAccessGroupsInPeriod(group.periodId, organization);
+
+        if (!isUsedPeriod) {
+            // Outside the period the organization is using, only grants that name this group or one of
+            // its categories still apply
+            permissions = permissions.onlyExplicitResources();
         }
 
         if (permissions.hasResourceAccess(PermissionsResourceType.Groups, group.id, permissionLevel)) {
@@ -182,7 +202,8 @@ export class ContextPermissions {
 
         // Check parent categories
         if (group.type === GroupType.Membership) {
-            const parentCategories = group.getParentCategories(organization.period.settings.categories);
+            const period = this.getPeriodOfGroup(group, organization);
+            const parentCategories = period ? group.getParentCategories(period.settings.categories) : [];
             for (const category of parentCategories) {
                 if (permissions.hasResourceAccess(PermissionsResourceType.GroupCategories, category.id, permissionLevel)) {
                     return true;
@@ -190,12 +211,12 @@ export class ContextPermissions {
             }
         }
 
-        if (group.type === GroupType.EventRegistration && group.event && group.event.organizationId === organization.id) {
+        if (isUsedPeriod && group.type === GroupType.EventRegistration && group.event && group.event.organizationId === organization.id) {
             // we'll need to check the event permissions
             return this.canWriteEventForOrganization(group.event, organization);
         }
 
-        if (group.type === GroupType.WaitingList && group.parentGroup && group.parentGroup.type === GroupType.EventRegistration && group.parentGroup.event && group.parentGroup.event.organizationId === organization.id) {
+        if (isUsedPeriod && group.type === GroupType.WaitingList && group.parentGroup && group.parentGroup.type === GroupType.EventRegistration && group.parentGroup.event && group.parentGroup.event.organizationId === organization.id) {
             // we'll need to check the event permissions
             return this.canWriteEventForOrganization(group.parentGroup.event, organization);
         }


### PR DESCRIPTION
Spiegel van #832. Moet identiek blijven aan de backend, anders verbergt de UI wat de API toelaat.

- `canAccessGroupsInPeriod(periodId, organization)` afgesplitst
- buiten dat werkjaar → `onlyExplicitResources()`, en de event- en wachtlijst-fallbacks vallen weg
- parent categories uit het werkjaar van de groep zelf, via de cache uit #834

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858135&installation_model_id=423362&pr_number=835&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F835&signature=b8da4df71c6a7159335957fe3227019e2c4dbd14ff1faf12e5ddc74493e05945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
