### PR TITLE
Block payment mandates after a chargeback

### DIFF
--- a/backend/app/api/src/crons/mollie-chargebacks.test.ts
+++ b/backend/app/api/src/crons/mollie-chargebacks.test.ts
@@ -1,0 +1,254 @@
+import { BalanceItemFactory, BalanceItemPayment, MolliePayment, Organization, OrganizationFactory, Payment, PaymentMandateChargebacks } from '@stamhoofd/models';
+import { PaymentMethod, PaymentProvider, PaymentStatus, PaymentType } from '@stamhoofd/structures';
+import { CreateMandateSettings } from '@stamhoofd/structures/checkout/CreateMandateSettings.js';
+import { TestUtils } from '@stamhoofd/test-utils';
+import type { MollieMockPayment } from '../../tests/helpers/MollieMocker.js';
+import { MollieMocker } from '../../tests/helpers/MollieMocker.js';
+import { initMembershipOrganization } from '../../tests/init/initMembershipOrganization.js';
+import { MollieService } from '../services/MollieService.js';
+import { PaymentMandateService } from '../services/PaymentMandateService.js';
+import { PaymentService } from '../services/PaymentService.js';
+import { checkMollieChargebacksFor } from './mollie-chargebacks.js';
+
+describe('Cron.mollie-chargebacks', () => {
+    let mollieMocker: MollieMocker;
+    let sellingOrganization: Organization;
+
+    beforeAll(async () => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker = new MollieMocker();
+        mollieMocker.start();
+
+        sellingOrganization = await initMembershipOrganization();
+        sellingOrganization.meta.registrationPaymentConfiguration.enableMandates = true;
+        await sellingOrganization.save();
+        await mollieMocker.setupToken(sellingOrganization);
+    });
+
+    afterAll(() => {
+        mollieMocker.stop();
+    });
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker.reset();
+    });
+
+    /**
+     * Create a paying organization with saved Mollie mandates (two for the same card, one for another card)
+     * and a succeeded recurring payment on the default mandate.
+     */
+    const init = async ({ withMandate = true }: { withMandate?: boolean } = {}) => {
+        const payingOrganization = await new OrganizationFactory({}).create();
+        const customerId = mollieMocker.createId('cst');
+        mollieMocker.customers.push({ id: customerId });
+
+        const mandate = mollieMocker.addMandate({ customerId, cardNumber: '1234' });
+        const sameCardMandate = mollieMocker.addMandate({ customerId, cardNumber: '1234' });
+        const otherMandate = mollieMocker.addMandate({ customerId, cardNumber: '9999' });
+
+        payingOrganization.serverMeta.mollieCustomerId = customerId;
+        payingOrganization.serverMeta.mollieMandateId = mandate.id;
+        await payingOrganization.save();
+
+        const price = 50_0000;
+        const balanceItem = await new BalanceItemFactory({
+            organizationId: sellingOrganization.id,
+            payingOrganizationId: payingOrganization.id,
+            amount: 1,
+            unitPrice: price,
+            pricePaid: price,
+        }).create();
+
+        const payment = new Payment();
+        payment.organizationId = sellingOrganization.id;
+        payment.payingOrganizationId = payingOrganization.id;
+        payment.method = PaymentMethod.CreditCard;
+        payment.provider = PaymentProvider.Mollie;
+        payment.status = PaymentStatus.Succeeded;
+        payment.type = PaymentType.Payment;
+        payment.price = price;
+        payment.paidAt = new Date();
+        payment.mandateId = withMandate ? mandate.id : null;
+        await payment.save();
+
+        const balanceItemPayment = new BalanceItemPayment();
+        balanceItemPayment.balanceItemId = balanceItem.id;
+        balanceItemPayment.paymentId = payment.id;
+        balanceItemPayment.organizationId = sellingOrganization.id;
+        balanceItemPayment.price = price;
+        await balanceItemPayment.save();
+
+        const mockPayment: MollieMockPayment = {
+            id: mollieMocker.createId('tr'),
+            status: 'paid',
+            amount: { currency: 'EUR', value: (Math.round(price / 100) / 100).toFixed(2) },
+            internalPaymentId: payment.id,
+            redirectUrl: null,
+            sequenceType: withMandate ? 'recurring' : 'oneoff',
+            customerId,
+            mandateId: withMandate ? mandate.id : null,
+            isCancelable: false,
+            details: null,
+        };
+        mollieMocker.payments.push(mockPayment);
+
+        const molliePayment = new MolliePayment();
+        molliePayment.paymentId = payment.id;
+        molliePayment.mollieId = mockPayment.id;
+        await molliePayment.save();
+
+        return { payingOrganization, payment, mockPayment, mandate, sameCardMandate, otherMandate };
+    };
+
+    const runCron = async () => {
+        const service = await MollieService.create({ sellingOrganization });
+        expect(service).not.toBeNull();
+        await checkMollieChargebacksFor(service!, false);
+    };
+
+    const getMandates = async (payingOrganization: Organization) => {
+        return await PaymentMandateService.getMandates({
+            sellingOrganization,
+            user: null,
+            payingOrganization: (await Organization.getByID(payingOrganization.id))!,
+        });
+    };
+
+    test('A chargeback blocks the mandate and other mandates of the same card', async () => {
+        const { payingOrganization, payment, mockPayment, mandate, sameCardMandate, otherMandate } = await init();
+
+        mollieMocker.createChargeback(mockPayment);
+        await runCron();
+
+        const chargebacks = await Payment.select().where('reversingPaymentId', payment.id).fetch();
+        expect(chargebacks).toHaveLength(1);
+        expect(chargebacks[0]).toMatchObject({
+            type: PaymentType.Chargeback,
+            status: PaymentStatus.Succeeded,
+            price: -50_0000,
+            mandateId: mandate.id,
+        });
+
+        const updated = (await Organization.getByID(payingOrganization.id))!;
+        expect(updated.serverMeta.blockedMandates.map(b => b.id).sort()).toEqual([mandate.id, sameCardMandate.id].sort());
+        expect(updated.serverMeta.blockedMandates[0].paymentId).toBe(chargebacks[0].id);
+
+        // The default moves to the first usable mandate
+        expect(updated.serverMeta.mollieMandateId).toBe(otherMandate.id);
+
+        // The chargeback is counted on the mandate
+        expect(updated.serverMeta.mandateChargebacks).toHaveLength(1);
+        expect(updated.serverMeta.mandateChargebacks[0]).toMatchObject({ id: mandate.id, identifier: '1234/12/2030' });
+        expect(updated.serverMeta.mandateChargebacks[0].dates).toHaveLength(1);
+
+        const mandates = await getMandates(payingOrganization);
+        expect(mandates.find(m => m.id === mandate.id)!.blockedAt).not.toBeNull();
+        expect(mandates.find(m => m.id === sameCardMandate.id)!.blockedAt).not.toBeNull();
+        expect(mandates.find(m => m.id === otherMandate.id)!.blockedAt).toBeNull();
+
+        // Usable mandates are listed before blocked ones
+        const grouped = PaymentMandateService.groupByMandate(mandates).mandates;
+        expect(grouped).toHaveLength(2);
+        expect(grouped[0].id).toBe(otherMandate.id);
+        expect([mandate.id, sameCardMandate.id]).toContain(grouped[1].id);
+
+        // Running the cron again does not register or block anything twice
+        await runCron();
+        expect(await Payment.select().where('reversingPaymentId', payment.id).fetch()).toHaveLength(1);
+        expect((await Organization.getByID(payingOrganization.id))!.serverMeta.blockedMandates).toHaveLength(2);
+    });
+
+    test('Chargeback dates per mandate are limited to the last 12 months and at most 5', () => {
+        const entry = PaymentMandateChargebacks.create({ id: 'mdt_test' });
+        const now = new Date('2026-09-03T10:00:00.000Z');
+        const day = 1000 * 60 * 60 * 24;
+
+        entry.add(new Date(now.getTime() - 400 * day));
+        entry.add(new Date(now.getTime() - 300 * day));
+        expect(entry.dates).toHaveLength(2);
+
+        for (let i = 0; i < 6; i++) {
+            entry.add(new Date(now.getTime() - i * day));
+        }
+
+        // The oldest ones are dropped, the one older than a year too
+        expect(entry.dates).toHaveLength(5);
+        expect(entry.dates[0]).toEqual(now);
+        expect(entry.dates[4]).toEqual(new Date(now.getTime() - 4 * day));
+    });
+
+    test('A blocked mandate can no longer be used to pay, nor can a new mandate for the same card', async () => {
+        const { payingOrganization, mockPayment, mandate, otherMandate } = await init();
+
+        mollieMocker.createChargeback(mockPayment);
+        await runCron();
+
+        // The same card is saved again after the block
+        const newSameCardMandate = mollieMocker.addMandate({ customerId: payingOrganization.serverMeta.mollieCustomerId!, cardNumber: '1234' });
+
+        const fresh = (await Organization.getByID(payingOrganization.id))!;
+        expect(fresh.serverMeta.blockedMandates.map(b => b.id)).not.toContain(newSameCardMandate.id);
+
+        const mandates = await getMandates(payingOrganization);
+        expect(mandates.find(m => m.id === newSameCardMandate.id)!.blockedAt).not.toBeNull();
+
+        const validate = (id: string) => PaymentService.validateMandate({
+            method: PaymentMethod.Unknown,
+            paymentConfiguration: sellingOrganization.meta.registrationPaymentConfiguration,
+            mandate: mandates.find(m => m.id === id)!,
+            payingOrganization: fresh,
+            sellingOrganization,
+            user: null,
+        });
+
+        await expect(validate(mandate.id)).rejects.toMatchObject({ code: 'mandate_blocked' });
+        await expect(validate(newSameCardMandate.id)).rejects.toMatchObject({ code: 'mandate_blocked' });
+        await expect(validate(otherMandate.id)).resolves.toMatchObject({ id: otherMandate.id });
+
+        // The grouped list only offers the other card as usable
+        const grouped = PaymentMandateService.groupByMandate(mandates).mandates;
+        expect(grouped.filter(m => !m.isBlocked).map(m => m.id)).toEqual([otherMandate.id]);
+    });
+
+    test('Validating the same card again with a new payment unblocks all mandates for that card', async () => {
+        const { payingOrganization, mockPayment, mandate, sameCardMandate, otherMandate } = await init();
+
+        mollieMocker.createChargeback(mockPayment);
+        await runCron();
+        expect((await Organization.getByID(payingOrganization.id))!.serverMeta.blockedMandates).toHaveLength(2);
+
+        // A new 'first' payment with the same card succeeds and creates a new mandate
+        const newMandate = mollieMocker.addMandate({ customerId: payingOrganization.serverMeta.mollieCustomerId!, cardNumber: '1234' });
+        const payment = new Payment();
+        payment.organizationId = sellingOrganization.id;
+        payment.payingOrganizationId = payingOrganization.id;
+        payment.method = PaymentMethod.CreditCard;
+        payment.provider = PaymentProvider.Mollie;
+        payment.status = PaymentStatus.Pending;
+        payment.type = PaymentType.Payment;
+        payment.price = 2_0000;
+        payment.mandateId = newMandate.id;
+        payment.createMandate = CreateMandateSettings.create({ saveAsDefault: false });
+        await payment.save();
+
+        await PaymentService.handlePaymentStatusUpdate(payment, sellingOrganization, PaymentStatus.Succeeded);
+
+        expect((await Organization.getByID(payingOrganization.id))!.serverMeta.blockedMandates).toHaveLength(0);
+
+        const mandates = await getMandates(payingOrganization);
+        for (const id of [mandate.id, sameCardMandate.id, otherMandate.id, newMandate.id]) {
+            expect(mandates.find(m => m.id === id)!.blockedAt).toBeNull();
+        }
+    });
+
+    test('A chargeback of a payment without mandate does not block anything', async () => {
+        const { payingOrganization, payment, mockPayment } = await init({ withMandate: false });
+
+        mollieMocker.createChargeback(mockPayment);
+        await runCron();
+
+        expect(await Payment.select().where('reversingPaymentId', payment.id).fetch()).toHaveLength(1);
+        expect((await Organization.getByID(payingOrganization.id))!.serverMeta.blockedMandates).toHaveLength(0);
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/billing/DeleteOrganizationMandateEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/billing/DeleteOrganizationMandateEndpoint.test.ts
@@ -1,0 +1,91 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Token } from '@stamhoofd/models';
+import { BlockedPaymentMandate, Organization, OrganizationFactory } from '@stamhoofd/models';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { MollieMocker } from '../../../../../tests/helpers/MollieMocker.js';
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { initAdmin } from '../../../../../tests/init/index.js';
+import { initMembershipOrganization } from '../../../../../tests/init/initMembershipOrganization.js';
+import { DeleteOrganizationMandateEndpoint } from './DeleteOrganizationMandateEndpoint.js';
+
+describe('Endpoint.DeleteOrganizationMandateEndpoint', () => {
+    const endpoint = new DeleteOrganizationMandateEndpoint();
+    let mollieMocker: MollieMocker;
+    let sellingOrganization: Organization;
+
+    beforeAll(async () => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker = new MollieMocker();
+        mollieMocker.start();
+
+        sellingOrganization = await initMembershipOrganization();
+        await mollieMocker.setupToken(sellingOrganization);
+    });
+
+    afterAll(() => {
+        mollieMocker.stop();
+    });
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker.reset();
+    });
+
+    const remove = async (mandateId: string, organization: Organization, token: Token) => {
+        const request = Request.buildJson('DELETE', `/billing/${sellingOrganization.id}/mandates/${mandateId}`, organization.getApiHost());
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    /**
+     * A paying organization with one usable default mandate and, optionally, blocked mandates
+     */
+    const init = async ({ usable = 1, blocked = 1 }: { usable?: number; blocked?: number } = {}) => {
+        const organization = await new OrganizationFactory({}).create();
+        const { adminToken } = await initAdmin({ organization });
+
+        const customerId = mollieMocker.createId('cst');
+        mollieMocker.customers.push({ id: customerId });
+        organization.serverMeta.mollieCustomerId = customerId;
+
+        const usableMandates = Array.from({ length: usable }, (_, i) => mollieMocker.addMandate({ customerId, cardNumber: '100' + i }));
+        const blockedMandates = Array.from({ length: blocked }, (_, i) => mollieMocker.addMandate({ customerId, cardNumber: '900' + i }));
+
+        organization.serverMeta.mollieMandateId = usableMandates[0]?.id ?? null;
+        for (const mandate of blockedMandates) {
+            organization.serverMeta.blockedMandates.push(BlockedPaymentMandate.create({ id: mandate.id }));
+        }
+        await organization.save();
+
+        return { organization, token: adminToken, usableMandates, blockedMandates };
+    };
+
+    test('A blocked mandate can be deleted even when it is the last one', async () => {
+        const { organization, token, blockedMandates } = await init({ usable: 0, blocked: 2 });
+
+        const response = await remove(blockedMandates[0].id, organization, token);
+        expect(response.status).toBe(201);
+        expect(mollieMocker.mandates.map(m => m.id)).toEqual([blockedMandates[1].id]);
+
+        const last = await remove(blockedMandates[1].id, organization, token);
+        expect(last.status).toBe(201);
+        expect(mollieMocker.mandates).toHaveLength(0);
+    });
+
+    test('The last usable mandate cannot be deleted', async () => {
+        const { organization, token, usableMandates } = await init({ usable: 2, blocked: 1 });
+
+        // Delete the usable one that is not the default
+        const response = await remove(usableMandates[1].id, organization, token);
+        expect(response.status).toBe(201);
+
+        // Only a blocked one remains next to the default: this one is the last usable
+        // (the default cannot be deleted either, but that is a separate rule)
+        const fresh = (await Organization.getByID(organization.id))!;
+        fresh.serverMeta.mollieMandateId = null;
+        await fresh.save();
+
+        await expect(remove(usableMandates[0].id, organization, token)).rejects.toMatchObject({ code: 'not_allowed' });
+        expect(mollieMocker.mandates.map(m => m.id)).toContain(usableMandates[0].id);
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/billing/OrganizationCheckoutEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/billing/OrganizationCheckoutEndpoint.test.ts
@@ -1,6 +1,6 @@
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Token } from '@stamhoofd/models';
-import { BalanceItem, GroupFactory, MemberFactory, Organization, OrganizationFactory, RegistrationFactory, STPackage, STPackageFactory } from '@stamhoofd/models';
+import { BalanceItem, BlockedPaymentMandate, GroupFactory, MemberFactory, Organization, OrganizationFactory, RegistrationFactory, STPackage, STPackageFactory } from '@stamhoofd/models';
 import {
     Address,
     BalanceItemStatus,
@@ -759,6 +759,30 @@ describe('Endpoint.OrganizationCheckoutEndpoint', () => {
             await renewed.refresh();
             expect(renewed.validAt).not.toBeNull();
             expectStartsAtEndOfCurrent(renewed, current);
+        });
+
+        test('Members renewal with a blocked mandate is refused', async () => {
+            freezeDate();
+            const { organization, token, customerCompany } = await createBuyer();
+            const mandate = await setupExistingMandate(organization);
+
+            const fresh = (await Organization.getByID(organization.id))!;
+            fresh.serverMeta.blockedMandates.push(BlockedPaymentMandate.create({ id: mandate.id }));
+            await fresh.save();
+
+            const current = await createActivePackage(organization, {
+                bundle: STPackageBundle.Members,
+                validUntil: new Date(Date.now() + 30 * DAY),
+            });
+
+            const checkout = buildRenewalCheckout({
+                customerCompany,
+                renewPackageIds: [current.id],
+                mandate,
+            });
+
+            await expect(post(membershipOrganization.id, checkout, organization, token)).rejects.toMatchObject({ code: 'mandate_blocked' });
+            expect(mollieMocker.payments).toHaveLength(0);
         });
 
         test('Members renewal via package bundles starts at the end of the current package (existing mandate)', async () => {

--- a/backend/app/api/src/endpoints/organization/dashboard/billing/PatchOrganizationMandatesEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/billing/PatchOrganizationMandatesEndpoint.test.ts
@@ -1,0 +1,126 @@
+import type { PatchableArrayAutoEncoder } from '@simonbackx/simple-encoding';
+import { PatchableArray } from '@simonbackx/simple-encoding';
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Token } from '@stamhoofd/models';
+import { BlockedPaymentMandate, Organization, OrganizationFactory } from '@stamhoofd/models';
+import { PaymentMandate } from '@stamhoofd/structures/PaymentMandate.js';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { MollieMocker } from '../../../../../tests/helpers/MollieMocker.js';
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { initAdmin, initPlatformAdmin } from '../../../../../tests/init/index.js';
+import { initMembershipOrganization } from '../../../../../tests/init/initMembershipOrganization.js';
+import { PatchOrganizationMandatesEndpoint } from './PatchOrganizationMandatesEndpoint.js';
+
+describe('Endpoint.PatchOrganizationMandatesEndpoint', () => {
+    const endpoint = new PatchOrganizationMandatesEndpoint();
+    let mollieMocker: MollieMocker;
+    let sellingOrganization: Organization;
+
+    beforeAll(async () => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker = new MollieMocker();
+        mollieMocker.start();
+
+        sellingOrganization = await initMembershipOrganization();
+        await mollieMocker.setupToken(sellingOrganization);
+    });
+
+    afterAll(() => {
+        mollieMocker.stop();
+    });
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker.reset();
+    });
+
+    const patch = async (body: PatchableArrayAutoEncoder<PaymentMandate>, organization: Organization, token: Token) => {
+        const request = Request.buildJson('PATCH', `/billing/${sellingOrganization.id}/mandates`, organization.getApiHost(), body);
+        request.headers.authorization = 'Bearer ' + token.accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    const init = async () => {
+        const organization = await new OrganizationFactory({}).create();
+        const { adminToken } = await initAdmin({ organization });
+
+        const customerId = mollieMocker.createId('cst');
+        mollieMocker.customers.push({ id: customerId });
+        const defaultMandate = mollieMocker.addMandate({ customerId, cardNumber: '1234' });
+        const blockedMandate = mollieMocker.addMandate({ customerId, cardNumber: '9999' });
+
+        organization.serverMeta.mollieCustomerId = customerId;
+        organization.serverMeta.mollieMandateId = defaultMandate.id;
+        organization.serverMeta.blockedMandates.push(BlockedPaymentMandate.create({ id: blockedMandate.id }));
+        await organization.save();
+
+        return { organization, token: adminToken, defaultMandate, blockedMandate };
+    };
+
+    const setDefaultPatch = (mandateId: string) => {
+        const arr: PatchableArrayAutoEncoder<PaymentMandate> = new PatchableArray();
+        arr.addPatch(PaymentMandate.patch({ id: mandateId, isDefault: true }));
+        return arr;
+    };
+
+    const setBlockedPatch = (mandateId: string, blocked: boolean) => {
+        const arr: PatchableArrayAutoEncoder<PaymentMandate> = new PatchableArray();
+        arr.addPatch(PaymentMandate.patch({ id: mandateId, blockedAt: blocked ? new Date() : null }));
+        return arr;
+    };
+
+    const getBlockedIds = async (organization: Organization) => {
+        return (await Organization.getByID(organization.id))!.serverMeta.blockedMandates.map(b => b.id).sort();
+    };
+
+    test('A blocked mandate cannot be set as default', async () => {
+        const { organization, token, defaultMandate, blockedMandate } = await init();
+
+        await expect(patch(setDefaultPatch(blockedMandate.id), organization, token)).rejects.toMatchObject({ code: 'mandate_blocked' });
+
+        const updated = (await Organization.getByID(organization.id))!;
+        expect(updated.serverMeta.mollieMandateId).toBe(defaultMandate.id);
+    });
+
+    test('The seller can block and unblock a mandate', async () => {
+        const { organization, defaultMandate, blockedMandate } = await init();
+        const { adminToken: sellerToken } = await initPlatformAdmin();
+
+        // Another mandate for the same card as the default one (the response groups these per card)
+        const sameCardMandate = mollieMocker.addMandate({ customerId: organization.serverMeta.mollieCustomerId!, cardNumber: '1234' });
+
+        const blockResponse = await patch(setBlockedPatch(defaultMandate.id, true), organization, sellerToken);
+        expect(blockResponse.status).toBe(200);
+        expect(blockResponse.body.find(m => m.id === defaultMandate.id)!.blockedAt).not.toBeNull();
+        expect(await getBlockedIds(organization)).toEqual([defaultMandate.id, sameCardMandate.id, blockedMandate.id].sort());
+
+        const unblockResponse = await patch(setBlockedPatch(defaultMandate.id, false), organization, sellerToken);
+        expect(unblockResponse.status).toBe(200);
+        expect(unblockResponse.body.find(m => m.id === defaultMandate.id)!.blockedAt).toBeNull();
+        expect(unblockResponse.body.find(m => m.id === blockedMandate.id)!.blockedAt).not.toBeNull();
+        expect(await getBlockedIds(organization)).toEqual([blockedMandate.id]);
+    });
+
+    test('The paying organization cannot block or unblock a mandate', async () => {
+        const { organization, token, defaultMandate, blockedMandate } = await init();
+
+        await expect(patch(setBlockedPatch(defaultMandate.id, true), organization, token)).rejects.toMatchObject({ code: 'permission_denied' });
+        await expect(patch(setBlockedPatch(blockedMandate.id, false), organization, token)).rejects.toMatchObject({ code: 'permission_denied' });
+        expect(await getBlockedIds(organization)).toEqual([blockedMandate.id]);
+    });
+
+    test('Blocked mandates are returned as blocked', async () => {
+        const { organization, token, defaultMandate, blockedMandate } = await init();
+
+        const response = await patch(setDefaultPatch(defaultMandate.id), organization, token);
+        expect(response.status).toBe(200);
+
+        const blocked = response.body.find(m => m.id === blockedMandate.id);
+        expect(blocked?.blockedAt).not.toBeNull();
+        expect(blocked?.isDefault).toBe(false);
+
+        const defaultResponse = response.body.find(m => m.id === defaultMandate.id);
+        expect(defaultResponse?.blockedAt).toBeNull();
+        expect(defaultResponse?.isDefault).toBe(true);
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/billing/PatchOrganizationMandatesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/billing/PatchOrganizationMandatesEndpoint.ts
@@ -13,7 +13,7 @@ type Query = undefined;
 type Body = PatchableArrayAutoEncoder<PaymentMandate>;
 type ResponseBody = PaymentMandate[];
 
-export class DeleteOrganizationMandateEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
+export class PatchOrganizationMandatesEndpoint extends Endpoint<Params, Query, Body, ResponseBody> {
     bodyDecoder = new PatchableArrayDecoder(
         PaymentMandate as Decoder<PaymentMandate>,
         PaymentMandate.patchType() as Decoder<AutoEncoderPatchType<PaymentMandate>>,
@@ -73,7 +73,39 @@ export class DeleteOrganizationMandateEndpoint extends Endpoint<Params, Query, B
                 });
             }
 
+            if (patch.blockedAt !== undefined) {
+                // Only the seller can block or unblock
+                if (!await Context.auth.canManagePayments(sellingOrganization.id)) {
+                    throw Context.auth.error();
+                }
+
+                if (patch.blockedAt) {
+                    await PaymentMandateService.blockMandate({
+                        mandateId: mandate.id,
+                        sellingOrganization,
+                        payingOrganizationId: payingOrganization.id,
+                        paymentId: null,
+                    });
+                    mandate.blockedAt = patch.blockedAt;
+                } else {
+                    await PaymentMandateService.unblockMandate({
+                        mandateId: mandate.id,
+                        sellingOrganization,
+                        payingOrganizationId: payingOrganization.id,
+                    });
+                    mandate.blockedAt = null;
+                }
+            }
+
             if (patch.isDefault === true) {
+                if (mandate.isBlocked) {
+                    throw new SimpleError({
+                        code: 'mandate_blocked',
+                        message: 'Cannot set a blocked mandate as default',
+                        human: $t('Een geblokkeerde betaalmethode kan niet als standaard ingesteld worden.'),
+                    });
+                }
+
                 await PaymentMandateService.setDefaultMandate({
                     mandateId: mandate.id,
                     sellingOrganizationId: sellingOrganization.id,
@@ -83,10 +115,11 @@ export class DeleteOrganizationMandateEndpoint extends Endpoint<Params, Query, B
             }
         }
 
+        // serverMeta was modified on a separate instance: reload before reading blocks and the default
         const updatedMandates = await PaymentMandateService.getMandates({
             sellingOrganization,
             user,
-            payingOrganization,
+            payingOrganization: await Organization.getByID(payingOrganization.id, true),
         });
 
         return new Response(PaymentMandateService.groupByMandate(updatedMandates).mandates);

--- a/backend/app/api/src/endpoints/organization/dashboard/receivable-balances/ChargeReceivableBalancesEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/receivable-balances/ChargeReceivableBalancesEndpoint.test.ts
@@ -1,0 +1,138 @@
+import { Request } from '@simonbackx/simple-endpoints';
+import type { Token } from '@stamhoofd/models';
+import { BalanceItemFactory, BlockedPaymentMandate, CachedBalance, Organization, OrganizationFactory, Payment } from '@stamhoofd/models';
+import { CountFilteredRequest, MollieOnboarding, MollieStatus, PaymentMethod, PaymentType } from '@stamhoofd/structures';
+import { TestUtils } from '@stamhoofd/test-utils';
+import { MollieMocker } from '../../../../../tests/helpers/MollieMocker.js';
+import { testServer } from '../../../../../tests/helpers/TestServer.js';
+import { initAdmin, initPlatformAdmin } from '../../../../../tests/init/index.js';
+import { initMembershipOrganization } from '../../../../../tests/init/initMembershipOrganization.js';
+import { ChargeReceivableBalancesEndpoint } from './ChargeReceivableBalancesEndpoint.js';
+
+describe('Endpoint.ChargeReceivableBalancesEndpoint', () => {
+    const endpoint = new ChargeReceivableBalancesEndpoint();
+    let mollieMocker: MollieMocker;
+    let sellingOrganization: Organization;
+    let sellerToken: Token;
+
+    beforeAll(async () => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker = new MollieMocker();
+        mollieMocker.start();
+
+        sellingOrganization = await initMembershipOrganization();
+        sellingOrganization.privateMeta.mollieOnboarding = MollieOnboarding.create({
+            canReceivePayments: true,
+            canReceiveSettlements: true,
+            status: MollieStatus.Completed,
+        });
+        const config = sellingOrganization.meta.registrationPaymentConfiguration;
+        if (!config.paymentMethods.includes(PaymentMethod.CreditCard)) {
+            config.paymentMethods.push(PaymentMethod.CreditCard);
+        }
+        config.enableMandates = true;
+        await sellingOrganization.save();
+        await mollieMocker.setupToken(sellingOrganization);
+
+        sellerToken = (await initPlatformAdmin()).adminToken;
+    });
+
+    afterAll(() => {
+        mollieMocker.stop();
+    });
+
+    beforeEach(() => {
+        TestUtils.setEnvironment('userMode', 'organization');
+        mollieMocker.reset();
+    });
+
+    const charge = async () => {
+        const request = Request.buildJson('POST', '/receivable-balances/charge', sellingOrganization.getApiHost(), new CountFilteredRequest({}));
+        request.headers.authorization = 'Bearer ' + sellerToken.accessToken;
+        return await testServer.test(endpoint, request);
+    };
+
+    /**
+     * Create a paying organization with an open balance at the seller and optionally a default mandate
+     */
+    const init = async ({ withMandate = true, blocked = false, withOtherMandate = false }: { withMandate?: boolean; blocked?: boolean; withOtherMandate?: boolean } = {}) => {
+        const payingOrganization = await new OrganizationFactory({}).create();
+        await initAdmin({ organization: payingOrganization });
+        const customerId = mollieMocker.createId('cst');
+        mollieMocker.customers.push({ id: customerId });
+        payingOrganization.serverMeta.mollieCustomerId = customerId;
+
+        const mandate = withMandate ? mollieMocker.addMandate({ customerId }) : null;
+        if (mandate) {
+            payingOrganization.serverMeta.mollieMandateId = mandate.id;
+            if (blocked) {
+                payingOrganization.serverMeta.blockedMandates.push(BlockedPaymentMandate.create({ id: mandate.id }));
+            }
+        }
+        const otherMandate = withOtherMandate ? mollieMocker.addMandate({ customerId, cardNumber: '9999' }) : null;
+        await payingOrganization.save();
+
+        await new BalanceItemFactory({
+            organizationId: sellingOrganization.id,
+            payingOrganizationId: payingOrganization.id,
+            amount: 1,
+            unitPrice: 50_0000,
+        }).create();
+        await CachedBalance.updateForOrganizations(sellingOrganization.id, [payingOrganization.id]);
+
+        return { payingOrganization, mandate, otherMandate };
+    };
+
+    const getPayments = async (payingOrganization: Organization) => {
+        return await Payment.select().where('payingOrganizationId', payingOrganization.id).fetch();
+    };
+
+    test('An open balance is charged on the default mandate', async () => {
+        const { payingOrganization, mandate } = await init();
+
+        const response = await charge();
+        expect(response.status).toBe(201);
+
+        const payments = await getPayments(payingOrganization);
+        expect(payments).toHaveLength(1);
+        expect(payments[0]).toMatchObject({
+            type: PaymentType.Payment,
+            price: 50_0000,
+            mandateId: mandate!.id,
+        });
+        expect(mollieMocker.payments).toHaveLength(1);
+        expect(mollieMocker.payments[0].mandateId).toBe(mandate!.id);
+    });
+
+    test('An open balance is not charged on a blocked default mandate', async () => {
+        const { payingOrganization } = await init({ blocked: true });
+
+        const response = await charge();
+        expect(response.status).toBe(201);
+
+        expect(await getPayments(payingOrganization)).toHaveLength(0);
+        expect(mollieMocker.payments).toHaveLength(0);
+    });
+
+    test('An open balance is charged on another usable mandate when the default is blocked', async () => {
+        const { payingOrganization, otherMandate } = await init({ blocked: true, withOtherMandate: true });
+
+        const response = await charge();
+        expect(response.status).toBe(201);
+
+        const payments = await getPayments(payingOrganization);
+        expect(payments).toHaveLength(1);
+        expect(payments[0].mandateId).toBe(otherMandate!.id);
+        expect(mollieMocker.payments[0].mandateId).toBe(otherMandate!.id);
+    });
+
+    test('An open balance is not charged without a default mandate', async () => {
+        const { payingOrganization } = await init({ withMandate: false });
+
+        const response = await charge();
+        expect(response.status).toBe(201);
+
+        expect(await getPayments(payingOrganization)).toHaveLength(0);
+        expect(mollieMocker.payments).toHaveLength(0);
+    });
+});

--- a/backend/app/api/src/endpoints/organization/dashboard/receivable-balances/ChargeReceivableBalancesEndpoint.ts
+++ b/backend/app/api/src/endpoints/organization/dashboard/receivable-balances/ChargeReceivableBalancesEndpoint.ts
@@ -114,11 +114,17 @@ export class ChargeReceivableBalancesEndpoint extends Endpoint<Params, Query, Bo
                     payingOrganization,
                 });
 
-                const mandate = mandates.find(m => m.isDefault);
+                if (!mandates.find(m => m.isDefault)) {
+                    // Not possible
+                    console.error('No mandates found for', cachedBalance.id);
+                    continue;
+                }
+
+                // The default if usable, otherwise the most recent usable one
+                const mandate = PaymentMandateService.groupByMandate(mandates).mandates.find(m => !m.isBlocked);
 
                 if (!mandate) {
-                // Not possible
-                    console.error('No mandates found for', cachedBalance.id);
+                    console.error('No usable mandate found for', cachedBalance.id);
                     continue;
                 }
 

--- a/backend/app/api/src/services/PaymentMandateService.ts
+++ b/backend/app/api/src/services/PaymentMandateService.ts
@@ -1,5 +1,5 @@
 import type { User } from '@stamhoofd/models';
-import { Organization } from '@stamhoofd/models';
+import { BlockedPaymentMandate, Organization, PaymentMandateChargebacks } from '@stamhoofd/models';
 import { Platform } from '@stamhoofd/models';
 import { PaymentMandateStatus } from '@stamhoofd/structures/PaymentMandate.js';
 import type { PaymentMandate } from '@stamhoofd/structures/PaymentMandate.js';
@@ -38,7 +38,172 @@ export class PaymentMandateService {
             return [];
         }
 
-        return await mollieService.getMandates({ payingOrganization, user });
+        const mandates = await mollieService.getMandates({ payingOrganization, user });
+        this.applyBlockedMandates(mandates, payingOrganization);
+        return mandates;
+    }
+
+    /**
+     * A block applies to every mandate for the same card or bank account (also ones created after the block),
+     * so re-adding the same card does not make it usable again.
+     */
+    static applyBlockedMandates(mandates: PaymentMandate[], payingOrganization: Organization) {
+        const blockedIdentifiers = new Map<string, Date>();
+
+        for (const blocked of payingOrganization.serverMeta.blockedMandates) {
+            if (blocked.identifier) {
+                const existing = blockedIdentifiers.get(blocked.identifier);
+                if (!existing || existing > blocked.blockedAt) {
+                    blockedIdentifiers.set(blocked.identifier, blocked.blockedAt);
+                }
+            }
+        }
+
+        for (const mandate of mandates) {
+            const blocked = payingOrganization.serverMeta.blockedMandates.find(b => b.id === mandate.id);
+            if (blocked) {
+                mandate.blockedAt = blocked.blockedAt;
+
+                // Blocks stored without identifier
+                if (mandate.identifier) {
+                    const existing = blockedIdentifiers.get(mandate.identifier);
+                    if (!existing || existing > blocked.blockedAt) {
+                        blockedIdentifiers.set(mandate.identifier, blocked.blockedAt);
+                    }
+                }
+            }
+        }
+
+        for (const mandate of mandates) {
+            if (!mandate.blockedAt && mandate.identifier) {
+                mandate.blockedAt = blockedIdentifiers.get(mandate.identifier) ?? null;
+            }
+        }
+    }
+
+    /**
+     * Block a mandate on our side only (it stays valid at the provider), so it can no longer be used for
+     * new payments. Other mandates for the same card or bank account are blocked too.
+     */
+    static async blockMandate({ mandateId, sellingOrganization, payingOrganizationId, paymentId }: {
+        mandateId: string;
+        sellingOrganization: Organization;
+        payingOrganizationId: string;
+        paymentId: string | null;
+    }) {
+        const payingOrganization = await Organization.getByID(payingOrganizationId, true);
+
+        const mandates = await PaymentMandateService.getMandates({
+            sellingOrganization,
+            user: null,
+            payingOrganization,
+        });
+        const match = mandates.find(m => m.id === mandateId);
+        const identifier = match?.identifier ?? null;
+        const ids = new Set([mandateId]);
+
+        if (identifier) {
+            for (const mandate of mandates) {
+                if (mandate.identifier === identifier) {
+                    ids.add(mandate.id);
+                }
+            }
+        }
+
+        let changed = false;
+        for (const id of ids) {
+            if (payingOrganization.serverMeta.blockedMandates.find(b => b.id === id)) {
+                continue;
+            }
+            console.log('Blocking mandate ' + id + ' for organization ' + payingOrganization.id + ' ' + payingOrganization.name);
+            payingOrganization.serverMeta.blockedMandates.push(BlockedPaymentMandate.create({ id, identifier, paymentId }));
+            changed = true;
+        }
+
+        if (payingOrganization.serverMeta.mollieMandateId && ids.has(payingOrganization.serverMeta.mollieMandateId)) {
+            // Move the default to the first usable mandate
+            this.applyBlockedMandates(mandates, payingOrganization);
+            const replacement = this.groupByMandate(mandates).mandates.find(m => !m.isBlocked);
+            if (replacement) {
+                console.log('Changing default mandate to ' + replacement.id + ' for organization ' + payingOrganization.id);
+                payingOrganization.serverMeta.mollieMandateId = replacement.id;
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            await payingOrganization.save();
+        }
+    }
+
+    /**
+     * Keep the most recent chargebacks per mandate (last 12 months, at most 5)
+     */
+    static async registerChargeback({ mandateId, sellingOrganization, payingOrganizationId, date }: {
+        mandateId: string;
+        sellingOrganization: Organization;
+        payingOrganizationId: string;
+        date: Date;
+    }) {
+        const payingOrganization = await Organization.getByID(payingOrganizationId, true);
+        let entry = payingOrganization.serverMeta.mandateChargebacks.find(c => c.id === mandateId);
+
+        if (!entry) {
+            const mandates = await PaymentMandateService.getMandates({
+                sellingOrganization,
+                user: null,
+                payingOrganization,
+            });
+            entry = PaymentMandateChargebacks.create({
+                id: mandateId,
+                identifier: mandates.find(m => m.id === mandateId)?.identifier ?? null,
+            });
+            payingOrganization.serverMeta.mandateChargebacks.push(entry);
+        }
+
+        entry.add(date);
+        await payingOrganization.save();
+    }
+
+    /**
+     * Lift the block of a mandate and of all mandates for the same card or bank account. Used when the
+     * card or account is validated again with a new payment, or when a seller unblocks it manually.
+     */
+    static async unblockMandate({ mandateId, sellingOrganization, payingOrganizationId }: {
+        mandateId: string;
+        sellingOrganization: Organization;
+        payingOrganizationId: string;
+    }) {
+        const payingOrganization = await Organization.getByID(payingOrganizationId, true);
+        if (payingOrganization.serverMeta.blockedMandates.length === 0) {
+            return;
+        }
+
+        const mandates = await PaymentMandateService.getMandates({
+            sellingOrganization,
+            user: null,
+            payingOrganization,
+        });
+        const match = mandates.find(m => m.id === mandateId);
+        const identifier = match?.identifier ?? payingOrganization.serverMeta.blockedMandates.find(b => b.id === mandateId)?.identifier ?? null;
+        const ids = new Set([mandateId]);
+
+        if (identifier) {
+            for (const mandate of mandates) {
+                if (mandate.identifier === identifier) {
+                    ids.add(mandate.id);
+                }
+            }
+        }
+
+        const remaining = payingOrganization.serverMeta.blockedMandates.filter(b => !ids.has(b.id) && !(identifier && b.identifier === identifier));
+        if (remaining.length === payingOrganization.serverMeta.blockedMandates.length) {
+            return;
+        }
+
+        console.log('Unblocking mandate ' + mandateId + ' for organization ' + payingOrganization.id + ' ' + payingOrganization.name);
+        payingOrganization.serverMeta.blockedMandates = remaining;
+        await payingOrganization.save();
     }
 
     static async deleteMandate({ mandateId, sellingOrganization, user, payingOrganization }: {
@@ -84,12 +249,13 @@ export class PaymentMandateService {
             }
         }
 
-        if (grouped.size <= 1) {
+        const usableGroups = [...grouped.values()].filter(group => group.some(m => m.status === PaymentMandateStatus.Valid && !m.isBlocked));
+        if (!match.isBlocked && usableGroups.length <= 1) {
             if (!Context.optionalAuth?.hasPlatformFullAccess()) {
                 throw new SimpleError({
                     code: 'not_allowed',
-                    message: 'You cannot delete the last mandate',
-                    human: $t('%1Q7'),
+                    message: 'You cannot delete the last usable mandate',
+                    human: $t('Je kan de laatste bruikbare betaalmethode niet verwijderen. Voeg eerst een nieuwe betaalmethode toe.'),
                 });
             }
         }
@@ -173,6 +339,8 @@ export class PaymentMandateService {
         base.sort((a, b) => {
             if (a.status === PaymentMandateStatus.Valid && b.status !== PaymentMandateStatus.Valid) return -1;
             if (a.status !== PaymentMandateStatus.Valid && b.status === PaymentMandateStatus.Valid) return 1;
+            if (!a.isBlocked && b.isBlocked) return -1;
+            if (a.isBlocked && !b.isBlocked) return 1;
             if (a.isDefault && !b.isDefault) return -1;
             if (!a.isDefault && b.isDefault) return 1;
             return b.createdAt.getTime() - a.createdAt.getTime();
@@ -201,6 +369,8 @@ export class PaymentMandateService {
         cleaned.sort((a, b) => {
             if (a.status === PaymentMandateStatus.Valid && b.status !== PaymentMandateStatus.Valid) return -1;
             if (a.status !== PaymentMandateStatus.Valid && b.status === PaymentMandateStatus.Valid) return 1;
+            if (!a.isBlocked && b.isBlocked) return -1;
+            if (a.isBlocked && !b.isBlocked) return 1;
             if (a.isDefault && !b.isDefault) return -1;
             if (!a.isDefault && b.isDefault) return 1;
             return b.createdAt.getTime() - a.createdAt.getTime();

--- a/backend/app/api/src/services/PaymentService.ts
+++ b/backend/app/api/src/services/PaymentService.ts
@@ -93,6 +93,11 @@ export class PaymentService {
                     }
                 }
 
+                await this.unblockMandateIfNeeded({
+                    payment,
+                    sellingOrganization: organization,
+                });
+
                 // It is possible the mandate succeeds immediately, in which case we might
                 // need to save it as the default payment method
                 await this.saveMandateIfNeeded({
@@ -236,6 +241,31 @@ export class PaymentService {
             return;
         }
 
+        if (payment.mandateId) {
+            try {
+                await PaymentMandateService.registerChargeback({
+                    mandateId: payment.mandateId,
+                    sellingOrganization: organization,
+                    payingOrganizationId: payment.payingOrganizationId,
+                    date: payment.paidAt ?? new Date(),
+                });
+            } catch (e) {
+                console.error('Failed to register chargeback count for mandate ' + payment.mandateId, e);
+            }
+
+            // Prevents an endless loop of automatic charges and chargebacks on the same mandate
+            try {
+                await PaymentMandateService.blockMandate({
+                    mandateId: payment.mandateId,
+                    sellingOrganization: organization,
+                    payingOrganizationId: payment.payingOrganizationId,
+                    paymentId: payment.id,
+                });
+            } catch (e) {
+                console.error('Failed to block mandate ' + payment.mandateId + ' after chargeback ' + payment.id, e);
+            }
+        }
+
         const payingOrganization = await Organization.getByID(payment.payingOrganizationId, true);
 
         await sendEmailTemplate(organization, {
@@ -304,6 +334,26 @@ export class PaymentService {
             if (payingOrganizationId && organization.id === platform.membershipOrganizationId) {
                 await STPackageService.markFailedPayment(payingOrganizationId);
             }
+        }
+    }
+
+    /**
+     * A succeeded payment that created a mandate validated the card or bank account again, so an earlier
+     * block (e.g. after a chargeback) is lifted.
+     */
+    static async unblockMandateIfNeeded({ payment, sellingOrganization }: { payment: Payment; sellingOrganization: Organization }) {
+        if (!payment.createMandate || !payment.mandateId || !payment.payingOrganizationId || payment.status !== PaymentStatus.Succeeded) {
+            return;
+        }
+
+        try {
+            await PaymentMandateService.unblockMandate({
+                mandateId: payment.mandateId,
+                sellingOrganization,
+                payingOrganizationId: payment.payingOrganizationId,
+            });
+        } catch (e) {
+            console.error('Failed to unblock mandate ' + payment.mandateId + ' after payment ' + payment.id, e);
         }
     }
 
@@ -1603,6 +1653,15 @@ export class PaymentService {
                 code: 'mandate_not_valid',
                 message: 'Mandate not valid',
                 human: $t('%1QA'),
+                field: 'mandateId',
+            });
+        }
+
+        if (existingMandate.isBlocked) {
+            throw new SimpleError({
+                code: 'mandate_blocked',
+                message: 'Mandate is blocked',
+                human: $t('Deze betaalmethode is geblokkeerd en kan niet meer gebruikt worden. Voeg een nieuwe betaalmethode toe.'),
                 field: 'mandateId',
             });
         }

--- a/backend/shared/models/src/structures/OrganizationServerMetaData.ts
+++ b/backend/shared/models/src/structures/OrganizationServerMetaData.ts
@@ -9,6 +9,58 @@ export class DripEmail extends AutoEncoder {
     date = new Date();
 }
 
+export class BlockedPaymentMandate extends AutoEncoder {
+    /**
+     * External mandate id of the provider
+     */
+    @field({ decoder: StringDecoder })
+    id: string;
+
+    @field({ decoder: DateDecoder })
+    blockedAt = new Date();
+
+    /**
+     * Card number or IBAN (PaymentMandate.identifier) of the blocked mandate, so newer mandates for the same
+     * card or account stay blocked even when this mandate is revoked at the provider
+     */
+    @field({ decoder: StringDecoder, nullable: true })
+    identifier: string | null = null;
+
+    /**
+     * The (chargeback) payment that caused the block, null when blocked manually
+     */
+    @field({ decoder: StringDecoder, nullable: true })
+    paymentId: string | null = null;
+}
+
+export class PaymentMandateChargebacks extends AutoEncoder {
+    /**
+     * External mandate id of the provider
+     */
+    @field({ decoder: StringDecoder })
+    id: string;
+
+    @field({ decoder: StringDecoder, nullable: true })
+    identifier: string | null = null;
+
+    /**
+     * Dates of the most recent chargebacks (last 12 months, at most 5)
+     */
+    @field({ decoder: new ArrayDecoder(DateDecoder) })
+    dates: Date[] = [];
+
+    static readonly maxDates = 5;
+    static readonly maxAge = 1000 * 60 * 60 * 24 * 365;
+
+    add(date: Date) {
+        const minimum = new Date(date.getTime() - PaymentMandateChargebacks.maxAge);
+        this.dates = [...this.dates, date]
+            .filter(d => d >= minimum)
+            .sort((a, b) => b.getTime() - a.getTime())
+            .slice(0, PaymentMandateChargebacks.maxDates);
+    }
+}
+
 export class OrganizationServerMetaData extends AutoEncoder {
     @field({ decoder: StringDecoder, optional: true })
     privateDKIMKey?: string;
@@ -51,6 +103,15 @@ export class OrganizationServerMetaData extends AutoEncoder {
 
     @field({ decoder: StringDecoder, optional: true, nullable: true })
     mollieMandateId: string | null = null;
+
+    /**
+     * Mandates that can no longer be used to pay, even if they are still valid at the provider
+     */
+    @field({ decoder: new ArrayDecoder(BlockedPaymentMandate), ...NextVersion })
+    blockedMandates: BlockedPaymentMandate[] = [];
+
+    @field({ decoder: new ArrayDecoder(PaymentMandateChargebacks), ...NextVersion })
+    mandateChargebacks: PaymentMandateChargebacks[] = [];
 
     @field({ decoder: OpenIDClientConfiguration, nullable: true, version: 189 })
     ssoConfiguration: OpenIDClientConfiguration | null = null;

--- a/frontend/app/admin/src/views/organizations/OrganizationPackagesView.vue
+++ b/frontend/app/admin/src/views/organizations/OrganizationPackagesView.vue
@@ -15,7 +15,7 @@
                     <h2 class="style-with-button">
                         <div>{{ $t('%1UB') }}</div>
                     </h2>
-                    <PaymentMandatesBox :paying-organization-id="organization.id" :selling-organization-id="platform.membershipOrganizationId!" />
+                    <PaymentMandatesBox :paying-organization-id="organization.id" :selling-organization-id="platform.membershipOrganizationId!" :can-block="true" />
                 </div>
 
                 <div class="container">

--- a/frontend/app/dashboard/src/views/dashboard/settings/packages/steps/PaymentSelectionWithMandatesStepView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/settings/packages/steps/PaymentSelectionWithMandatesStepView.vue
@@ -208,13 +208,13 @@ const { mandates } = props.model.forceNewMandate || !props.model.sellingOrganiza
 watch(mandates, (n, old) => {
     if (old === null && n !== null && n.length) {
         // Select default mandate
-        mandateId.value = n[0].id;
+        mandateId.value = n.find(m => !m.isBlocked)?.id ?? null;
     }
 
     if (n && mandateId.value) {
-        if (!n.find(pp => pp.id === mandateId.value)) {
-            // Mandate became invalid: reset
-            mandateId.value = n[0]?.id ?? null;
+        if (!n.find(pp => pp.id === mandateId.value && !pp.isBlocked)) {
+            // Mandate became invalid or blocked: reset
+            mandateId.value = n.find(m => !m.isBlocked)?.id ?? null;
         }
     }
 });

--- a/frontend/shared/components/src/mandates/PaymentMandateRadioRow.vue
+++ b/frontend/shared/components/src/mandates/PaymentMandateRadioRow.vue
@@ -1,15 +1,20 @@
 <template>
-    <STGridItem :selectable="true" element-name="label" class="right-stack left-center">
+    <STGridItem :selectable="!mandate.isBlocked" element-name="label" class="right-stack left-center">
         <template #left>
-            <Radio v-model="model" name="choose-mandate" :value="mandate.id" />
+            <Radio v-model="model" name="choose-mandate" :value="mandate.id" :disabled="mandate.isBlocked" />
         </template>
 
         <h3 class="style-title-list">
             <span>{{ mandate.name }}</span>
-            <span v-if="mandate.isDefault && model === mandate.id" class="style-tag success">{{ $t('%v6') }}</span>
+            <span v-if="mandate.isBlocked" class="style-tag error">{{ $t('Geblokkeerd') }}</span>
+            <span v-else-if="mandate.isDefault && model === mandate.id" class="style-tag success">{{ $t('%v6') }}</span>
         </h3>
         <p v-if="mandate.description" class="style-description-small">
             {{ mandate.description }}
+        </p>
+
+        <p v-if="mandate.isBlocked" class="style-description-small">
+            {{ $t('Deze betaalmethode is geblokkeerd (bv. na een terugvordering) en kan niet meer gebruikt worden. Voeg ze opnieuw toe om ze te deblokkeren.') }}
         </p>
 
         <p v-if="mandate.bankName" class="style-description-small">

--- a/frontend/shared/components/src/mandates/PaymentMandateRow.vue
+++ b/frontend/shared/components/src/mandates/PaymentMandateRow.vue
@@ -6,11 +6,16 @@
         
         <h3 class="style-title-list">
             <span>{{ mandate.name }}</span>
-            <span v-if="mandate.isDefault" class="style-tag success">{{ $t('%v6') }}</span>
+            <span v-if="mandate.isBlocked" class="style-tag error">{{ $t('Geblokkeerd') }}</span>
+            <span v-else-if="mandate.isDefault" class="style-tag success">{{ $t('%v6') }}</span>
         </h3>
 
         <p v-if="mandate.description" class="style-description-small">
             {{ mandate.description }}
+        </p>
+
+        <p v-if="mandate.isBlocked" class="style-description-small">
+            {{ $t('Deze betaalmethode is geblokkeerd (bv. na een terugvordering) en kan niet meer gebruikt worden. Voeg ze opnieuw toe om ze te deblokkeren.') }}
         </p>
 
         <p v-if="mandate.bankName" class="style-description-small">

--- a/frontend/shared/components/src/mandates/PaymentMandatesBox.vue
+++ b/frontend/shared/components/src/mandates/PaymentMandatesBox.vue
@@ -30,13 +30,19 @@ import { Toast } from '#overlays/Toast';
 const props = withDefaults(defineProps<{
     payingOrganizationId?: string | null;
     sellingOrganizationId: string;
+
+    /**
+     * Whether the viewer is an admin of the selling organization and may block or unblock mandates
+     */
+    canBlock?: boolean;
 }>(), {
     payingOrganizationId: null,
+    canBlock: false,
 });
 
 const errors = useErrors();
 
-const { mandates, deleteMandate: doDeleteMandate, updatingMandates, setDefaultMandate } = useOrganizationPaymentMandates({
+const { mandates, deleteMandate: doDeleteMandate, updatingMandates, setDefaultMandate, setMandateBlocked } = useOrganizationPaymentMandates({
     payingOrganizationId: props.payingOrganizationId,
     sellingOrganizationId: props.sellingOrganizationId,
     errors,
@@ -52,11 +58,30 @@ async function showContextMenu(event: MouseEvent, mandateId: string) {
             new ContextMenuItem({
                 name: $t(`%1Tc`),
                 icon: 'success',
-                disabled: isDefault,
+                disabled: isDefault || mandate?.isBlocked,
                 action: async () => {
                     await setDefaultMandate(mandateId);
                 },
             }),
+            ...(props.canBlock
+                ? [
+                        mandate?.isBlocked
+                            ? new ContextMenuItem({
+                                    name: $t('Deblokkeren'),
+                                    icon: 'unlock',
+                                    action: async () => {
+                                        await setMandateBlocked(mandateId, false);
+                                    },
+                                })
+                            : new ContextMenuItem({
+                                    name: $t('Blokkeren'),
+                                    icon: 'lock',
+                                    action: async () => {
+                                        await blockMandate(mandateId);
+                                    },
+                                }),
+                    ]
+                : []),
 
             new ContextMenuItem({
                 name: $t(`%CJ`),
@@ -69,6 +94,20 @@ async function showContextMenu(event: MouseEvent, mandateId: string) {
         ],
     ]);
     await menu.show({ clickEvent: event });
+}
+
+async function blockMandate(mandateId: string) {
+    const mandate = mandates.value?.find(m => m.id === mandateId);
+
+    if (!await CenteredMessage.confirm({
+        title: $t('Ben je zeker dat je {cardNumber} wilt blokkeren?', { cardNumber: mandate?.name ?? $t('%ZgC') }),
+        description: $t('Deze betaalmethode kan dan niet meer gebruikt worden voor nieuwe betalingen, tot ze opnieuw toegevoegd of gedeblokkeerd wordt.'),
+        confirmText: $t('Blokkeren'),
+        destructive: true,
+    })) {
+        return;
+    }
+    await setMandateBlocked(mandateId, true);
 }
 
 async function deleteMandate(mandateId: string) {

--- a/frontend/shared/components/src/mandates/useOrganizationPaymentMandates.ts
+++ b/frontend/shared/components/src/mandates/useOrganizationPaymentMandates.ts
@@ -1,7 +1,7 @@
 import { ErrorBox } from '#errors/ErrorBox';
 import { useContext } from '#hooks/useContext.ts';
 import { Toast } from '#overlays/Toast';
-import type { Decoder } from '@simonbackx/simple-encoding';
+import type { AutoEncoderPatchType, Decoder } from '@simonbackx/simple-encoding';
 import { ArrayDecoder, deepSetArray, PatchableArray } from '@simonbackx/simple-encoding';
 import { useRequestOwner } from '@stamhoofd/networking/hooks/useRequestOwner';
 import { PaymentMandate } from '@stamhoofd/structures/PaymentMandate.js';
@@ -78,7 +78,8 @@ export function useOrganizationPaymentMandates({
         }
     }
 
-    async function setDefaultMandate(mandateId: string) {
+    async function patchMandate(patch: AutoEncoderPatchType<PaymentMandate>, successMessage: string) {
+        const mandateId = patch.id;
         if (updatingMandates.has(mandateId)) {
             return;
         }
@@ -86,10 +87,7 @@ export function useOrganizationPaymentMandates({
 
         try {
             const arr = new PatchableArray();
-            arr.addPatch(PaymentMandate.patch({
-                id: mandateId,
-                isDefault: true
-            }))
+            arr.addPatch(patch)
 
             const response = await (payingOrganizationId ? context.value.getAuthenticatedServerForOrganization(payingOrganizationId) : context.value.authenticatedServer).request({
                 method: 'PATCH',
@@ -106,7 +104,7 @@ export function useOrganizationPaymentMandates({
                 mandates.value = response.data;
             }
 
-            Toast.success($t('%1QZ')).show()
+            Toast.success(successMessage).show()
         } catch (e) {
             Toast.fromError(e).show()
         } finally {
@@ -114,10 +112,28 @@ export function useOrganizationPaymentMandates({
         }
     }
 
+    async function setDefaultMandate(mandateId: string) {
+        await patchMandate(PaymentMandate.patch({
+            id: mandateId,
+            isDefault: true
+        }), $t('%1QZ'))
+    }
+
+    /**
+     * Block or unblock a mandate (only allowed for the selling organization)
+     */
+    async function setMandateBlocked(mandateId: string, blocked: boolean) {
+        await patchMandate(PaymentMandate.patch({
+            id: mandateId,
+            blockedAt: blocked ? new Date() : null
+        }), blocked ? $t('De betaalmethode is geblokkeerd') : $t('De betaalmethode is gedeblokkeerd'))
+    }
+
     return {
         loading,
         deleteMandate,
         setDefaultMandate,
+        setMandateBlocked,
         updatingMandates,
         mandates
     };

--- a/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
+++ b/frontend/shared/components/src/payments/ReceivableBalanceBox.vue
@@ -101,7 +101,7 @@
                 <h2 class="style-with-button">
                     <div>{{ $t('%1UB') }}</div>
                 </h2>
-                <PaymentMandatesBox :paying-organization-id="detailedItem.object.id" :selling-organization-id="detailedItem.organizationId" />
+                <PaymentMandatesBox :paying-organization-id="detailedItem.object.id" :selling-organization-id="detailedItem.organizationId" :can-block="auth.canManagePayments()" />
             </div>
 
             <template v-if="pendingPayments.length > 0">

--- a/shared/structures/src/PaymentMandate.ts
+++ b/shared/structures/src/PaymentMandate.ts
@@ -76,6 +76,17 @@ export class PaymentMandate extends AutoEncoder {
     @field({ decoder: DateDecoder })
     createdAt: Date;
 
+    /**
+     * Set when the mandate was blocked on our side (e.g. after a chargeback). The mandate can still be valid at
+     * the provider, but it can no longer be used for new payments.
+     */
+    @field({ decoder: DateDecoder, nullable: true, ...NextVersion })
+    blockedAt: Date | null = null;
+
+    get isBlocked() {
+        return this.blockedAt !== null;
+    }
+
     get identifier() {
         if (this.details.iban) {
             return Formatter.iban(this.details.iban);


### PR DESCRIPTION
Stops the payment → chargeback → payment loop on saved mandates. After a chargeback, the mandate is blocked on our side only (it stays valid at Mollie), stored in the paying organization's `serverMeta.blockedMandates`. A block covers every mandate for the same card or IBAN, including mandates created later (so re-adding the same card does not bypass it). Blocked mandates cannot be used to pay and cannot be set as default.

- Blocking a default mandate moves the default to the first usable mandate. The automatic charge of receivable balances uses the default if usable, otherwise the first usable mandate, and skips organizations without a usable one.
- Chargebacks are counted per mandate in `serverMeta.mandateChargebacks` (last 12 months, at most 5 dates) for future blocking decisions.
- The last usable (non-blocked) mandate cannot be deleted; blocked mandates can always be deleted.
- A succeeded payment that creates a mandate again for the same card or account lifts the block (revalidation).
- Sellers with payment management rights can block and unblock a mandate manually via the mandates context menu (receivable balance view + admin packages view). The paying organization cannot.
- `PaymentMandate` gets a `blockedAt` field (`...NextVersion`); the UI shows a "Geblokkeerd" tag and disables the option in checkout.

Gotchas: the `PATCH /billing/:id/mandates` endpoint reloads the paying organization before building its response, because the block/default changes are saved on a separate model instance. Its class was renamed from the duplicate `DeleteOrganizationMandateEndpoint`. The block/unblock context-menu actions have no Playwright test yet (backend paths are covered by unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)