### PR TITLE
Bill application fees per UTC day

### DIFF
--- a/backend/app/api/src/helpers/ApplicationFeeInvoicer.test.ts
+++ b/backend/app/api/src/helpers/ApplicationFeeInvoicer.test.ts
@@ -1,4 +1,3 @@
-import { EmailMocker } from '@stamhoofd/email';
 import type { StripeAccount, Organization } from '@stamhoofd/models';
 import { BalanceItem, BalanceItemPayment, OrganizationFactory, Payment } from '@stamhoofd/models';
 import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
@@ -13,10 +12,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { StripeMocker } from '../../tests/helpers/StripeMocker.js';
 import { initMembershipOrganization } from '../../tests/init/initMembershipOrganization.js';
-import { ApplicationFeeService, LEGACY_FEE_PAYMENT_REFERENCE_PREFIX } from '../services/ApplicationFeeService.js';
+import { ApplicationFeeService } from '../services/ApplicationFeeService.js';
 import { SettlementService } from '../services/SettlementService.js';
 import { ApplicationFeeInvoicer } from './ApplicationFeeInvoicer.js';
-import { WebmasterReport } from './WebmasterReport.js';
 
 describe('ApplicationFeeInvoicer', () => {
     const stripeMocker = new StripeMocker();
@@ -57,10 +55,12 @@ describe('ApplicationFeeInvoicer', () => {
         stripeMocker.clear();
         ApplicationFeeService.resetWarnings();
 
-        // The test database persists across runs: leftover fees of this month would be billed again
+        // The test database persists across runs: leftover fees would be billed again
         await ApplicationFee.delete()
             .where('occurredAt', '>=', new Date(Date.UTC(2024, 6, 1)))
             .where('occurredAt', '<', new Date(Date.UTC(2024, 7, 1)));
+        await ApplicationFee.delete()
+            .where('payingStripeAccountId', null);
     });
 
     const init = async () => {
@@ -113,13 +113,10 @@ describe('ApplicationFeeInvoicer', () => {
     };
 
     const createInvoicer = () => new ApplicationFeeInvoicer({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
+    const startOfUtcDay = (date: Date) => new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 
-    /**
-     * Bills the day as if the run started a second from now: fees stored in the current second
-     * are deliberately left for the next run, and a test stores them right before billing.
-     */
     const invoiceDay = async (when = day) => {
-        await createInvoicer().generateInvoicesForDay(membershipOrganization, when, new Date(Date.now() + 1000));
+        await createInvoicer().generateInvoicesForDay(membershipOrganization, when);
     };
 
     test('a day is billed per paying account, and every fee carries its balance item', async () => {
@@ -301,32 +298,6 @@ describe('ApplicationFeeInvoicer', () => {
         expect(lines.reduce((total, line) => total + line.amount, 0)).toBe(payment.price);
     });
 
-    test('a month the legacy invoicer billed is never billed again', async () => {
-        const { organization, stripeAccount } = await init();
-
-        // A legacy payment without balance items: the inline linking can't reach it, so the fee
-        // stays uninvoiced and the invoicer may not bill it either
-        const legacy = new Payment();
-        legacy.organizationId = membershipOrganization.id;
-        legacy.payingOrganizationId = organization.id;
-        legacy.stripeAccountId = stripeAccount.id;
-        legacy.method = PaymentMethod.AccountDeductions;
-        legacy.provider = PaymentProvider.Stripe;
-        legacy.status = PaymentStatus.Succeeded;
-        legacy.reference = LEGACY_FEE_PAYMENT_REFERENCE_PREFIX + '2024-07-01';
-        legacy.price = 30_00;
-        legacy.paidAt = occurredAt;
-        await legacy.save();
-
-        const fee = await createFee(organization, stripeAccount, { amount: 30_00 });
-        expect(fee.balanceItemId).toBeNull();
-
-        await invoiceDay();
-
-        expect(await getFeePayments(organization)).toHaveLength(0);
-        expect((await ApplicationFee.getByID(fee.id))!.balanceItemId).toBeNull();
-    });
-
     test('fees of the current UTC day are not billed yet', async () => {
         const { organization, stripeAccount } = await init();
         const now = new Date();
@@ -341,57 +312,79 @@ describe('ApplicationFeeInvoicer', () => {
         expect(payments).toHaveLength(0);
     });
 
-    test('a broken account does not block the other accounts', async () => {
+    test('a broken payer does not block the other payers', async () => {
         const { organization, stripeAccount } = await init();
-        const broken = await stripeMocker.createStripeAccount(organization.id);
+        const { organization: self, stripeAccount: selfAccount } = await init();
+
+        // Billing the platform's own company throws for that group
+        self.meta.companies = membershipOrganization.meta.companies;
+        await self.save();
 
         await createFee(organization, stripeAccount, { amount: 30_00 });
-        await createFee(organization, broken, { amount: 40_00 });
-
-        // A month the legacy invoicer billed may never be billed again: that group throws
-        const legacy = new Payment();
-        legacy.organizationId = membershipOrganization.id;
-        legacy.payingOrganizationId = organization.id;
-        legacy.stripeAccountId = broken.id;
-        legacy.method = PaymentMethod.AccountDeductions;
-        legacy.provider = PaymentProvider.Stripe;
-        legacy.status = PaymentStatus.Succeeded;
-        legacy.reference = LEGACY_FEE_PAYMENT_REFERENCE_PREFIX + '2024-07-01';
-        legacy.price = 40_00;
-        legacy.paidAt = occurredAt;
-        await legacy.save();
+        await createFee(self, selfAccount, { amount: 40_00 });
 
         await invoiceDay();
 
         const payments = await getFeePayments(organization);
         expect(payments).toHaveLength(1);
         expect(payments[0].price).toBe(30_00);
+        expect(await getFeePayments(self)).toHaveLength(0);
     });
 
-    test('fees without the Stripe account they were deducted from are skipped, not retried forever', async () => {
+    test('fees without the Stripe account they were deducted from are billed without one after 14 days', async () => {
         const { organization, stripeAccount } = await init();
         const removed = await stripeMocker.createStripeAccount(organization.id);
 
         await createFee(organization, stripeAccount, { amount: 30_00 });
         const orphaned = await createFee(organization, removed, { amount: 40_00 });
 
-        // Deleting the account row clears payingStripeAccountId: that fee can no longer be checked
-        // against what the legacy invoicer billed per account, so it is not billed at all
+        // Deleting the account row clears payingStripeAccountId
         await removed.delete();
 
-        await WebmasterReport.group('Overslaan applicatiekosten', async () => {
-            await invoiceDay();
-        });
+        await invoiceDay();
 
         const payments = await getFeePayments(organization);
+        expect(payments.map(p => [p.price, p.stripeAccountId]).sort()).toEqual([[30_00, stripeAccount.id], [40_00, null]]);
+        expect((await ApplicationFee.getByID(orphaned.id))!.balanceItemId).not.toBeNull();
+    });
+
+    test('fees without a payer wait 14 days before they are billed', async () => {
+        const { organization, stripeAccount } = await init();
+        const removed = await stripeMocker.createStripeAccount(organization.id);
+        const recentDay = startOfUtcDay(new Date(Date.now() - 3 * 24 * 60 * 60 * 1000));
+        const recentReference = 'application-fees-' + recentDay.toISOString().slice(0, 10);
+
+        await createFee(organization, stripeAccount, { amount: 30_00, when: new Date(recentDay.getTime() + 12 * 60 * 60 * 1000) });
+        const orphaned = await createFee(organization, removed, { amount: 40_00, when: new Date(recentDay.getTime() + 12 * 60 * 60 * 1000) });
+        await removed.delete();
+
+        await invoiceDay(recentDay);
+
+        const payments = await getFeePayments(organization, recentReference);
         expect(payments).toHaveLength(1);
         expect(payments[0].price).toBe(30_00);
         expect((await ApplicationFee.getByID(orphaned.id))!.balanceItemId).toBeNull();
+    });
 
-        // Skipping is silent here: the sync that stored the fee already reported it, and this run
-        // repeats every night
-        const emails = (await EmailMocker.transactional.getSucceededEmails()).filter(e => e.subject.startsWith('Overslaan applicatiekosten'));
-        expect(emails).toHaveLength(0);
+    test('a failure while stamping rolls back the balance items and stamps of that payer', async () => {
+        const { organization, stripeAccount } = await init();
+        const first = await createFee(organization, stripeAccount, { type: ApplicationFeeType.Service, amount: 30_00 });
+        const second = await createFee(organization, stripeAccount, { type: ApplicationFeeType.Transfer, amount: 40_00 });
+
+        const markInvoiced = ApplicationFeeService.markInvoiced.bind(ApplicationFeeService);
+        const spy = vi.spyOn(ApplicationFeeService, 'markInvoiced').mockImplementationOnce(markInvoiced).mockImplementationOnce(() => {
+            throw new Error('Simulated failure');
+        });
+        try {
+            await invoiceDay();
+        } finally {
+            spy.mockRestore();
+        }
+
+        expect(await getFeePayments(organization)).toHaveLength(0);
+        expect((await ApplicationFee.getByID(first.id))!.balanceItemId).toBeNull();
+        expect((await ApplicationFee.getByID(second.id))!.balanceItemId).toBeNull();
+        expect(await BalanceItem.select().where('payingOrganizationId', organization.id).fetch()).toHaveLength(0);
     });
 
     test('charges of a billed fee keep pointing at the deduction row', async () => {
@@ -405,7 +398,7 @@ describe('ApplicationFeeInvoicer', () => {
         expect(charge!.amount).toBe(-30_00);
     });
 
-    test('fees of a deleted organization are never billed, and do not block the other accounts', async () => {
+    test('fees of a deleted organization are billed without a payer after 14 days', async () => {
         const { organization, stripeAccount } = await init();
         const { organization: other, stripeAccount: otherAccount } = await init();
 
@@ -417,14 +410,29 @@ describe('ApplicationFeeInvoicer', () => {
 
         await invoiceDay();
 
-        const payments = await getFeePayments(other);
-        expect(payments).toHaveLength(1);
-        expect(payments[0].price).toBe(40_00);
+        const otherPayments = await getFeePayments(other);
+        expect(otherPayments).toHaveLength(1);
+        expect(otherPayments[0].price).toBe(40_00);
 
-        const stored = await ApplicationFee.getByID(orphaned.id);
-        expect(stored).toBeDefined();
-        expect(stored!.payingOrganizationId).toBeNull();
-        expect(stored!.settlementChargeId).toBeNull();
-        expect(stored!.balanceItemId).toBeNull();
+        const stored = (await ApplicationFee.getByID(orphaned.id))!;
+        expect(stored.payingOrganizationId).toBeNull();
+        expect(stored.settlementChargeId).toBeNull();
+        expect(stored.balanceItemId).not.toBeNull();
+
+        const balanceItem = (await BalanceItem.getByID(stored.balanceItemId!))!;
+        expect(balanceItem.payingOrganizationId).toBeNull();
+        expect(balanceItem.unitPrice).toBe(30_00);
+
+        const balanceItemPayment = (await BalanceItemPayment.select().where('balanceItemId', balanceItem.id).first(true));
+        const payment = (await Payment.getByID(balanceItemPayment.paymentId))!;
+        expect(payment).toMatchObject({
+            price: 30_00,
+            status: PaymentStatus.Succeeded,
+            reference,
+            organizationId: membershipOrganization.id,
+            payingOrganizationId: null,
+            stripeAccountId: null,
+            customer: null,
+        });
     });
 });

--- a/backend/app/api/src/helpers/ApplicationFeeInvoicer.test.ts
+++ b/backend/app/api/src/helpers/ApplicationFeeInvoicer.test.ts
@@ -1,6 +1,6 @@
 import { EmailMocker } from '@stamhoofd/email';
-import type { StripeAccount } from '@stamhoofd/models';
-import { BalanceItem, BalanceItemPayment, Organization, OrganizationFactory, Payment } from '@stamhoofd/models';
+import type { StripeAccount, Organization } from '@stamhoofd/models';
+import { BalanceItem, BalanceItemPayment, OrganizationFactory, Payment } from '@stamhoofd/models';
 import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
 import { PaymentSettlement } from '@stamhoofd/models/models/PaymentSettlement.js';
 import type { Settlement } from '@stamhoofd/models/models/Settlement.js';
@@ -22,10 +22,9 @@ describe('ApplicationFeeInvoicer', () => {
     const stripeMocker = new StripeMocker();
     let membershipOrganization: Organization;
 
-    // A month in the past that no other test writes fee rows in
-    const month = new Date(2024, 6, 1);
-    const occurredAt = new Date(2024, 6, 10);
-    const reference = 'application-fees-2024-07-01';
+    const day = new Date(Date.UTC(2024, 6, 10));
+    const occurredAt = new Date(Date.UTC(2024, 6, 10, 12));
+    const reference = 'application-fees-2024-07-10';
 
     const belgianAddress = () => Address.create({
         street: 'Teststraat',
@@ -60,8 +59,8 @@ describe('ApplicationFeeInvoicer', () => {
 
         // The test database persists across runs: leftover fees of this month would be billed again
         await ApplicationFee.delete()
-            .where('occurredAt', '>=', month)
-            .where('occurredAt', '<', new Date(2024, 7, 1));
+            .where('occurredAt', '>=', new Date(Date.UTC(2024, 6, 1)))
+            .where('occurredAt', '<', new Date(Date.UTC(2024, 7, 1)));
     });
 
     const init = async () => {
@@ -105,10 +104,10 @@ describe('ApplicationFeeInvoicer', () => {
         });
     };
 
-    const getFeePayments = async (organization: Organization) => {
+    const getFeePayments = async (organization: Organization, paymentReference = reference) => {
         return await Payment.select()
             .where('payingOrganizationId', organization.id)
-            .where('reference', reference)
+            .where('reference', paymentReference)
             .where('method', PaymentMethod.AccountDeductions)
             .fetch();
     };
@@ -116,19 +115,19 @@ describe('ApplicationFeeInvoicer', () => {
     const createInvoicer = () => new ApplicationFeeInvoicer({ secretKey: STAMHOOFD.STRIPE_SECRET_KEY! });
 
     /**
-     * Bills the month as if the run started a second from now: fees stored in the current second
+     * Bills the day as if the run started a second from now: fees stored in the current second
      * are deliberately left for the next run, and a test stores them right before billing.
      */
-    const invoiceMonth = async () => {
-        await createInvoicer().generateInvoicesForMonth(membershipOrganization, month, new Date(Date.now() + 1000));
+    const invoiceDay = async (when = day) => {
+        await createInvoicer().generateInvoicesForDay(membershipOrganization, when, new Date(Date.now() + 1000));
     };
 
-    test('a month is billed per paying account, and every fee carries its balance item', async () => {
+    test('a day is billed per paying account, and every fee carries its balance item', async () => {
         const { organization, stripeAccount } = await init();
         const serviceFee = await createFee(organization, stripeAccount, { type: ApplicationFeeType.Service, amount: 30_00 });
         const transferFee = await createFee(organization, stripeAccount, { type: ApplicationFeeType.Transfer, amount: 2_20_00 });
 
-        await invoiceMonth();
+        await invoiceDay();
 
         const payments = await getFeePayments(organization);
         expect(payments).toHaveLength(1);
@@ -149,6 +148,11 @@ describe('ApplicationFeeInvoicer', () => {
         expect(transferItem.unitPrice).toBe(2_20_00);
         expect(serviceItem.organizationId).toBe(membershipOrganization.id);
         expect(serviceItem.payingOrganizationId).toBe(organization.id);
+        expect(serviceItem.startDate).toEqual(new Date(Date.UTC(2024, 6, 10)));
+        expect(serviceItem.endDate).toEqual(new Date(Date.UTC(2024, 6, 10, 23, 59, 59)));
+        expect(serviceItem.name).toBe('Servicekosten op 10 juli 2024');
+        expect(serviceItem.description).toBe('Ingehouden via Stripe op 10 juli 2024 (UTC)');
+        expect(transferItem.name).toBe('Transactiekosten op 10 juli 2024');
 
         expect((await ApplicationFee.getByID(serviceFee.id))!.balanceItemId).toBe(serviceItem.id);
         expect((await ApplicationFee.getByID(transferFee.id))!.balanceItemId).toBe(transferItem.id);
@@ -161,7 +165,7 @@ describe('ApplicationFeeInvoicer', () => {
         await createFee(organization, stripeAccount, { amount: 30_00 });
         await createFee(organization, second, { amount: 40_00 });
 
-        await invoiceMonth();
+        await invoiceDay();
 
         const payments = await getFeePayments(organization);
         expect(payments).toHaveLength(2);
@@ -169,24 +173,66 @@ describe('ApplicationFeeInvoicer', () => {
         expect(payments.map(p => p.stripeAccountId).sort()).toEqual([stripeAccount.id, second.id].sort());
     });
 
+    test('days are cut at UTC midnight, one payment per day', async () => {
+        const { organization, stripeAccount } = await init();
+        const lastOfDay = await createFee(organization, stripeAccount, { amount: 30_00, when: new Date(Date.UTC(2024, 6, 10, 23, 59, 59)) });
+        const firstOfNextDay = await createFee(organization, stripeAccount, { amount: 5_00, when: new Date(Date.UTC(2024, 6, 11, 0, 0, 0)) });
+
+        await invoiceDay(new Date(Date.UTC(2024, 6, 10)));
+        await invoiceDay(new Date(Date.UTC(2024, 6, 11)));
+
+        const payments = await getFeePayments(organization);
+        expect(payments).toHaveLength(1);
+        expect(payments[0].price).toBe(30_00);
+
+        const nextDayPayments = await getFeePayments(organization, 'application-fees-2024-07-11');
+        expect(nextDayPayments).toHaveLength(1);
+        expect(nextDayPayments[0].price).toBe(5_00);
+
+        expect((await ApplicationFee.getByID(lastOfDay.id))!.balanceItemId).not.toBe((await ApplicationFee.getByID(firstOfNextDay.id))!.balanceItemId);
+    });
+
+    test('generateInvoices bills every past day separately', async () => {
+        const { organization, stripeAccount } = await init();
+
+        vitest.useFakeTimers({ shouldAdvanceTime: true, toFake: ['Date'] }).setSystemTime(new Date(Date.UTC(2024, 6, 20, 12)));
+        try {
+            await createFee(organization, stripeAccount, { amount: 30_00, when: new Date(Date.UTC(2024, 6, 10, 12)) });
+            await createFee(organization, stripeAccount, { amount: 5_00, when: new Date(Date.UTC(2024, 6, 12, 12)) });
+
+            await createInvoicer().generateInvoices(membershipOrganization);
+        } finally {
+            vitest.useRealTimers();
+        }
+
+        const payments = await Payment.select()
+            .where('payingOrganizationId', organization.id)
+            .where('method', PaymentMethod.AccountDeductions)
+            .fetch();
+        expect(payments.map(p => [p.reference, p.price]).sort()).toEqual([
+            ['application-fees-2024-07-10', 30_00],
+            ['application-fees-2024-07-12', 5_00],
+        ]);
+    });
+
     test('re-running bills nothing more', async () => {
         const { organization, stripeAccount } = await init();
         await createFee(organization, stripeAccount);
 
-        await invoiceMonth();
-        await invoiceMonth();
+        await invoiceDay();
+        await invoiceDay();
 
         expect(await getFeePayments(organization)).toHaveLength(1);
     });
 
-    test('a fee that arrives after its month was billed lands in an extra payment', async () => {
+    test('a fee that arrives after its day was billed lands in an extra payment', async () => {
         const { organization, stripeAccount } = await init();
         await createFee(organization, stripeAccount, { amount: 30_00 });
 
-        await invoiceMonth();
+        await invoiceDay();
 
         const late = await createFee(organization, stripeAccount, { amount: 5_00 });
-        await invoiceMonth();
+        await invoiceDay();
 
         const payments = await getFeePayments(organization);
         expect(payments).toHaveLength(2);
@@ -194,12 +240,11 @@ describe('ApplicationFeeInvoicer', () => {
         expect((await ApplicationFee.getByID(late.id))!.balanceItemId).not.toBeNull();
     });
 
-    test('a fee the month\'s Stripe sync stores is billed in the same run', async () => {
+    test('a fee the day\'s Stripe sync stores is billed in the same run', async () => {
         const { organization, stripeAccount } = await init();
 
-        // Only months inside the invoicing window are walked at Stripe
         const now = new Date();
-        const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 10);
+        const lastMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 10, 12));
         const stored = await createFee(organization, stripeAccount, { amount: 30_00, when: lastMonth });
 
         const payment = new Payment();
@@ -241,11 +286,11 @@ describe('ApplicationFeeInvoicer', () => {
             stripeAccountId: null,
             organizationId: membershipOrganization.id,
             amount: 30_00,
-            settledAt: new Date(2024, 6, 20),
+            settledAt: new Date(Date.UTC(2024, 6, 20)),
         });
         await createFee(organization, stripeAccount, { amount: 30_00, settlement: payout });
 
-        await invoiceMonth();
+        await invoiceDay();
 
         const payment = (await getFeePayments(organization))[0];
         const lines = await PaymentSettlement.select().where('paymentId', payment.id).fetch();
@@ -276,16 +321,16 @@ describe('ApplicationFeeInvoicer', () => {
         const fee = await createFee(organization, stripeAccount, { amount: 30_00 });
         expect(fee.balanceItemId).toBeNull();
 
-        await invoiceMonth();
+        await invoiceDay();
 
         expect(await getFeePayments(organization)).toHaveLength(0);
         expect((await ApplicationFee.getByID(fee.id))!.balanceItemId).toBeNull();
     });
 
-    test('fees of the current month are not billed yet', async () => {
+    test('fees of the current UTC day are not billed yet', async () => {
         const { organization, stripeAccount } = await init();
         const now = new Date();
-        await createFee(organization, stripeAccount, { when: new Date(now.getFullYear(), now.getMonth(), 1, 12) });
+        await createFee(organization, stripeAccount, { when: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())) });
 
         await createInvoicer().generateInvoices(membershipOrganization);
 
@@ -316,7 +361,7 @@ describe('ApplicationFeeInvoicer', () => {
         legacy.paidAt = occurredAt;
         await legacy.save();
 
-        await invoiceMonth();
+        await invoiceDay();
 
         const payments = await getFeePayments(organization);
         expect(payments).toHaveLength(1);
@@ -335,7 +380,7 @@ describe('ApplicationFeeInvoicer', () => {
         await removed.delete();
 
         await WebmasterReport.group('Overslaan applicatiekosten', async () => {
-            await invoiceMonth();
+            await invoiceDay();
         });
 
         const payments = await getFeePayments(organization);
@@ -353,7 +398,7 @@ describe('ApplicationFeeInvoicer', () => {
         const { organization, stripeAccount } = await init();
         const fee = await createFee(organization, stripeAccount);
 
-        await invoiceMonth();
+        await invoiceDay();
 
         const charge = await SettlementCharge.getByID(fee.settlementChargeId!);
         expect(charge).toBeDefined();
@@ -370,7 +415,7 @@ describe('ApplicationFeeInvoicer', () => {
         // Takes the Stripe account and the deduction charge with it, but not our income
         await organization.delete();
 
-        await invoiceMonth();
+        await invoiceDay();
 
         const payments = await getFeePayments(other);
         expect(payments).toHaveLength(1);

--- a/backend/app/api/src/helpers/ApplicationFeeInvoicer.ts
+++ b/backend/app/api/src/helpers/ApplicationFeeInvoicer.ts
@@ -13,10 +13,6 @@ import { VATService } from '../services/VATService.js';
 import { StripeSettlementSync } from './StripeSettlementSync.js';
 import { WebmasterReport } from './WebmasterReport.js';
 
-/**
- * A month can hold hundreds of thousands of fees, so they are never all loaded at once: every pass
- * iterates them in batches of this size.
- */
 const FEE_BATCH_SIZE = 500;
 
 /**
@@ -24,6 +20,19 @@ const FEE_BATCH_SIZE = 500;
  * never billed, instead of every run walking further and further back.
  */
 const MAXIMUM_INVOICE_MONTHS = 12;
+
+// UTC days match Stripe's payout cutoffs
+function startOfUtcDay(date: Date): Date {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function nextUtcDay(day: Date): Date {
+    return new Date(Date.UTC(day.getUTCFullYear(), day.getUTCMonth(), day.getUTCDate() + 1));
+}
+
+function utcDateIso(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
 
 /**
  * Stored timestamps have no milliseconds, so a boundary compared against them may not either: a
@@ -39,51 +48,41 @@ async function nextSecondBoundary(): Promise<Date> {
     return boundary;
 }
 
-/**
- * What one paying Stripe account owes for one month.
- */
 type AccountTotals = {
     payingOrganizationId: string;
     amountPerType: Map<ApplicationFeeType, number>;
 };
 
 /**
- * Bills the stored application fees to the paying organizations: per (account, month) with
- * uninvoiced fees, one ServiceFee/TransferFee balance item pair paid by one AccountDeductions
- * payment (the fees were already deducted from the account's payouts).
- *
- * Idempotency is per fee: a fee with a balanceItemId is billed, everything else still needs
- * billing. A fee that arrives after its month was billed simply lands in an extra payment on the
- * next run. The payment reference is informational only.
+ * Bills uninvoiced application fees per (paying account, UTC day): one ServiceFee/TransferFee
+ * balance item pair paid by one AccountDeductions payment. A fee with a balanceItemId is billed.
  */
 export class ApplicationFeeInvoicer {
     readonly #secretKey: string;
+    readonly #reportedLegacyMonths = new Set<string>();
 
     constructor({ secretKey }: { secretKey: string }) {
         this.#secretKey = secretKey;
     }
 
-    static reference(periodStart: Date): string {
-        return FEE_PAYMENT_REFERENCE_PREFIX + Formatter.dateIso(periodStart);
+    static reference(day: Date): string {
+        return FEE_PAYMENT_REFERENCE_PREFIX + utcDateIso(day);
     }
 
-    /**
-     * Bills every uninvoiced fee of the months before the current one.
-     */
     async generateInvoices(sellingOrganization: Organization): Promise<void> {
         if (!sellingOrganization.meta.companies[0]) {
             return;
         }
 
         await WebmasterReport.group('Aanrekenen applicatiekosten', async () => {
-            await this.#billUninvoicedMonths(sellingOrganization);
+            await this.#billUninvoicedDays(sellingOrganization);
         });
     }
 
-    async #billUninvoicedMonths(sellingOrganization: Organization): Promise<void> {
-        const currentPeriodStart = SettlementService.getPeriodStart(new Date());
+    async #billUninvoicedDays(sellingOrganization: Organization): Promise<void> {
+        const today = startOfUtcDay(new Date());
         const oldest = await this.#selectBillableFees(sellingOrganization)
-            .where('occurredAt', '<', currentPeriodStart)
+            .where('occurredAt', '<', today)
             .orderBy('occurredAt', 'ASC')
             .first(false);
 
@@ -91,60 +90,48 @@ export class ApplicationFeeInvoicer {
             return;
         }
 
-        // A month that can't be billed (its data needs repair first) stays uninvoiced, so without a
-        // window every following run would walk it again, forever
-        const windowStart = new Date(currentPeriodStart.getFullYear(), currentPeriodStart.getMonth() - MAXIMUM_INVOICE_MONTHS, 1);
-        const oldestMonth = SettlementService.getPeriodStart(oldest.occurredAt);
+        const windowStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - MAXIMUM_INVOICE_MONTHS, 1));
+        const oldestDay = startOfUtcDay(oldest.occurredAt);
 
-        if (oldestMonth < windowStart) {
+        if (oldestDay < windowStart) {
             WebmasterReport.report(
-                'Applicatiekosten van voor ' + Formatter.dateIso(windowStart) + ' worden niet meer aangerekend',
-                'Er staan nog niet-aangerekende applicatiekosten van ' + Formatter.dateIso(oldestMonth) + '. Die maand valt buiten het venster van ' + MAXIMUM_INVOICE_MONTHS + ' maanden en wordt niet meer automatisch aangerekend.',
+                'Applicatiekosten van voor ' + utcDateIso(windowStart) + ' worden niet meer aangerekend',
+                'Er staan nog niet-aangerekende applicatiekosten van ' + utcDateIso(oldestDay) + '. Die dag valt buiten het venster van ' + MAXIMUM_INVOICE_MONTHS + ' maanden en wordt niet meer automatisch aangerekend.',
             );
         }
 
         const platformSync = new StripeSettlementSync({ secretKey: this.#secretKey });
-        let month = oldestMonth < windowStart ? windowStart : oldestMonth;
+        let day = oldestDay < windowStart ? windowStart : oldestDay;
 
-        while (month < currentPeriodStart) {
-            const nextMonth = new Date(month.getFullYear(), month.getMonth() + 1, 1);
-
-            // Walking a month at Stripe is expensive: only months that still owe us something
-            if (!await this.#hasUninvoicedFees(sellingOrganization, month, nextMonth)) {
-                month = nextMonth;
-                continue;
+        while (day < today) {
+            const next = await this.#selectBillableFees(sellingOrganization)
+                .where('occurredAt', '>=', day)
+                .where('occurredAt', '<', today)
+                .orderBy('occurredAt', 'ASC')
+                .first(false);
+            if (!next) {
+                break;
             }
+            day = startOfUtcDay(next.occurredAt);
+            const nextDay = nextUtcDay(day);
 
-            // Only a complete, error-free fee walk may invoice the month: a missing fee means the
-            // month waits (and someone gets an email), never a short invoice
-            const { start, end } = SettlementService.getMonthUnixStartEnd(month);
             try {
-                await platformSync.syncFees({ start: new Date(start * 1000), end: new Date(end * 1000) });
-                await this.generateInvoicesForMonth(sellingOrganization, month);
+                await platformSync.syncFees({ start: day, end: new Date(nextDay.getTime() - 1000) });
+                await this.generateInvoicesForDay(sellingOrganization, day);
             } catch (e) {
-                console.error('Invoicing application fees failed for month ' + Formatter.dateIso(month), e);
-                WebmasterReport.report('Aanmaken kosten-facturatie voor ' + Formatter.dateIso(month) + ' overgeslagen', e);
+                console.error('Invoicing application fees failed for day ' + utcDateIso(day), e);
+                WebmasterReport.report('Aanmaken kosten-facturatie voor ' + utcDateIso(day) + ' overgeslagen', e);
             }
 
-            month = new Date(month.getFullYear(), month.getMonth() + 1, 1);
+            day = nextDay;
         }
     }
 
-    async #hasUninvoicedFees(sellingOrganization: Organization, periodStart: Date, nextPeriodStart: Date): Promise<boolean> {
-        return !!await this.#selectUninvoicedFees(sellingOrganization, periodStart, nextPeriodStart).first(false);
-    }
-
-    /**
-     * Bills the uninvoiced fees of one month, one payment per paying account. An error for one
-     * account never affects the other accounts.
-     */
-    async generateInvoicesForMonth(sellingOrganization: Organization, month: Date, snapshot?: Date): Promise<void> {
-        // Fees stored while this month is billed are excluded from every pass, so the totals a
-        // balance item is created for and the fees stamped with it can't drift apart. Taken after
-        // the month's Stripe sync, or the fees it just stored would wait for the next run
+    async generateInvoicesForDay(sellingOrganization: Organization, day: Date, snapshot?: Date): Promise<void> {
+        // Excludes fees stored during this run, so totals and stamped fees can't drift apart
         snapshot ??= await nextSecondBoundary();
-        const periodStart = SettlementService.getPeriodStart(month);
-        const nextPeriodStart = new Date(periodStart.getFullYear(), periodStart.getMonth() + 1, 1);
+        const periodStart = startOfUtcDay(day);
+        const nextPeriodStart = nextUtcDay(periodStart);
         const reference = ApplicationFeeInvoicer.reference(periodStart);
 
         await QueueHandler.schedule(reference, async () => {
@@ -171,13 +158,6 @@ export class ApplicationFeeInvoicer {
         });
     }
 
-    /**
-     * A fee this invoicer cannot bill is left out everywhere, or every run would walk its month at
-     * Stripe and report it again: without a paying organization there is nobody left to bill, and
-     * without its Stripe account a month cannot be checked against what the legacy invoicer billed
-     * per account — billing it anyway risks charging it twice. Both are reported by the sync that
-     * stored them (StripeSettlementSync.reportUnattributedFee).
-     */
     #selectUninvoicedFees(sellingOrganization: Organization, periodStart: Date, nextPeriodStart: Date, snapshot?: Date) {
         const query = this.#selectBillableFees(sellingOrganization)
             .where('occurredAt', '>=', periodStart)
@@ -223,18 +203,23 @@ export class ApplicationFeeInvoicer {
             });
         }
 
-        // Uninvoiced fees in a month the legacy invoicer billed mean the inline legacy linking
-        // failed (and already emailed): billing them again would charge the account twice
+        // Uninvoiced fees in a legacy-billed month mean linking failed: never bill them twice
+        const legacyMonthStart = new Date(Date.UTC(periodStart.getUTCFullYear(), periodStart.getUTCMonth(), 1));
         const legacyPayments = await ApplicationFeeService.findLegacyFeePayments({
             organizationId: sellingOrganization.id,
             payingOrganizationId: organization.id,
             payingStripeAccountId: stripeAccount.id,
-            periodStart,
+            periodStart: legacyMonthStart,
         });
         if (legacyPayments.length > 0) {
+            const key = stripeAccount.id + ':' + utcDateIso(legacyMonthStart);
+            if (this.#reportedLegacyMonths.has(key)) {
+                return;
+            }
+            this.#reportedLegacyMonths.add(key);
             throw new SimpleError({
                 code: 'legacy_month_not_linked',
-                message: 'Month ' + Formatter.dateIso(periodStart) + ' was billed by the legacy invoicer but has uninvoiced fees: linking failed, not billing them again',
+                message: 'Month ' + Formatter.dateIso(legacyMonthStart) + ' was billed by the legacy invoicer but has uninvoiced fees: linking failed, not billing them again',
             });
         }
 
@@ -256,7 +241,7 @@ export class ApplicationFeeInvoicer {
             return;
         }
 
-        const monthEnd = new Date(nextPeriodStart.getTime() - 1000);
+        const dayEnd = new Date(nextPeriodStart.getTime() - 1000);
         const itemPerType = new Map<ApplicationFeeType, BalanceItem>();
 
         for (const type of [ApplicationFeeType.Service, ApplicationFeeType.Transfer]) {
@@ -264,7 +249,7 @@ export class ApplicationFeeInvoicer {
             if (amount === 0) {
                 continue;
             }
-            itemPerType.set(type, await this.#createBalanceItem({ sellingOrganization, organization, type, amount, periodStart, monthEnd }));
+            itemPerType.set(type, await this.#createBalanceItem({ sellingOrganization, organization, type, amount, periodStart, dayEnd }));
         }
 
         const balanceItems = [...itemPerType.values()];
@@ -338,8 +323,6 @@ export class ApplicationFeeInvoicer {
             await balanceItemPayment.save();
         }
 
-        // Paid now, not in the billed month: the invoices cron only picks up recent payments, so a
-        // month that is billed late would otherwise never end up on an invoice
         await PaymentService.handlePaymentStatusUpdate(payment, sellingOrganization, PaymentStatus.Succeeded, new Date());
         await SettlementService.updatePaymentSettlementsForApplicationFeePayment(payment);
     }
@@ -375,31 +358,27 @@ export class ApplicationFeeInvoicer {
             if (orphaned.length > 0) {
                 throw new SimpleError({
                     code: 'orphaned_balance_items',
-                    message: 'Balance items ' + orphaned.join(', ') + ' bill application fees but have no payment: repair before invoicing more fees of this month',
+                    message: 'Balance items ' + orphaned.join(', ') + ' bill application fees but have no payment: repair before invoicing more fees of this day',
                 });
             }
         }
     }
 
-    async #createBalanceItem({ sellingOrganization, organization, type, amount, periodStart, monthEnd }: {
+    async #createBalanceItem({ sellingOrganization, organization, type, amount, periodStart, dayEnd }: {
         sellingOrganization: Organization;
         organization: Organization;
         type: ApplicationFeeType;
         amount: number;
         periodStart: Date;
-        monthEnd: Date;
+        dayEnd: Date;
     }): Promise<BalanceItem> {
         const item = new BalanceItem();
         item.type = type === ApplicationFeeType.Service ? BalanceItemType.ServiceFee : BalanceItemType.TransferFee;
+        const date = Formatter.date(periodStart, true, { timezone: 'UTC' });
         item.name = type === ApplicationFeeType.Service
-            ? $t('%1Wd', {
-                    startDate: Formatter.startDate(periodStart, false, true),
-                    endDate: Formatter.endDate(monthEnd, false, true),
-                })
-            : $t('%1Xx', {
-                    startDate: Formatter.startDate(periodStart, false, true),
-                    endDate: Formatter.endDate(monthEnd, false, true),
-                });
+            ? $t('Servicekosten op {date}', { date })
+            : $t('Transactiekosten op {date}', { date });
+        item.description = $t('Ingehouden via Stripe op {date} (UTC)', { date });
         item.relations.set(BalanceItemRelationType.PaymentProvider, BalanceItemRelation.create({
             id: PaymentProvider.Stripe,
             name: TranslatedString.create(getPaymentProviderName(PaymentProvider.Stripe)),
@@ -418,7 +397,7 @@ export class ApplicationFeeInvoicer {
         item.createdAt = new Date();
         item.status = BalanceItemStatus.Hidden;
         item.startDate = periodStart;
-        item.endDate = monthEnd;
+        item.endDate = dayEnd;
         await item.save();
         return item;
     }

--- a/backend/app/api/src/helpers/ApplicationFeeInvoicer.ts
+++ b/backend/app/api/src/helpers/ApplicationFeeInvoicer.ts
@@ -1,12 +1,14 @@
+import { Database } from '@simonbackx/simple-database';
 import { SimpleError } from '@simonbackx/simple-errors';
 import { BalanceItem, BalanceItemPayment, Organization, Payment, StripeAccount, User } from '@stamhoofd/models';
 import { ApplicationFee } from '@stamhoofd/models/models/ApplicationFee.js';
 import { QueueHandler } from '@stamhoofd/queues';
+import { SQL } from '@stamhoofd/sql';
 import { BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, getPaymentProviderName, PaymentCustomer, PaymentMethod, PaymentProvider, PaymentStatus, PaymentType, TranslatedString } from '@stamhoofd/structures';
 import { ApplicationFeeType } from '@stamhoofd/structures/settlements/ApplicationFeeType.js';
 import { Formatter, sleep } from '@stamhoofd/utility';
 
-import { ApplicationFeeService, FEE_PAYMENT_REFERENCE_PREFIX } from '../services/ApplicationFeeService.js';
+import { ApplicationFeeService, FEE_PAYMENT_REFERENCE_PREFIX, ORPHANED_FEE_DELAY_DAYS } from '../services/ApplicationFeeService.js';
 import { PaymentService } from '../services/PaymentService.js';
 import { SettlementService } from '../services/SettlementService.js';
 import { VATService } from '../services/VATService.js';
@@ -20,6 +22,10 @@ const FEE_BATCH_SIZE = 500;
  * never billed, instead of every run walking further and further back.
  */
 const MAXIMUM_INVOICE_MONTHS = 12;
+
+function orphanedFeeCutoff(): Date {
+    return new Date(Date.now() - ORPHANED_FEE_DELAY_DAYS * 24 * 60 * 60 * 1000);
+}
 
 // UTC days match Stripe's payout cutoffs
 function startOfUtcDay(date: Date): Date {
@@ -49,17 +55,19 @@ async function nextSecondBoundary(): Promise<Date> {
 }
 
 type AccountTotals = {
-    payingOrganizationId: string;
+    payingOrganizationId: string | null;
+    payingStripeAccountId: string | null;
     amountPerType: Map<ApplicationFeeType, number>;
 };
 
 /**
- * Bills uninvoiced application fees per (paying account, UTC day): one ServiceFee/TransferFee
- * balance item pair paid by one AccountDeductions payment. A fee with a balanceItemId is billed.
+ * Bills uninvoiced application fees per (paying organization, paying account, UTC day): one
+ * ServiceFee/TransferFee balance item pair paid by one AccountDeductions payment. A fee with a
+ * balanceItemId is billed. Fees whose payer was deleted are billed without one, so they can be
+ * receipted manually.
  */
 export class ApplicationFeeInvoicer {
     readonly #secretKey: string;
-    readonly #reportedLegacyMonths = new Set<string>();
 
     constructor({ secretKey }: { secretKey: string }) {
         this.#secretKey = secretKey;
@@ -116,7 +124,7 @@ export class ApplicationFeeInvoicer {
             const nextDay = nextUtcDay(day);
 
             try {
-                await platformSync.syncFees({ start: day, end: new Date(nextDay.getTime() - 1000) });
+                await platformSync.syncFees({ start: day, end: nextDay });
                 await this.generateInvoicesForDay(sellingOrganization, day);
             } catch (e) {
                 console.error('Invoicing application fees failed for day ' + utcDateIso(day), e);
@@ -127,109 +135,94 @@ export class ApplicationFeeInvoicer {
         }
     }
 
-    async generateInvoicesForDay(sellingOrganization: Organization, day: Date, snapshot?: Date): Promise<void> {
+    async generateInvoicesForDay(sellingOrganization: Organization, day: Date): Promise<void> {
         // Excludes fees stored during this run, so totals and stamped fees can't drift apart
-        snapshot ??= await nextSecondBoundary();
+        const snapshot = await nextSecondBoundary();
+        const orphanedBefore = orphanedFeeCutoff();
         const periodStart = startOfUtcDay(day);
         const nextPeriodStart = nextUtcDay(periodStart);
         const reference = ApplicationFeeInvoicer.reference(periodStart);
 
         await QueueHandler.schedule(reference, async () => {
-            const totalsPerAccount = new Map<string, AccountTotals>();
+            const totalsPerPayer = new Map<string, AccountTotals>();
 
-            // Both ids are non-null: #selectUninvoicedFees only returns fees that can be billed
-            for await (const fee of this.#selectUninvoicedFees(sellingOrganization, periodStart, nextPeriodStart, snapshot).all()) {
-                const totals = totalsPerAccount.get(fee.payingStripeAccountId!) ?? {
-                    payingOrganizationId: fee.payingOrganizationId!,
+            for await (const fee of this.#selectUninvoicedFees(sellingOrganization, periodStart, nextPeriodStart, snapshot, orphanedBefore).all()) {
+                const key = (fee.payingOrganizationId ?? '') + ':' + (fee.payingStripeAccountId ?? '');
+                const totals = totalsPerPayer.get(key) ?? {
+                    payingOrganizationId: fee.payingOrganizationId,
+                    payingStripeAccountId: fee.payingStripeAccountId,
                     amountPerType: new Map<ApplicationFeeType, number>(),
                 };
                 totals.amountPerType.set(fee.type, (totals.amountPerType.get(fee.type) ?? 0) + fee.amount);
-                totalsPerAccount.set(fee.payingStripeAccountId!, totals);
+                totalsPerPayer.set(key, totals);
             }
 
-            for (const [payingStripeAccountId, totals] of totalsPerAccount) {
+            for (const [key, totals] of totalsPerPayer) {
                 try {
-                    await this.#invoiceGroup({ sellingOrganization, payingStripeAccountId, totals, periodStart, nextPeriodStart, snapshot });
+                    await this.#invoiceGroup({ sellingOrganization, totals, periodStart, nextPeriodStart, snapshot, orphanedBefore });
                 } catch (e) {
-                    console.error('Invoicing application fees failed for account ' + payingStripeAccountId + ' - ' + reference, e);
-                    WebmasterReport.report('Aanrekenen applicatiekosten voor ' + payingStripeAccountId + ' - ' + reference + ' mislukt', e);
+                    console.error('Invoicing application fees failed for payer ' + key + ' - ' + reference, e);
+                    WebmasterReport.report('Aanrekenen applicatiekosten voor ' + key + ' - ' + reference + ' mislukt', e);
                 }
             }
         });
     }
 
-    #selectUninvoicedFees(sellingOrganization: Organization, periodStart: Date, nextPeriodStart: Date, snapshot?: Date) {
-        const query = this.#selectBillableFees(sellingOrganization)
+    #selectUninvoicedFees(sellingOrganization: Organization, periodStart: Date, nextPeriodStart: Date, snapshot: Date, orphanedBefore: Date) {
+        return this.#selectBillableFees(sellingOrganization, orphanedBefore)
             .where('occurredAt', '>=', periodStart)
             .where('occurredAt', '<', nextPeriodStart)
+            .where('createdAt', '<', snapshot)
             .limit(FEE_BATCH_SIZE);
-        return snapshot ? query.where('createdAt', '<', snapshot) : query;
     }
 
-    #selectBillableFees(sellingOrganization: Organization) {
+    #selectBillableFees(sellingOrganization: Organization, orphanedBefore = orphanedFeeCutoff()) {
         return ApplicationFee.select()
             .where('organizationId', sellingOrganization.id)
             .where('balanceItemId', null)
-            .where('payingOrganizationId', '!=', null)
-            .where('payingStripeAccountId', '!=', null);
+            .where(
+                SQL.where('payingOrganizationId', '!=', null)
+                    .and('payingStripeAccountId', '!=', null)
+                    .or('occurredAt', '<', orphanedBefore),
+            );
     }
 
-    async #invoiceGroup({ sellingOrganization, payingStripeAccountId, totals, periodStart, nextPeriodStart, snapshot }: {
+    async #invoiceGroup({ sellingOrganization, totals, periodStart, nextPeriodStart, snapshot, orphanedBefore }: {
         sellingOrganization: Organization;
-        payingStripeAccountId: string;
         totals: AccountTotals;
         periodStart: Date;
         nextPeriodStart: Date;
         snapshot: Date;
+        orphanedBefore: Date;
     }): Promise<void> {
         const seller = sellingOrganization.meta.companies[0];
         if (!seller) {
             return;
         }
 
-        const stripeAccount = await StripeAccount.getByID(payingStripeAccountId);
-        if (!stripeAccount) {
+        const stripeAccount = (totals.payingStripeAccountId ? await StripeAccount.getByID(totals.payingStripeAccountId) : null) ?? null;
+        if (totals.payingStripeAccountId && !stripeAccount) {
             throw new SimpleError({
                 code: 'stripe_account_not_found',
-                message: 'Stripe account ' + payingStripeAccountId + ' of uninvoiced application fees does not exist',
+                message: 'Stripe account ' + totals.payingStripeAccountId + ' of uninvoiced application fees does not exist',
             });
         }
 
-        const organization = await Organization.getByID(totals.payingOrganizationId);
-        if (!organization) {
+        const organization = (totals.payingOrganizationId ? await Organization.getByID(totals.payingOrganizationId) : null) ?? null;
+        if (totals.payingOrganizationId && !organization) {
             throw new SimpleError({
                 code: 'organization_not_found',
-                message: 'No organization found for Stripe account ' + stripeAccount.accountId,
+                message: 'Organization ' + totals.payingOrganizationId + ' of uninvoiced application fees does not exist',
             });
         }
 
-        // Uninvoiced fees in a legacy-billed month mean linking failed: never bill them twice
-        const legacyMonthStart = new Date(Date.UTC(periodStart.getUTCFullYear(), periodStart.getUTCMonth(), 1));
-        const legacyPayments = await ApplicationFeeService.findLegacyFeePayments({
-            organizationId: sellingOrganization.id,
-            payingOrganizationId: organization.id,
-            payingStripeAccountId: stripeAccount.id,
-            periodStart: legacyMonthStart,
-        });
-        if (legacyPayments.length > 0) {
-            const key = stripeAccount.id + ':' + utcDateIso(legacyMonthStart);
-            if (this.#reportedLegacyMonths.has(key)) {
-                return;
-            }
-            this.#reportedLegacyMonths.add(key);
-            throw new SimpleError({
-                code: 'legacy_month_not_linked',
-                message: 'Month ' + Formatter.dateIso(legacyMonthStart) + ' was billed by the legacy invoicer but has uninvoiced fees: linking failed, not billing them again',
-            });
-        }
+        const customer = organization
+            ? PaymentCustomer.create({
+                    company: organization.defaultCompanies[0],
+                })
+            : null;
 
-        await this.#assertNoOrphanedBalanceItems(sellingOrganization, stripeAccount.id, periodStart, nextPeriodStart);
-
-        const customer = PaymentCustomer.create({
-            company: organization.defaultCompanies[0],
-        });
-
-        if (customer.company!.isSameEntity(seller)) {
+        if (customer?.company?.isSameEntity(seller)) {
             throw new SimpleError({
                 code: 'same_customer',
                 message: 'Cannot invoice self',
@@ -241,132 +234,98 @@ export class ApplicationFeeInvoicer {
             return;
         }
 
-        const dayEnd = new Date(nextPeriodStart.getTime() - 1000);
-        const itemPerType = new Map<ApplicationFeeType, BalanceItem>();
+        const payment = await Database.beginTransaction(async () => {
+            const dayEnd = new Date(nextPeriodStart.getTime() - 1000);
+            const itemPerType = new Map<ApplicationFeeType, BalanceItem>();
 
-        for (const type of [ApplicationFeeType.Service, ApplicationFeeType.Transfer]) {
-            const amount = totals.amountPerType.get(type) ?? 0;
-            if (amount === 0) {
-                continue;
-            }
-            itemPerType.set(type, await this.#createBalanceItem({ sellingOrganization, organization, type, amount, periodStart, dayEnd }));
-        }
-
-        const balanceItems = [...itemPerType.values()];
-        let total = 0;
-        for (const balanceItem of balanceItems) {
-            total += balanceItem.priceWithVAT;
-        }
-        if (total !== totalAmount) {
-            throw new SimpleError({
-                code: 'price_mismatched',
-                message: 'The charged amount does not match the total application fee for the payment',
-            });
-        }
-
-        // Stamp before creating the payment: a crash in between leaves detectable unpaid items
-        // (see #assertNoOrphanedBalanceItems), never fees that get billed twice
-        let stampedAmount = 0;
-        for await (const fees of this.#selectUninvoicedFees(sellingOrganization, periodStart, nextPeriodStart, snapshot)
-            .where('payingStripeAccountId', stripeAccount.id)
-            .allBatched()) {
-            for (const fee of fees) {
-                const item = itemPerType.get(fee.type);
-                if (!item) {
-                    throw new SimpleError({
-                        code: 'missing_balance_item',
-                        message: 'No ' + fee.type + ' balance item was created for fee ' + fee.externalId,
-                    });
+            for (const type of [ApplicationFeeType.Service, ApplicationFeeType.Transfer]) {
+                const amount = totals.amountPerType.get(type) ?? 0;
+                if (amount === 0) {
+                    continue;
                 }
-                await ApplicationFeeService.markInvoiced(fee, item.id, { payment: null });
-                stampedAmount += fee.amount;
+                itemPerType.set(type, await this.#createBalanceItem({ sellingOrganization, organization, type, amount, periodStart, dayEnd }));
             }
-        }
 
-        if (stampedAmount !== totalAmount) {
-            throw new SimpleError({
-                code: 'price_mismatched',
-                message: 'Stamped ' + stampedAmount + ' of application fees but billed ' + totalAmount,
-            });
-        }
+            const balanceItems = [...itemPerType.values()];
+            let total = 0;
+            for (const balanceItem of balanceItems) {
+                total += balanceItem.priceWithVAT;
+            }
+            if (total !== totalAmount) {
+                throw new SimpleError({
+                    code: 'price_mismatched',
+                    message: 'The charged amount does not match the total application fee for the payment',
+                });
+            }
 
-        const systemUser = await User.getSystem();
+            let stampedAmount = 0;
+            for await (const fees of this.#selectUninvoicedFees(sellingOrganization, periodStart, nextPeriodStart, snapshot, orphanedBefore)
+                .where('payingOrganizationId', totals.payingOrganizationId)
+                .where('payingStripeAccountId', totals.payingStripeAccountId)
+                .allBatched()) {
+                for (const fee of fees) {
+                    const item = itemPerType.get(fee.type);
+                    if (!item) {
+                        throw new SimpleError({
+                            code: 'missing_balance_item',
+                            message: 'No ' + fee.type + ' balance item was created for fee ' + fee.externalId,
+                        });
+                    }
+                    await ApplicationFeeService.markInvoiced(fee, item.id, { payment: null });
+                    stampedAmount += fee.amount;
+                }
+            }
 
-        const payment = new Payment();
-        payment.adminUserId = systemUser.id;
+            if (stampedAmount !== totalAmount) {
+                throw new SimpleError({
+                    code: 'price_mismatched',
+                    message: 'Stamped ' + stampedAmount + ' of application fees but billed ' + totalAmount,
+                });
+            }
 
-        // The receiver of the fees
-        payment.organizationId = sellingOrganization.id;
+            const systemUser = await User.getSystem();
 
-        // The payer
-        payment.payingOrganizationId = organization.id;
-        payment.customer = customer;
+            const payment = new Payment();
+            payment.adminUserId = systemUser.id;
 
-        payment.status = PaymentStatus.Pending;
-        payment.price = totalAmount;
-        payment.roundingAmount = 0;
-        payment.method = PaymentMethod.AccountDeductions;
-        payment.type = PaymentType.Payment;
-        payment.createMandate = null;
-        payment.reference = ApplicationFeeInvoicer.reference(periodStart);
+            // The receiver of the fees
+            payment.organizationId = sellingOrganization.id;
 
-        payment.provider = PaymentProvider.Stripe;
-        payment.stripeAccountId = stripeAccount.id;
-        await payment.save();
+            // The payer, unless deleted
+            payment.payingOrganizationId = organization?.id ?? null;
+            payment.customer = customer;
 
-        for (const balanceItem of balanceItems) {
-            const balanceItemPayment = new BalanceItemPayment();
-            balanceItemPayment.balanceItemId = balanceItem.id;
-            balanceItemPayment.paymentId = payment.id;
-            balanceItemPayment.organizationId = payment.organizationId;
-            balanceItemPayment.price = balanceItem.priceWithVAT;
-            await balanceItemPayment.save();
-        }
+            payment.status = PaymentStatus.Pending;
+            payment.price = totalAmount;
+            payment.roundingAmount = 0;
+            payment.method = PaymentMethod.AccountDeductions;
+            payment.type = PaymentType.Payment;
+            payment.createMandate = null;
+            payment.reference = ApplicationFeeInvoicer.reference(periodStart);
+
+            payment.provider = PaymentProvider.Stripe;
+            payment.stripeAccountId = stripeAccount?.id ?? null;
+            await payment.save();
+
+            for (const balanceItem of balanceItems) {
+                const balanceItemPayment = new BalanceItemPayment();
+                balanceItemPayment.balanceItemId = balanceItem.id;
+                balanceItemPayment.paymentId = payment.id;
+                balanceItemPayment.organizationId = payment.organizationId;
+                balanceItemPayment.price = balanceItem.priceWithVAT;
+                await balanceItemPayment.save();
+            }
+
+            return payment;
+        });
 
         await PaymentService.handlePaymentStatusUpdate(payment, sellingOrganization, PaymentStatus.Succeeded, new Date());
         await SettlementService.updatePaymentSettlementsForApplicationFeePayment(payment);
     }
 
-    /**
-     * A crash between stamping the fees and creating the payment leaves balance items without a
-     * payment. Never bill on top of that: the totals of a new payment would no longer match the
-     * items, someone has to repair first.
-     */
-    async #assertNoOrphanedBalanceItems(sellingOrganization: Organization, payingStripeAccountId: string, periodStart: Date, nextPeriodStart: Date): Promise<void> {
-        const checked = new Set<string>();
-
-        for await (const fees of ApplicationFee.select()
-            .where('organizationId', sellingOrganization.id)
-            .where('payingStripeAccountId', payingStripeAccountId)
-            .where('balanceItemId', '!=', null)
-            .where('occurredAt', '>=', periodStart)
-            .where('occurredAt', '<', nextPeriodStart)
-            .limit(FEE_BATCH_SIZE)
-            .allBatched()) {
-            const balanceItemIds = Formatter.uniqueArray(fees.map(fee => fee.balanceItemId!)).filter(id => !checked.has(id));
-            if (balanceItemIds.length === 0) {
-                continue;
-            }
-            balanceItemIds.forEach(id => checked.add(id));
-
-            const balanceItemPayments = await BalanceItemPayment.select()
-                .where('balanceItemId', balanceItemIds)
-                .fetch();
-            const paidItemIds = new Set(balanceItemPayments.map(b => b.balanceItemId));
-
-            const orphaned = balanceItemIds.filter(id => !paidItemIds.has(id));
-            if (orphaned.length > 0) {
-                throw new SimpleError({
-                    code: 'orphaned_balance_items',
-                    message: 'Balance items ' + orphaned.join(', ') + ' bill application fees but have no payment: repair before invoicing more fees of this day',
-                });
-            }
-        }
-    }
-
     async #createBalanceItem({ sellingOrganization, organization, type, amount, periodStart, dayEnd }: {
         sellingOrganization: Organization;
-        organization: Organization;
+        organization: Organization | null;
         type: ApplicationFeeType;
         amount: number;
         periodStart: Date;
@@ -383,11 +342,11 @@ export class ApplicationFeeInvoicer {
             id: PaymentProvider.Stripe,
             name: TranslatedString.create(getPaymentProviderName(PaymentProvider.Stripe)),
         }));
-        item.payingOrganizationId = organization.id;
+        item.payingOrganizationId = organization?.id ?? null;
         item.organizationId = sellingOrganization.id;
         item.VATPercentage = 21;
         item.VATExcempt = VATService.getVATExcempt({
-            company: organization.defaultCompanies[0] ?? null,
+            company: organization?.defaultCompanies[0] ?? null,
             sellingOrganization,
             type: 'services',
         });

--- a/backend/app/api/src/helpers/StripeSettlementSync.ts
+++ b/backend/app/api/src/helpers/StripeSettlementSync.ts
@@ -12,7 +12,7 @@ import { SettlementStatus } from '@stamhoofd/structures/settlements/SettlementSt
 import { SettlementSyncError } from '@stamhoofd/structures/settlements/SettlementSyncError.js';
 import Stripe from 'stripe';
 
-import { ApplicationFeeService } from '../services/ApplicationFeeService.js';
+import { ApplicationFeeService, ORPHANED_FEE_DELAY_DAYS } from '../services/ApplicationFeeService.js';
 import { SettlementService } from '../services/SettlementService.js';
 import { ApplicationFeeDetails } from './ApplicationFeeDetails.js';
 import { getPaymentIdForStripeCharge } from './getPaymentIdForStripeCharge.js';
@@ -76,9 +76,9 @@ export class StripeSettlementSync {
     }
 
     /**
-     * A fee we can't fully attribute is stored anyway (it is our income), so it would otherwise
-     * only exist as a number nobody looks at: the invoicer skips it, and no payout of the payer
-     * links it. Reported once per account, so someone decides whether to repair or write it off.
+     * A fee we can't fully attribute is stored anyway (it is our income). The invoicer bills it
+     * without a payer after a delay, and no payout of the payer links it. Reported once per
+     * account, so someone can repair the data before then.
      */
     static reportUnattributedFee(payingAccountId: string, payer: ApplicationFeePayer | null) {
         if (this.#reportedUnattributedAccounts.has(payingAccountId)) {
@@ -87,10 +87,10 @@ export class StripeSettlementSync {
         this.#reportedUnattributedAccounts.add(payingAccountId);
 
         WebmasterReport.report(
-            'Applicatiekosten van Stripe account ' + payingAccountId + ' worden niet aangerekend',
+            'Applicatiekosten van Stripe account ' + payingAccountId + ' hebben geen betaler',
             payer
-                ? 'Dat account staat niet meer in onze database. De kosten zijn wel opgeslagen op vereniging ' + payer.organizationId + ', maar worden niet automatisch gefactureerd.'
-                : 'Dat account en de vereniging erachter staan niet meer in onze database. De kosten zijn opgeslagen als niet-aanrekenbare inkomsten.',
+                ? 'Dat account staat niet meer in onze database. De kosten zijn opgeslagen op vereniging ' + payer.organizationId + ' en worden na ' + ORPHANED_FEE_DELAY_DAYS + ' dagen aangerekend zonder Stripe account.'
+                : 'Dat account en de vereniging erachter staan niet meer in onze database. De kosten worden na ' + ORPHANED_FEE_DELAY_DAYS + ' dagen aangerekend zonder betaler, zodat er handmatig een ontvangstbewijs voor kan worden gemaakt.',
         );
     }
 

--- a/backend/app/api/src/services/ApplicationFeeService.test.ts
+++ b/backend/app/api/src/services/ApplicationFeeService.test.ts
@@ -206,17 +206,17 @@ describe('ApplicationFeeService', () => {
             expect((await SettlementCharge.getByID(charge.id))!.providerInvoiceId).toBeNull();
         });
 
-        test('stampInvoicedPayments stamps and clears the charges of an invoice', async () => {
+        test('setProviderInvoiceIdsForSettlementCharges stamps and clears the charges of an invoice', async () => {
             const { organization, stripeAccount } = await init();
             const { payment } = await createLegacyFeePayment(organization, stripeAccount);
             const { charge, fee } = await upsertFee(organization, stripeAccount);
             expect(fee.balanceItemId).not.toBeNull();
 
             const invoice = await createInvoice(payment, '2025042');
-            await ApplicationFeeService.stampInvoicedPayments([payment], invoice);
+            await ApplicationFeeService.setProviderInvoiceIdsForSettlementCharges([payment], invoice);
             expect((await SettlementCharge.getByID(charge.id))!.providerInvoiceId).toBe('2025042');
 
-            await ApplicationFeeService.stampInvoicedPayments([payment], null);
+            await ApplicationFeeService.setProviderInvoiceIdsForSettlementCharges([payment], null);
             expect((await SettlementCharge.getByID(charge.id))!.providerInvoiceId).toBeNull();
         });
 
@@ -230,7 +230,7 @@ describe('ApplicationFeeService', () => {
             payment.price = 10_00;
             await payment.save();
 
-            await expect(ApplicationFeeService.stampInvoicedPayments([payment], null)).resolves.toBeUndefined();
+            await expect(ApplicationFeeService.setProviderInvoiceIdsForSettlementCharges([payment], null)).resolves.toBeUndefined();
         });
     });
 

--- a/backend/app/api/src/services/ApplicationFeeService.ts
+++ b/backend/app/api/src/services/ApplicationFeeService.ts
@@ -17,6 +17,12 @@ export const LEGACY_FEE_PAYMENT_REFERENCE_PREFIX = 'stripe-fees-';
 export const FEE_PAYMENT_REFERENCE_PREFIX = 'application-fees-';
 
 /**
+ * Fees without a payer (their organization or Stripe account was deleted) wait this long before
+ * they are billed without one, in case the missing data is restored.
+ */
+export const ORPHANED_FEE_DELAY_DAYS = 14;
+
+/**
  * Fees read per batch when a whole invoice is stamped at once.
  */
 const FEE_BATCH_SIZE = 500;
@@ -128,7 +134,7 @@ export class ApplicationFeeService {
         if (payment === null) {
             return;
         }
-        await this.stampProviderInvoiceId(fee, { payment });
+        await this.setProviderInvoiceIdForSettlementChargeOfApplicationFee(fee, { payment });
     }
 
     /**
@@ -255,9 +261,9 @@ export class ApplicationFeeService {
     /**
      * Stamps the Stamhoofd invoice number that bills this fee on the payer's deduction charge, so
      * the payer can link the cost in their settlement export to our invoice. No invoice (yet) means
-     * no stamp: stampInvoicedPayments runs when the invoice is created later.
+     * no stamp: setProviderInvoiceIdsForSettlementCharges runs when the invoice is created later.
      */
-    private static async stampProviderInvoiceId(fee: ApplicationFee, { payment }: { payment?: Payment } = {}) {
+    private static async setProviderInvoiceIdForSettlementChargeOfApplicationFee(fee: ApplicationFee, { payment }: { payment?: Payment } = {}) {
         if (!fee.settlementChargeId) {
             return;
         }
@@ -292,7 +298,7 @@ export class ApplicationFeeService {
      * null): stamps or clears the invoice number on the deduction charges of every application fee
      * the payments billed. A no-op for invoices without fee payments.
      */
-    static async stampInvoicedPayments(payments: Payment[], invoice: Invoice | null) {
+    static async setProviderInvoiceIdsForSettlementCharges(payments: Payment[], invoice: Invoice | null) {
         if (payments.length === 0) {
             return;
         }

--- a/backend/app/api/src/services/InvoiceService.ts
+++ b/backend/app/api/src/services/InvoiceService.ts
@@ -322,7 +322,7 @@ export class InvoiceService {
             // The deduction charges of application fees billed by these payments now link to a
             // numbered invoice. Only after the try/catch: a stamping error must never delete an
             // invoice that was already sent
-            await ApplicationFeeService.stampInvoicedPayments(payments, model);
+            await ApplicationFeeService.setProviderInvoiceIdsForSettlementCharges(payments, model);
         } catch (e) {
             console.error('Failed to stamp application fee charges for invoice ' + model.id, e);
             WebmasterReport.report('Factuurnummer op applicatiekosten zetten mislukt voor factuur ' + (model.number ?? model.id) + ' (de factuur zelf is wel verstuurd)', e);
@@ -403,7 +403,7 @@ export class InvoiceService {
         await BalanceItemService.updateInvoiced(balanceItemIds);
 
         // The invoice number stamped on application fee deduction charges no longer exists
-        await ApplicationFeeService.stampInvoicedPayments(payments, null);
+        await ApplicationFeeService.setProviderInvoiceIdsForSettlementCharges(payments, null);
     }
 
     private static shouldForwardInvoice(invoice: Invoice, organization: Organization) {

--- a/backend/app/api/src/services/SettlementService.ts
+++ b/backend/app/api/src/services/SettlementService.ts
@@ -322,8 +322,8 @@ export class SettlementService {
             .where('payingStripeAccountId', '!=', null)
             .sum(SQL.column('amount')) ?? 0;
 
-        // The negation of what the invoicer bills (ApplicationFeeInvoicer#selectBillableFees), so
-        // every uninvoiced fee sits in exactly one of the two sums
+        // Fees without a payer: billed later without one. Every uninvoiced fee sits in exactly
+        // one of the two sums
         const uncollectibleFees = await ApplicationFee.select()
             .where('settlementId', settlement.id)
             .where('balanceItemId', null)

--- a/backend/app/api/src/services/SettlementService.ts
+++ b/backend/app/api/src/services/SettlementService.ts
@@ -100,10 +100,6 @@ export class SettlementService {
         });
     }
 
-    /**
-     * Month bucket of a charge, in server-local time: the same boundaries as
-     * getMonthUnixStartEnd, which drive the monthly invoice grouping.
-     */
     static getPeriodStart(date: Date): Date {
         return new Date(date.getFullYear(), date.getMonth(), 1);
     }

--- a/backend/shared/models/src/models/ApplicationFee.ts
+++ b/backend/shared/models/src/models/ApplicationFee.ts
@@ -87,9 +87,6 @@ export class ApplicationFee extends QueryableModel {
     @column({ type: 'string', nullable: true })
     balanceItemId: string | null = null;
 
-    /**
-     * When the provider created the fee. Drives the monthly invoice grouping.
-     */
     @column({ type: 'datetime' })
     occurredAt: Date;
 

--- a/backend/shared/models/src/models/ApplicationFee.ts
+++ b/backend/shared/models/src/models/ApplicationFee.ts
@@ -46,8 +46,7 @@ export class ApplicationFee extends QueryableModel {
 
     /**
      * The paying organization: the connected organization whose payout the fee was deducted from.
-     * NULL when that organization no longer exists: the fee stays as income of the receiving
-     * organization, but can never be invoiced anymore.
+     * NULL when that organization no longer exists: the fee is then billed without a payer.
      */
     @column({ type: 'string', nullable: true })
     payingOrganizationId: string | null = null;

--- a/shared/structures/src/BalanceItem.test.ts
+++ b/shared/structures/src/BalanceItem.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import type { AutoEncoderPatchType, Decoder } from '@simonbackx/simple-encoding';
 import { ObjectData } from '@simonbackx/simple-encoding';
 import { TestUtils } from '@stamhoofd/test-utils';
@@ -386,5 +387,32 @@ describe('BalanceItem.categoryFilter / articleFilter', () => {
 
             expect([type, NAME_TITLED_BALANCE_ITEM_TYPES.has(type)]).toEqual([type, usesName]);
         }
+    });
+});
+
+describe('BalanceItem.itemTitle', () => {
+    // $t is a key-returning stub in these tests: the month name of July is %tU
+    const t = vi.fn((key: string) => key);
+
+    beforeEach(() => {
+        vi.stubGlobal('$t', t);
+        t.mockClear();
+    });
+
+    afterAll(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test.each([
+        [BalanceItemType.ServiceFee, '%1cJ'],
+        [BalanceItemType.TransferFee, '%1Yq'],
+    ])('%s item spanning one day in UTC or in the display timezone is titled with that day', (type, key) => {
+        expect(BalanceItem.create({ type, startDate: new Date('2024-07-10T00:00:00.000Z'), endDate: new Date('2024-07-10T23:59:59.000Z') }).itemTitle).toBe(key);
+        expect(t).toHaveBeenLastCalledWith(key, { date: '10 %tU 2024' });
+
+        expect(BalanceItem.create({ type, startDate: new Date('2024-07-09T22:00:00.000Z'), endDate: new Date('2024-07-10T21:59:59.000Z') }).itemTitle).toBe(key);
+        expect(t).toHaveBeenLastCalledWith(key, { date: '10 %tU 2024' });
+
+        expect(BalanceItem.create({ type, startDate: new Date('2024-07-01T00:00:00.000Z'), endDate: new Date('2024-07-31T23:59:59.000Z') }).itemTitle).not.toBe(key);
     });
 });

--- a/shared/structures/src/BalanceItem.ts
+++ b/shared/structures/src/BalanceItem.ts
@@ -372,6 +372,20 @@ export type BalanceItemVATSubtotal = {
     VAT: number;
 };
 
+/**
+ * Fee days are cut in the display timezone (Mollie) or in UTC (Stripe): formatted date when the
+ * period is one day in either, null otherwise.
+ */
+function getFeeDay(startDate: Date, endDate: Date): string | null {
+    if (Formatter.dateIso(startDate) === Formatter.dateIso(endDate)) {
+        return Formatter.date(startDate, true);
+    }
+    if (startDate.toISOString().slice(0, 10) === endDate.toISOString().slice(0, 10)) {
+        return Formatter.date(startDate, true, { timezone: 'UTC' });
+    }
+    return null;
+}
+
 export class BalanceItem extends AutoEncoder {
     @field({ decoder: StringDecoder, defaultValue: () => uuidv4() })
     id: string;
@@ -1090,8 +1104,20 @@ export class BalanceItem extends AutoEncoder {
                 const pack = this.relations.get(BalanceItemRelationType.STPackage);
                 return pack?.name.toString() || getBalanceItemTypeName(BalanceItemType.STPackage);
             }
-            case BalanceItemType.ServiceFee: return this.startDate && this.endDate ? (Formatter.dateIso(this.startDate) !== Formatter.dateIso(this.endDate) ? $t(`%1Z1`, { startDate: Formatter.startDate(this.startDate, false, true), endDate: Formatter.endDate(this.endDate, false, true) }) : $t(`%1cJ`, { date: Formatter.date(this.startDate, true) })) : $t('%1UX');
-            case BalanceItemType.TransferFee: return this.startDate && this.endDate ? (Formatter.dateIso(this.startDate) !== Formatter.dateIso(this.endDate) ? $t(`%1bd`, { startDate: Formatter.startDate(this.startDate, false, true), endDate: Formatter.endDate(this.endDate, false, true) }) : $t(`%1Yq`, { date: Formatter.date(this.startDate, true) })) : $t('%wZ');
+            case BalanceItemType.ServiceFee: {
+                if (!this.startDate || !this.endDate) {
+                    return $t('%1UX');
+                }
+                const day = getFeeDay(this.startDate, this.endDate);
+                return day ? $t(`%1cJ`, { date: day }) : $t(`%1Z1`, { startDate: Formatter.startDate(this.startDate, false, true), endDate: Formatter.endDate(this.endDate, false, true) });
+            }
+            case BalanceItemType.TransferFee: {
+                if (!this.startDate || !this.endDate) {
+                    return $t('%wZ');
+                }
+                const day = getFeeDay(this.startDate, this.endDate);
+                return day ? $t(`%1Yq`, { date: day }) : $t(`%1bd`, { startDate: Formatter.startDate(this.startDate, false, true), endDate: Formatter.endDate(this.endDate, false, true) });
+            }
         }
         return this.name;
     }

--- a/shared/utility/src/Formatter.ts
+++ b/shared/utility/src/Formatter.ts
@@ -147,14 +147,15 @@ export class Formatter {
     /**
      * 1 januari (2020). Year only in different year and in the future, if withYear is null (default)
      */
-    static date(date: Date, withYear: boolean | null = null): string {
+    static date(date: Date, withYear: boolean | null = null, options?: { timezone?: string }): string {
         if (!date) {
             // Crash protection in case undefined get passed
             return '?';
         }
-        const currentYear = DateTime.now().setZone(this.timezone).year;
+        const timezone = options?.timezone ?? this.timezone;
+        const currentYear = DateTime.now().setZone(timezone).year;
 
-        const datetime = DateTime.fromJSDate(date).setZone(this.timezone);
+        const datetime = DateTime.fromJSDate(date).setZone(timezone);
         const year = datetime.year;
         return datetime.day + ' ' + this.month(datetime.month) + (withYear !== false && (currentYear !== year || withYear === true || date < new Date()) ? (' ' + year) : '');
     }


### PR DESCRIPTION
The ApplicationFeeInvoicer now creates one ServiceFee/TransferFee balance item pair and one AccountDeductions payment per paying account per **UTC day** instead of per month, so a day of fees matches a day of Stripe payouts (Stripe cuts payouts at UTC midnight). Balance items get a name (`Servicekosten op 10 juli 2024`) and a description (`Ingehouden via Stripe op 10 juli 2024 (UTC)`).

Fees whose paying organization or Stripe account was deleted are billed too, without a payer (payment and balance item have no paying organization, account or customer), but only once they are older than 14 days so missing data can still be restored. The invoices cron skips payments without a paying organization, so receipts for those are made manually in the UI. The legacy-month guard is removed: no uninvoiced legacy fees remain.

Gotchas:
- `BalanceItem.itemTitle` compared start/end dates in Europe/Brussels, so a UTC day (00:00Z–23:59:59Z) rendered as a two-day range with times. It now treats a range as one day when it is one day in UTC *or* in the display timezone, since the Mollie service-fee cron still cuts its days in Brussels. `Formatter.date` got an optional timezone for this.
- The walk jumps to the next day with uninvoiced fees instead of probing every calendar day in the 12-month window.
- Billing one payer runs in a transaction: a failure while stamping fees rolls back its balance items and stamps.
- Settlement totals still count uninvoiced fees without a payer as `uncollectibleFees`; after 14 days those get billed and leave that sum. The column name is now slightly off, left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)