### PR TITLE
✨ Added support for multiple images on a product

### DIFF
--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/EditProductView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/EditProductView.vue
@@ -877,21 +877,6 @@ const images = computed<Image[]>({
     },
 });
 
-const editImage = (index: number) => computed({
-    get: () => patchedProduct.value.images[index] ?? null,
-    set: (image: Image | null) => {
-        if (image) {
-            const p = Product.patch({});
-
-            const originalImage = patchedProduct.value.images[index];
-            if (originalImage) {
-                p.images.addDelete(originalImage.id);
-                p.images.addPut(image);
-            }
-        }
-    },
-});
-
 const newImage = computed({
     get: () => null,
     set: (image: Image | null) => {
@@ -907,30 +892,6 @@ const newImage = computed({
 const getImageSrc = (image: Image) => {
     return image.getPathForSize(140, undefined);
 };
-
-// const image = computed<Image | null>({
-//     get: () => patchedProduct.value.images[0] ?? null,
-//     set: (image: Image | null) => {
-//         const p = Product.patch({ });
-
-//         for (const i of patchedProduct.value.images) {
-//             p.images.addDelete(i.id);
-//         }
-
-//         if (image) {
-//             p.images.addPut(image);
-//         }
-
-//         addProductPatch(p);
-//     },
-// });
-
-// const imageSrc = computed(() => {
-//     if (!image.value) {
-//         return null;
-//     }
-//     return image.value.getPathForSize(140, undefined);
-// });
 
 function addOptionMenu() {
     const optionMenu = OptionMenu.create({

--- a/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/EditProductView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/edit/products/EditProductView.vue
@@ -210,12 +210,12 @@
                 </p>
             </STListItem>
 
-            <STListItem v-if="!image" :selectable="true" element-name="label" class="button">
+            <STListItem v-if="images.length === 0" :selectable="true" element-name="label" class="button">
                 <template #left>
                     <span class="icon camera gray" />
                 </template>
 
-                <UploadButton v-model="image" :resolutions="resolutions" element-name="div">
+                <UploadButton v-model="newImage" :resolutions="resolutions" element-name="div">
                     <h3 class="style-title-list">
                         {{ $t('%Tf') }}
                     </h3>
@@ -226,20 +226,32 @@
             </STListItem>
         </STList>
 
-        <template v-if="image">
-            <hr><h2 class="style-with-button">
-                <div>{{ $t('%Tg') }}</div>
+        <template v-if="images.length > 0">
+            <hr>
+            <h2 class="style-with-button">
+                <div>{{ $t('Foto\'s') }}</div>
                 <div>
-                    <button v-if="image" type="button" class="button text only-icon-smartphone" @click="image = null">
+                    <button type="button" class="button text only-icon-smartphone" @click="images = []">
                         <span class="icon trash" />
-                        <span>{{ $t('%CJ') }}</span>
+                        <span>{{ $t('Allemaal verwijderen') }}</span>
                     </button>
-                    <UploadButton v-model="image" :text="image ? $t(`%He`) : $t(`%Hf`)" :resolutions="resolutions" />
+
+                    <UploadButton v-model="newImage" :text="$t(`Extra uploaden`)" :resolutions="resolutions" />
                 </div>
             </h2>
+            <p>{{ $t('De eerste foto zal gebruikt worden als omslagfoto van dit product.') }}</p>
 
-            <div class="image-box">
-                <img v-if="image" :src="imageSrc ?? undefined" class="image">
+            <div class="images-box">
+                <div v-for="image, index in images" :key="image.id" class="image-box">
+                    <img :src="getImageSrc(image)" class="image">
+
+                    <div class="image-box-actions">
+                        <button type="button" class="button text only-icon-smartphone" @click="images.splice(index, 1)">
+                            <span class="icon trash" />
+                            <span>{{ $t('Verwijderen') }}</span>
+                        </button>
+                    </div>
+                </div>
             </div>
         </template>
 
@@ -846,29 +858,79 @@ const resolutions = computed(() => [
     }),
 ]);
 
-const image = computed<Image | null>({
-    get: () => patchedProduct.value.images[0] ?? null,
-    set: (image: Image | null) => {
-        const p = Product.patch({ });
+const images = computed<Image[]>({
+    get: () => patchedProduct.value.images,
+    set: (images: Image[]) => {
+        const p = Product.patch({});
 
         for (const i of patchedProduct.value.images) {
             p.images.addDelete(i.id);
         }
 
-        if (image) {
-            p.images.addPut(image);
+        if (images.length > 0) {
+            for (const image of images) {
+                p.images.addPut(image);
+            }
         }
 
         addProductPatch(p);
     },
 });
 
-const imageSrc = computed(() => {
-    if (!image.value) {
-        return null;
-    }
-    return image.value.getPathForSize(140, undefined);
+const editImage = (index: number) => computed({
+    get: () => patchedProduct.value.images[index] ?? null,
+    set: (image: Image | null) => {
+        if (image) {
+            const p = Product.patch({});
+
+            const originalImage = patchedProduct.value.images[index];
+            if (originalImage) {
+                p.images.addDelete(originalImage.id);
+                p.images.addPut(image);
+            }
+        }
+    },
 });
+
+const newImage = computed({
+    get: () => null,
+    set: (image: Image | null) => {
+        if (image) {
+            const p = Product.patch({});
+            p.images.addPut(image);
+
+            addProductPatch(p);
+        }
+    },
+});
+
+const getImageSrc = (image: Image) => {
+    return image.getPathForSize(140, undefined);
+};
+
+// const image = computed<Image | null>({
+//     get: () => patchedProduct.value.images[0] ?? null,
+//     set: (image: Image | null) => {
+//         const p = Product.patch({ });
+
+//         for (const i of patchedProduct.value.images) {
+//             p.images.addDelete(i.id);
+//         }
+
+//         if (image) {
+//             p.images.addPut(image);
+//         }
+
+//         addProductPatch(p);
+//     },
+// });
+
+// const imageSrc = computed(() => {
+//     if (!image.value) {
+//         return null;
+//     }
+//     return image.value.getPathForSize(140, undefined);
+// });
 
 function addOptionMenu() {
     const optionMenu = OptionMenu.create({
@@ -1070,21 +1132,55 @@ defineExpose({ shouldNavigateAway });
 @use "@stamhoofd/scss/base/variables.scss" as *;
 
 .product-edit-view {
-    .image-box {
-        margin: 0 -5px;
+    .images-box {
         display: flex;
-        flex-direction: row;
         flex-wrap: wrap;
-        overflow: hidden;
+        gap: 15px;
 
-        img.image {
-            margin: 5px;
-            max-height: 140px;
-            max-width: 100%;
-            border-radius: $border-radius;
-            align-self: flex-start;
+        .image-box {
+            position: relative;
+            margin: 0 -5px;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            overflow: hidden;
+
+            img.image {
+                margin: 5px;
+                max-height: 140px;
+                max-width: 100%;
+                border-radius: $border-radius;
+                align-self: flex-start;
+            }
+
+            .image-box-actions {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                flex-direction: column;
+
+                background-color: rgba(0, 0, 0, .75);
+                border-radius: $border-radius;
+
+                opacity: 0;
+                pointer-events: none;
+
+                transition: opacity .2s ease-out;
+            }
+
+            &:hover{
+                .image-box-actions {
+                    opacity: 1;
+                    pointer-events: all;
+                }
+            }
         }
     }
-
 }
 </style>

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -448,9 +448,6 @@ const suffix = computed(() => {
     return props.cartItem.product.type === ProductType.Person ? $t(`%12R`) : $t(`%12S`);
 });
 
-const image = computed(() => props.cartItem.product.images[0]?.getResolutionForSize(600, undefined));
-const imageSrc = computed(() => image.value?.file?.getPublicPath());
-
 const images = computed(() => props.cartItem.product.images.map(i => i.getResolutionForSize(600, undefined)));
 const imagesSrc = computed(() => images.value.map(i => i.file.getPublicPath()));
 

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -11,20 +11,48 @@
         <main>
             <h1>{{ cartItem.product.name }}</h1>
 
-            <figure v-if="imagesSrc.length > 0" class="images-box">
-                <div
-                    v-for="src, index in imagesSrc"
-                    :key="index"
-                    class="image-box"
-                >
-                    <img
-
-                        :src="src"
-                        :width="images[index].width"
-                        :height="images[index].height"
+            <div v-if="imagesSrc.length > 0" class="images-box">
+                <div ref="imagesContainer" class="images-box-images">
+                    <figure
+                        v-for="src, index in imagesSrc"
+                        :key="index"
+                        ref="imageBoxes"
+                        class="image-box"
                     >
+                        <img
+                            :src="src"
+                            :width="images[index].width"
+                            :height="images[index].height"
+                        >
+                    </figure>
                 </div>
-            </figure>
+                <div v-if="imagesSrc.length > 1" class="images-box-actions">
+                    <button
+                        type="button"
+                        :class="['button icon arrow-left', currentImage === 0 ? 'hide' : '']"
+                        @click="currentImage--"
+                    />
+
+                    <div class="thumbnails">
+                        <div
+                            v-for="_, index in imagesSrc"
+                            :key="index"
+                            :class="['thumbnail', currentImage === index ? 'active' : '']"
+                            @click="currentImage = index"
+                        >
+                            <img
+                                :src="imagesSrc[index]"
+                            >
+                        </div>
+                    </div>
+
+                    <button
+                        type="button"
+                        :class="['button icon arrow-right', currentImage === imagesSrc.length - 1 ? 'hide' : '']"
+                        @click="currentImage++"
+                    />
+                </div>
+            </div>
             <p v-if="cartItem.product.description" class="description" v-text="cartItem.product.description" />
 
             <p v-if="oldItem && oldItem.cartError" class="error-box small">
@@ -450,6 +478,19 @@ const suffix = computed(() => {
 
 const images = computed(() => props.cartItem.product.images.map(i => i.getResolutionForSize(600, undefined)));
 const imagesSrc = computed(() => images.value.map(i => i.file.getPublicPath()));
+const currentImage = ref(0);
+const imagesContainer = ref<HTMLElement>();
+const imageBoxes = ref<HTMLElement[]>();
+
+watch(currentImage, () => {
+    if (imageBoxes.value && imagesContainer.value) {
+        const offset = imageBoxes.value[currentImage.value]?.offsetLeft ?? 0;
+        imagesContainer.value.scroll({
+            left: offset,
+            behavior: 'smooth',
+        });
+    }
+});
 
 const product = computed(() => props.cartItem.product);
 const remainingReduced = computed(() => {
@@ -590,36 +631,90 @@ defineExpose({
     }
 
     .images-box {
-        position: relative;
-        overflow: hidden;
-        overflow-x: auto;
-        scroll-snap-type: x mandatory;
-
-        display: flex;
-        align-items: center;
-        flex-direction: row;
-        gap: 15px;
-        width: 100%;
-
-        .image-box {
-            min-width: 100%;
+        .images-box-images {
+            position: relative;
             overflow: hidden;
-            border-radius: $border-radius;
-            scroll-snap-align: center;
+            overflow-x: auto;
+            scroll-snap-type: x mandatory;
 
-            > div {
-                display: flex;
-                flex-direction: row;
-                justify-content: center;
+            display: flex;
+            align-items: center;
+            flex-direction: row;
+            gap: 15px;
+            width: 100%;
+
+            &::-webkit-scrollbar {
+                display: none;
             }
 
-            img {
-                height: auto;
-                max-width: 100%;
+            .image-box {
+                min-width: 100%;
+                overflow: hidden;
                 border-radius: $border-radius;
-                object-fit: cover;
+                scroll-snap-align: center;
+
+                > div {
+                    display: flex;
+                    flex-direction: row;
+                    justify-content: center;
+                }
+
+                img {
+                    height: auto;
+                    max-width: 100%;
+                    border-radius: $border-radius;
+                    object-fit: cover;
+                }
             }
         }
+
+        .images-box-actions {
+            margin-top: 15px;
+            width: 100%;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+
+            .button {
+                transition: opacity .2s ease-out;
+
+                &.hide {
+                    opacity: 0;
+                    pointer-events: none;
+                }
+            }
+
+            .thumbnails {
+                display: flex;
+                gap: 5px;
+
+                .thumbnail {
+                    border-radius: $border-radius;
+                    border: 2px solid $color-border;
+                    width: 32px;
+                    height: 32px;
+                    cursor: pointer;
+
+                    transition: border-color .2s ease-out;
+
+                    &:hover {
+                        border-color: $color-border-shade-darker;
+                    }
+
+                    &.active {
+                        border-color: $color-primary;
+                    }
+
+                    img {
+                        object-fit: cover;
+                        width: 100%;
+                        height: 100%;
+                        border-radius: $border-radius;
+                    }
+                }
+            }
+        }
+
     }
 
     .image {

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -691,9 +691,9 @@ defineExpose({
                 .thumbnail {
                     border-radius: $border-radius;
                     border: 2px solid $color-border;
-                    width: 32px;
-                    height: 32px;
                     cursor: pointer;
+                    display: grid;
+                    place-content: center;
 
                     transition: border-color .2s ease-out;
 
@@ -706,10 +706,10 @@ defineExpose({
                     }
 
                     img {
-                        object-fit: cover;
-                        width: 100%;
-                        height: 100%;
-                        border-radius: $border-radius;
+                        object-fit: fill;
+                        height: 48px;
+                        border-radius: $border-radius / 2;
+                        margin: 2px;
                     }
                 }
             }

--- a/frontend/shared/components/src/views/CartItemView.vue
+++ b/frontend/shared/components/src/views/CartItemView.vue
@@ -11,9 +11,18 @@
         <main>
             <h1>{{ cartItem.product.name }}</h1>
 
-            <figure v-if="imageSrc" class="image-box">
-                <div>
-                    <img :src="imageSrc" :width="image.width" :height="image.height">
+            <figure v-if="imagesSrc.length > 0" class="images-box">
+                <div
+                    v-for="src, index in imagesSrc"
+                    :key="index"
+                    class="image-box"
+                >
+                    <img
+
+                        :src="src"
+                        :width="images[index].width"
+                        :height="images[index].height"
+                    >
                 </div>
             </figure>
             <p v-if="cartItem.product.description" class="description" v-text="cartItem.product.description" />
@@ -441,6 +450,10 @@ const suffix = computed(() => {
 
 const image = computed(() => props.cartItem.product.images[0]?.getResolutionForSize(600, undefined));
 const imageSrc = computed(() => image.value?.file?.getPublicPath());
+
+const images = computed(() => props.cartItem.product.images.map(i => i.getResolutionForSize(600, undefined)));
+const imagesSrc = computed(() => images.value.map(i => i.file.getPublicPath()));
+
 const product = computed(() => props.cartItem.product);
 const remainingReduced = computed(() => {
     if (props.cartItem.productPrice.discountPrice === null) {
@@ -579,24 +592,39 @@ defineExpose({
        --st-horizontal-padding: 25px;
     }
 
-    .image-box {
+    .images-box {
         position: relative;
         overflow: hidden;
-        border-radius: $border-radius;
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
 
-        > div {
-            display: flex;
-            flex-direction: row;
-            justify-content: center;
-        }
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+        gap: 15px;
+        width: 100%;
 
-        img {
-            height: auto;
-            max-width: 100%;
+        .image-box {
+            min-width: 100%;
+            overflow: hidden;
             border-radius: $border-radius;
-            object-fit: cover;
+            scroll-snap-align: center;
+
+            > div {
+                display: flex;
+                flex-direction: row;
+                justify-content: center;
+            }
+
+            img {
+                height: auto;
+                max-width: 100%;
+                border-radius: $border-radius;
+                object-fit: cover;
+            }
         }
     }
+
     .image {
         width: 100%;
         border-radius: $border-radius;


### PR DESCRIPTION
Voegt de mogelijkheid toe aan producten om meerdere foto's toe te voegen. Dit was al voorzien in de `Product`-structure, maar de frontend liet het niet toe.

<img width="782" height="262" alt="image" src="https://github.com/user-attachments/assets/88d45094-a40c-4aaf-acc3-6a1fe1786f04" />

https://github.com/user-attachments/assets/eaf5dab6-91e0-422b-b927-c59d941a840e

In de webshop worden ze naast elkaar getoond met `scroll-snap-type: x mandatory`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948473&installation_model_id=423362&pr_number=842&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F842&signature=ea87e5803bd0e526a25594e5a7cf2fb057a666e9ec8761536a9a51d7f1373572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->