### PR TITLE
Show the periods a role has access to

### DIFF
--- a/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
+++ b/frontend/app/dashboard/src/views/members/MembersMenuModern.vue
@@ -34,7 +34,7 @@
 
             <GroupCategoryMenuBox :period="period" />
 
-            <div v-if="!props.period && auth.hasFullAccess()" class="container footer">
+            <div v-if="!props.period" class="container footer">
                 <hr>
 
                 <button class="st-menu-item" type="button" @click="switchPeriod">
@@ -314,6 +314,23 @@ async function startPeriod(p: RegistrationPeriod) {
     });
 }
 
+function getPeriodDisabledReason(p: RegistrationPeriod, organizationPeriod: OrganizationRegistrationPeriod | undefined): string | false {
+    if (p.id === period.value.period.id) {
+        return $t('%1b0');
+    }
+
+    if (!organizationPeriod) {
+        // Choosing this period starts it
+        return hasFullAccess.value ? false : $t('Dit werkjaar is nog niet gestart');
+    }
+
+    if (!auth.hasSomeAccessInPeriod(organizationPeriod)) {
+        return $t('Je hebt geen toegang tot dit werkjaar');
+    }
+
+    return false;
+}
+
 async function switchPeriod(event: MouseEvent) {
     let periods: RegistrationPeriodList;
     try {
@@ -325,11 +342,12 @@ async function switchPeriod(event: MouseEvent) {
 
     const menu = new ContextMenu([
         periods.periods.map((p) => {
+            const existing = periods.organizationPeriods.find(pp => pp.period.id === p.id);
+
             return new ContextMenuItem({
                 name: p.name,
-                disabled: p.id === period.value.period.id ? $t('%1b0') : false,
+                disabled: getPeriodDisabledReason(p, existing),
                 action: async () => {
-                    const existing = periods.organizationPeriods.find(pp => pp.period.id === p.id);
                     if (existing) {
                         await $navigate(Routes.Period, {
                             properties: {
@@ -344,7 +362,7 @@ async function switchPeriod(event: MouseEvent) {
             });
         }),
 
-        ...(STAMHOOFD.userMode === 'organization'
+        ...(STAMHOOFD.userMode === 'organization' && hasFullAccess.value
             ? ([
                     [
                         new ContextMenuItem({

--- a/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
+++ b/frontend/shared/components/src/members/classes/MemberActionBuilder.ts
@@ -535,15 +535,15 @@ export class MemberActionBuilder {
         const organization = this.organizations[0];
         const fallback = [selectedOrganizationRegistrationPeriod ?? organization.period];
 
-        // Only the context organization's periods can be fetched, and only full-access users may switch periods.
-        if (!this.context.auth.hasFullAccess() || !this.fetchOrganizationPeriods || this.context.organization?.id !== organization.id) {
+        // Only the context organization's periods can be fetched
+        if (!this.fetchOrganizationPeriods || this.context.organization?.id !== organization.id) {
             this.resolvedPeriods = fallback;
             return;
         }
 
         try {
             const list = await this.fetchOrganizationPeriods({ shouldRetry: true });
-            const periods = list.organizationPeriods.filter(p => !p.period.locked);
+            const periods = list.organizationPeriods.filter(p => !p.period.locked && this.context.auth.hasSomeAccessInPeriod(p));
             this.resolvedPeriods = periods.length > 0 ? periods : fallback;
         } catch (e) {
             console.error('Failed to load organization registration periods', e);

--- a/frontend/shared/components/src/members/classes/RegistrationsActionBuilder.ts
+++ b/frontend/shared/components/src/members/classes/RegistrationsActionBuilder.ts
@@ -80,15 +80,15 @@ export class RegistrationsActionBuilder {
     async loadResolvedPeriods(selectedOrganizationRegistrationPeriod?: OrganizationRegistrationPeriod): Promise<void> {
         const fallback = [selectedOrganizationRegistrationPeriod ?? this.organization.period];
 
-        // Only the context organization's periods can be fetched, and only full-access users may switch periods.
-        if (!this.context.auth.hasFullAccess() || !this.fetchOrganizationPeriods || this.context.organization?.id !== this.organization.id) {
+        // Only the context organization's periods can be fetched
+        if (!this.fetchOrganizationPeriods || this.context.organization?.id !== this.organization.id) {
             this.resolvedPeriods = fallback;
             return;
         }
 
         try {
             const list = await this.fetchOrganizationPeriods({ shouldRetry: true });
-            const periods = list.organizationPeriods.filter(p => !p.period.locked);
+            const periods = list.organizationPeriods.filter(p => !p.period.locked && this.context.auth.hasSomeAccessInPeriod(p));
             this.resolvedPeriods = periods.length > 0 ? periods : fallback;
         } catch (e) {
             console.error('Failed to load organization registration periods', e);

--- a/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
+++ b/frontend/shared/components/src/registrations/classes/RegistrationActionBuilder.ts
@@ -128,15 +128,15 @@ export class RegistrationActionBuilder {
         const organization = this.organizations[0];
         const fallback = [selectedOrganizationRegistrationPeriod ?? organization.period];
 
-        // Only the context organization's periods can be fetched, and only full-access users may switch periods.
-        if (!this.context.auth.hasFullAccess() || !this.fetchOrganizationPeriods || this.context.organization?.id !== organization.id) {
+        // Only the context organization's periods can be fetched
+        if (!this.fetchOrganizationPeriods || this.context.organization?.id !== organization.id) {
             this.resolvedPeriods = fallback;
             return;
         }
 
         try {
             const list = await this.fetchOrganizationPeriods({ shouldRetry: true });
-            const periods = list.organizationPeriods.filter(p => !p.period.locked);
+            const periods = list.organizationPeriods.filter(p => !p.period.locked && this.context.auth.hasSomeAccessInPeriod(p));
             this.resolvedPeriods = periods.length > 0 ? periods : fallback;
         } catch (e) {
             console.error('Failed to load organization registration periods', e);

--- a/frontend/shared/networking/src/ContextPermissions.ts
+++ b/frontend/shared/networking/src/ContextPermissions.ts
@@ -403,6 +403,24 @@ export class ContextPermissions {
         return !!this.permissions && !this.permissions.isEmpty;
     }
 
+    hasSomeAccessInPeriod(period: OrganizationRegistrationPeriod): boolean {
+        if (this.hasFullAccess()) {
+            return true;
+        }
+
+        let permissions = this.permissions;
+        const organization = this.organization;
+        if (!permissions || !organization) {
+            return false;
+        }
+
+        if (!this.canAccessGroupsInPeriod(period.period.id, organization)) {
+            permissions = permissions.onlyExplicitResources();
+        }
+
+        return period.groups.some(g => g.hasReadAccess(permissions, period.settings.categories));
+    }
+
     hasPlatformFullAccess(): boolean {
         return !!this.platformPermissions && !!this.platformPermissions.hasFullAccess();
     }


### PR DESCRIPTION
`hasSomeAccessInPeriod(period)` in `ContextPermissions`, naast `hasSomeAccess()`:
- full access → true
- huidige werkjaar → gewone permissions
- ander werkjaar → `onlyExplicitResources()`
- → `period.groups.some(g => g.hasReadAccess(...))`

**Werkjaarwissel** (`MembersMenuModern`): `v-if="!props.period && auth.hasFullAccess()"` → een rol met toegang tot een ander werkjaar raakte er niet.
- `auth.hasFullAccess()` weg, `!props.period` blijft
- context menu: werkjaren zonder toegang staan disabled met reden, naast de bestaande "dit werkjaar bekijk je al"
- niet-full admins: werkjaren zonder `organizationPeriod` ook disabled, want kiezen = werkjaar starten
- "nieuw werkjaar starten" / werkjaar-instellingen blijven full admin

**Inschrijvingen verplaatsen**: `loadResolvedPeriods` in `RegistrationsActionBuilder`, `RegistrationActionBuilder` en `MemberActionBuilder` bood enkel werkjaren aan full admins aan → nu de werkjaren waar de rol toegang toe heeft.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858139&installation_model_id=423362&pr_number=836&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F836&signature=5e2d11969825788985a974a7d54f6915039e05710f9e090fea2b0ce6dd35849f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
