### PR TITLE
Rename balance item description to name, add optional description

### DIFF
--- a/backend/app/api/src/audit-logs/BalanceItemLogger.ts
+++ b/backend/app/api/src/audit-logs/BalanceItemLogger.ts
@@ -77,7 +77,7 @@ export const BalanceItemLogger = new ModelLogger(BalanceItem, {
         return new Map([
             ['b', AuditLogReplacement.create({
                 id: model.id,
-                value: model.description || getBalanceItemTypeName(model.type),
+                value: model.name || getBalanceItemTypeName(model.type),
                 type: AuditLogReplacementType.BalanceItem,
             })],
             ['payer', options.data.payer],

--- a/backend/app/api/src/crons/service-fees.ts
+++ b/backend/app/api/src/crons/service-fees.ts
@@ -100,7 +100,7 @@ async function chargeServiceFees() {
 
                 const item = new BalanceItem();
                 item.type = BalanceItemType.ServiceFee;
-                item.description = $t('%1cJ', { date: day });
+                item.name = $t('%1cJ', { date: day });
                 item.payingOrganizationId = organization.id;
                 item.organizationId = membershipOrganizationId;
                 item.VATPercentage = 21;

--- a/backend/app/api/src/crons/transfer-fees.ts
+++ b/backend/app/api/src/crons/transfer-fees.ts
@@ -114,7 +114,7 @@ async function chargeTransferFees() {
 
                     const item = new BalanceItem();
                     item.type = BalanceItemType.TransferFee;
-                    item.description = $t('%1Yq', { date: day });
+                    item.name = $t('%1Yq', { date: day });
 
                     if (provider) {
                         item.relations.set(BalanceItemRelationType.PaymentProvider, BalanceItemRelation.create({

--- a/backend/app/api/src/email-replacements/getEmailReplacementsForPayment.ts
+++ b/backend/app/api/src/email-replacements/getEmailReplacementsForPayment.ts
@@ -305,7 +305,7 @@ function unboxBalanceItemPayments({ balanceItemPayments }: PaymentGeneral, order
                 itemTitle: cartItem.product.name,
                 itemDescription: cartItem.description,
                 balanceItem: {
-                    description: cartItem.description,
+                    name: cartItem.description,
                 },
                 quantity,
                 unitPrice,

--- a/backend/app/api/src/endpoints/admin/members/ChargeMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/admin/members/ChargeMembersEndpoint.ts
@@ -32,12 +32,12 @@ export class ChargeMembersEndpoint extends Endpoint<Params, Query, Body, Respons
     }
 
     static throwIfInvalidBody(body: Body) {
-        if (!body.description?.trim()?.length) {
+        if (!body.name?.trim()?.length) {
             throw new SimpleError({
                 code: 'invalid_field',
-                message: 'Invalid description',
+                message: 'Invalid name',
                 human: $t(`%Cr`),
-                field: 'description',
+                field: 'name',
             });
         }
 
@@ -96,6 +96,7 @@ export class ChargeMembersEndpoint extends Endpoint<Params, Query, Body, Respons
                     membersToCharge: data.members,
                     price: body.price,
                     amount: body.amount ?? 1,
+                    name: body.name,
                     description: body.description,
                     dueAt: body.dueAt,
                     createdAt: body.createdAt,

--- a/backend/app/api/src/endpoints/admin/organizations/ChargeOrganizationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/admin/organizations/ChargeOrganizationsEndpoint.ts
@@ -67,6 +67,7 @@ export class ChargeOrganizationsEndpoint extends Endpoint<Params, Query, Body, R
                     organizationsToCharge: data,
                     price: body.price,
                     amount: body.amount ?? 1,
+                    name: body.name,
                     description: body.description,
                     dueAt: body.dueAt,
                     createdAt: body.createdAt,

--- a/backend/app/api/src/endpoints/admin/registrations/ChargeRegistrationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/admin/registrations/ChargeRegistrationsEndpoint.ts
@@ -76,6 +76,7 @@ export class ChargeRegistrationsEndpoint extends Endpoint<Params, Query, Body, R
                             memberToCharge: registration.member,
                             price: body.price,
                             amount: body.amount ?? 1,
+                            name: body.name,
                             description: body.description,
                             dueAt: body.dueAt,
                             createdAt: body.createdAt,

--- a/backend/app/api/src/endpoints/global/registration/RegisterMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration/RegisterMembersEndpoint.ts
@@ -540,7 +540,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             return relation;
         }
 
-        async function createBalanceItem({ registration, periodId, skipZero, amount, unitPrice, description, type, relations }: { amount?: number; skipZero?: boolean; registration: { id: string; payingOrganizationId: string | null; memberId: string; trialUntil: Date | null }; periodId: string; unitPrice: number; description: string; relations: Map<BalanceItemRelationType, BalanceItemRelation>; type: BalanceItemType }) {
+        async function createBalanceItem({ registration, periodId, skipZero, amount, unitPrice, name, type, relations }: { amount?: number; skipZero?: boolean; registration: { id: string; payingOrganizationId: string | null; memberId: string; trialUntil: Date | null }; periodId: string; unitPrice: number; name: string; relations: Map<BalanceItemRelationType, BalanceItemRelation>; type: BalanceItemType }) {
             // NOTE: We also need to save zero-price balance items because for online payments, we need to know which registrations to activate after payment
             if (skipZero === true) {
                 if (unitPrice === 0 || amount === 0) {
@@ -559,7 +559,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             balanceItem.registrationId = registration.id;
             balanceItem.unitPrice = unitPrice;
             balanceItem.amount = amount ?? 1;
-            balanceItem.description = description;
+            balanceItem.name = name;
             balanceItem.relations = relations;
             balanceItem.type = type;
 
@@ -642,7 +642,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
                 unitPrice: item.groupPrice.price.forMember(item.member),
                 type: BalanceItemType.Registration,
                 skipZero: false, // Always create at least one balance item for each registration - even when the price is zero
-                description: `${item.member.patchedMember.name} bij ${item.group.settings.name.toString()}`,
+                name: `${item.member.patchedMember.name} bij ${item.group.settings.name.toString()}`,
                 relations: new Map([
                     ...sharedRelations,
                 ]),
@@ -657,7 +657,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
                     unitPrice: option.option.price.forMember(item.member),
                     skipZero: true, // Do not create for zero option prices
                     type: BalanceItemType.Registration,
-                    description: `${option.optionMenu.name}: ${option.option.name}`,
+                    name: `${option.optionMenu.name}: ${option.option.name}`,
                     relations: new Map([
                         ...sharedRelations,
                         [
@@ -689,7 +689,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
                         periodId: item.group.periodId,
                         unitPrice: -discountValue,
                         type: BalanceItemType.RegistrationBundleDiscount,
-                        description: discount.name,
+                        name: discount.name,
                         relations: new Map([
                             ...sharedRelations,
                             [
@@ -758,7 +758,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
                     periodId: registration.group.periodId,
                     unitPrice: -difference,
                     type: BalanceItemType.RegistrationBundleDiscount,
-                    description: discount.name,
+                    name: discount.name,
                     relations: new Map([
                         ...sharedRelations,
                         [
@@ -779,7 +779,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             const balanceItem = new BalanceItem();
             balanceItem.type = BalanceItemType.FreeContribution;
             balanceItem.unitPrice = checkout.freeContribution;
-            balanceItem.description = `Vrije bijdrage`;
+            balanceItem.name = `Vrije bijdrage`;
             balanceItem.pricePaid = 0;
             balanceItem.userId = user.id;
             balanceItem.organizationId = organization.id;
@@ -799,7 +799,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             const balanceItem = new BalanceItem();
             balanceItem.type = BalanceItemType.AdministrationFee;
             balanceItem.unitPrice = checkout.administrationFee;
-            balanceItem.description = `Administratiekosten`;
+            balanceItem.name = `Administratiekosten`;
             balanceItem.pricePaid = 0;
             balanceItem.organizationId = organization.id;
 

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemBreakdownEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemBreakdownEndpoint.test.ts
@@ -200,12 +200,12 @@ describe('Endpoint.GetBalanceItemBreakdownEndpoint', () => {
         expect(exported.body.balanceItemCount).toBe(1);
     });
 
-    test('items without relations are a category per description, and export as one', async () => {
+    test('items without relations are a category per name, and export as one', async () => {
         const organization = await new OrganizationFactory({}).create();
         const user = await createFinanceUser(organization);
 
-        await new BalanceItemFactory({ organizationId: organization.id, type: BalanceItemType.Other, amount: 1, unitPrice: 30_00, description: 'Kampinschrijving' }).create();
-        await new BalanceItemFactory({ organizationId: organization.id, type: BalanceItemType.Other, amount: 1, unitPrice: 12_00, description: 'Drankkaart' }).create();
+        await new BalanceItemFactory({ organizationId: organization.id, type: BalanceItemType.Other, amount: 1, unitPrice: 30_00, name: 'Kampinschrijving' }).create();
+        await new BalanceItemFactory({ organizationId: organization.id, type: BalanceItemType.Other, amount: 1, unitPrice: 12_00, name: 'Drankkaart' }).create();
 
         const all = await getBreakdown({ organization, user });
         expect(all.body.byCategory.map(g => g.name.toString())).toEqual(['Kampinschrijving', 'Drankkaart']);

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/GetBalanceItemsEndpoint.ts
@@ -66,7 +66,7 @@ export class GetBalanceItemsEndpoint extends Endpoint<Params, Query, Body, Respo
         if (q.search) {
             let searchFilter: StamhoofdFilter | null = null;
             searchFilter = {
-                description: {
+                name: {
                     $contains: q.search,
                 },
             };

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/PatchBalanceItemsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/PatchBalanceItemsEndpoint.test.ts
@@ -2,7 +2,7 @@ import type { AutoEncoderPatchType } from '@simonbackx/simple-encoding';
 import { PatchableArray } from '@simonbackx/simple-encoding';
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, User } from '@stamhoofd/models';
-import { AuditLog, BalanceItemFactory, MemberFactory, OrganizationFactory, UserFactory } from '@stamhoofd/models';
+import { AuditLog, BalanceItem, BalanceItemFactory, MemberFactory, OrganizationFactory, UserFactory } from '@stamhoofd/models';
 import { AuditLogReplacementType, AuditLogSource, AuditLogType, BalanceItemStatus, BalanceItemWithPayments, PermissionLevel, Permissions } from '@stamhoofd/structures';
 import { testServer } from '../../../../../tests/helpers/TestServer.js';
 import '../../../../audit-logs/init.js';
@@ -24,6 +24,56 @@ describe('Endpoint.PatchBalanceItemsEndpoint', () => {
         AuditLogService.listen();
     });
 
+    describe('Description', () => {
+        test('a balance item can be created with a description and the description can be changed or cleared', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const admin = await new UserFactory({ organization, permissions: Permissions.create({ level: PermissionLevel.Full }) }).create();
+            const member = await new MemberFactory({ organization }).create();
+
+            const putBody = new PatchableArray<string, BalanceItemWithPayments, AutoEncoderPatchType<BalanceItemWithPayments>>();
+            putBody.addPut(BalanceItemWithPayments.create({
+                name: 'Kampgeld',
+                description: 'Weekend aan zee',
+                unitPrice: 25_00,
+                amount: 1,
+                memberId: member.id,
+            }));
+
+            const created = (await patchBalanceItems({ body: putBody, organization, user: admin })).body[0];
+            expect(created.name).toBe('Kampgeld');
+            expect(created.description).toBe('Weekend aan zee');
+
+            const patchBody = new PatchableArray<string, BalanceItemWithPayments, AutoEncoderPatchType<BalanceItemWithPayments>>();
+            patchBody.addPatch(BalanceItemWithPayments.patch({ id: created.id, description: 'Weekend in de Ardennen' }));
+            const patched = (await patchBalanceItems({ body: patchBody, organization, user: admin })).body[0];
+            expect(patched.name).toBe('Kampgeld');
+            expect(patched.description).toBe('Weekend in de Ardennen');
+
+            const clearBody = new PatchableArray<string, BalanceItemWithPayments, AutoEncoderPatchType<BalanceItemWithPayments>>();
+            clearBody.addPatch(BalanceItemWithPayments.patch({ id: created.id, description: null }));
+            const cleared = (await patchBalanceItems({ body: clearBody, organization, user: admin })).body[0];
+            expect(cleared.description).toBeNull();
+
+            const model = await BalanceItem.getByID(created.id);
+            expect(model?.name).toBe('Kampgeld');
+            expect(model?.description).toBeNull();
+        });
+
+        test('a patch without description keeps the existing description', async () => {
+            const organization = await new OrganizationFactory({}).create();
+            const admin = await new UserFactory({ organization, permissions: Permissions.create({ level: PermissionLevel.Full }) }).create();
+            const member = await new MemberFactory({ organization }).create();
+            const balanceItem = await new BalanceItemFactory({ organizationId: organization.id, memberId: member.id, name: 'Kampgeld', description: 'Weekend aan zee', amount: 1, unitPrice: 25_00 }).create();
+
+            const body = new PatchableArray<string, BalanceItemWithPayments, AutoEncoderPatchType<BalanceItemWithPayments>>();
+            body.addPatch(BalanceItemWithPayments.patch({ id: balanceItem.id, name: 'Weekendgeld' }));
+            const patched = (await patchBalanceItems({ body, organization, user: admin })).body[0];
+
+            expect(patched.name).toBe('Weekendgeld');
+            expect(patched.description).toBe('Weekend aan zee');
+        });
+    });
+
     describe('Audit logs', () => {
         test('creating a balance item is logged with the member as payer', async () => {
             const organization = await new OrganizationFactory({}).create();
@@ -32,7 +82,7 @@ describe('Endpoint.PatchBalanceItemsEndpoint', () => {
 
             const body = new PatchableArray<string, BalanceItemWithPayments, AutoEncoderPatchType<BalanceItemWithPayments>>();
             body.addPut(BalanceItemWithPayments.create({
-                description: 'Kampgeld',
+                name: 'Kampgeld',
                 unitPrice: 25_00,
                 amount: 2,
                 memberId: member.id,
@@ -61,7 +111,7 @@ describe('Endpoint.PatchBalanceItemsEndpoint', () => {
             const balanceItem = await new BalanceItemFactory({
                 organizationId: organization.id,
                 memberId: member.id,
-                description: 'Kampgeld',
+                name: 'Kampgeld',
                 unitPrice: 25_00,
                 amount: 1,
                 createdAt: new Date(Date.now() - 60_000),
@@ -70,7 +120,7 @@ describe('Endpoint.PatchBalanceItemsEndpoint', () => {
             const body = new PatchableArray<string, BalanceItemWithPayments, AutoEncoderPatchType<BalanceItemWithPayments>>();
             body.addPatch(BalanceItemWithPayments.patch({
                 id: balanceItem.id,
-                description: 'Weekendgeld',
+                name: 'Weekendgeld',
                 unitPrice: 30_00,
                 status: BalanceItemStatus.Canceled,
             }));
@@ -84,7 +134,7 @@ describe('Endpoint.PatchBalanceItemsEndpoint', () => {
             expect(log.replacements.get('b')).toMatchObject({ id: balanceItem.id, value: 'Weekendgeld', type: AuditLogReplacementType.BalanceItem });
 
             const keys = log.patchList.map(p => p.key.toKey());
-            expect(keys).toEqual(expect.arrayContaining(['description', 'unitPrice', 'status']));
+            expect(keys).toEqual(expect.arrayContaining(['name', 'unitPrice', 'status']));
             expect(keys).not.toEqual(expect.arrayContaining(['priceTotal']));
             expect(keys).not.toEqual(expect.arrayContaining(['priceOpen']));
 
@@ -100,7 +150,7 @@ describe('Endpoint.PatchBalanceItemsEndpoint', () => {
 
             const body = new PatchableArray<string, BalanceItemWithPayments, AutoEncoderPatchType<BalanceItemWithPayments>>();
             body.addPut(BalanceItemWithPayments.create({
-                description: 'Lidgeld',
+                name: 'Lidgeld',
                 unitPrice: 10_00,
                 amount: 1,
                 payingOrganizationId: payingOrganization.id,

--- a/backend/app/api/src/endpoints/organization/dashboard/balance-items/PatchBalanceItemsEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/balance-items/PatchBalanceItemsEndpoint.ts
@@ -52,6 +52,7 @@ export class PatchBalanceItemsEndpoint extends Endpoint<Params, Query, Body, Res
             for (const { put } of request.body.getPuts()) {
                 // Create a new balance item
                 const model = new BalanceItem();
+                model.name = put.name;
                 model.description = put.description;
                 model.amount = put.amount;
                 model.type = BalanceItemType.Other;
@@ -183,7 +184,8 @@ export class PatchBalanceItemsEndpoint extends Endpoint<Params, Query, Body, Res
                     }
                 }
 
-                model.description = patch.description ?? model.description;
+                model.name = patch.name ?? model.name;
+                model.description = patch.description === undefined ? model.description : patch.description;
                 model.unitPrice = patch.unitPrice ?? model.unitPrice;
                 model.amount = patch.amount ?? model.amount;
                 model.dueAt = patch.dueAt === undefined ? model.dueAt : patch.dueAt;

--- a/backend/app/api/src/endpoints/organization/dashboard/billing/OrganizationCheckoutEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/billing/OrganizationCheckoutEndpoint.ts
@@ -233,7 +233,7 @@ export class OrganizationCheckoutEndpoint extends Endpoint<Params, Query, Body, 
         if (totalPrice < minimumAmount) {
             const item = new BalanceItem();
             item.type = BalanceItemType.AdministrationFee;
-            item.description = $t('%1Q4');
+            item.name = $t('%1Q4');
             item.payingOrganizationId = organization.id;
             item.organizationId = sellingOrganization.id;
             item.VATPercentage = 21;

--- a/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/webshops/PatchWebshopOrdersEndpoint.ts
@@ -197,7 +197,7 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
                         balanceItem.orderId = order.id;
                         balanceItem.type = BalanceItemType.Order;
                         balanceItem.unitPrice = totalPrice;
-                        balanceItem.description = webshop.meta.name;
+                        balanceItem.name = webshop.meta.name;
                         balanceItem.pricePaid = 0;
                         balanceItem.organizationId = organization.id;
                         balanceItem.status = BalanceItemStatus.Due;
@@ -233,7 +233,7 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
                             throw new Error('Unsupported payment method');
                         }
 
-                        balanceItem.description = order.generateBalanceDescription(webshop);
+                        balanceItem.name = order.generateBalanceDescription(webshop);
                         await balanceItem.save();
 
                         // Update the cached pricePending of the balance item, so the unresolved payment is visible
@@ -329,7 +329,7 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
                         } else {
                             paidItem.status = BalanceItemStatus.Canceled;
                         }
-                        paidItem.description = model.generateBalanceDescription(webshop);
+                        paidItem.name = model.generateBalanceDescription(webshop);
                         await paidItem.save();
 
                         // Zero out the other items
@@ -343,7 +343,7 @@ export class PatchWebshopOrdersEndpoint extends Endpoint<Params, Query, Body, Re
                         balanceItem.unitPrice = model.data.totalPrice;
                         balanceItem.amount = 1;
                         balanceItem.status = BalanceItemStatus.Due;
-                        balanceItem.description = model.generateBalanceDescription(webshop);
+                        balanceItem.name = model.generateBalanceDescription(webshop);
                         balanceItem.pricePaid = 0;
                         balanceItem.organizationId = organization.id;
                         await balanceItem.save();

--- a/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/webshops/PlaceOrderEndpoint.ts
@@ -215,7 +215,7 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                 balanceItem.type = BalanceItemType.Order;
                 balanceItem.orderId = order.id;
                 balanceItem.unitPrice = totalPrice;
-                balanceItem.description = webshop.meta.name;
+                balanceItem.name = webshop.meta.name;
                 balanceItem.pricePaid = 0;
                 balanceItem.organizationId = organization.id;
                 balanceItem.status = BalanceItemStatus.Hidden;
@@ -246,7 +246,7 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                     await OrderService.markValid(order, payment, []);
 
                     if (order.number) {
-                        balanceItem.description = order.generateBalanceDescription(webshop);
+                        balanceItem.name = order.generateBalanceDescription(webshop);
                     }
 
                     balanceItem.status = BalanceItemStatus.Due;
@@ -257,7 +257,7 @@ export class PlaceOrderEndpoint extends Endpoint<Params, Query, Body, ResponseBo
                     await OrderService.markPaid(order, payment, organization, webshop);
 
                     if (order.number) {
-                        balanceItem.description = order.generateBalanceDescription(webshop);
+                        balanceItem.name = order.generateBalanceDescription(webshop);
                     }
 
                     balanceItem.status = BalanceItemStatus.Due;

--- a/backend/app/api/src/excel-loaders/balance-items.ts
+++ b/backend/app/api/src/excel-loaders/balance-items.ts
@@ -61,11 +61,11 @@ function getBalanceItemColumns(): XlsxTransformerColumn<BalanceItemWithPayments>
             },
         },
         {
-            id: 'description',
-            name: $t(`%6o`),
+            id: 'name',
+            name: $t('Naam'),
             width: 40,
             getValue: (object: BalanceItemWithPayments) => ({
-                value: object.description,
+                value: object.name,
             }),
         },
         {

--- a/backend/app/api/src/excel-loaders/payments.test.ts
+++ b/backend/app/api/src/excel-loaders/payments.test.ts
@@ -56,7 +56,7 @@ function createPayment(price: number): PaymentGeneral {
                     id: 'balance-item-1',
                     type: BalanceItemType.Order,
                     orderId: 'order-1',
-                    description: 'Bestelling #1',
+                    name: 'Bestelling #1',
                     amount: 1,
                     unitPrice: price,
                     relations: new Map([
@@ -87,12 +87,12 @@ describe('payments excel loader', () => {
 
             expect(rows).toHaveLength(2);
             expect(rows[0].customTitle).toBe('Koffie');
-            expect(rows[0].balanceItem.description).toBe('Groot');
+            expect(rows[0].balanceItem.name).toBe('Groot');
             expect(rows[0].amount).toBe(2);
             expect(rows[0].unitPrice).toBe(3500);
             expect(rows[0].price).toBe(7000);
             expect(rows[1].customTitle).toBe('Administratiekosten');
-            expect(rows[1].balanceItem.description).toBe('Administratiekosten');
+            expect(rows[1].balanceItem.name).toBe('Administratiekosten');
             expect(rows[1].amount).toBe(1);
             expect(rows[1].price).toBe(500);
             expectRowsToMatchReplacedPayment(rows, payment);
@@ -116,7 +116,7 @@ describe('payments excel loader', () => {
                 'Korting',
                 'Administratiekosten',
             ]);
-            expect(rows.map(row => row.balanceItem.description)).toEqual([
+            expect(rows.map(row => row.balanceItem.name)).toEqual([
                 'Groot',
                 'Korting (10%)',
                 'Vaste korting',
@@ -148,7 +148,7 @@ describe('payments excel loader', () => {
                 'Korting (100%)',
                 'Administratiekosten',
             ]);
-            expect(rows.map(row => row.balanceItem.description)).toEqual([
+            expect(rows.map(row => row.balanceItem.name)).toEqual([
                 'Groot',
                 'Korting (100%)',
                 'Administratiekosten',
@@ -169,13 +169,13 @@ describe('payments excel loader', () => {
 
             const changedRows = expandPaymentBalanceItemPayments(createPayment(1000), orderMap);
             expect(changedRows).toHaveLength(1);
-            expect(changedRows[0].balanceItem.description).toBe('Gedeeltelijke betaling/terugbetaling voor bestelling #123');
+            expect(changedRows[0].balanceItem.name).toBe('Gedeeltelijke betaling/terugbetaling voor bestelling #123');
             expect(changedRows[0].amount).toBe(1);
             expect(changedRows[0].price).toBe(1000);
 
             const refundRows = expandPaymentBalanceItemPayments(createPayment(-1000), orderMap);
             expect(refundRows).toHaveLength(1);
-            expect(refundRows[0].balanceItem.description).toBe('Gedeeltelijke betaling/terugbetaling voor bestelling #123');
+            expect(refundRows[0].balanceItem.name).toBe('Gedeeltelijke betaling/terugbetaling voor bestelling #123');
             expect(refundRows[0].amount).toBe(1);
             expect(refundRows[0].price).toBe(-1000);
         });
@@ -192,7 +192,7 @@ describe('payments excel loader', () => {
 
             expect(firstRows).toHaveLength(2);
             expect(secondRows).toHaveLength(1);
-            expect(secondRows[0].balanceItem.description).toBe('Gedeeltelijke betaling/terugbetaling voor bestelling #123');
+            expect(secondRows[0].balanceItem.name).toBe('Gedeeltelijke betaling/terugbetaling voor bestelling #123');
             expect(secondRows[0].price).toBe(orderData.totalPrice);
             expectRowsToMatchReplacedPayment(firstRows, createPayment(orderData.totalPrice));
             expectRowsToMatchReplacedPayment(secondRows, createPayment(orderData.totalPrice));

--- a/backend/app/api/src/excel-loaders/payments.ts
+++ b/backend/app/api/src/excel-loaders/payments.ts
@@ -285,7 +285,7 @@ function createSyntheticBalanceItemPayment({
             ...source.balanceItem,
             type: BalanceItemType.Order,
             relations: new Map(source.balanceItem.relations),
-            description,
+            name: description,
             amount,
             unitPrice: amount === 0 ? 0 : price / amount,
         }),
@@ -363,7 +363,7 @@ function getBalanceItemColumns(): XlsxTransformerColumn<PaymentWithItem>[] {
             name: $t(`%6o`),
             width: 50,
             getValue: (object: PaymentWithItem) => ({
-                value: object.balanceItemPayment.balanceItem.itemDescription || object.balanceItemPayment.balanceItem.description,
+                value: object.balanceItemPayment.balanceItem.itemDescription || object.balanceItemPayment.balanceItem.name,
                 style: {
                     alignment: {
                         wrapText: true,

--- a/backend/app/api/src/excel-loaders/receivable-balances.ts
+++ b/backend/app/api/src/excel-loaders/receivable-balances.ts
@@ -85,11 +85,11 @@ function getBalanceItemColumns(): XlsxTransformerColumn<ReceivableBalanceWithIte
             },
         },
         {
-            id: 'description',
-            name: $t(`%6o`),
+            id: 'name',
+            name: $t('Naam'),
             width: 40,
             getValue: (object: ReceivableBalanceWithItem) => ({
-                value: object.balanceItem.description,
+                value: object.balanceItem.name,
             }),
         },
         {

--- a/backend/app/api/src/helpers/ApplicationFeeInvoicer.ts
+++ b/backend/app/api/src/helpers/ApplicationFeeInvoicer.ts
@@ -390,7 +390,7 @@ export class ApplicationFeeInvoicer {
     }): Promise<BalanceItem> {
         const item = new BalanceItem();
         item.type = type === ApplicationFeeType.Service ? BalanceItemType.ServiceFee : BalanceItemType.TransferFee;
-        item.description = type === ApplicationFeeType.Service
+        item.name = type === ApplicationFeeType.Service
             ? $t('%1Wd', {
                     startDate: Formatter.startDate(periodStart, false, true),
                     endDate: Formatter.endDate(monthEnd, false, true),

--- a/backend/app/api/src/helpers/LegacyBillingConverter.ts
+++ b/backend/app/api/src/helpers/LegacyBillingConverter.ts
@@ -151,7 +151,7 @@ async function buildBalanceItem(item: STInvoiceItem, options: {
 
                     // Don't copy the name, as in the past we would have put a reason why the credit was used
                     // but that should not be reused
-                    original.description = item.name || item.description || '';
+                    original.name = item.name || item.description || '';
 
                     return original;
                 }
@@ -161,7 +161,7 @@ async function buildBalanceItem(item: STInvoiceItem, options: {
 
     const vatInfo = getVatInfo(legacyMeta);
 
-    balanceItem.description = item.name || item.description || '';
+    balanceItem.name = item.name || item.description || '';
     balanceItem.amount = item.amount;
     balanceItem.unitPrice = item.unitPrice * 100;
     balanceItem.VATPercentage = vatInfo.VATPercentage;
@@ -527,7 +527,7 @@ export async function convertCredit(credit: STCredit, ctx: ConversionContext): P
     balanceItem.organizationId = ctx.membershipOrganization.id;
     balanceItem.payingOrganizationId = credit.organizationId;
     balanceItem.type = BalanceItemType.ReferralDiscount;
-    balanceItem.description = credit.description;
+    balanceItem.name = credit.description;
     balanceItem.amount = 1;
     balanceItem.unitPrice = -credit.change;
     balanceItem.VATPercentage = 21;
@@ -568,7 +568,7 @@ export async function convertRemainingCredit(organization: Organization, balance
     balanceItem.organizationId = ctx.membershipOrganization.id;
     balanceItem.payingOrganizationId = organization.id;
     balanceItem.type = BalanceItemType.ReferralDiscount;
-    balanceItem.description = 'Tegoed';
+    balanceItem.name = 'Tegoed';
     balanceItem.amount = 1;
     balanceItem.unitPrice = -balance;
     balanceItem.VATPercentage = 21;

--- a/backend/app/api/src/helpers/MemberCharger.ts
+++ b/backend/app/api/src/helpers/MemberCharger.ts
@@ -3,10 +3,11 @@ import type { MemberWithRegistrationsBlob } from '@stamhoofd/structures';
 import { BalanceItemType } from '@stamhoofd/structures';
 
 export class MemberCharger {
-    static async chargeMany({ chargingOrganizationId, membersToCharge, price, amount, description, dueAt, createdAt }: { chargingOrganizationId: string; membersToCharge: MemberWithRegistrationsBlob[]; price: number; amount?: number; description: string; dueAt: Date | null; createdAt: Date | null }) {
+    static async chargeMany({ chargingOrganizationId, membersToCharge, price, amount, name, description, dueAt, createdAt }: { chargingOrganizationId: string; membersToCharge: MemberWithRegistrationsBlob[]; price: number; amount?: number; name: string; description: string | null; dueAt: Date | null; createdAt: Date | null }) {
         await Promise.all(membersToCharge.map(memberToCharge => MemberCharger.charge({
             price,
             amount,
+            name,
             description,
             chargingOrganizationId,
             memberToCharge,
@@ -15,10 +16,11 @@ export class MemberCharger {
         })));
     }
 
-    static async charge({ chargingOrganizationId, memberToCharge, price, amount, description, dueAt, createdAt }: { chargingOrganizationId: string; memberToCharge: MemberWithRegistrationsBlob; price: number; amount?: number; description: string; dueAt: Date | null; createdAt: Date | null }) {
+    static async charge({ chargingOrganizationId, memberToCharge, price, amount, name, description, dueAt, createdAt }: { chargingOrganizationId: string; memberToCharge: MemberWithRegistrationsBlob; price: number; amount?: number; name: string; description: string | null; dueAt: Date | null; createdAt: Date | null }) {
         const balanceItem = MemberCharger.createBalanceItem({
             price,
             amount,
+            name,
             description,
             chargingOrganizationId,
             memberBeingCharged: memberToCharge,
@@ -29,11 +31,12 @@ export class MemberCharger {
         await balanceItem.save();
     }
 
-    private static createBalanceItem({ price, amount, description, chargingOrganizationId, memberBeingCharged, dueAt, createdAt }: { price: number; amount?: number; description: string; chargingOrganizationId: string; memberBeingCharged: MemberWithRegistrationsBlob; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
+    private static createBalanceItem({ price, amount, name, description, chargingOrganizationId, memberBeingCharged, dueAt, createdAt }: { price: number; amount?: number; name: string; description: string | null; chargingOrganizationId: string; memberBeingCharged: MemberWithRegistrationsBlob; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
         const balanceItem = new BalanceItem();
         balanceItem.unitPrice = price;
         balanceItem.amount = amount ?? 1;
-        balanceItem.name = description;
+        balanceItem.name = name;
+        balanceItem.description = description;
         balanceItem.type = BalanceItemType.Other;
         balanceItem.memberId = memberBeingCharged.id;
         balanceItem.organizationId = chargingOrganizationId;

--- a/backend/app/api/src/helpers/MemberCharger.ts
+++ b/backend/app/api/src/helpers/MemberCharger.ts
@@ -33,7 +33,7 @@ export class MemberCharger {
         const balanceItem = new BalanceItem();
         balanceItem.unitPrice = price;
         balanceItem.amount = amount ?? 1;
-        balanceItem.description = description;
+        balanceItem.name = description;
         balanceItem.type = BalanceItemType.Other;
         balanceItem.memberId = memberBeingCharged.id;
         balanceItem.organizationId = chargingOrganizationId;

--- a/backend/app/api/src/helpers/MembershipCharger.ts
+++ b/backend/app/api/src/helpers/MembershipCharger.ts
@@ -105,7 +105,7 @@ export const MembershipCharger = {
                 const balanceItem = new BalanceItem();
                 balanceItem.unitPrice = membership.price;
                 balanceItem.amount = 1;
-                balanceItem.description = Formatter.dateNumber(membership.startDate, true) + ' ' + $t(`%10C`) + ' ' + Formatter.dateNumber(membership.expireDate ?? membership.endDate, true);
+                balanceItem.name = Formatter.dateNumber(membership.startDate, true) + ' ' + $t(`%10C`) + ' ' + Formatter.dateNumber(membership.expireDate ?? membership.endDate, true);
                 balanceItem.relations = new Map([
                     [
                         BalanceItemRelationType.Member,

--- a/backend/app/api/src/helpers/OrganizationCharger.ts
+++ b/backend/app/api/src/helpers/OrganizationCharger.ts
@@ -3,10 +3,11 @@ import type { Organization as OrganizationStruct } from '@stamhoofd/structures';
 import { BalanceItemType } from '@stamhoofd/structures';
 
 export class OrganizationCharger {
-    static async chargeMany({ chargingOrganizationId, organizationsToCharge, price, amount, description, dueAt, createdAt }: { chargingOrganizationId: string; organizationsToCharge: OrganizationStruct[]; price: number; amount?: number; description: string; dueAt: Date | null; createdAt: Date | null }) {
+    static async chargeMany({ chargingOrganizationId, organizationsToCharge, price, amount, name, description, dueAt, createdAt }: { chargingOrganizationId: string; organizationsToCharge: OrganizationStruct[]; price: number; amount?: number; name: string; description: string | null; dueAt: Date | null; createdAt: Date | null }) {
         const balanceItems = organizationsToCharge.map(organizationBeingCharged => OrganizationCharger.createBalanceItem({
             price,
             amount,
+            name,
             description,
             chargingOrganizationId,
             organizationBeingCharged,
@@ -17,11 +18,12 @@ export class OrganizationCharger {
         await Promise.all(balanceItems.map(balanceItem => balanceItem.save()));
     }
 
-    private static createBalanceItem({ price, amount, description, chargingOrganizationId, organizationBeingCharged, dueAt, createdAt }: { price: number; amount?: number; description: string; chargingOrganizationId: string; organizationBeingCharged: OrganizationStruct; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
+    private static createBalanceItem({ price, amount, name, description, chargingOrganizationId, organizationBeingCharged, dueAt, createdAt }: { price: number; amount?: number; name: string; description: string | null; chargingOrganizationId: string; organizationBeingCharged: OrganizationStruct; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
         const balanceItem = new BalanceItem();
         balanceItem.unitPrice = price;
         balanceItem.amount = amount ?? 1;
-        balanceItem.name = description;
+        balanceItem.name = name;
+        balanceItem.description = description;
         balanceItem.type = BalanceItemType.Other;
         balanceItem.payingOrganizationId = organizationBeingCharged.id;
         balanceItem.organizationId = chargingOrganizationId;

--- a/backend/app/api/src/helpers/OrganizationCharger.ts
+++ b/backend/app/api/src/helpers/OrganizationCharger.ts
@@ -21,7 +21,7 @@ export class OrganizationCharger {
         const balanceItem = new BalanceItem();
         balanceItem.unitPrice = price;
         balanceItem.amount = amount ?? 1;
-        balanceItem.description = description;
+        balanceItem.name = description;
         balanceItem.type = BalanceItemType.Other;
         balanceItem.payingOrganizationId = organizationBeingCharged.id;
         balanceItem.organizationId = chargingOrganizationId;

--- a/backend/app/api/src/services/BalanceItemService.ts
+++ b/backend/app/api/src/services/BalanceItemService.ts
@@ -248,7 +248,7 @@ export class BalanceItemService {
                     const webshop = await Webshop.getByID(order.webshopId);
 
                     if (webshop) {
-                        balanceItem.description = order.generateBalanceDescription(webshop);
+                        balanceItem.name = order.generateBalanceDescription(webshop);
                         await balanceItem.save();
                     }
                 }

--- a/backend/app/api/src/services/EmailSendService.test.ts
+++ b/backend/app/api/src/services/EmailSendService.test.ts
@@ -894,7 +894,7 @@ describe('EmailSendService', () => {
                     type: BalanceItemType.Other,
                     amount: 2,
                     unitPrice: 12_99_00,
-                    description: 'Test balance item',
+                    name: 'Test balance item',
                 }).create();
                 await CachedBalance.updateForUsers(organization.id, [existingUser.id]);
 

--- a/backend/app/api/src/services/InvoiceService.ts
+++ b/backend/app/api/src/services/InvoiceService.ts
@@ -274,7 +274,7 @@ export class InvoiceService {
 
                 invoiced.totalWithoutVAT = item.totalWithoutVAT;
 
-                invoiced.name = item.name || balanceItem.description;
+                invoiced.name = item.name || balanceItem.name;
                 invoiced.description = item.description;
 
                 await invoiced.save();

--- a/backend/app/api/src/services/ReferralService.ts
+++ b/backend/app/api/src/services/ReferralService.ts
@@ -53,7 +53,7 @@ export class ReferralService {
         if (code.value > 0) {
             credit = new BalanceItem();
             credit.type = BalanceItemType.ReferralDiscount;
-            credit.description = otherOrganization ? ('Tegoed gekregen van ' + otherOrganization.name) : code.description;
+            credit.name = otherOrganization ? ('Tegoed gekregen van ' + otherOrganization.name) : code.description;
             credit.payingOrganizationId = organization.id;
             credit.organizationId = membershipOrganization.id;
             credit.VATPercentage = 21;
@@ -151,7 +151,7 @@ export class ReferralService {
 
         const credit = new BalanceItem();
         credit.type = BalanceItemType.ReferralDiscount;
-        credit.description = $t('%1ZE', { 'organization-name': organization.name });
+        credit.name = $t('%1ZE', { 'organization-name': organization.name });
         credit.payingOrganizationId = code.organizationId;
         credit.organizationId = (await Platform.getShared()).membershipOrganizationId!; // where do we get this discount from
         credit.VATPercentage = 21;
@@ -180,7 +180,7 @@ export class ReferralService {
             // The receiving organization is invoiced instead of the organization for the usage of Stamhoofd.
             const item = new BalanceItem();
             item.type = BalanceItemType.Other;
-            item.description = 'Aankoop Stamhoofd voor ' + organization.name;
+            item.name = 'Aankoop Stamhoofd voor ' + organization.name;
             item.payingOrganizationId = receivingOrganization.id;
             item.organizationId = membershipOrganizationId;
             item.VATPercentage = 21;

--- a/backend/app/api/src/services/STPackageService.ts
+++ b/backend/app/api/src/services/STPackageService.ts
@@ -162,7 +162,7 @@ export class STPackageService {
 
         const item = new BalanceItem();
         item.type = BalanceItemType.STPackage;
-        item.description = pack.meta.name + ' ' + (
+        item.name = pack.meta.name + ' ' + (
             pack.endDate
                 ? $t('%1LM', { startDate: Formatter.startDate(now, false, true), endDate: Formatter.endDate(pack.endDate, false, true) })
                 : $t('%1LN', { startDate: Formatter.startDate(pack.meta.startDate, false, true) })

--- a/backend/app/api/src/sql-filters/balance-items.ts
+++ b/backend/app/api/src/sql-filters/balance-items.ts
@@ -130,10 +130,16 @@ export const balanceItemFilterCompilers: SQLFilterDefinitions = {
         nullable: false,
     }),
 
+    name: createColumnFilter({
+        expression: SQL.column('balance_items', 'name'),
+        type: SQLValueType.String,
+        nullable: false,
+    }),
+
     description: createColumnFilter({
         expression: SQL.column('balance_items', 'description'),
         type: SQLValueType.String,
-        nullable: false,
+        nullable: true,
     }),
 
     priceWithVAT: createColumnFilter({

--- a/backend/app/api/src/sql-filters/payments.ts
+++ b/backend/app/api/src/sql-filters/payments.ts
@@ -284,7 +284,7 @@ export function getPaymentSearchFilter(search: string): StamhoofdFilter {
         $or: [
             { customer: { name: { $contains: search } } },
             { customer: { company: { name: { $contains: search } } } },
-            { balanceItemPayments: { $elemMatch: { balanceItem: { description: { $contains: search } } } } },
+            { balanceItemPayments: { $elemMatch: { balanceItem: { name: { $contains: search } } } } },
             { transferDescription: { $contains: search } },
         ],
     };

--- a/backend/app/api/tests/e2e/charge-members.test.ts
+++ b/backend/app/api/tests/e2e/charge-members.test.ts
@@ -192,7 +192,7 @@ describe('E2E.ChargeMembers', () => {
             expect(balanceItem1.unitPrice).toEqual(3_00);
             expect(balanceItem1.priceWithVAT).toEqual(12_00);
             expect(balanceItem1.amount).toEqual(body.amount);
-            expect(balanceItem1.description).toEqual(body.description);
+            expect(balanceItem1.name).toEqual(body.description);
             expect(balanceItem1.organizationId).toEqual(organization.id);
             // const dueAt = balanceItem1.dueAt!;
             expect(balanceItem1.dueAt).toEqual(body.dueAt);
@@ -372,7 +372,7 @@ describe('E2E.ChargeMembers', () => {
                 expect(balanceItem1.unitPrice).toEqual(3_00);
                 expect(balanceItem1.priceWithVAT).toEqual(12_00);
                 expect(balanceItem1.amount).toEqual(4);
-                expect(balanceItem1.description).toEqual('test description');
+                expect(balanceItem1.name).toEqual('test description');
                 expect(balanceItem1.organizationId).toEqual(organization.id);
                 expect(balanceItem1.dueAt).toEqual(new Date(2023, 0, 10));
                 expect(balanceItem1.createdAt).toEqual(body.createdAt);

--- a/backend/app/api/tests/e2e/charge-members.test.ts
+++ b/backend/app/api/tests/e2e/charge-members.test.ts
@@ -109,7 +109,7 @@ describe('E2E.ChargeMembers', () => {
         };
 
         const body = ChargeRequest.create({
-            description: 'test description',
+            name: 'test name',
             price: 3_00,
             amount: 4,
             dueAt: new Date(2023, 0, 10),
@@ -173,6 +173,7 @@ describe('E2E.ChargeMembers', () => {
         };
 
         const body = ChargeRequest.create({
+            name: 'test name',
             description: 'test description',
             price: 3_00,
             amount: 4,
@@ -192,7 +193,8 @@ describe('E2E.ChargeMembers', () => {
             expect(balanceItem1.unitPrice).toEqual(3_00);
             expect(balanceItem1.priceWithVAT).toEqual(12_00);
             expect(balanceItem1.amount).toEqual(body.amount);
-            expect(balanceItem1.name).toEqual(body.description);
+            expect(balanceItem1.name).toEqual(body.name);
+            expect(balanceItem1.description).toEqual('test description');
             expect(balanceItem1.organizationId).toEqual(organization.id);
             // const dueAt = balanceItem1.dueAt!;
             expect(balanceItem1.dueAt).toEqual(body.dueAt);
@@ -238,7 +240,7 @@ describe('E2E.ChargeMembers', () => {
         const otherFinancialDirectorToken = await SessionService.createSession(otherFinancialDirector);
 
         const body = ChargeRequest.create({
-            description: 'test description',
+            name: 'test name',
             price: 3_00,
             amount: 4,
             dueAt: new Date(2023, 0, 10),
@@ -275,18 +277,18 @@ describe('E2E.ChargeMembers', () => {
         };
 
         const testCases: [body: ChargeRequest, expectedErrorMessage: string][] = [
-            // empty description
+            // empty name
             [ChargeRequest.create({
-                description: ' ',
+                name: ' ',
                 price: 3_00,
                 amount: 4,
                 dueAt: new Date(2023, 0, 10),
                 createdAt: new Date(2023, 0, 4),
-            }), 'Invalid description'],
+            }), 'Invalid name'],
 
             // price 0
             [ChargeRequest.create({
-                description: 'test description',
+                name: 'test name',
                 price: 0,
                 amount: 4,
                 dueAt: new Date(2023, 0, 10),
@@ -295,7 +297,7 @@ describe('E2E.ChargeMembers', () => {
 
             // amount 0
             [ChargeRequest.create({
-                description: 'test description',
+                name: 'test name',
                 price: 3_00,
                 amount: 0,
                 dueAt: new Date(2023, 0, 10),
@@ -353,7 +355,7 @@ describe('E2E.ChargeMembers', () => {
             };
 
             const body = ChargeRequest.create({
-                description: 'test description',
+                name: 'test name',
                 price: 3_00,
                 amount: 4,
                 dueAt: new Date(2023, 0, 10),
@@ -372,7 +374,7 @@ describe('E2E.ChargeMembers', () => {
                 expect(balanceItem1.unitPrice).toEqual(3_00);
                 expect(balanceItem1.priceWithVAT).toEqual(12_00);
                 expect(balanceItem1.amount).toEqual(4);
-                expect(balanceItem1.name).toEqual('test description');
+                expect(balanceItem1.name).toEqual('test name');
                 expect(balanceItem1.organizationId).toEqual(organization.id);
                 expect(balanceItem1.dueAt).toEqual(new Date(2023, 0, 10));
                 expect(balanceItem1.createdAt).toEqual(body.createdAt);
@@ -423,7 +425,7 @@ describe('E2E.ChargeMembers', () => {
             };
 
             const body = ChargeRequest.create({
-                description: 'test description',
+                name: 'test name',
                 price: 3_00,
                 amount: 4,
                 dueAt: new Date(2023, 0, 10),

--- a/backend/shared/models/src/factories/BalanceItemFactory.ts
+++ b/backend/shared/models/src/factories/BalanceItemFactory.ts
@@ -22,7 +22,8 @@ class Options {
     updatedAt?: Date;
     status?: BalanceItemStatus;
     relations?: Map<BalanceItemRelationType, BalanceItemRelation>;
-    description?: string;
+    name?: string;
+    description?: string | null;
 }
 
 export class BalanceItemFactory extends Factory<Options, BalanceItem> {
@@ -36,7 +37,8 @@ export class BalanceItemFactory extends Factory<Options, BalanceItem> {
         balanceItem.orderId = this.options.orderId ?? null;
         balanceItem.dependingBalanceItemId = this.options.dependingBalanceItemId ?? null;
         balanceItem.relations = this.options.relations ?? new Map();
-        balanceItem.description = this.options.description ?? '';
+        balanceItem.name = this.options.name ?? '';
+        balanceItem.description = this.options.description ?? null;
 
         if (this.options.type) {
             balanceItem.type = this.options.type;

--- a/backend/shared/models/src/migrations/1788350700-balance-items-rename-description-to-name.sql
+++ b/backend/shared/models/src/migrations/1788350700-balance-items-rename-description-to-name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `balance_items` RENAME COLUMN `description` TO `name`;

--- a/backend/shared/models/src/migrations/1788350701-balance-items-add-description.sql
+++ b/backend/shared/models/src/migrations/1788350701-balance-items-add-description.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `balance_items` ADD COLUMN `description` text NULL AFTER `name`;

--- a/backend/shared/models/src/models/BalanceItem.ts
+++ b/backend/shared/models/src/models/BalanceItem.ts
@@ -70,7 +70,10 @@ export class BalanceItem extends QueryableModel {
     relations: Map<BalanceItemRelationType, BalanceItemRelation> = new Map();
 
     @column({ type: 'string' })
-    description = '';
+    name = '';
+
+    @column({ type: 'string', nullable: true })
+    description: string | null = null;
 
     /**
      * In case this balance item is associated with an item that was charged for a certain period, the startDate is saved here.
@@ -422,6 +425,7 @@ export class BalanceItem extends QueryableModel {
 
         item.type = BalanceItemType.CancellationFee;
         item.relations = this.relations;
+        item.name = this.name;
         item.description = this.description;
         item.amount = 1;
         item.unitPrice = fee;

--- a/frontend/app/dashboard/src/views/dashboard/balance-items/BalanceItemsTableView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/balance-items/BalanceItemsTableView.vue
@@ -248,9 +248,9 @@ const allColumns: Column<ObjectType, any>[] = [
     }),
 
     new Column<ObjectType, string>({
-        id: 'description',
-        name: $t('%6o'),
-        getValue: object => object.description,
+        id: 'name',
+        name: $t('Naam'),
+        getValue: object => object.name,
         minimumWidth: 100,
         recommendedWidth: 300,
         enabled: false,

--- a/frontend/app/dashboard/src/views/dashboard/balance-items/getSelectableWorkbook.ts
+++ b/frontend/app/dashboard/src/views/dashboard/balance-items/getSelectableWorkbook.ts
@@ -47,8 +47,8 @@ export function getSelectableWorkbook(organization: Organization | null, platfor
                     }),
 
                     new SelectableColumn({
-                        id: 'description',
-                        name: $t(`%6o`),
+                        id: 'name',
+                        name: $t('Naam'),
                     }),
 
                     new SelectableColumn({

--- a/frontend/app/dashboard/src/views/dashboard/receivable-balances/getSelectableWorkbook.ts
+++ b/frontend/app/dashboard/src/views/dashboard/receivable-balances/getSelectableWorkbook.ts
@@ -66,8 +66,8 @@ export function getSelectableWorkbook($t: ReturnType<typeof useTranslate>, $feat
                     }),
 
                     new SelectableColumn({
-                        id: 'description',
-                        name: $t(`%6o`),
+                        id: 'name',
+                        name: $t('Naam'),
                     }),
 
                     ...Object.values(BalanceItemRelationType).map(relationType => new SelectableColumn({

--- a/frontend/shared/components/src/payments/EditBalanceItemView.vue
+++ b/frontend/shared/components/src/payments/EditBalanceItemView.vue
@@ -335,7 +335,7 @@ const name = computed({
 
 const description = computed({
     get: () => patchedBalanceItem.value.description ?? '',
-    set: value => addPatch({ description: value.trim() ? value : null }),
+    set: value => addPatch({ description: value ? value : null }),
 });
 
 const unitPrice = computed({

--- a/frontend/shared/components/src/payments/EditBalanceItemView.vue
+++ b/frontend/shared/components/src/payments/EditBalanceItemView.vue
@@ -17,8 +17,8 @@
 
         <STErrorsDefault :error-box="errors.errorBox" />
 
-        <STInputBox v-if="balanceItem.relations.size === 0 && !balanceItem.startDate" error-fields="description" :error-box="errors.errorBox" :title="$t(`%6o`)" class="max">
-            <input ref="firstInput" v-model="description" class="input" type="text" autocomplete="off" :disabled="!!balanceItem.relations.size" :placeholder="$t(`%gp`)">
+        <STInputBox v-if="balanceItem.relations.size === 0 && !balanceItem.startDate" error-fields="name" :error-box="errors.errorBox" :title="$t('Naam')" class="max">
+            <input ref="firstInput" v-model="name" class="input" type="text" autocomplete="off" :disabled="!!balanceItem.relations.size" :placeholder="$t(`%gp`)">
         </STInputBox>
         <STList v-else>
             <STListItem>
@@ -55,6 +55,10 @@
                 </template>
             </STListItem>
         </STList>
+
+        <STInputBox error-fields="description" :error-box="errors.errorBox" :title="$t('Beschrijving')" class="max">
+            <textarea v-model="description" class="input" :placeholder="$t('Optioneel')" />
+        </STInputBox>
 
         <div class="split-inputs">
             <div>
@@ -324,9 +328,14 @@ const status = computed({
     set: value => addPatch({ status: value }),
 });
 
+const name = computed({
+    get: () => patchedBalanceItem.value.name,
+    set: value => addPatch({ name: value }),
+});
+
 const description = computed({
-    get: () => patchedBalanceItem.value.description,
-    set: value => addPatch({ description: value }),
+    get: () => patchedBalanceItem.value.description ?? '',
+    set: value => addPatch({ description: value.trim() ? value : null }),
 });
 
 const unitPrice = computed({
@@ -484,12 +493,12 @@ async function save() {
             loading.value = false;
             return;
         }
-        if (patchedBalanceItem.value.description.length === 0 && patchedBalanceItem.value.relations.size === 0) {
+        if (patchedBalanceItem.value.name.length === 0 && patchedBalanceItem.value.relations.size === 0) {
             throw new SimpleError({
                 code: 'invalid_field',
-                field: 'description',
-                message: 'description cannot be empty',
-                human: $t('%1Hz'),
+                field: 'name',
+                message: 'name cannot be empty',
+                human: $t('Vul een naam in'),
             });
         }
         if (patchedBalanceItem.value.unitPrice === 0) {

--- a/frontend/shared/components/src/payments/PayableBalanceTable.test.ts
+++ b/frontend/shared/components/src/payments/PayableBalanceTable.test.ts
@@ -5,10 +5,10 @@ import { render } from 'vitest-browser-vue';
 import { userEvent } from 'vitest/browser';
 import PayableBalanceTable from './PayableBalanceTable.vue';
 
-function createItem(overrides: Partial<{ unitPrice: number; amount: number; VATPercentage: number | null; VATIncluded: boolean; description: string }> = {}) {
+function createItem(overrides: Partial<{ unitPrice: number; amount: number; VATPercentage: number | null; VATIncluded: boolean; name: string }> = {}) {
     return BalanceItemWithPayments.create({
         type: BalanceItemType.Other,
-        description: overrides.description ?? 'Test item',
+        name: overrides.name ?? 'Test item',
         amount: overrides.amount ?? 1,
         unitPrice: overrides.unitPrice ?? 4_13_00,
         VATPercentage: overrides.VATPercentage === undefined ? 21 : overrides.VATPercentage,
@@ -107,7 +107,7 @@ test('VAT-inclusive items in the same basket also show unit prices excluding VAT
     // (2 x 12,10 incl. 21% VAT) must then show its unit price excluding VAT (10,00) too
     renderTable(createBalance([
         createItem({ unitPrice: 4_13_00, amount: 1, VATPercentage: 21, VATIncluded: false }),
-        createItem({ unitPrice: 12_10_00, amount: 2, VATPercentage: 21, VATIncluded: true, description: 'Inclusive item' }),
+        createItem({ unitPrice: 12_10_00, amount: 2, VATPercentage: 21, VATIncluded: true, name: 'Inclusive item' }),
     ]));
 
     const itemList = document.querySelector('.st-grid')!;

--- a/frontend/shared/components/src/payments/PaymentItemsBox.vue
+++ b/frontend/shared/components/src/payments/PaymentItemsBox.vue
@@ -51,7 +51,7 @@ const sortedItems = computed(() => {
     return props.payment.balanceItemPayments.slice().sort((a, b) => {
         return Sorter.stack(
             Sorter.byNumberValue(a.price, b.price),
-            Sorter.byStringValue(a.itemDescription ?? a.balanceItem.description, b.itemDescription ?? b.balanceItem.description),
+            Sorter.byStringValue(a.itemDescription ?? a.balanceItem.name, b.itemDescription ?? b.balanceItem.name),
         );
     });
 });

--- a/frontend/shared/components/src/views/ChargeView.vue
+++ b/frontend/shared/components/src/views/ChargeView.vue
@@ -16,7 +16,7 @@
                 <OrganizationSelect v-model="selectedOrganization" />
             </STInputBox>
 
-            <STInputBox :title="$t('%6o')" error-fields="description" :error-box="errors.errorBox">
+            <STInputBox :title="$t('%6o')" error-fields="name" :error-box="errors.errorBox">
                 <input v-model="description" class="input" type="text" :placeholder="$t('%6p')" autocomplete="given-name">
             </STInputBox>
         </div>
@@ -152,7 +152,7 @@ useValidation(errors.validator, () => {
         se.addError(new SimpleError({
             code: 'invalid_field',
             message: $t(`%Cr`),
-            field: 'description',
+            field: 'name',
         }));
     }
 
@@ -197,7 +197,7 @@ async function save() {
     try {
         const body = ChargeRequest.create({
             price: price.value,
-            description: description.value,
+            name: description.value,
             amount: amount.value,
             dueAt: dueAt.value,
             createdAt: createdAt.value,

--- a/shared/structures/src/BalanceItem.test.ts
+++ b/shared/structures/src/BalanceItem.test.ts
@@ -1,5 +1,7 @@
+import type { AutoEncoderPatchType, Decoder } from '@simonbackx/simple-encoding';
+import { ObjectData } from '@simonbackx/simple-encoding';
 import { TestUtils } from '@stamhoofd/test-utils';
-import { BalanceItem, BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, BalanceItemWithPayments, DESCRIPTION_TITLED_BALANCE_ITEM_TYPES, getApplicableBalanceItemRelationTypes, getApplicableBalanceItemTypes, GroupedBalanceItems, VATExcemptReason } from './BalanceItem.js';
+import { BalanceItem, BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, BalanceItemWithPayments, NAME_TITLED_BALANCE_ITEM_TYPES, getApplicableBalanceItemRelationTypes, getApplicableBalanceItemTypes, GroupedBalanceItems, VATExcemptReason } from './BalanceItem.js';
 import type { InMemoryFilterDefinitions } from './filters/InMemoryFilter.js';
 import { baseInMemoryFilterCompilers, compileToInMemoryFilter, createInMemoryFilterCompiler } from './filters/InMemoryFilter.js';
 import type { StamhoofdFilter } from './filters/StamhoofdFilter.js';
@@ -7,15 +9,16 @@ import { TranslatedString } from './TranslatedString.js';
 import { DetailedPayableBalance } from './endpoints/PayableBalanceCollection.js';
 import { BaseOrganization, Organization } from './Organization.js';
 import { Platform } from './Platform.js';
+import { Version } from './Version.js';
 
 /**
  * Helper to create a payable (Due) balance item with an exclusive VAT rate.
  * unitPrice is in the internal integer format (1 euro = 10000).
  */
-function createItem(overrides: Partial<{ unitPrice: number; amount: number; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; type: BalanceItemType; description: string }> = {}) {
+function createItem(overrides: Partial<{ unitPrice: number; amount: number; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; type: BalanceItemType; name: string }> = {}) {
     return BalanceItemWithPayments.create({
         type: overrides.type ?? BalanceItemType.Other,
-        description: overrides.description ?? 'Test item',
+        name: overrides.name ?? 'Test item',
         amount: overrides.amount ?? 1,
         unitPrice: overrides.unitPrice ?? 4_13_00,
         VATPercentage: overrides.VATPercentage === undefined ? 21 : overrides.VATPercentage,
@@ -272,10 +275,10 @@ describe('BalanceItem.categoryFilter / articleFilter', () => {
         TestUtils.setEnvironment('platformName', 'stamhoofd');
     });
 
-    function createItem(type: BalanceItemType, relations: [BalanceItemRelationType, string][] = [], description = '') {
+    function createItem(type: BalanceItemType, relations: [BalanceItemRelationType, string][] = [], name = '') {
         return BalanceItem.create({
             type,
-            description,
+            name,
             relations: new Map(relations.map(([relationType, id]) => [
                 relationType,
                 BalanceItemRelation.create({ id, name: new TranslatedString(id) }),
@@ -290,7 +293,7 @@ describe('BalanceItem.categoryFilter / articleFilter', () => {
     const balanceItemFilterCompilers: InMemoryFilterDefinitions = {
         ...baseInMemoryFilterCompilers,
         type: createInMemoryFilterCompiler('type'),
-        description: createInMemoryFilterCompiler('description'),
+        name: createInMemoryFilterCompiler('name'),
         relations: {
             ...baseInMemoryFilterCompilers,
             ...Object.fromEntries(
@@ -340,7 +343,7 @@ describe('BalanceItem.categoryFilter / articleFilter', () => {
     });
 
     describe('articleFilter selects exactly the items with the same articleCode', () => {
-        test('an administration fee with a description is a different article than one without', () => {
+        test('an administration fee with a name is a different article than one without', () => {
             const named = createItem(BalanceItemType.AdministrationFee, [], 'Kosten');
             const unnamed = createItem(BalanceItemType.AdministrationFee);
 
@@ -349,7 +352,7 @@ describe('BalanceItem.categoryFilter / articleFilter', () => {
             expect(matches(unnamed.articleFilter, named)).toBe(false);
         });
 
-        test('a registration is not told apart by its description', () => {
+        test('a registration is not told apart by its name', () => {
             const first = createItem(BalanceItemType.Registration, [[BalanceItemRelationType.Group, 'group-a']], 'Inschrijving Kapoenen');
             const second = createItem(BalanceItemType.Registration, [[BalanceItemRelationType.Group, 'group-a']], 'Inschrijving Kapoenen 2026');
 
@@ -358,13 +361,30 @@ describe('BalanceItem.categoryFilter / articleFilter', () => {
         });
     });
 
-    test('DESCRIPTION_TITLED_BALANCE_ITEM_TYPES lists exactly the types whose itemTitle is their description', () => {
-        const description = 'A description no itemTitle would ever build on its own';
+    test('old clients read and write the name as description', () => {
+        const item = BalanceItem.create({ name: 'Kampgeld', description: 'Weekend aan zee' });
+        const oldVersion = Version - 1;
+
+        const encoded = JSON.parse(JSON.stringify(item.encode({ version: oldVersion }))) as Record<string, unknown>;
+        expect(encoded.description).toBe('Kampgeld');
+        expect(encoded.name).toBeUndefined();
+
+        const decoded = new ObjectData(encoded, { version: oldVersion }).decode(BalanceItem as Decoder<BalanceItem>);
+        expect(decoded.name).toBe('Kampgeld');
+        expect(decoded.description).toBeNull();
+
+        const patch = new ObjectData({ id: item.id, description: 'Weekendgeld' }, { version: oldVersion }).decode(BalanceItem.patchType() as Decoder<AutoEncoderPatchType<BalanceItem>>);
+        expect(patch.name).toBe('Weekendgeld');
+        expect(patch.description).toBeUndefined();
+    });
+
+    test('NAME_TITLED_BALANCE_ITEM_TYPES lists exactly the types whose itemTitle is their name', () => {
+        const name = 'A name no itemTitle would ever build on its own';
 
         for (const type of Object.values(BalanceItemType)) {
-            const usesDescription = BalanceItem.create({ type, description }).itemTitle === description;
+            const usesName = BalanceItem.create({ type, name }).itemTitle === name;
 
-            expect([type, DESCRIPTION_TITLED_BALANCE_ITEM_TYPES.has(type)]).toEqual([type, usesDescription]);
+            expect([type, NAME_TITLED_BALANCE_ITEM_TYPES.has(type)]).toEqual([type, usesName]);
         }
     });
 });

--- a/shared/structures/src/BalanceItem.ts
+++ b/shared/structures/src/BalanceItem.ts
@@ -302,20 +302,20 @@ function isArticleRelationType(item: BalanceItem, relationType: BalanceItemRelat
 }
 
 /**
- * The types whose itemTitle is their description, which is then the only thing that tells two of their
+ * The types whose itemTitle is their name, which is then the only thing that tells two of their
  * articles apart. Kept in sync with itemTitle by a test.
  *
  * Decided per type instead of per item: two items of the same type have to agree on what makes them the
  * same article, otherwise no filter can select exactly one of those articles.
  */
-export const DESCRIPTION_TITLED_BALANCE_ITEM_TYPES: ReadonlySet<BalanceItemType> = new Set([
+export const NAME_TITLED_BALANCE_ITEM_TYPES: ReadonlySet<BalanceItemType> = new Set([
     BalanceItemType.AdministrationFee,
     BalanceItemType.Other,
     BalanceItemType.ReferralDiscount,
 ]);
 
-function getArticleDescriptionCode(item: BalanceItem): string {
-    return DESCRIPTION_TITLED_BALANCE_ITEM_TYPES.has(item.type) ? '-description-' + item.description : '';
+function getArticleNameCode(item: BalanceItem): string {
+    return NAME_TITLED_BALANCE_ITEM_TYPES.has(item.type) ? '-name-' + item.name : '';
 }
 
 export function doBalanceItemRelationsMatch(a: Map<BalanceItemRelationType, BalanceItemRelation>, b: Map<BalanceItemRelationType, BalanceItemRelation>, allowedDifference = 0) {
@@ -382,8 +382,15 @@ export class BalanceItem extends AutoEncoder {
     @field({ decoder: new MapDecoder(new EnumDecoder(BalanceItemRelationType), BalanceItemRelation), version: 307 })
     relations: Map<BalanceItemRelationType, BalanceItemRelation> = new Map();
 
-    @field({ decoder: StringDecoder })
-    description = '';
+    @field({ decoder: StringDecoder, field: 'description' })
+    @field({ decoder: StringDecoder, field: 'name', ...NextVersion })
+    name = '';
+
+    /**
+     * Optional extra text for the item, shown below the name (e.g. on invoices)
+     */
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    description: string | null = null;
 
     /**
      * quantity, should be renamed to quantity in the future
@@ -794,7 +801,7 @@ export class BalanceItem extends AutoEncoder {
             case BalanceItemType.AdministrationFee: return $t(`%lq`);
             case BalanceItemType.FreeContribution: return $t(`%lr`);
             case BalanceItemType.Order: return this.relations.get(BalanceItemRelationType.Webshop)?.name.toString() || $t(`%ls`);
-            case BalanceItemType.Other: return this.description;
+            case BalanceItemType.Other: return this.name;
             case BalanceItemType.PlatformMembership: return $t(`%lt`) + ' ' + this.relations.get(BalanceItemRelationType.MembershipType)?.name || $t(`%lu`);
             case BalanceItemType.STPackage: return this.itemTitle;
             case BalanceItemType.ServiceFee: return $t('%1dA');
@@ -819,7 +826,7 @@ export class BalanceItem extends AutoEncoder {
             case BalanceItemType.AdministrationFee: return $t(`%lq`);
             case BalanceItemType.FreeContribution: return $t(`%lr`);
             case BalanceItemType.Order: return this.relations.get(BalanceItemRelationType.Webshop)?.name.toString() ?? $t(`%ls`);
-            case BalanceItemType.Other: return this.description;
+            case BalanceItemType.Other: return this.name;
             case BalanceItemType.PlatformMembership: return this.relations.get(BalanceItemRelationType.MembershipType)?.name.toString() ?? $t(`%BV`);
             case BalanceItemType.STPackage: return $t('%1Mu');
             case BalanceItemType.ServiceFee: return $t('%1dA');
@@ -873,8 +880,8 @@ export class BalanceItem extends AutoEncoder {
         }
 
         if (this.type === BalanceItemType.Other) {
-            // These have no relations: the description is the only thing that distinguishes them
-            return this.type + ':' + this.description;
+            // These have no relations: the name is the only thing that distinguishes them
+            return this.type + ':' + this.name;
         }
 
         // Everything else is one category per type
@@ -901,8 +908,8 @@ export class BalanceItem extends AutoEncoder {
         }
 
         if (this.type === BalanceItemType.Other) {
-            // These have no relations: the description is the only thing that distinguishes them
-            filters.push({ description: this.description });
+            // These have no relations: the name is the only thing that distinguishes them
+            filters.push({ name: this.name });
         }
 
         return { $and: filters };
@@ -926,7 +933,7 @@ export class BalanceItem extends AutoEncoder {
             .sort();
 
         return 'type-' + this.type
-            + getArticleDescriptionCode(this)
+            + getArticleNameCode(this)
             + '-relations-' + relations.join('-');
     }
 
@@ -947,8 +954,8 @@ export class BalanceItem extends AutoEncoder {
             filters.push({ relations: { [relationType]: { id: this.relations.get(relationType)?.id ?? null } } });
         }
 
-        if (DESCRIPTION_TITLED_BALANCE_ITEM_TYPES.has(this.type)) {
-            filters.push({ description: this.description });
+        if (NAME_TITLED_BALANCE_ITEM_TYPES.has(this.type)) {
+            filters.push({ name: this.name });
         }
 
         return { $and: filters };
@@ -1030,7 +1037,7 @@ export class BalanceItem extends AutoEncoder {
                 + '-vat-percentage-' + this.VATPercentage
                 + '-vat-included-' + this.VATIncluded
                 + '-vat-excempt-' + this.VATExcempt
-                + '-description-' + this.description
+                + '-name-' + this.name
                 + '-due-date-' + (this.dueAt ? Formatter.dateIso(this.dueAt) : 'null');
         }
 
@@ -1073,11 +1080,11 @@ export class BalanceItem extends AutoEncoder {
             }
             case BalanceItemType.CancellationFee: return $t(`%17G`);
             case BalanceItemType.AdministrationFee: {
-                return this.description || $t(`%xK`);
+                return this.name || $t(`%xK`);
             }
             case BalanceItemType.FreeContribution: return $t(`%Ot`);
             case BalanceItemType.Order: return this.relations.get(BalanceItemRelationType.Webshop)?.name.toString() || $t(`%m2`);
-            case BalanceItemType.Other: return this.description;
+            case BalanceItemType.Other: return this.name;
             case BalanceItemType.PlatformMembership: return $t(`%m3`) + ' ' + this.relations.get(BalanceItemRelationType.MembershipType)?.name.toString() || $t(`%m4`);
             case BalanceItemType.STPackage: {
                 const pack = this.relations.get(BalanceItemRelationType.STPackage);
@@ -1086,7 +1093,7 @@ export class BalanceItem extends AutoEncoder {
             case BalanceItemType.ServiceFee: return this.startDate && this.endDate ? (Formatter.dateIso(this.startDate) !== Formatter.dateIso(this.endDate) ? $t(`%1Z1`, { startDate: Formatter.startDate(this.startDate, false, true), endDate: Formatter.endDate(this.endDate, false, true) }) : $t(`%1cJ`, { date: Formatter.date(this.startDate, true) })) : $t('%1UX');
             case BalanceItemType.TransferFee: return this.startDate && this.endDate ? (Formatter.dateIso(this.startDate) !== Formatter.dateIso(this.endDate) ? $t(`%1bd`, { startDate: Formatter.startDate(this.startDate, false, true), endDate: Formatter.endDate(this.endDate, false, true) }) : $t(`%1Yq`, { date: Formatter.date(this.startDate, true) })) : $t('%wZ');
         }
-        return this.description;
+        return this.name;
     }
 
     /**

--- a/shared/structures/src/billing/InvoicedBalanceItem.test.ts
+++ b/shared/structures/src/billing/InvoicedBalanceItem.test.ts
@@ -1,11 +1,68 @@
-import { BalanceItem, VATExcemptReason } from '../BalanceItem.js';
+import { BalanceItem, BalanceItemRelation, BalanceItemRelationType, BalanceItemType, VATExcemptReason } from '../BalanceItem.js';
+import { TranslatedString } from '../TranslatedString.js';
 import { InvoicedBalanceItem } from './InvoicedBalanceItem.js';
 
 describe('InvoicedBalanceItem', () => {
     describe('createFor', () => {
+        function createBalanceItem(overrides: Partial<{ name: string; description: string | null; type: BalanceItemType; relations: Map<BalanceItemRelationType, BalanceItemRelation> }> = {}) {
+            return BalanceItem.create({
+                unitPrice: 5_00_00,
+                amount: 1,
+                VATPercentage: 21,
+                VATIncluded: true,
+                ...overrides,
+            });
+        }
+
+        test('copies the name and description of an item without relations', () => {
+            const invoicedItem = InvoicedBalanceItem.createFor(createBalanceItem({ name: 'Kampgeld', description: 'Weekend aan zee' }), 5_00_00);
+
+            expect(invoicedItem.name).toBe('Kampgeld');
+            expect(invoicedItem.description).toBe('Weekend aan zee');
+        });
+
+        test('an item without relations and without description is invoiced with an empty description', () => {
+            const invoicedItem = InvoicedBalanceItem.createFor(createBalanceItem({ name: 'Kampgeld', description: null }), 5_00_00);
+
+            expect(invoicedItem.name).toBe('Kampgeld');
+            expect(invoicedItem.description).toBe('');
+        });
+
+        test('an item with relations and without description uses the generated title and description', () => {
+            const balanceItem = createBalanceItem({
+                type: BalanceItemType.Registration,
+                name: 'Jan bij Kapoenen',
+                description: null,
+                relations: new Map([
+                    [BalanceItemRelationType.Group, BalanceItemRelation.create({ id: 'group-1', name: new TranslatedString('Kapoenen') })],
+                    [BalanceItemRelationType.Member, BalanceItemRelation.create({ id: 'member-1', name: new TranslatedString('Jan Janssens') })],
+                ]),
+            });
+            const invoicedItem = InvoicedBalanceItem.createFor(balanceItem, 5_00_00);
+
+            expect(invoicedItem.name).toBe(balanceItem.itemTitle);
+            expect(invoicedItem.description).toBe(balanceItem.itemDescription);
+            expect(invoicedItem.name).not.toBe('Jan bij Kapoenen');
+        });
+
+        test('an item with relations and a description uses its own name and description', () => {
+            const balanceItem = createBalanceItem({
+                type: BalanceItemType.Registration,
+                name: 'Jan bij Kapoenen',
+                description: 'Inclusief kampvuur',
+                relations: new Map([
+                    [BalanceItemRelationType.Group, BalanceItemRelation.create({ id: 'group-1', name: new TranslatedString('Kapoenen') })],
+                ]),
+            });
+            const invoicedItem = InvoicedBalanceItem.createFor(balanceItem, 5_00_00);
+
+            expect(invoicedItem.name).toBe('Jan bij Kapoenen');
+            expect(invoicedItem.description).toBe('Inclusief kampvuur');
+        });
+
         test('Create an invoice item for a balance item including VAT with quantity of 1', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 5_00_00; // 5 euro, including VAT
             balanceItem.quantity = 1;
             balanceItem.VATPercentage = 21;
@@ -29,7 +86,7 @@ describe('InvoicedBalanceItem', () => {
 
         test('Create an invoice item for a balance item including VAT with quantity of 3', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 5_00_00; // 5 euro, including VAT
             balanceItem.quantity = 3;
             balanceItem.VATPercentage = 21;
@@ -107,7 +164,7 @@ describe('InvoicedBalanceItem', () => {
 
         test('Create an invoice item for a balance item excluding VAT with quantity of 1', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 20_00; // 0,20 euro, excluding VAT
             balanceItem.quantity = 1;
             balanceItem.VATPercentage = 21;
@@ -131,7 +188,7 @@ describe('InvoicedBalanceItem', () => {
 
         test('Create an invoice item for a balance item excluding 0% VAT with quantity of 1', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 20_00; // 0,20 euro, excluding VAT
             balanceItem.quantity = 1;
             balanceItem.VATPercentage = 0;
@@ -155,7 +212,7 @@ describe('InvoicedBalanceItem', () => {
 
         test('Create an invoice item for a balance item including 0% VAT with quantity of 1', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 20_00; // 0,20 euro, excluding VAT
             balanceItem.quantity = 1;
             balanceItem.VATPercentage = 0;
@@ -179,7 +236,7 @@ describe('InvoicedBalanceItem', () => {
 
         test('Create an invoice item for a balance item excluding VAT with quantity of 1 that is excempt VAT', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 20_00; // 0,20 euro, excluding VAT
             balanceItem.quantity = 1;
             balanceItem.VATPercentage = 21;
@@ -203,7 +260,7 @@ describe('InvoicedBalanceItem', () => {
 
         test('Create an invoice item for a balance item including VAT with quantity of 1 that is excempt VAT', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 24_20; // 0,242 euro, including VAT
             balanceItem.quantity = 1;
             balanceItem.VATPercentage = 21;
@@ -227,7 +284,7 @@ describe('InvoicedBalanceItem', () => {
 
         test('Paying 1/3 of a balance item causes 33.33% quantity', () => {
             const balanceItem = new BalanceItem();
-            balanceItem.description = 'Test Item';
+            balanceItem.name = 'Test Item';
             balanceItem.unitPrice = 30_00; // = 0,30 euro
             balanceItem.quantity = 1;
             balanceItem.VATPercentage = 21;

--- a/shared/structures/src/billing/InvoicedBalanceItem.ts
+++ b/shared/structures/src/billing/InvoicedBalanceItem.ts
@@ -127,8 +127,13 @@ export class InvoicedBalanceItem extends AutoEncoder {
         const item = new InvoicedBalanceItem();
         item.type = balanceItem.type;
         item.balanceItemId = balanceItem.id;
-        item.name = balanceItem.itemTitle;
-        item.description = balanceItem.itemDescription ?? '';
+        if (balanceItem.relations.size > 0 && !balanceItem.description) {
+            item.name = balanceItem.itemTitle;
+            item.description = balanceItem.itemDescription ?? '';
+        } else {
+            item.name = balanceItem.name || balanceItem.itemTitle;
+            item.description = balanceItem.description ?? '';
+        }
         item.balanceInvoicedAmount = amount;
         item.VATPercentage = balanceItem.VATPercentage;
         item.VATExcempt = balanceItem.VATExcempt;

--- a/shared/structures/src/breakdown/breakdownBuilders.test.ts
+++ b/shared/structures/src/breakdown/breakdownBuilders.test.ts
@@ -1298,12 +1298,12 @@ describe('Breakdown builders', () => {
 
     describe('Keeping the number of rows readable', () => {
         /**
-         * A one-off correction has no relations, so every description is a category of its own.
+         * A one-off correction has no relations, so every name is a category of its own.
          */
         function createCorrection(index: number) {
             return BalanceItem.create({
                 type: BalanceItemType.Other,
-                description: 'Correctie ' + index,
+                name: 'Correctie ' + index,
                 amount: 1,
                 unitPrice: (200 - index) * 100,
             });

--- a/shared/structures/src/circular-dependencies/ExampleReplacementsDependencies.ts
+++ b/shared/structures/src/circular-dependencies/ExampleReplacementsDependencies.ts
@@ -124,11 +124,11 @@ function fillReplacements(replacements: Replacement[]) {
     }));
 
     const balance1 = BalanceItem.create({
-        description: $t(`%13U`),
+        name: $t(`%13U`),
         unitPrice: 1234_00,
     });
     const balance2 = BalanceItem.create({
-        description: $t(`%13V`),
+        name: $t(`%13V`),
         unitPrice: 1234_00,
         amount: 2,
     });

--- a/shared/structures/src/email/exampleReplacements.ts
+++ b/shared/structures/src/email/exampleReplacements.ts
@@ -56,13 +56,13 @@ function getReplacements() {
     const textPlaceholder = $t(`%13X`);
 
     const exampleBalanceItem = BalanceItem.create({
-        description: $t('%Ze8'),
+        name: $t('%Ze8'),
         amount: 3,
         unitPrice: 80000,
     });
 
     const exampleBalanceItem2 = BalanceItem.create({
-        description: $t('%Ze7'),
+        name: $t('%Ze7'),
         amount: 1,
         unitPrice: 150000,
     });

--- a/shared/structures/src/endpoints/ChargeRequest.ts
+++ b/shared/structures/src/endpoints/ChargeRequest.ts
@@ -3,8 +3,12 @@ import { StamhoofdFilterDecoder } from '../filters/FilteredRequest.js';
 import type { StamhoofdFilter } from '../filters/StamhoofdFilter.js';
 
 export class ChargeRequest extends AutoEncoder {
-    @field({ decoder: StringDecoder })
-    description: string;
+    @field({ decoder: StringDecoder, field: 'description' })
+    @field({ decoder: StringDecoder, field: 'name', ...NextVersion })
+    name: string;
+
+    @field({ decoder: StringDecoder, nullable: true, ...NextVersion })
+    description: string | null = null;
 
     @field({ decoder: NumberDecoder })
     price: number;

--- a/shared/structures/src/members/PaymentGeneral.ts
+++ b/shared/structures/src/members/PaymentGeneral.ts
@@ -164,12 +164,12 @@ export class PaymentGeneral extends PrivatePayment {
     }
 }
 
-export type BalanceItemPaymentsHtmlTableItem = { price: number; itemDescription: string | null; balanceItem: { description: string }; itemTitle: string; quantity: number; unitPrice: number };
+export type BalanceItemPaymentsHtmlTableItem = { price: number; itemDescription: string | null; balanceItem: { name: string }; itemTitle: string; quantity: number; unitPrice: number };
 export function getBalanceItemPaymentsHtmlTable(balanceItemPayments: BalanceItemPaymentsHtmlTableItem[]) {
     const payments = balanceItemPayments.slice().sort((a, b) => {
         return Sorter.stack(
             Sorter.byNumberValue(a.price, b.price),
-            Sorter.byStringValue(a.itemDescription ?? a.balanceItem.description, b.itemDescription ?? b.balanceItem.description),
+            Sorter.byStringValue(a.itemDescription ?? a.balanceItem.name, b.itemDescription ?? b.balanceItem.name),
         );
     });
 

--- a/tests/playwright/src/tests/bulk-refund-payments.spec.ts
+++ b/tests/playwright/src/tests/bulk-refund-payments.spec.ts
@@ -93,7 +93,7 @@ test.describe('Bulk refund payments @bulk-refund-payments', () => {
 
         const balanceItem = await new BalanceItemFactory({
             organizationId: organization.id,
-            description,
+            name: description,
             amount: 1,
             unitPrice: price,
             pricePaid: succeeded ? price : 0,

--- a/tests/playwright/src/tests/member-portal-pay-balance.spec.ts
+++ b/tests/playwright/src/tests/member-portal-pay-balance.spec.ts
@@ -43,7 +43,7 @@ test.describe('Member portal - pay outstanding balance @member-portal-pay-balanc
             organizationId: organization.id,
             memberId: member.id,
             type: BalanceItemType.Other,
-            description: 'Kamp',
+            name: 'Kamp',
             amount: 1,
             unitPrice: 30_0000,
         }).create();
@@ -52,7 +52,7 @@ test.describe('Member portal - pay outstanding balance @member-portal-pay-balanc
             organizationId: organization.id,
             memberId: member.id,
             type: BalanceItemType.Other,
-            description: 'Uniform',
+            name: 'Uniform',
             amount: 1,
             unitPrice: 20_0000,
         }).create();
@@ -61,7 +61,7 @@ test.describe('Member portal - pay outstanding balance @member-portal-pay-balanc
             organizationId: organization.id,
             memberId: member.id,
             type: BalanceItemType.Other,
-            description: 'Terugbetaling weekend',
+            name: 'Terugbetaling weekend',
             amount: 1,
             unitPrice: -10_0000,
         }).create();

--- a/tests/playwright/src/tests/receivable-balance-invoices.spec.ts
+++ b/tests/playwright/src/tests/receivable-balance-invoices.spec.ts
@@ -89,7 +89,7 @@ test.describe('Receivable balance invoices', () => {
             memberId: member.id,
             amount: 1,
             unitPrice: 40_00_00,
-            description: 'Kampinschrijving',
+            name: 'Kampinschrijving',
         }).create();
 
         // A VAT percentage is required to invoice a balance item

--- a/tests/playwright/src/tests/receivable-balances.spec.ts
+++ b/tests/playwright/src/tests/receivable-balances.spec.ts
@@ -286,7 +286,7 @@ test.describe('Balance items (organization mode) @balance-items', () => {
 
         const member = await new MemberFactory({ organization, firstName: 'Dupli', lastName: 'Cate' }).create();
 
-        const description = `Duplicate Test Item ${WorkerData.id}`;
+        const name = `Duplicate Test Item ${WorkerData.id}`;
 
         // A single manual (Other) balance item of 25 euro that is due
         await new BalanceItemFactory({
@@ -296,7 +296,7 @@ test.describe('Balance items (organization mode) @balance-items', () => {
             status: BalanceItemStatus.Due,
             amount: 1,
             unitPrice: 25_0000,
-            description,
+            name,
         }).create();
 
         // Make sure the member shows up in the receivable balances table
@@ -317,7 +317,7 @@ test.describe('Balance items (organization mode) @balance-items', () => {
         await table.getRow('Dupli Cate').click();
 
         // The manual balance item is shown in the individual list
-        const itemRow = page.getByText(description).first();
+        const itemRow = page.getByText(name).first();
         await expect(itemRow).toBeVisible();
 
         // Right-clicking an individual item shows a context menu with Edit + Duplicate
@@ -337,11 +337,11 @@ test.describe('Balance items (organization mode) @balance-items', () => {
         // The organization now has two identical balance items (original + duplicate)
         await expect.poll(async () => {
             const items = await BalanceItem.select().where('organizationId', organization.id).fetch();
-            return items.filter(i => i.description === description).length;
+            return items.filter(i => i.name === name).length;
         }).toBe(2);
 
         const items = await BalanceItem.select().where('organizationId', organization.id).fetch();
-        const duplicates = items.filter(i => i.description === description);
+        const duplicates = items.filter(i => i.name === name);
         expect(duplicates).toHaveLength(2);
 
         // Both are fresh, fully payable items with the same price and no paid amount
@@ -364,7 +364,7 @@ test.describe('Balance items (organization mode) @balance-items', () => {
 
         const member = await new MemberFactory({ organization, firstName: 'Dele', lastName: 'Table' }).create();
 
-        const description = `Delete Test Item ${WorkerData.id}`;
+        const name = `Delete Test Item ${WorkerData.id}`;
 
         // A single manual (Other) balance item of 40 euro that is due and unpaid
         const item = await new BalanceItemFactory({
@@ -374,7 +374,7 @@ test.describe('Balance items (organization mode) @balance-items', () => {
             status: BalanceItemStatus.Due,
             amount: 1,
             unitPrice: 40_0000,
-            description,
+            name,
         }).create();
 
         // Make sure the member shows up in the receivable balances table
@@ -394,7 +394,7 @@ test.describe('Balance items (organization mode) @balance-items', () => {
         await table.waitForFirstRow();
         await table.getRow('Dele Table').click();
 
-        const itemRow = page.getByText(description).first();
+        const itemRow = page.getByText(name).first();
         await expect(itemRow).toBeVisible();
 
         // An unpaid item offers Delete (and not Cancel, which is reserved for (partially) paid items)
@@ -413,7 +413,7 @@ test.describe('Balance items (organization mode) @balance-items', () => {
             return updated?.status ?? null;
         }).toBe(BalanceItemStatus.Hidden);
 
-        await expect(page.getByText(description)).toHaveCount(0);
+        await expect(page.getByText(name)).toHaveCount(0);
         await expect(page.getByText('Geen openstaand bedrag')).toBeVisible();
     });
 });

--- a/tests/playwright/src/tests/registration-platform.spec.ts
+++ b/tests/playwright/src/tests/registration-platform.spec.ts
@@ -616,7 +616,7 @@ test.describe('Registration', () => {
                     organizationId: creditOrganization.id,
                     memberId: member.id,
                     type: BalanceItemType.Other,
-                    description: creditName,
+                    name: creditName,
                     amount: 1,
                     unitPrice: -40_0000,
                 }).create();


### PR DESCRIPTION
- BalanceItem \`description\` → \`name\` (DB column, model, structure). Old clients keep reading/writing the name through the \`description\` key via a versioned field.
- New nullable \`description\` column, edited with an optional textarea in the balance item view.
- Invoicing copies name and description. Items with relations and an empty description keep the generated title/description.

Notes:
- Deploy migrations together with the code: an old API instance would read the new empty \`description\` as the title after the rename.
- External SQL (Metabase) on \`balance_items.description\` must switch to \`name\`.
- The new description is not yet shown in item rows, only in the edit view and on invoices.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790944191&installation_model_id=423362&pr_number=841&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F841&signature=8329e0431ac8c8fffc97c0053375b1d2a0322a8442ac35837370de10fbf5786a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->