### PR TITLE
Add basic in-app notifications backend

### DIFF
--- a/backend/app/api/src/endpoints/global/notifications/GetNotificationsEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/notifications/GetNotificationsEndpoint.test.ts
@@ -1,0 +1,127 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { User } from '@stamhoofd/models';
+import { OrganizationFactory, UserFactory } from '@stamhoofd/models';
+import { Notification } from '@stamhoofd/models/models/Notification.js';
+import type { PaginatedResponse, StamhoofdFilter } from '@stamhoofd/structures';
+import { LimitedFilteredRequest, SortItemDirection } from '@stamhoofd/structures';
+import { NotificationType } from '@stamhoofd/structures/notifications/NotificationType.js';
+import type { UserNotification } from '@stamhoofd/structures/notifications/UserNotification.js';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { NotificationService } from '../../../services/NotificationService.js';
+import { SessionService } from '../../../services/SessionService.js';
+import { GetNotificationsEndpoint } from './GetNotificationsEndpoint.js';
+
+describe('Endpoint.GetNotificationsEndpoint', () => {
+    const endpoint = new GetNotificationsEndpoint();
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    afterEach(async () => {
+        await Notification.delete();
+    });
+
+    async function get(user: User | null, query: Partial<ConstructorParameters<typeof LimitedFilteredRequest>[0]> = {}) {
+        const request = Request.get({
+            path: '/notifications',
+            query: new LimitedFilteredRequest({ limit: 10, ...query }),
+            headers: user ? { authorization: 'Bearer ' + (await SessionService.createSession(user)).accessToken } : {},
+        });
+        return await testServer.test<PaginatedResponse<UserNotification[], LimitedFilteredRequest>>(endpoint, request);
+    }
+
+    async function send(users: User[], options: { organizationId?: string; type?: NotificationType } = {}) {
+        return (await NotificationService.send({
+            type: options.type ?? NotificationType.RegistrationCreated,
+            payload: { n: users.length },
+            organizationId: options.organizationId,
+            to: { users },
+        }))!;
+    }
+
+    test('returns only the notifications of the authenticated user, newest first', async () => {
+        const user = await new UserFactory({}).create();
+        const other = await new UserFactory({}).create();
+
+        const first = await send([user, other]);
+        await send([other]);
+        const third = await send([user]);
+
+        const response = await get(user);
+        expect(response.status).toBe(200);
+        expect(response.body.results.map(r => r.notificationId)).toEqual([third.id, first.id]);
+        expect(response.body.results[0]).toMatchObject({
+            type: NotificationType.RegistrationCreated,
+            payload: { n: 1 },
+            readAt: null,
+            readCount: 0,
+            groupResourceCount: 0,
+        });
+        expect(response.body.next).toBeUndefined();
+    });
+
+    test('paginates with the next request', async () => {
+        const user = await new UserFactory({}).create();
+        const ids: string[] = [];
+        for (let i = 0; i < 5; i++) {
+            ids.push((await send([user])).id);
+        }
+
+        const page1 = await get(user, { limit: 2 });
+        expect(page1.body.results.map(r => r.notificationId)).toEqual([ids[4], ids[3]]);
+        expect(page1.body.next).toBeDefined();
+
+        const page2 = await get(user, page1.body.next!);
+        expect(page2.body.results.map(r => r.notificationId)).toEqual([ids[2], ids[1]]);
+
+        const page3 = await get(user, page2.body.next!);
+        expect(page3.body.results.map(r => r.notificationId)).toEqual([ids[0]]);
+        expect(page3.body.next).toBeUndefined();
+    });
+
+    test('supports filters on notification and recipient columns', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({}).create();
+
+        const inOrganization = await send([user], { organizationId: organization.id });
+        await send([user]);
+
+        const byOrganization = await get(user, { filter: { organizationId: organization.id } });
+        expect(byOrganization.body.results.map(r => r.notificationId)).toEqual([inOrganization.id]);
+
+        const unread = await get(user, { filter: { readAt: null } });
+        expect(unread.body.results).toHaveLength(2);
+
+        const read = await get(user, { filter: { readAt: { $neq: null } } as StamhoofdFilter });
+        expect(read.body.results).toHaveLength(0);
+
+        const byType = await get(user, { filter: { type: 'something.else' } });
+        expect(byType.body.results).toHaveLength(0);
+    });
+
+    test('only allows sorting by id descending', async () => {
+        const user = await new UserFactory({}).create();
+        await send([user]);
+
+        const explicit = await get(user, { sort: [{ key: 'id', order: SortItemDirection.DESC }] });
+        expect(explicit.body.results).toHaveLength(1);
+
+        await expect(get(user, { sort: [{ key: 'id', order: SortItemDirection.ASC }] })).rejects.toThrow(STExpect.simpleError({ code: 'invalid_field', field: 'sort' }));
+        await expect(get(user, { sort: [{ key: 'createdAt', order: SortItemDirection.DESC }] })).rejects.toThrow(STExpect.simpleError({ code: 'invalid_field', field: 'sort' }));
+    });
+
+    test('validates the limit and requires authentication', async () => {
+        const user = await new UserFactory({}).create();
+
+        await expect(get(user, { limit: 101 })).rejects.toThrow(STExpect.simpleError({ code: 'invalid_field', field: 'limit' }));
+        await expect(get(user, { limit: 0 })).rejects.toThrow(STExpect.simpleError({ code: 'invalid_field', field: 'limit' }));
+        await expect(get(null)).rejects.toThrow(STExpect.simpleError({ code: 'not_authenticated' }));
+    });
+
+    test('does not support search', async () => {
+        const user = await new UserFactory({}).create();
+        await expect(get(user, { search: 'x' })).rejects.toThrow(STExpect.simpleError({ code: 'not_supported' }));
+    });
+});

--- a/backend/app/api/src/endpoints/global/notifications/GetNotificationsEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/notifications/GetNotificationsEndpoint.ts
@@ -1,0 +1,138 @@
+import type { SQLResultNamespacedRow } from '@simonbackx/simple-database';
+import type { Decoder } from '@simonbackx/simple-encoding';
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { SimpleError } from '@simonbackx/simple-errors';
+import { Notification } from '@stamhoofd/models/models/Notification.js';
+import { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import { SQL, SQLSelect, applySQLSorter, compileToSQLFilter } from '@stamhoofd/sql';
+import type { CountFilteredRequest } from '@stamhoofd/structures';
+import { LimitedFilteredRequest, PaginatedResponse, SortItemDirection } from '@stamhoofd/structures';
+import type { UserNotification } from '@stamhoofd/structures/notifications/UserNotification.js';
+
+import { Context } from '../../../helpers/Context.js';
+import { LimitedFilteredRequestHelper } from '../../../helpers/LimitedFilteredRequestHelper.js';
+import { notificationFilterCompilers, notificationJoin } from '../../../sql-filters/notifications.js';
+import { notificationSorters } from '../../../sql-sorters/notifications.js';
+
+type Params = Record<string, never>;
+type Query = LimitedFilteredRequest;
+type Body = undefined;
+type ResponseBody = PaginatedResponse<UserNotification[], LimitedFilteredRequest>;
+
+type RecipientWithNotification = NotificationRecipient & { notification: Notification };
+
+/**
+ * Notifications of the authenticated user, newest first.
+ */
+export class GetNotificationsEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    queryDecoder = LimitedFilteredRequest as Decoder<LimitedFilteredRequest>;
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'GET') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/notifications', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    static selectRecipientsWithNotification(): SQLSelect<RecipientWithNotification> {
+        const transformer = (row: SQLResultNamespacedRow): RecipientWithNotification => {
+            const recipient = NotificationRecipient.fromRow(row[NotificationRecipient.table]);
+            const notification = Notification.fromRow(row[Notification.table]);
+
+            if (!recipient || !notification) {
+                console.error('Could not transform row', row, 'into notification models, check if the primary keys are returned in the query');
+                throw new Error('Missing data for notification');
+            }
+
+            return Object.assign(recipient, { notification });
+        };
+
+        return new SQLSelect(transformer, SQL.wildcard(NotificationRecipient.table), SQL.wildcard(Notification.table))
+            .from(SQL.table(NotificationRecipient.table))
+            .join(notificationJoin);
+    }
+
+    static async buildQuery(q: CountFilteredRequest | LimitedFilteredRequest) {
+        const query = this.selectRecipientsWithNotification()
+            .where(SQL.column(NotificationRecipient.table, 'userId'), Context.impersonatedUserOrUser.id);
+
+        if (q.filter) {
+            query.where(await compileToSQLFilter(q.filter, notificationFilterCompilers));
+        }
+
+        if (q.search) {
+            throw new SimpleError({
+                code: 'not_supported',
+                message: 'Search is not possible in notifications',
+                human: $t('Zoeken is niet mogelijk in meldingen'),
+            });
+        }
+
+        if (q instanceof LimitedFilteredRequest) {
+            if (q.pageFilter) {
+                query.where(await compileToSQLFilter(q.pageFilter, notificationFilterCompilers));
+            }
+
+            q.sort = this.assertSort(q.sort);
+            applySQLSorter(query, q.sort, notificationSorters);
+            query.limit(q.limit);
+        }
+
+        return query;
+    }
+
+    /**
+     * Only the (indexed) newest-first order is supported
+     */
+    private static assertSort(sort: LimitedFilteredRequest['sort']): LimitedFilteredRequest['sort'] {
+        const allowed = [{ key: 'id', order: SortItemDirection.DESC }];
+
+        if (sort.length === 0) {
+            return allowed;
+        }
+
+        if (sort.length === 1 && sort[0].key === 'id' && sort[0].order === SortItemDirection.DESC) {
+            return allowed;
+        }
+
+        throw new SimpleError({
+            code: 'invalid_field',
+            field: 'sort',
+            message: 'Notifications can only be sorted by id DESC',
+        });
+    }
+
+    static async buildData(requestQuery: LimitedFilteredRequest): Promise<ResponseBody> {
+        const query = await this.buildQuery(requestQuery);
+        const results = await query.fetch();
+
+        const next = LimitedFilteredRequestHelper.fixInfiniteLoadingLoop({
+            request: requestQuery,
+            results,
+            sorters: notificationSorters,
+        });
+
+        return new PaginatedResponse<UserNotification[], LimitedFilteredRequest>({
+            results: results.map(r => r.getStructure(r.notification)),
+            next,
+        });
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        await Context.setUserOrganizationScope();
+        await Context.authenticate();
+
+        LimitedFilteredRequestHelper.throwIfInvalidLimit({ request: request.query, maxLimit: 100 });
+
+        return new Response(
+            await GetNotificationsEndpoint.buildData(request.query),
+        );
+    }
+}

--- a/backend/app/api/src/endpoints/global/notifications/GetUnreadNotificationsCountEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/notifications/GetUnreadNotificationsCountEndpoint.test.ts
@@ -1,0 +1,65 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { User } from '@stamhoofd/models';
+import { OrganizationFactory, UserFactory } from '@stamhoofd/models';
+import { Notification } from '@stamhoofd/models/models/Notification.js';
+import { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import type { CountResponse, StamhoofdFilter } from '@stamhoofd/structures';
+import { CountFilteredRequest } from '@stamhoofd/structures';
+import { NotificationType } from '@stamhoofd/structures/notifications/NotificationType.js';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { NotificationService } from '../../../services/NotificationService.js';
+import { SessionService } from '../../../services/SessionService.js';
+import { GetUnreadNotificationsCountEndpoint } from './GetUnreadNotificationsCountEndpoint.js';
+
+describe('Endpoint.GetUnreadNotificationsCountEndpoint', () => {
+    const endpoint = new GetUnreadNotificationsCountEndpoint();
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    afterEach(async () => {
+        await Notification.delete();
+    });
+
+    async function count(user: User, filter: StamhoofdFilter | null = null) {
+        const request = Request.get({
+            path: '/notifications/unread-count',
+            query: new CountFilteredRequest({ filter }),
+            headers: { authorization: 'Bearer ' + (await SessionService.createSession(user)).accessToken },
+        });
+        return (await testServer.test<CountResponse>(endpoint, request)).body.count;
+    }
+
+    async function send(users: User[], organizationId?: string) {
+        return (await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            organizationId,
+            to: { users },
+        }))!;
+    }
+
+    test('counts unread, not dismissed notifications of the user', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({}).create();
+        const other = await new UserFactory({}).create();
+
+        await send([user], organization.id);
+        await send([user, other]);
+        const read = await send([user]);
+        const dismissed = await send([user]);
+        await send([other]);
+
+        await NotificationService.markAsRead(await NotificationRecipient.select().where('notificationId', read.id).first(true));
+
+        const dismissedRecipient = await NotificationRecipient.select().where('notificationId', dismissed.id).first(true);
+        dismissedRecipient.dismissedAt = new Date();
+        await dismissedRecipient.save();
+
+        expect(await count(user)).toBe(2);
+        expect(await count(other)).toBe(2);
+        expect(await count(user, { organizationId: organization.id })).toBe(1);
+    });
+});

--- a/backend/app/api/src/endpoints/global/notifications/GetUnreadNotificationsCountEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/notifications/GetUnreadNotificationsCountEndpoint.ts
@@ -1,0 +1,50 @@
+import type { Decoder } from '@simonbackx/simple-encoding';
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import { SQL } from '@stamhoofd/sql';
+import { CountFilteredRequest, CountResponse } from '@stamhoofd/structures';
+
+import { Context } from '../../../helpers/Context.js';
+import { GetNotificationsEndpoint } from './GetNotificationsEndpoint.js';
+
+type Params = Record<string, never>;
+type Query = CountFilteredRequest;
+type Body = undefined;
+type ResponseBody = CountResponse;
+
+/**
+ * Number of unread, not dismissed notifications of the authenticated user.
+ */
+export class GetUnreadNotificationsCountEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    queryDecoder = CountFilteredRequest as Decoder<CountFilteredRequest>;
+
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'GET') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/notifications/unread-count', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(request: DecodedRequest<Params, Query, Body>) {
+        await Context.setUserOrganizationScope();
+        await Context.authenticate();
+
+        const query = await GetNotificationsEndpoint.buildQuery(request.query);
+        query
+            .where(SQL.column(NotificationRecipient.table, 'readAt'), null)
+            .where(SQL.column(NotificationRecipient.table, 'dismissedAt'), null);
+
+        return new Response(
+            CountResponse.create({
+                count: await query.count(),
+            }),
+        );
+    }
+}

--- a/backend/app/api/src/endpoints/global/notifications/MarkAllNotificationsReadEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/notifications/MarkAllNotificationsReadEndpoint.test.ts
@@ -1,0 +1,87 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { User } from '@stamhoofd/models';
+import { UserFactory } from '@stamhoofd/models';
+import { Notification } from '@stamhoofd/models/models/Notification.js';
+import { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import { NamedObject } from '@stamhoofd/structures';
+import type { CountResponse } from '@stamhoofd/structures';
+import { NotificationType } from '@stamhoofd/structures/notifications/NotificationType.js';
+import { STExpect, TestUtils } from '@stamhoofd/test-utils';
+import { testServer } from '../../../../tests/helpers/TestServer.js';
+import { NotificationService } from '../../../services/NotificationService.js';
+import { SessionService } from '../../../services/SessionService.js';
+import { MarkAllNotificationsReadEndpoint } from './MarkAllNotificationsReadEndpoint.js';
+
+describe('Endpoint.MarkAllNotificationsReadEndpoint', () => {
+    const endpoint = new MarkAllNotificationsReadEndpoint();
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    afterEach(async () => {
+        await Notification.delete();
+    });
+
+    async function post(user: User | null) {
+        const request = Request.post({
+            path: '/notifications/mark-all-read',
+            headers: user ? { authorization: 'Bearer ' + (await SessionService.createSession(user)).accessToken } : {},
+        });
+        return await testServer.test<CountResponse>(endpoint, request);
+    }
+
+    test('marks all unread notifications of the user as read with the current group count', async () => {
+        const user = await new UserFactory({}).create();
+        const other = await new UserFactory({}).create();
+
+        const grouped = (await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            group: { key: 'registrations', resource: NamedObject.create({ id: '1', name: '1' }) },
+            to: { users: [user, other] },
+        }))!;
+        await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            group: { key: 'registrations', resource: NamedObject.create({ id: '2', name: '2' }) },
+            to: { users: [user, other] },
+        });
+        const single = (await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            to: { users: [user] },
+        }))!;
+
+        const seenAt = new Date(2026, 0, 1);
+        const seenRecipient = await NotificationRecipient.select().where('notificationId', single.id).first(true);
+        seenRecipient.seenAt = seenAt;
+        await seenRecipient.save();
+
+        const alreadyRead = (await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            to: { users: [user] },
+        }))!;
+        await NotificationService.markAsRead(await NotificationRecipient.select().where('notificationId', alreadyRead.id).first(true));
+
+        const response = await post(user);
+        expect(response.status).toBe(200);
+        expect(response.body.count).toBe(2);
+
+        const recipients = await NotificationRecipient.select().where('userId', user.id).fetch();
+        expect(recipients).toHaveLength(3);
+        expect(recipients.every(r => r.readAt !== null && r.seenAt !== null)).toBe(true);
+        expect(recipients.find(r => r.notificationId === grouped.id)!.readCount).toBe(2);
+        expect(recipients.find(r => r.notificationId === single.id)!.seenAt).toEqual(seenAt);
+
+        const otherRecipients = await NotificationRecipient.select().where('userId', other.id).fetch();
+        expect(otherRecipients.every(r => r.readAt === null)).toBe(true);
+
+        expect((await post(user)).body.count).toBe(0);
+    });
+
+    test('requires authentication', async () => {
+        await expect(post(null)).rejects.toThrow(STExpect.simpleError({ code: 'not_authenticated' }));
+    });
+});

--- a/backend/app/api/src/endpoints/global/notifications/MarkAllNotificationsReadEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/notifications/MarkAllNotificationsReadEndpoint.ts
@@ -1,0 +1,40 @@
+import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
+import { Endpoint, Response } from '@simonbackx/simple-endpoints';
+import { CountResponse } from '@stamhoofd/structures';
+
+import { Context } from '../../../helpers/Context.js';
+import { NotificationService } from '../../../services/NotificationService.js';
+
+type Params = Record<string, never>;
+type Query = undefined;
+type Body = undefined;
+type ResponseBody = CountResponse;
+
+/**
+ * Marks every unread notification of the authenticated user as read. Returns how many were marked.
+ */
+export class MarkAllNotificationsReadEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+    protected doesMatch(request: Request): [true, Params] | [false] {
+        if (request.method !== 'POST') {
+            return [false];
+        }
+
+        const params = Endpoint.parseParameters(request.url, '/notifications/mark-all-read', {});
+
+        if (params) {
+            return [true, params as Params];
+        }
+        return [false];
+    }
+
+    async handle(_: DecodedRequest<Params, Query, Body>) {
+        await Context.setUserOrganizationScope();
+        await Context.authenticate();
+
+        const count = await NotificationService.markAllAsRead(Context.impersonatedUserOrUser);
+
+        return new Response(
+            CountResponse.create({ count }),
+        );
+    }
+}

--- a/backend/app/api/src/services/NotificationService.test.ts
+++ b/backend/app/api/src/services/NotificationService.test.ts
@@ -1,0 +1,163 @@
+import { MemberFactory, OrganizationFactory, UserFactory } from '@stamhoofd/models';
+import { Notification } from '@stamhoofd/models/models/Notification.js';
+import { NotificationPreference } from '@stamhoofd/models/models/NotificationPreference.js';
+import { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import { NamedObject } from '@stamhoofd/structures';
+import { NotificationChannel } from '@stamhoofd/structures/notifications/NotificationChannel.js';
+import { NotificationSubjectType } from '@stamhoofd/structures/notifications/NotificationSubjectType.js';
+import { NotificationType } from '@stamhoofd/structures/notifications/NotificationType.js';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { NotificationService } from './NotificationService.js';
+
+describe('NotificationService', () => {
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'platform');
+    });
+
+    afterEach(async () => {
+        vitest.useRealTimers();
+        await Notification.delete();
+        await NotificationPreference.delete();
+    });
+
+    const resource = (id: string) => NamedObject.create({ id, name: 'Registration ' + id });
+
+    async function recipientsOf(notification: Notification) {
+        return await NotificationRecipient.select().where('notificationId', notification.id).fetch();
+    }
+
+    test('targets users and the users linked to members, without duplicates', async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({}).create();
+        const parent = await new UserFactory({}).create();
+        const member = await new MemberFactory({ organization, user: parent }).create();
+        const memberWithoutUser = await new MemberFactory({ organization }).create();
+
+        const notification = await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: { hello: 'world' },
+            organizationId: organization.id,
+            subjectType: NotificationSubjectType.Registration,
+            subjectId: 'registration-1',
+            to: { users: [user, parent.id], members: [member, memberWithoutUser.id] },
+        });
+
+        expect(notification).not.toBeNull();
+        expect(notification!.payload).toEqual({ hello: 'world' });
+        expect(notification!.subjectType).toBe(NotificationSubjectType.Registration);
+        expect(notification!.groupResourceCount).toBe(0);
+
+        const recipients = await recipientsOf(notification!);
+        expect(recipients.map(r => r.userId).sort()).toEqual([user.id, parent.id].sort());
+        expect(recipients.every(r => r.readAt === null && r.readCount === 0)).toBe(true);
+    });
+
+    test('returns null without any targets and skips users that disabled the in-app channel', async () => {
+        const user = await new UserFactory({}).create();
+        const disabledUser = await new UserFactory({}).create();
+
+        const savePreference = async (userId: string, channel: NotificationChannel, enabled: boolean) => {
+            const preference = new NotificationPreference();
+            preference.userId = userId;
+            preference.notificationType = NotificationType.RegistrationCreated;
+            preference.channel = channel;
+            preference.enabled = enabled;
+            await preference.save();
+        };
+        await savePreference(disabledUser.id, NotificationChannel.InApp, false);
+        // Other channels and enabled preferences don't suppress in-app delivery
+        await savePreference(user.id, NotificationChannel.Push, false);
+        await savePreference(user.id, NotificationChannel.InApp, true);
+
+        expect(await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            to: { users: [disabledUser] },
+        })).toBeNull();
+        expect(await Notification.select().count()).toBe(0);
+
+        const notification = await NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            to: { users: [user, disabledUser] },
+        });
+        expect((await recipientsOf(notification!)).map(r => r.userId)).toEqual([user.id]);
+    });
+
+    test('groups notifications with the same key on the same day and reactivates read recipients', async () => {
+        vitest.useFakeTimers({ shouldAdvanceTime: true, toFake: ['Date'] }).setSystemTime(new Date('2026-09-03T10:00:00Z'));
+
+        const organization = await new OrganizationFactory({}).create();
+        const reader = await new UserFactory({}).create();
+        const other = await new UserFactory({}).create();
+        const newcomer = await new UserFactory({}).create();
+
+        const send = (id: string, users: typeof reader[]) => NotificationService.send({
+            type: NotificationType.RegistrationCreated,
+            payload: {},
+            organizationId: organization.id,
+            group: { key: 'registrations', resource: resource(id) },
+            to: { users },
+        });
+
+        const first = (await send('1', [reader, other]))!;
+        expect(first.groupResourceCount).toBe(1);
+
+        const readerRecipient = await NotificationService.markAsRead((await recipientsOf(first)).find(r => r.userId === reader.id)!);
+        expect(readerRecipient.readCount).toBe(1);
+        expect(readerRecipient.readAt).not.toBeNull();
+
+        await send('2', [reader, other]);
+        await send('3', [reader, other]);
+        const fourth = await send('4', [reader, other, newcomer]);
+
+        expect(fourth!.id).toBe(first.id);
+        expect(await Notification.select().count()).toBe(1);
+
+        const merged = (await Notification.getByID(first.id))!;
+        expect(merged.groupResourceCount).toBe(4);
+        expect(merged.groupResources.map(r => r.id)).toEqual(['2', '3', '4']);
+
+        const recipients = await recipientsOf(merged);
+        expect(recipients).toHaveLength(3);
+
+        const reactivated = recipients.find(r => r.userId === reader.id)!;
+        expect(reactivated.readAt).toBeNull();
+        expect(reactivated.seenAt).toBeNull();
+        expect(reactivated.readCount).toBe(1);
+
+        const added = recipients.find(r => r.userId === newcomer.id)!;
+        expect(added.readAt).toBeNull();
+        expect(added.readCount).toBe(3);
+    });
+
+    test('does not group across days, organizations, types or group keys', async () => {
+        // Grouping uses the Europe/Brussels day: 21:30Z is 23:30 local
+        vitest.useFakeTimers({ shouldAdvanceTime: true, toFake: ['Date'] }).setSystemTime(new Date('2026-09-03T21:30:00Z'));
+
+        const organization = await new OrganizationFactory({}).create();
+        const otherOrganization = await new OrganizationFactory({}).create();
+        const user = await new UserFactory({}).create();
+
+        const send = (options: { organizationId: string; key: string; type?: NotificationType }) => NotificationService.send({
+            type: options.type ?? NotificationType.RegistrationCreated,
+            payload: {},
+            organizationId: options.organizationId,
+            group: { key: options.key, resource: resource('x') },
+            to: { users: [user] },
+        });
+
+        const base = (await send({ organizationId: organization.id, key: 'a' }))!;
+        const otherOrg = (await send({ organizationId: otherOrganization.id, key: 'a' }))!;
+        const otherKey = (await send({ organizationId: organization.id, key: 'b' }))!;
+        const otherType = (await send({ organizationId: organization.id, key: 'a', type: 'other.created' as NotificationType }))!;
+
+        expect(new Set([base.id, otherOrg.id, otherKey.id, otherType.id]).size).toBe(4);
+
+        vitest.setSystemTime(new Date('2026-09-03T22:30:00Z'));
+        const nextDay = (await send({ organizationId: organization.id, key: 'a' }))!;
+        expect(nextDay.id).not.toBe(base.id);
+        expect(nextDay.groupResourceCount).toBe(1);
+        expect((await Notification.getByID(base.id))!.groupResourceCount).toBe(1);
+    });
+});

--- a/backend/app/api/src/services/NotificationService.ts
+++ b/backend/app/api/src/services/NotificationService.ts
@@ -1,0 +1,202 @@
+import { Database } from '@simonbackx/simple-database';
+import type { Member, User } from '@stamhoofd/models';
+import { Notification } from '@stamhoofd/models/models/Notification.js';
+import { NotificationPreference } from '@stamhoofd/models/models/NotificationPreference.js';
+import { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import { QueueHandler } from '@stamhoofd/queues';
+import { SQL } from '@stamhoofd/sql';
+import type { NamedObject } from '@stamhoofd/structures';
+import { NotificationChannel } from '@stamhoofd/structures/notifications/NotificationChannel.js';
+import type { NotificationSubjectType } from '@stamhoofd/structures/notifications/NotificationSubjectType.js';
+import type { NotificationType } from '@stamhoofd/structures/notifications/NotificationType.js';
+import { Formatter } from '@stamhoofd/utility';
+import { v7 as uuidv7 } from 'uuid';
+
+export type NotificationTarget = {
+    users?: (User | string)[];
+    /**
+     * Resolved to the users linked to these members
+     */
+    members?: (Member | string)[];
+};
+
+export type SendNotificationOptions = {
+    type: NotificationType;
+    payload: unknown;
+    organizationId?: string | null;
+    subjectType?: NotificationSubjectType | null;
+    subjectId?: string | null;
+    /**
+     * Recent notifications with the same type, organizationId and key are merged into one
+     */
+    group?: {
+        key: string;
+        resource?: NamedObject;
+    };
+    to: NotificationTarget;
+};
+
+/**
+ * Notifications with the same group key are merged within the same calendar day
+ */
+function groupingWindowStart(now: Date): Date {
+    return Formatter.luxon(now).startOf('day').toJSDate();
+}
+
+const maxGroupResources = 3;
+
+export class NotificationService {
+    static async send(options: SendNotificationOptions): Promise<Notification | null> {
+        const userIds = await this.resolveUserIds(options.to);
+        const enabledUserIds = await this.filterDisabledUsers(userIds, options.type);
+
+        if (enabledUserIds.length === 0) {
+            return null;
+        }
+
+        if (options.group) {
+            const group = options.group;
+            // Serializes merges per group within this process only; the notificationId_userId unique key catches cross-process races
+            const queue = 'notifications/group/' + (options.organizationId ?? '') + '/' + options.type + '/' + group.key;
+            return await QueueHandler.schedule(queue, async () => {
+                const existing = await this.findGroupedNotification(options, group.key);
+                if (existing) {
+                    await this.mergeInto(existing, group.resource, enabledUserIds);
+                    return existing;
+                }
+                return await this.create(options, enabledUserIds);
+            });
+        }
+
+        return await this.create(options, enabledUserIds);
+    }
+
+    /**
+     * Returns the updated recipient. The group count is read in SQL so a concurrent merge can't leave a stale readCount.
+     */
+    static async markAsRead(recipient: NotificationRecipient): Promise<NotificationRecipient> {
+        await this.markRead('r.id = ?', [recipient.id]);
+        return await NotificationRecipient.getByID(recipient.id) as NotificationRecipient;
+    }
+
+    /**
+     * Returns the number of notifications that were unread
+     */
+    static async markAllAsRead(user: User): Promise<number> {
+        return await this.markRead('r.userId = ? AND r.readAt IS NULL', [user.id]);
+    }
+
+    private static async markRead(where: string, params: unknown[]): Promise<number> {
+        const now = new Date();
+        now.setMilliseconds(0);
+
+        const [result] = await Database.update(
+            `UPDATE \`${NotificationRecipient.table}\` r
+            JOIN \`${Notification.table}\` n ON n.id = r.notificationId
+            SET r.readAt = ?, r.seenAt = COALESCE(r.seenAt, ?), r.readCount = n.groupResourceCount
+            WHERE ${where}`,
+            [now, now, ...params],
+        );
+        return result.affectedRows;
+    }
+
+    private static async resolveUserIds(target: NotificationTarget): Promise<string[]> {
+        const userIds = (target.users ?? []).map(u => typeof u === 'string' ? u : u.id);
+        const memberIds = (target.members ?? []).map(m => typeof m === 'string' ? m : m.id);
+
+        if (memberIds.length > 0) {
+            const rows = await SQL.select('usersId')
+                .from('_members_users')
+                .where('membersId', memberIds)
+                .fetch();
+            userIds.push(...rows.map(r => r._members_users.usersId as string));
+        }
+
+        return Formatter.uniqueArray(userIds);
+    }
+
+    private static async filterDisabledUsers(userIds: string[], type: NotificationType): Promise<string[]> {
+        if (userIds.length === 0) {
+            return [];
+        }
+
+        const disabled = await NotificationPreference.select()
+            .where('userId', userIds)
+            .andWhere('notificationType', type)
+            .andWhere('channel', NotificationChannel.InApp)
+            .andWhere('enabled', false)
+            .fetch();
+
+        const disabledIds = new Set(disabled.map(p => p.userId));
+        return userIds.filter(id => !disabledIds.has(id));
+    }
+
+    private static async findGroupedNotification(options: SendNotificationOptions, groupKey: string): Promise<Notification | null> {
+        const windowStart = groupingWindowStart(new Date());
+
+        return await Notification.select()
+            .where('organizationId', options.organizationId ?? null)
+            .andWhere('type', options.type)
+            .andWhere('groupKey', groupKey)
+            .andWhere('createdAt', '>=', windowStart)
+            .orderBy(SQL.column('createdAt'), 'DESC')
+            .first(false);
+    }
+
+    private static async mergeInto(notification: Notification, resource: NamedObject | undefined, userIds: string[]) {
+        notification.groupResourceCount += 1;
+        if (resource) {
+            notification.groupResources = [...notification.groupResources, resource].slice(-maxGroupResources);
+        }
+        await notification.save();
+
+        await SQL.update(NotificationRecipient.table)
+            .set('readAt', null)
+            .set('seenAt', null)
+            .where('notificationId', notification.id)
+            .update();
+
+        const existingRecipients = await NotificationRecipient.select()
+            .where('notificationId', notification.id)
+            .andWhere('userId', userIds)
+            .fetch();
+        const existingUserIds = new Set(existingRecipients.map(r => r.userId));
+        const newUserIds = userIds.filter(id => !existingUserIds.has(id));
+
+        // A new recipient only has the item that just arrived as unread
+        await this.insertRecipients(notification, newUserIds, notification.groupResourceCount - 1);
+    }
+
+    private static async create(options: SendNotificationOptions, userIds: string[]): Promise<Notification> {
+        const notification = new Notification();
+        notification.type = options.type;
+        notification.payload = options.payload;
+        notification.organizationId = options.organizationId ?? null;
+        notification.subjectType = options.subjectType ?? null;
+        notification.subjectId = options.subjectId ?? null;
+
+        if (options.group) {
+            notification.groupKey = options.group.key;
+            notification.groupResourceCount = 1;
+            notification.groupResources = options.group.resource ? [options.group.resource] : [];
+        }
+
+        await notification.save();
+        await this.insertRecipients(notification, userIds, 0);
+        return notification;
+    }
+
+    private static async insertRecipients(notification: Notification, userIds: string[], readCount: number) {
+        if (userIds.length === 0) {
+            return;
+        }
+
+        const createdAt = new Date();
+        createdAt.setMilliseconds(0);
+
+        await SQL.insert(NotificationRecipient.table)
+            .columns('id', 'notificationId', 'userId', 'readCount', 'createdAt')
+            .values(...userIds.map(userId => [uuidv7(), notification.id, userId, readCount, createdAt]))
+            .insert();
+    }
+}

--- a/backend/app/api/src/sql-filters/notifications.ts
+++ b/backend/app/api/src/sql-filters/notifications.ts
@@ -1,0 +1,68 @@
+import { Notification } from '@stamhoofd/models/models/Notification.js';
+import { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import type { SQLFilterDefinitions } from '@stamhoofd/sql';
+import { baseSQLFilterCompilers, createColumnFilter, SQL, SQLValueType } from '@stamhoofd/sql';
+
+export const notificationJoin = SQL.join(Notification.table).where(SQL.column(Notification.table, 'id'), SQL.column(NotificationRecipient.table, 'notificationId'));
+
+/**
+ * Columns are table-qualified because the notifications query joins recipients with notifications.
+ */
+export const notificationFilterCompilers: SQLFilterDefinitions = {
+    ...baseSQLFilterCompilers,
+    id: createColumnFilter({
+        expression: SQL.column(NotificationRecipient.table, 'id'),
+        type: SQLValueType.String,
+        nullable: false,
+    }),
+    notificationId: createColumnFilter({
+        expression: SQL.column(NotificationRecipient.table, 'notificationId'),
+        type: SQLValueType.String,
+        nullable: false,
+    }),
+    readAt: createColumnFilter({
+        expression: SQL.column(NotificationRecipient.table, 'readAt'),
+        type: SQLValueType.Datetime,
+        nullable: true,
+    }),
+    seenAt: createColumnFilter({
+        expression: SQL.column(NotificationRecipient.table, 'seenAt'),
+        type: SQLValueType.Datetime,
+        nullable: true,
+    }),
+    dismissedAt: createColumnFilter({
+        expression: SQL.column(NotificationRecipient.table, 'dismissedAt'),
+        type: SQLValueType.Datetime,
+        nullable: true,
+    }),
+    type: createColumnFilter({
+        expression: SQL.column(Notification.table, 'type'),
+        type: SQLValueType.String,
+        nullable: false,
+    }),
+    organizationId: createColumnFilter({
+        expression: SQL.column(Notification.table, 'organizationId'),
+        type: SQLValueType.String,
+        nullable: true,
+    }),
+    subjectType: createColumnFilter({
+        expression: SQL.column(Notification.table, 'subjectType'),
+        type: SQLValueType.String,
+        nullable: true,
+    }),
+    subjectId: createColumnFilter({
+        expression: SQL.column(Notification.table, 'subjectId'),
+        type: SQLValueType.String,
+        nullable: true,
+    }),
+    groupKey: createColumnFilter({
+        expression: SQL.column(Notification.table, 'groupKey'),
+        type: SQLValueType.String,
+        nullable: true,
+    }),
+    createdAt: createColumnFilter({
+        expression: SQL.column(Notification.table, 'createdAt'),
+        type: SQLValueType.Datetime,
+        nullable: false,
+    }),
+};

--- a/backend/app/api/src/sql-sorters/notifications.ts
+++ b/backend/app/api/src/sql-sorters/notifications.ts
@@ -1,0 +1,20 @@
+import type { NotificationRecipient } from '@stamhoofd/models/models/NotificationRecipient.js';
+import type { SQLOrderByDirection, SQLSortDefinitions } from '@stamhoofd/sql';
+import { SQL, SQLOrderBy } from '@stamhoofd/sql';
+
+/**
+ * Only the recipient id is sortable: it is a uuidv7, so it follows creation order and is indexed per user.
+ */
+export const notificationSorters: SQLSortDefinitions<NotificationRecipient> = {
+    id: {
+        getValue(a) {
+            return a.id;
+        },
+        toSQL: (direction: SQLOrderByDirection): SQLOrderBy => {
+            return new SQLOrderBy({
+                column: SQL.column('notification_recipients', 'id'),
+                direction,
+            });
+        },
+    },
+};

--- a/backend/shared/models/src/migrations/1788385713-notifications-table.sql
+++ b/backend/shared/models/src/migrations/1788385713-notifications-table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `notifications` (
+  `id` varchar(36) NOT NULL,
+  `type` varchar(64) NOT NULL,
+  `organizationId` varchar(36) DEFAULT NULL,
+  `subjectType` varchar(36) DEFAULT NULL,
+  `subjectId` varchar(36) DEFAULT NULL,
+  `payload` json NOT NULL,
+  `groupKey` varchar(255) DEFAULT NULL,
+  `groupResourceCount` int NOT NULL DEFAULT '0',
+  `groupResources` json NOT NULL,
+  `createdAt` datetime NOT NULL,
+  `updatedAt` datetime NOT NULL,
+  PRIMARY KEY (`id` DESC),
+  KEY `groupKey` (`organizationId`,`type`,`groupKey`,`createdAt` DESC) USING BTREE,
+  CONSTRAINT `notifications_ibfk_1` FOREIGN KEY (`organizationId`) REFERENCES `organizations` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/backend/shared/models/src/migrations/1788385714-notification-recipients-table.sql
+++ b/backend/shared/models/src/migrations/1788385714-notification-recipients-table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `notification_recipients` (
+  `id` varchar(36) NOT NULL,
+  `notificationId` varchar(36) NOT NULL,
+  `userId` varchar(36) NOT NULL,
+  `readCount` int NOT NULL DEFAULT '0',
+  `readAt` datetime DEFAULT NULL,
+  `seenAt` datetime DEFAULT NULL,
+  `dismissedAt` datetime DEFAULT NULL,
+  `createdAt` datetime NOT NULL,
+  PRIMARY KEY (`id` DESC),
+  UNIQUE KEY `notificationId_userId` (`notificationId`,`userId`),
+  KEY `userId_id` (`userId`,`id` DESC) USING BTREE,
+  KEY `userId_readAt` (`userId`,`readAt`),
+  CONSTRAINT `notification_recipients_ibfk_1` FOREIGN KEY (`notificationId`) REFERENCES `notifications` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `notification_recipients_ibfk_2` FOREIGN KEY (`userId`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/backend/shared/models/src/migrations/1788385715-notification-preferences-table.sql
+++ b/backend/shared/models/src/migrations/1788385715-notification-preferences-table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `notification_preferences` (
+  `id` varchar(36) NOT NULL,
+  `userId` varchar(36) NOT NULL,
+  `notificationType` varchar(64) NOT NULL,
+  `channel` varchar(32) NOT NULL,
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `createdAt` datetime NOT NULL,
+  `updatedAt` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `userId_type_channel` (`userId`,`notificationType`,`channel`),
+  CONSTRAINT `notification_preferences_ibfk_1` FOREIGN KEY (`userId`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/backend/shared/models/src/models/Notification.ts
+++ b/backend/shared/models/src/models/Notification.ts
@@ -1,0 +1,74 @@
+import { column } from '@simonbackx/simple-database';
+import { AnyDecoder, ArrayDecoder } from '@simonbackx/simple-encoding';
+import { QueryableModel } from '@stamhoofd/sql';
+import { NamedObject } from '@stamhoofd/structures';
+import type { NotificationSubjectType } from '@stamhoofd/structures/notifications/NotificationSubjectType.js';
+import type { NotificationType } from '@stamhoofd/structures/notifications/NotificationType.js';
+import { v7 as uuidv7 } from 'uuid';
+
+/**
+ * Shared between all its recipients (see NotificationRecipient).
+ */
+export class Notification extends QueryableModel {
+    static table = 'notifications';
+
+    @column({
+        primary: true, type: 'string', beforeSave(value) {
+            // uuidv7 keeps ids sortable by creation time
+            return value ?? uuidv7();
+        },
+    })
+    id!: string;
+
+    @column({ type: 'string' })
+    type: NotificationType;
+
+    @column({ type: 'string', nullable: true })
+    organizationId: string | null = null;
+
+    @column({ type: 'string', nullable: true })
+    subjectType: NotificationSubjectType | null = null;
+
+    @column({ type: 'string', nullable: true })
+    subjectId: string | null = null;
+
+    /**
+     * Shape depends on `type`
+     */
+    @column({ type: 'json', decoder: AnyDecoder })
+    payload: unknown = {};
+
+    /**
+     * Recent notifications with the same type, organizationId and groupKey are merged into one
+     */
+    @column({ type: 'string', nullable: true })
+    groupKey: string | null = null;
+
+    @column({ type: 'integer' })
+    groupResourceCount = 0;
+
+    @column({ type: 'json', decoder: new ArrayDecoder(NamedObject) })
+    groupResources: NamedObject[] = [];
+
+    @column({
+        type: 'datetime', beforeSave(old?: any) {
+            if (old !== undefined) {
+                return old;
+            }
+            const date = new Date();
+            date.setMilliseconds(0);
+            return date;
+        },
+    })
+    createdAt: Date;
+
+    @column({
+        type: 'datetime', beforeSave() {
+            const date = new Date();
+            date.setMilliseconds(0);
+            return date;
+        },
+        skipUpdate: true,
+    })
+    updatedAt: Date;
+}

--- a/backend/shared/models/src/models/NotificationPreference.ts
+++ b/backend/shared/models/src/models/NotificationPreference.ts
@@ -1,0 +1,50 @@
+import { column } from '@simonbackx/simple-database';
+import { QueryableModel } from '@stamhoofd/sql';
+import type { NotificationChannel } from '@stamhoofd/structures/notifications/NotificationChannel.js';
+import type { NotificationType } from '@stamhoofd/structures/notifications/NotificationType.js';
+import { v4 as uuidv4 } from 'uuid';
+
+export class NotificationPreference extends QueryableModel {
+    static table = 'notification_preferences';
+
+    @column({
+        primary: true, type: 'string', beforeSave(value) {
+            return value ?? uuidv4();
+        },
+    })
+    id!: string;
+
+    @column({ type: 'string' })
+    userId: string;
+
+    @column({ type: 'string' })
+    notificationType: NotificationType;
+
+    @column({ type: 'string' })
+    channel: NotificationChannel;
+
+    @column({ type: 'boolean' })
+    enabled = true;
+
+    @column({
+        type: 'datetime', beforeSave(old?: any) {
+            if (old !== undefined) {
+                return old;
+            }
+            const date = new Date();
+            date.setMilliseconds(0);
+            return date;
+        },
+    })
+    createdAt: Date;
+
+    @column({
+        type: 'datetime', beforeSave() {
+            const date = new Date();
+            date.setMilliseconds(0);
+            return date;
+        },
+        skipUpdate: true,
+    })
+    updatedAt: Date;
+}

--- a/backend/shared/models/src/models/NotificationRecipient.ts
+++ b/backend/shared/models/src/models/NotificationRecipient.ts
@@ -1,0 +1,70 @@
+import { column } from '@simonbackx/simple-database';
+import { QueryableModel } from '@stamhoofd/sql';
+import { UserNotification } from '@stamhoofd/structures/notifications/UserNotification.js';
+import { v7 as uuidv7 } from 'uuid';
+import type { Notification } from './Notification.js';
+
+export class NotificationRecipient extends QueryableModel {
+    static table = 'notification_recipients';
+
+    @column({
+        primary: true, type: 'string', beforeSave(value) {
+            return value ?? uuidv7();
+        },
+    })
+    id!: string;
+
+    @column({ type: 'string' })
+    notificationId: string;
+
+    @column({ type: 'string' })
+    userId: string;
+
+    /**
+     * Notification.groupResourceCount at the moment the user last read it
+     */
+    @column({ type: 'integer' })
+    readCount = 0;
+
+    @column({ type: 'datetime', nullable: true })
+    readAt: Date | null = null;
+
+    @column({ type: 'datetime', nullable: true })
+    seenAt: Date | null = null;
+
+    @column({ type: 'datetime', nullable: true })
+    dismissedAt: Date | null = null;
+
+    @column({
+        type: 'datetime', beforeSave(old?: any) {
+            if (old !== undefined) {
+                return old;
+            }
+            const date = new Date();
+            date.setMilliseconds(0);
+            return date;
+        },
+    })
+    createdAt: Date;
+
+    getStructure(notification: Notification): UserNotification {
+        return UserNotification.create({
+            id: this.id,
+            notificationId: notification.id,
+            type: notification.type,
+            organizationId: notification.organizationId,
+            subjectType: notification.subjectType,
+            subjectId: notification.subjectId,
+            payload: notification.payload,
+            groupKey: notification.groupKey,
+            groupResourceCount: notification.groupResourceCount,
+            groupResources: notification.groupResources,
+            readCount: this.readCount,
+            readAt: this.readAt,
+            seenAt: this.seenAt,
+            dismissedAt: this.dismissedAt,
+            createdAt: notification.createdAt,
+            updatedAt: notification.updatedAt,
+        });
+    }
+}

--- a/shared/structures/src/notifications/NotificationChannel.ts
+++ b/shared/structures/src/notifications/NotificationChannel.ts
@@ -1,0 +1,4 @@
+export enum NotificationChannel {
+    InApp = 'inApp',
+    Push = 'push',
+}

--- a/shared/structures/src/notifications/NotificationSubjectType.ts
+++ b/shared/structures/src/notifications/NotificationSubjectType.ts
@@ -1,0 +1,6 @@
+export enum NotificationSubjectType {
+    Member = 'member',
+    Registration = 'registration',
+    Order = 'order',
+    Organization = 'organization',
+}

--- a/shared/structures/src/notifications/NotificationType.ts
+++ b/shared/structures/src/notifications/NotificationType.ts
@@ -1,0 +1,15 @@
+/**
+ * Formatted as '<subject>.<event>'. The payload of a notification depends on its type.
+ */
+export enum NotificationType {
+    RegistrationCreated = 'registration.created',
+}
+
+export class NotificationTypeHelper {
+    static getName(type: NotificationType): string {
+        switch (type) {
+            case NotificationType.RegistrationCreated:
+                return $t('Nieuwe inschrijving');
+        }
+    }
+}

--- a/shared/structures/src/notifications/UserNotification.ts
+++ b/shared/structures/src/notifications/UserNotification.ts
@@ -1,0 +1,67 @@
+import { AnyDecoder, ArrayDecoder, AutoEncoder, DateDecoder, field, IntegerDecoder, StringDecoder } from '@simonbackx/simple-encoding';
+import { NamedObject } from '../Event.js';
+import type { NotificationSubjectType } from './NotificationSubjectType.js';
+import type { NotificationType } from './NotificationType.js';
+
+/**
+ * A notification as seen by one user: the recipient row joined with its shared notification.
+ * `type` and `subjectType` are decoded as plain strings so older clients keep working when new values are added.
+ */
+export class UserNotification extends AutoEncoder {
+    /**
+     * Id of the recipient row (uuidv7, sortable)
+     */
+    @field({ decoder: StringDecoder })
+    id: string;
+
+    @field({ decoder: StringDecoder })
+    notificationId: string;
+
+    @field({ decoder: StringDecoder })
+    type: NotificationType;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    organizationId: string | null = null;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    subjectType: NotificationSubjectType | null = null;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    subjectId: string | null = null;
+
+    @field({ decoder: AnyDecoder })
+    payload: unknown = {};
+
+    @field({ decoder: StringDecoder, nullable: true })
+    groupKey: string | null = null;
+
+    @field({ decoder: IntegerDecoder })
+    groupResourceCount = 0;
+
+    /**
+     * The most recently grouped resources (capped by the backend)
+     */
+    @field({ decoder: new ArrayDecoder(NamedObject) })
+    groupResources: NamedObject[] = [];
+
+    /**
+     * groupResourceCount at the time the user last read the notification
+     */
+    @field({ decoder: IntegerDecoder })
+    readCount = 0;
+
+    @field({ decoder: DateDecoder, nullable: true })
+    readAt: Date | null = null;
+
+    @field({ decoder: DateDecoder, nullable: true })
+    seenAt: Date | null = null;
+
+    @field({ decoder: DateDecoder, nullable: true })
+    dismissedAt: Date | null = null;
+
+    @field({ decoder: DateDecoder })
+    createdAt: Date;
+
+    @field({ decoder: DateDecoder })
+    updatedAt: Date;
+}


### PR DESCRIPTION
Adds the storage and API for in-app notifications, without UI or event hooks yet. `NotificationService.send` targets users and/or members (resolved to their linked users), skips users who disabled the in-app channel, and stores one `notifications` row shared by all recipients with a `notification_recipients` row per user. Endpoints: `GET /notifications` (paginated, filterable, only `id DESC`), `GET /notifications/unread-count`, `POST /notifications/mark-all-read`. A `notification_preferences` table is prepared but has no endpoints yet.

Grouping: notifications with the same type, organization and group key are merged within the same Europe/Brussels day. A merge bumps `groupResourceCount`, keeps the last 3 resources, resets `readAt`/`seenAt` for existing recipients (so `readCount` shows how many were read before) and inserts new recipients with `readCount = groupResourceCount - 1`, so a newly added admin only sees the item that just arrived as new. `dismissedAt` is deliberately not reset.

Gotchas:
- The struct is named `UserNotification` to avoid shadowing the DOM `Notification` global in frontend code. `type`/`subjectType` decode as plain strings so old clients keep working when types are added.
- The merge lock is a per-process `QueueHandler` queue; cross-process races are caught by the `notificationId_userId` unique key.
- Both uuidv7 tables use `PRIMARY KEY (id DESC)` like `audit_logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)