### PR TITLE
Add description and VAT options to bulk charge view

### DIFF
--- a/backend/app/api/src/endpoints/admin/members/ChargeMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/admin/members/ChargeMembersEndpoint.ts
@@ -98,6 +98,9 @@ export class ChargeMembersEndpoint extends Endpoint<Params, Query, Body, Respons
                     amount: body.amount ?? 1,
                     name: body.name,
                     description: body.description,
+                    VATPercentage: body.VATPercentage,
+                    VATIncluded: body.VATIncluded,
+                    VATExcempt: body.VATExcempt,
                     dueAt: body.dueAt,
                     createdAt: body.createdAt,
                 });

--- a/backend/app/api/src/endpoints/admin/organizations/ChargeOrganizationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/admin/organizations/ChargeOrganizationsEndpoint.ts
@@ -69,6 +69,9 @@ export class ChargeOrganizationsEndpoint extends Endpoint<Params, Query, Body, R
                     amount: body.amount ?? 1,
                     name: body.name,
                     description: body.description,
+                    VATPercentage: body.VATPercentage,
+                    VATIncluded: body.VATIncluded,
+                    VATExcempt: body.VATExcempt,
                     dueAt: body.dueAt,
                     createdAt: body.createdAt,
                 });

--- a/backend/app/api/src/endpoints/admin/registrations/ChargeRegistrationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/admin/registrations/ChargeRegistrationsEndpoint.ts
@@ -78,6 +78,9 @@ export class ChargeRegistrationsEndpoint extends Endpoint<Params, Query, Body, R
                             amount: body.amount ?? 1,
                             name: body.name,
                             description: body.description,
+                            VATPercentage: body.VATPercentage,
+                            VATIncluded: body.VATIncluded,
+                            VATExcempt: body.VATExcempt,
                             dueAt: body.dueAt,
                             createdAt: body.createdAt,
                         });

--- a/backend/app/api/src/helpers/MemberCharger.ts
+++ b/backend/app/api/src/helpers/MemberCharger.ts
@@ -1,14 +1,17 @@
 import { BalanceItem } from '@stamhoofd/models';
-import type { MemberWithRegistrationsBlob } from '@stamhoofd/structures';
+import type { MemberWithRegistrationsBlob, VATExcemptReason } from '@stamhoofd/structures';
 import { BalanceItemType } from '@stamhoofd/structures';
 
 export class MemberCharger {
-    static async chargeMany({ chargingOrganizationId, membersToCharge, price, amount, name, description, dueAt, createdAt }: { chargingOrganizationId: string; membersToCharge: MemberWithRegistrationsBlob[]; price: number; amount?: number; name: string; description: string | null; dueAt: Date | null; createdAt: Date | null }) {
+    static async chargeMany({ chargingOrganizationId, membersToCharge, price, amount, name, description, VATPercentage, VATIncluded, VATExcempt, dueAt, createdAt }: { chargingOrganizationId: string; membersToCharge: MemberWithRegistrationsBlob[]; price: number; amount?: number; name: string; description: string | null; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; dueAt: Date | null; createdAt: Date | null }) {
         await Promise.all(membersToCharge.map(memberToCharge => MemberCharger.charge({
             price,
             amount,
             name,
             description,
+            VATPercentage,
+            VATIncluded,
+            VATExcempt,
             chargingOrganizationId,
             memberToCharge,
             dueAt,
@@ -16,12 +19,15 @@ export class MemberCharger {
         })));
     }
 
-    static async charge({ chargingOrganizationId, memberToCharge, price, amount, name, description, dueAt, createdAt }: { chargingOrganizationId: string; memberToCharge: MemberWithRegistrationsBlob; price: number; amount?: number; name: string; description: string | null; dueAt: Date | null; createdAt: Date | null }) {
+    static async charge({ chargingOrganizationId, memberToCharge, price, amount, name, description, VATPercentage, VATIncluded, VATExcempt, dueAt, createdAt }: { chargingOrganizationId: string; memberToCharge: MemberWithRegistrationsBlob; price: number; amount?: number; name: string; description: string | null; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; dueAt: Date | null; createdAt: Date | null }) {
         const balanceItem = MemberCharger.createBalanceItem({
             price,
             amount,
             name,
             description,
+            VATPercentage,
+            VATIncluded,
+            VATExcempt,
             chargingOrganizationId,
             memberBeingCharged: memberToCharge,
             dueAt,
@@ -31,12 +37,15 @@ export class MemberCharger {
         await balanceItem.save();
     }
 
-    private static createBalanceItem({ price, amount, name, description, chargingOrganizationId, memberBeingCharged, dueAt, createdAt }: { price: number; amount?: number; name: string; description: string | null; chargingOrganizationId: string; memberBeingCharged: MemberWithRegistrationsBlob; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
+    private static createBalanceItem({ price, amount, name, description, VATPercentage, VATIncluded, VATExcempt, chargingOrganizationId, memberBeingCharged, dueAt, createdAt }: { price: number; amount?: number; name: string; description: string | null; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; chargingOrganizationId: string; memberBeingCharged: MemberWithRegistrationsBlob; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
         const balanceItem = new BalanceItem();
         balanceItem.unitPrice = price;
         balanceItem.amount = amount ?? 1;
         balanceItem.name = name;
         balanceItem.description = description;
+        balanceItem.VATPercentage = VATPercentage;
+        balanceItem.VATIncluded = VATIncluded;
+        balanceItem.VATExcempt = VATExcempt;
         balanceItem.type = BalanceItemType.Other;
         balanceItem.memberId = memberBeingCharged.id;
         balanceItem.organizationId = chargingOrganizationId;

--- a/backend/app/api/src/helpers/OrganizationCharger.ts
+++ b/backend/app/api/src/helpers/OrganizationCharger.ts
@@ -1,14 +1,17 @@
 import { BalanceItem } from '@stamhoofd/models';
-import type { Organization as OrganizationStruct } from '@stamhoofd/structures';
+import type { Organization as OrganizationStruct, VATExcemptReason } from '@stamhoofd/structures';
 import { BalanceItemType } from '@stamhoofd/structures';
 
 export class OrganizationCharger {
-    static async chargeMany({ chargingOrganizationId, organizationsToCharge, price, amount, name, description, dueAt, createdAt }: { chargingOrganizationId: string; organizationsToCharge: OrganizationStruct[]; price: number; amount?: number; name: string; description: string | null; dueAt: Date | null; createdAt: Date | null }) {
+    static async chargeMany({ chargingOrganizationId, organizationsToCharge, price, amount, name, description, VATPercentage, VATIncluded, VATExcempt, dueAt, createdAt }: { chargingOrganizationId: string; organizationsToCharge: OrganizationStruct[]; price: number; amount?: number; name: string; description: string | null; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; dueAt: Date | null; createdAt: Date | null }) {
         const balanceItems = organizationsToCharge.map(organizationBeingCharged => OrganizationCharger.createBalanceItem({
             price,
             amount,
             name,
             description,
+            VATPercentage,
+            VATIncluded,
+            VATExcempt,
             chargingOrganizationId,
             organizationBeingCharged,
             dueAt,
@@ -18,12 +21,15 @@ export class OrganizationCharger {
         await Promise.all(balanceItems.map(balanceItem => balanceItem.save()));
     }
 
-    private static createBalanceItem({ price, amount, name, description, chargingOrganizationId, organizationBeingCharged, dueAt, createdAt }: { price: number; amount?: number; name: string; description: string | null; chargingOrganizationId: string; organizationBeingCharged: OrganizationStruct; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
+    private static createBalanceItem({ price, amount, name, description, VATPercentage, VATIncluded, VATExcempt, chargingOrganizationId, organizationBeingCharged, dueAt, createdAt }: { price: number; amount?: number; name: string; description: string | null; VATPercentage: number | null; VATIncluded: boolean; VATExcempt: VATExcemptReason | null; chargingOrganizationId: string; organizationBeingCharged: OrganizationStruct; dueAt: Date | null; createdAt: Date | null }): BalanceItem {
         const balanceItem = new BalanceItem();
         balanceItem.unitPrice = price;
         balanceItem.amount = amount ?? 1;
         balanceItem.name = name;
         balanceItem.description = description;
+        balanceItem.VATPercentage = VATPercentage;
+        balanceItem.VATIncluded = VATIncluded;
+        balanceItem.VATExcempt = VATExcempt;
         balanceItem.type = BalanceItemType.Other;
         balanceItem.payingOrganizationId = organizationBeingCharged.id;
         balanceItem.organizationId = chargingOrganizationId;

--- a/backend/app/api/tests/e2e/charge-members.test.ts
+++ b/backend/app/api/tests/e2e/charge-members.test.ts
@@ -2,7 +2,7 @@ import { Request, Response } from '@simonbackx/simple-endpoints';
 import type { Organization, RegistrationPeriod, Token } from '@stamhoofd/models';
 import { GroupFactory, MemberFactory, OrganizationFactory, RegistrationFactory, RegistrationPeriodFactory, UserFactory } from '@stamhoofd/models';
 import type { BalanceItemWithPayments, StamhoofdFilter } from '@stamhoofd/structures';
-import { AccessRight, ChargeRequest, LimitedFilteredRequest, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions, Version } from '@stamhoofd/structures';
+import { AccessRight, ChargeRequest, LimitedFilteredRequest, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions, VATExcemptReason, Version } from '@stamhoofd/structures';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { ChargeMembersEndpoint } from '../../src/endpoints/admin/members/ChargeMembersEndpoint.js';
 import { testServer } from '../helpers/TestServer.js';
@@ -203,6 +203,36 @@ describe('E2E.ChargeMembers', () => {
 
         testBalanceResponse(await getBalance(member1.id, organization, financialDirectorToken));
         testBalanceResponse(await getBalance(member2.id, organization, financialDirectorToken));
+    });
+
+    test('Should store VAT settings on created balance items', async () => {
+        const member = await new MemberFactory({ }).create();
+        await new RegistrationFactory({ member, organization }).create();
+
+        const filter: StamhoofdFilter = {
+            id: member.id,
+        };
+
+        const body = ChargeRequest.create({
+            name: 'test name',
+            price: 10_00,
+            amount: 2,
+            VATPercentage: 21,
+            VATIncluded: false,
+            VATExcempt: VATExcemptReason.IntraCommunityServices,
+        });
+
+        await postCharge(filter, organization, body, financialDirectorToken);
+
+        const response = await getBalance(member.id, organization, financialDirectorToken);
+        expect(response.length).toBe(1);
+        const balanceItem = response[0];
+        expect(balanceItem.VATPercentage).toBe(21);
+        expect(balanceItem.VATIncluded).toBe(false);
+        expect(balanceItem.VATExcempt).toBe(VATExcemptReason.IntraCommunityServices);
+        expect(balanceItem.priceWithoutVAT).toBe(20_00);
+        // VAT is kept at zero while the exemption applies
+        expect(balanceItem.priceWithVAT).toBe(20_00);
     });
 
     test('Should not charge members of other organization', async () => {

--- a/backend/app/api/tests/e2e/charge-organizations.test.ts
+++ b/backend/app/api/tests/e2e/charge-organizations.test.ts
@@ -1,0 +1,95 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Organization } from '@stamhoofd/models';
+import { BalanceItem, OrganizationFactory } from '@stamhoofd/models';
+import { BalanceItemType, ChargeRequest, VATExcemptReason, Version } from '@stamhoofd/structures';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+import { ChargeOrganizationsEndpoint } from '../../src/endpoints/admin/organizations/ChargeOrganizationsEndpoint.js';
+import { testServer } from '../helpers/TestServer.js';
+import { initPlatformAdmin } from '../init/initPlatformAdmin.js';
+import { initMembershipOrganization } from '../init/initMembershipOrganization.js';
+import { SessionService } from '../../src/services/SessionService.js';
+import { UserFactory } from '@stamhoofd/models';
+
+describe('E2E.ChargeOrganizations', () => {
+    const endpoint = new ChargeOrganizationsEndpoint();
+    let chargingOrganization: Organization;
+
+    const postCharge = async (body: ChargeRequest, accessToken: string) => {
+        const request = Request.buildJson('POST', `/v${Version}/admin/charge-organizations`, chargingOrganization.getApiHost(), body);
+        request.headers.authorization = 'Bearer ' + accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    const getBalanceItems = async (organization: Organization) => {
+        return await BalanceItem.select().where('payingOrganizationId', organization.id).fetch();
+    };
+
+    beforeEach(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    beforeAll(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+        chargingOrganization = await initMembershipOrganization();
+    });
+
+    test('Should create balance items with description and VAT settings for organizations', async () => {
+        const { adminToken } = await initPlatformAdmin();
+        const organization1 = await new OrganizationFactory({}).create();
+        const organization2 = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+
+        const body = ChargeRequest.create({
+            name: 'test name',
+            description: 'test description',
+            price: 10_00,
+            amount: 2,
+            VATPercentage: 21,
+            VATIncluded: false,
+            VATExcempt: VATExcemptReason.IntraCommunityServices,
+            dueAt: new Date(2023, 0, 10),
+            createdAt: new Date(2023, 0, 4),
+            filter: { id: { $in: [organization1.id, organization2.id] } },
+        });
+
+        await postCharge(body, adminToken.accessToken);
+
+        for (const organization of [organization1, organization2]) {
+            const items = await getBalanceItems(organization);
+            expect(items.length).toBe(1);
+            const item = items[0];
+            expect(item.organizationId).toBe(chargingOrganization.id);
+            expect(item.type).toBe(BalanceItemType.Other);
+            expect(item.name).toBe('test name');
+            expect(item.description).toBe('test description');
+            expect(item.unitPrice).toBe(10_00);
+            expect(item.amount).toBe(2);
+            expect(item.VATPercentage).toBe(21);
+            expect(item.VATIncluded).toBe(false);
+            expect(item.VATExcempt).toBe(VATExcemptReason.IntraCommunityServices);
+            expect(item.dueAt).toEqual(body.dueAt);
+            expect(item.createdAt).toEqual(body.createdAt);
+        }
+
+        expect(await getBalanceItems(otherOrganization)).toHaveLength(0);
+    });
+
+    test('Should fail without platform full access', async () => {
+        const user = await new UserFactory({ organization: chargingOrganization }).create();
+        const token = await SessionService.createSession(user);
+        const organization = await new OrganizationFactory({}).create();
+
+        const body = ChargeRequest.create({
+            name: 'test name',
+            price: 10_00,
+            amount: 1,
+            filter: { id: organization.id },
+        });
+
+        await expect(postCharge(body, token.accessToken))
+            .rejects
+            .toThrow(STExpect.errorWithCode('permission_denied'));
+
+        expect(await getBalanceItems(organization)).toHaveLength(0);
+    });
+});

--- a/backend/app/api/tests/e2e/charge-registrations.test.ts
+++ b/backend/app/api/tests/e2e/charge-registrations.test.ts
@@ -1,0 +1,96 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Organization, RegistrationPeriod, Token } from '@stamhoofd/models';
+import { BalanceItem, MemberFactory, OrganizationFactory, RegistrationFactory, RegistrationPeriodFactory, UserFactory } from '@stamhoofd/models';
+import { AccessRight, ChargeRequest, PermissionLevel, PermissionRoleDetailed, Permissions, PermissionsResourceType, ResourcePermissions, VATExcemptReason, Version } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { ChargeRegistrationsEndpoint } from '../../src/endpoints/admin/registrations/ChargeRegistrationsEndpoint.js';
+import { SessionService } from '../../src/services/SessionService.js';
+import { testServer } from '../helpers/TestServer.js';
+
+describe('E2E.ChargeRegistrations', () => {
+    const endpoint = new ChargeRegistrationsEndpoint();
+    let period: RegistrationPeriod;
+    let organization: Organization;
+    let financialDirectorToken: Token;
+
+    const postCharge = async (body: ChargeRequest) => {
+        const request = Request.buildJson('POST', `/v${Version}/admin/charge-registrations`, organization.getApiHost(), body);
+        request.headers.authorization = 'Bearer ' + financialDirectorToken.accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    const getBalanceItems = async (memberId: string) => {
+        return await BalanceItem.select().where('memberId', memberId).fetch();
+    };
+
+    beforeEach(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    beforeAll(async () => {
+        TestUtils.setEnvironment('userMode', 'platform');
+        period = await new RegistrationPeriodFactory({
+            startDate: new Date(2023, 0, 1),
+            endDate: new Date(2023, 11, 31),
+        }).create();
+
+        const role = PermissionRoleDetailed.create({
+            name: 'financial director',
+            accessRights: [AccessRight.OrganizationFinanceDirector],
+        });
+        organization = await new OrganizationFactory({ period, roles: [role] }).create();
+
+        const user = await new UserFactory({
+            organization,
+            permissions: Permissions.create({
+                level: PermissionLevel.None,
+                roles: [role],
+                resources: new Map([[PermissionsResourceType.Groups, new Map([[
+                    '',
+                    ResourcePermissions.create({ level: PermissionLevel.Write }),
+                ]])]]),
+            }),
+        }).create();
+        financialDirectorToken = await SessionService.createSession(user);
+    });
+
+    test('Should charge each member once with description and VAT settings', async () => {
+        const member1 = await new MemberFactory({}).create();
+        const member2 = await new MemberFactory({}).create();
+        const otherMember = await new MemberFactory({}).create();
+
+        const registration1a = await new RegistrationFactory({ member: member1, organization }).create();
+        const registration1b = await new RegistrationFactory({ member: member1, organization }).create();
+        const registration2 = await new RegistrationFactory({ member: member2, organization }).create();
+        await new RegistrationFactory({ member: otherMember, organization }).create();
+
+        const body = ChargeRequest.create({
+            name: 'test name',
+            description: 'test description',
+            price: 10_00,
+            amount: 2,
+            VATPercentage: 21,
+            VATIncluded: false,
+            VATExcempt: VATExcemptReason.IntraCommunityServices,
+            filter: { id: { $in: [registration1a.id, registration1b.id, registration2.id] } },
+        });
+
+        await postCharge(body);
+
+        for (const member of [member1, member2]) {
+            const items = await getBalanceItems(member.id);
+            expect(items.length).toBe(1);
+            const item = items[0];
+            expect(item.organizationId).toBe(organization.id);
+            expect(item.name).toBe('test name');
+            expect(item.description).toBe('test description');
+            expect(item.unitPrice).toBe(10_00);
+            expect(item.amount).toBe(2);
+            expect(item.VATPercentage).toBe(21);
+            expect(item.VATIncluded).toBe(false);
+            expect(item.VATExcempt).toBe(VATExcemptReason.IntraCommunityServices);
+        }
+
+        expect(await getBalanceItems(otherMember.id)).toHaveLength(0);
+    });
+});

--- a/frontend/shared/components/src/payments/EditBalanceItemView.vue
+++ b/frontend/shared/components/src/payments/EditBalanceItemView.vue
@@ -65,12 +65,8 @@
                 <STInputBox error-fields="unitPrice" :error-box="errors.errorBox" :title="$t(`%6q`)">
                     <PriceInput v-model="unitPrice" :min="null" :placeholder="$t(`%1Mn`)" />
 
-                    <template v-if="organization?.meta.invoicesEnabled || !VATIncluded" #right>
-                        <button class="button text small" type="button" @click="VATIncluded = !VATIncluded">
-                            <span v-if="VATIncluded">{{ $t('%1Hs') }}</span>
-                            <span v-else>{{ $t('%1Ht') }}</span>
-                            <span class="icon arrow-swap small" />
-                        </button>
+                    <template #right>
+                        <VATIncludedToggle v-model="VATIncluded" :invoices-enabled="invoicesEnabled" />
                     </template>
 
                     <p v-if="patchedBalanceItem.status === BalanceItemStatus.Canceled && (patchedBalanceItem.unitPrice !== balanceItem.unitPrice || patchedBalanceItem.amount !== balanceItem.amount)" class="warning-box small">
@@ -99,65 +95,7 @@
             </div>
         </div>
 
-        <STInputBox v-if="organization?.meta.invoicesEnabled || VATPercentage !== null" error-fields="VATPercentage" :error-box="errors.errorBox" :title="$t('%1Hu')" class="max">
-            <template #right>
-                <button v-if="!VATExcempt" class="button text small" type="button" @click="toggleVATExcempt">
-                    <span>Verleggen</span>
-                    <span class="icon arrow-down-small small" />
-                </button>
-            </template>
-
-            <STList>
-                <STListItem :selectable="true" element-name="label">
-                    <template #left>
-                        <Radio v-model="VATPercentage" :value="null" autocomplete="off" name="VATPercentage" />
-                    </template>
-                    <h4 class="style-list-title">
-                        {{ $t('%1Hv') }}
-                        <span v-if="VATPercentage === null && VATExcempt" class="style-tag inline-first">{{ $t('%1Hw') }}</span>
-                    </h4>
-                </STListItem>
-
-                <STListItem :selectable="true" element-name="label">
-                    <template #left>
-                        <Radio v-model="VATPercentage" :value="21" autocomplete="off" name="VATPercentage" />
-                    </template>
-                    <h4 class="style-list-title">
-                        21%
-                        <span v-if="VATPercentage === 21 && VATExcempt" class="style-tag inline-first">{{ $t('%1Hw') }}</span>
-                    </h4>
-                </STListItem>
-
-                <STListItem :selectable="true" element-name="label">
-                    <template #left>
-                        <Radio v-model="VATPercentage" :value="12" autocomplete="off" name="VATPercentage" />
-                    </template>
-                    <h4 class="style-list-title">
-                        12%
-                        <span v-if="VATPercentage === 12 && VATExcempt" class="style-tag inline-first">{{ $t('%1Hw') }}</span>
-                    </h4>
-                </STListItem>
-
-                <STListItem :selectable="true" element-name="label">
-                    <template #left>
-                        <Radio v-model="VATPercentage" :value="6" autocomplete="off" name="VATPercentage" />
-                    </template>
-                    <h4 class="style-list-title">
-                        6%
-                        <span v-if="VATPercentage === 6 && VATExcempt" class="style-tag inline-first">{{ $t('%1Hw') }}</span>
-                    </h4>
-                </STListItem>
-            </STList>
-        </STInputBox>
-        <p v-if="VATExcempt" class="style-description-small">
-            <I18nComponent :t="$t('%1Hx', {reden: getVATExcemptReasonName(VATExcempt)})">
-                <template #button="{content}">
-                    <button class="inline-link" type="button" @click="toggleVATExcempt">
-                        {{ content }}
-                    </button>
-                </template>
-            </I18nComponent>
-        </p>
+        <VATPercentageInput v-model:percentage="VATPercentage" v-model:excempt="VATExcempt" :invoices-enabled="invoicesEnabled" :error-box="errors.errorBox" />
 
         <PriceBreakdownBox :price-breakdown="patchedBalanceItem.priceBreakown" />
 
@@ -250,17 +188,15 @@ import DateSelection from '#inputs/DateSelection.vue';
 import PriceInput from '#inputs/PriceInput.vue';
 import { useShowMember } from '#members/hooks/useShowMember.ts';
 import { CenteredMessage } from '#overlays/CenteredMessage.ts';
-import { ContextMenu, ContextMenuItem } from '#overlays/ContextMenu.ts';
 import { Toast } from '#overlays/Toast.ts';
 import PriceBreakdownBox from '#views/PriceBreakdownBox.vue';
 import type { AutoEncoderPatchType, Decoder, PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
 import { ArrayDecoder, PatchableArray } from '@simonbackx/simple-encoding';
 import { SimpleError } from '@simonbackx/simple-errors';
 import { usePop, usePresent, useShow } from '@simonbackx/vue-app-navigation';
-import I18nComponent from '@stamhoofd/frontend-i18n/I18nComponent';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import type { BalanceItemRelation, Invoice } from '@stamhoofd/structures';
-import { AccessRight, BalanceItem, BalanceItemRelationType, BalanceItemStatus, BalanceItemWithPayments, getBalanceItemRelationTypeDescription, getBalanceItemRelationTypeName, getBalanceItemTypeName, getVATExcemptReasonName, InvoiceTypeHelper, LimitedFilteredRequest, PlatformFamily, SortItemDirection, UserWithMembers, VATExcemptReason } from '@stamhoofd/structures';
+import { AccessRight, BalanceItem, BalanceItemRelationType, BalanceItemStatus, BalanceItemWithPayments, getBalanceItemRelationTypeDescription, getBalanceItemRelationTypeName, getBalanceItemTypeName, InvoiceTypeHelper, LimitedFilteredRequest, PlatformFamily, SortItemDirection, UserWithMembers } from '@stamhoofd/structures';
 import { Formatter, Sorter } from '@stamhoofd/utility';
 import type { Ref } from 'vue';
 import { computed, onMounted, ref } from 'vue';
@@ -273,6 +209,8 @@ import { useLoadFamilyFromId } from '../members/hooks/useLoadFamily';
 import ActionButtonsBox from './components/ActionButtonsBox.vue';
 import type { ActionButton } from './components/ActionButtonsBox.vue';
 import PaymentRow from './components/PaymentRow.vue';
+import VATIncludedToggle from './components/VATIncludedToggle.vue';
+import VATPercentageInput from './components/VATPercentageInput.vue';
 
 const props = withDefaults(defineProps<{
     balanceItem: BalanceItemWithPayments | BalanceItem;
@@ -303,6 +241,7 @@ const show = useShow();
 const present = usePresent();
 const invoicesObjectFetcher = useInvoicesObjectFetcher();
 const invoices = ref([]) as Ref<Invoice[]>;
+const invoicesEnabled = computed(() => organization.value?.meta.invoicesEnabled ?? false);
 
 // Load mmeber on load
 loadMember().catch(console.error);
@@ -439,35 +378,6 @@ async function viewAudit() {
         ],
         modalDisplayStyle: 'popup',
     });
-}
-
-async function toggleVATExcempt(event: MouseEvent) {
-    const menu = new ContextMenu([
-        [
-            new ContextMenuItem({
-                name: $t('%1Hy'),
-                selected: VATExcempt.value === null,
-                action: () => {
-                    VATExcempt.value = null;
-                },
-            }),
-            new ContextMenuItem({
-                name: getVATExcemptReasonName(VATExcemptReason.IntraCommunityServices),
-                selected: VATExcempt.value === VATExcemptReason.IntraCommunityServices,
-                action: () => {
-                    VATExcempt.value = VATExcemptReason.IntraCommunityServices;
-                },
-            }),
-            new ContextMenuItem({
-                name: getVATExcemptReasonName(VATExcemptReason.IntraCommunityGoods),
-                selected: VATExcempt.value === VATExcemptReason.IntraCommunityGoods,
-                action: () => {
-                    VATExcempt.value = VATExcemptReason.IntraCommunityGoods;
-                },
-            }),
-        ],
-    ]);
-    await menu.show({ clickEvent: event });
 }
 
 onMounted(() => {

--- a/frontend/shared/components/src/payments/components/VATIncludedToggle.vue
+++ b/frontend/shared/components/src/payments/components/VATIncludedToggle.vue
@@ -1,0 +1,15 @@
+<template>
+    <button v-if="invoicesEnabled || !model" class="button text small" type="button" @click="model = !model">
+        <span v-if="model">{{ $t('%1Hs') }}</span>
+        <span v-else>{{ $t('%1Ht') }}</span>
+        <span class="icon arrow-swap small" />
+    </button>
+</template>
+
+<script lang="ts" setup>
+defineProps<{
+    invoicesEnabled: boolean;
+}>();
+
+const model = defineModel<boolean>({ required: true });
+</script>

--- a/frontend/shared/components/src/payments/components/VATPercentageInput.vue
+++ b/frontend/shared/components/src/payments/components/VATPercentageInput.vue
@@ -1,0 +1,67 @@
+<template>
+    <STInputBox v-if="invoicesEnabled || percentage !== null" error-fields="VATPercentage" :error-box="errorBox" :title="$t('%1Hu')" class="max">
+        <template #right>
+            <button v-if="!excempt" class="button text small" type="button" @click="toggleVATExcempt">
+                <span>{{ $t('Verleggen') }}</span>
+                <span class="icon arrow-down-small small" />
+            </button>
+        </template>
+
+        <STList>
+            <STListItem v-for="option in options" :key="option.value ?? 'none'" :selectable="true" element-name="label">
+                <template #left>
+                    <Radio v-model="percentage" :value="option.value" autocomplete="off" name="VATPercentage" />
+                </template>
+                <h4 class="style-list-title">
+                    {{ option.name }}
+                    <span v-if="percentage === option.value && excempt" class="style-tag inline-first">{{ $t('%1Hw') }}</span>
+                </h4>
+            </STListItem>
+        </STList>
+    </STInputBox>
+    <p v-if="excempt" class="style-description-small">
+        <I18nComponent :t="$t('%1Hx', {reden: getVATExcemptReasonName(excempt)})">
+            <template #button="{content}">
+                <button class="inline-link" type="button" @click="toggleVATExcempt">
+                    {{ content }}
+                </button>
+            </template>
+        </I18nComponent>
+    </p>
+</template>
+
+<script lang="ts" setup>
+import type { ErrorBox } from '#errors/ErrorBox.ts';
+import { ContextMenu, ContextMenuItem } from '#overlays/ContextMenu.ts';
+import I18nComponent from '@stamhoofd/frontend-i18n/I18nComponent';
+import { getVATExcemptReasonName, VATExcemptReason } from '@stamhoofd/structures';
+
+defineProps<{
+    invoicesEnabled: boolean;
+    errorBox: ErrorBox | null;
+}>();
+
+const percentage = defineModel<number | null>('percentage', { required: true });
+const excempt = defineModel<VATExcemptReason | null>('excempt', { required: true });
+
+const options = [
+    { value: null, name: $t('%1Hv') },
+    { value: 21, name: '21%' },
+    { value: 12, name: '12%' },
+    { value: 6, name: '6%' },
+];
+
+async function toggleVATExcempt(event: MouseEvent) {
+    const reasons = [null, VATExcemptReason.IntraCommunityServices, VATExcemptReason.IntraCommunityGoods];
+    const menu = new ContextMenu([
+        reasons.map(reason => new ContextMenuItem({
+            name: reason === null ? $t('%1Hy') : getVATExcemptReasonName(reason),
+            selected: excempt.value === reason,
+            action: () => {
+                excempt.value = reason;
+            },
+        })),
+    ]);
+    await menu.show({ clickEvent: event });
+}
+</script>

--- a/frontend/shared/components/src/views/ChargeView.vue
+++ b/frontend/shared/components/src/views/ChargeView.vue
@@ -16,13 +16,25 @@
                 <OrganizationSelect v-model="selectedOrganization" />
             </STInputBox>
 
-            <STInputBox :title="$t('%6o')" error-fields="name" :error-box="errors.errorBox">
-                <input v-model="description" class="input" type="text" :placeholder="$t('%6p')" autocomplete="given-name">
+            <STInputBox :title="$t('Naam')" error-fields="name" :error-box="errors.errorBox">
+                <input v-model="name" class="input" type="text" :placeholder="$t('Naam van de aanrekening')" autocomplete="off">
             </STInputBox>
         </div>
 
+        <STInputBox error-fields="description" :error-box="errors.errorBox" :title="$t('Beschrijving')" class="max">
+            <textarea v-model="description" class="input" :placeholder="$t('Optioneel')" />
+        </STInputBox>
+
         <div class="split-inputs">
-            <PriceInputBox v-model="price" :title="$t('%6q')" error-fields="price" :error-box="errors.errorBox" :placeholder="formatPrice(0)" :required="true" :min="null" :validator="errors.validator" />
+            <div>
+                <STInputBox error-fields="price" :error-box="errors.errorBox" :title="$t('%6q')">
+                    <PriceInput v-model="price" :min="null" :placeholder="formatPrice(0)" />
+
+                    <template #right>
+                        <VATIncludedToggle v-model="VATIncluded" :invoices-enabled="invoicesEnabled" />
+                    </template>
+                </STInputBox>
+            </div>
             <NumberInputBox v-model="amount" :title="$t('%M4')" error-fields="amount" :error-box="errors.errorBox" :validator="errors.validator" :min="1" :stepper="true" />
         </div>
 
@@ -39,7 +51,9 @@
             </div>
         </div>
 
-        <PriceBreakdownBox :price-breakdown="priceBreakdown" />
+        <VATPercentageInput v-model:percentage="VATPercentage" v-model:excempt="VATExcempt" :invoices-enabled="invoicesEnabled" :error-box="errors.errorBox" />
+
+        <PriceBreakdownBox :price-breakdown="balanceItem.priceBreakown" />
     </SaveView>
 </template>
 
@@ -53,19 +67,21 @@ import { useContext } from '#hooks/useContext.ts';
 import { useOrganization } from '#hooks/useOrganization.ts';
 import { usePlatform } from '#hooks/usePlatform.ts';
 import DateSelection from '#inputs/DateSelection.vue';
+import PriceInput from '#inputs/PriceInput.vue';
 import { CenteredMessage } from '#overlays/CenteredMessage.ts';
 import { Toast } from '#overlays/Toast.ts';
+import VATIncludedToggle from '#payments/components/VATIncludedToggle.vue';
+import VATPercentageInput from '#payments/components/VATPercentageInput.vue';
 import PriceBreakdownBox from '#views/PriceBreakdownBox.vue';
 import { SimpleError, SimpleErrors } from '@simonbackx/simple-errors';
 import { usePop } from '@simonbackx/vue-app-navigation';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
-import type { Organization, StamhoofdFilter } from '@stamhoofd/structures';
-import { ChargeRequest } from '@stamhoofd/structures';
+import type { Organization, StamhoofdFilter, VATExcemptReason } from '@stamhoofd/structures';
+import { BalanceItem, ChargeRequest } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import type { Ref } from 'vue';
 import { computed, ref, watch } from 'vue';
 import NumberInputBox from '../inputs/NumberInputBox.vue';
-import PriceInputBox from '../inputs/PriceInputBox.vue';
 import OrganizationSelect from '../organizations/components/OrganizationSelect.vue';
 import { useChargeCount } from './hooks/useChargeCount';
 
@@ -98,21 +114,27 @@ count(props.filter)
 const selectionCount = ref<number | null>(null);
 const organization = useOrganization();
 const selectedOrganization = ref<Organization | null>(organization.value) as Ref<Organization | null>;
+const name = ref('');
 const description = ref('');
 const price = ref(0);
 const amount = ref(1);
-const hasChanges = computed(() => description.value !== '' || price.value !== 0);
-const total = computed(() => price.value * amount.value);
+const VATPercentage = ref<number | null>(null);
+const VATIncluded = ref(true);
+const VATExcempt = ref<VATExcemptReason | null>(null);
+const invoicesEnabled = computed(() => selectedOrganization.value?.meta.invoicesEnabled ?? false);
+const hasChanges = computed(() => name.value !== '' || description.value !== '' || price.value !== 0);
 
 const createdAt = ref(new Date());
 const dueAt = ref(null);
 
-const priceBreakdown = computed(() => {
-    return [{
-        name: $t(`%xL`),
-        price: total.value,
-    }];
-});
+const balanceItem = computed(() => BalanceItem.create({
+    unitPrice: price.value,
+    amount: amount.value,
+    VATPercentage: VATPercentage.value,
+    VATIncluded: VATIncluded.value,
+    VATExcempt: VATExcempt.value,
+}));
+const total = computed(() => balanceItem.value.priceWithVAT);
 
 const chargeViewDescription = computed(() => {
     if (selectionCount.value === null) {
@@ -146,9 +168,7 @@ useValidation(errors.validator, () => {
         }));
     }
 
-    const descriptionNormalized = description.value.trim();
-
-    if (descriptionNormalized.length === 0) {
+    if (name.value.trim().length === 0) {
         se.addError(new SimpleError({
             code: 'invalid_field',
             message: $t(`%Cr`),
@@ -197,8 +217,12 @@ async function save() {
     try {
         const body = ChargeRequest.create({
             price: price.value,
-            name: description.value,
+            name: name.value,
+            description: description.value.trim() || null,
             amount: amount.value,
+            VATPercentage: VATPercentage.value,
+            VATIncluded: VATIncluded.value,
+            VATExcempt: VATExcempt.value,
             dueAt: dueAt.value,
             createdAt: createdAt.value,
             filter: props.filter,

--- a/shared/structures/src/endpoints/ChargeRequest.ts
+++ b/shared/structures/src/endpoints/ChargeRequest.ts
@@ -1,4 +1,5 @@
-import { AutoEncoder, DateDecoder, field, NumberDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { AutoEncoder, BooleanDecoder, DateDecoder, EnumDecoder, field, IntegerDecoder, NumberDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { VATExcemptReason } from '../BalanceItem.js';
 import { StamhoofdFilterDecoder } from '../filters/FilteredRequest.js';
 import type { StamhoofdFilter } from '../filters/StamhoofdFilter.js';
 
@@ -15,6 +16,15 @@ export class ChargeRequest extends AutoEncoder {
 
     @field({ decoder: NumberDecoder, nullable: true })
     amount: number | null;
+
+    @field({ decoder: IntegerDecoder, nullable: true, ...NextVersion })
+    VATPercentage: number | null = null;
+
+    @field({ decoder: BooleanDecoder, ...NextVersion })
+    VATIncluded = true;
+
+    @field({ decoder: new EnumDecoder(VATExcemptReason), nullable: true, ...NextVersion })
+    VATExcempt: VATExcemptReason | null = null;
 
     @field({ decoder: DateDecoder, nullable: true })
     dueAt: Date | null = null;


### PR DESCRIPTION
Adds an optional description and the VAT options (rate, incl./excl., exemption) to the bulk charge view, matching what EditBalanceItemView already offers. `ChargeRequest` gains `VATPercentage`, `VATIncluded` and `VATExcempt`, which the chargers copy onto the created balance items.

The VAT rate list and the incl./excl. toggle are extracted into `VATPercentageInput` and `VATIncludedToggle` so both views share them. They take an `invoicesEnabled` prop instead of reading the context organization, so in the admin app the controls follow the selected charging organization.

Gotchas:
- The existing charge-members test passes the filter via the query string, which the endpoint ignores (it reads `body.filter`). The new organizations/registrations tests send it in the body and assert that unselected records are untouched.
- `VATPercentage` isn't validated on the backend, consistent with the existing balance item PUT path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951785&installation_model_id=423362&pr_number=843&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F843&signature=c5733923e0540ae0ac73f9f78e519e235255cf2e9a5a06a02967bfaf4fd21300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->