### PR TITLE
Prevent overbooking groups under concurrent registrations (STA-1408)

### DIFF
--- a/backend/app/api/src/endpoints/global/registration/RegisterMembersEndpoint.test.ts
+++ b/backend/app/api/src/endpoints/global/registration/RegisterMembersEndpoint.test.ts
@@ -3,7 +3,8 @@ import { Request } from '@simonbackx/simple-endpoints';
 import { EmailMocker } from '@stamhoofd/email';
 import type { MemberWithUsersRegistrationsAndGroups, Organization, RegistrationPeriod, Token } from '@stamhoofd/models';
 import { BalanceItem, BalanceItemFactory, EventFactory, Group, GroupFactory, Member, MemberFactory, OrganizationFactory, OrganizationRegistrationPeriodFactory, Registration, RegistrationFactory, RegistrationPeriodFactory, UserFactory } from '@stamhoofd/models';
-import { AccessRight, BalanceItemCartItem, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, BooleanStatus, Company, EventMeta, GroupOption, GroupOptionMenu, IDRegisterCart, IDRegisterCheckout, IDRegisterItem, OrganizationPackages, PaymentCustomer, PaymentMethod, PermissionLevel, Permissions, PermissionsResourceType, ReduceablePrice, RegisterItemOption, ResourcePermissions, GroupType, STPackageStatus, STPackageType, UitpasNumberDetails, UitpasSocialTariff, UitpasSocialTariffStatus, UserPermissions, Version } from '@stamhoofd/structures';
+import { StockReservation, TranslatedString, GroupPrice, AccessRight, BalanceItemCartItem, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, BooleanStatus, Company, EventMeta, GroupOption, GroupOptionMenu, IDRegisterCart, IDRegisterCheckout, IDRegisterItem, OrganizationPackages, PaymentCustomer, PaymentMethod, PermissionLevel, Permissions, PermissionsResourceType, ReduceablePrice, RegisterItemOption, ResourcePermissions, GroupType, STPackageStatus, STPackageType, UitpasNumberDetails, UitpasSocialTariff, UitpasSocialTariffStatus, UserPermissions, Version } from '@stamhoofd/structures';
+import { QueueHandler } from '@stamhoofd/queues';
 import { STExpect, TestUtils } from '@stamhoofd/test-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { assertBalances } from '../../../../tests/assertions/assertBalances.js';
@@ -3567,6 +3568,254 @@ describe('Endpoint.RegisterMembers', () => {
             await post(body1, organization, token);
             await expect(post(body2, organization, token)).rejects.toThrow(/Cannot delete inactive registration/);
             // #endregion
+        });
+    });
+
+    describe('Maximum members under concurrent registrations', () => {
+        /**
+         * Each user has their own family with one member, like unrelated users registering at the same time.
+         */
+        async function initUsers({ organization, amount }: { organization: Organization; amount: number }) {
+            const users: { member: MemberWithUsersRegistrationsAndGroups; token: Token }[] = [];
+            for (let i = 0; i < amount; i++) {
+                const user = await new UserFactory({ organization }).create();
+                const member = await new MemberFactory({ organization, user }).create();
+                users.push({ member, token: await SessionService.createSession(user) });
+            }
+            return users;
+        }
+
+        function buildBody({ organization, group, member, paymentMethod, groupPrice = group.settings.prices[0] }: { organization: Organization; group: Group; member: MemberWithUsersRegistrationsAndGroups; paymentMethod: PaymentMethod; groupPrice?: GroupPrice }) {
+            return IDRegisterCheckout.create({
+                cart: IDRegisterCart.create({
+                    items: [
+                        IDRegisterItem.create({
+                            id: uuidv4(),
+                            groupPrice,
+                            organizationId: organization.id,
+                            groupId: group.id,
+                            memberId: member.id,
+                        }),
+                    ],
+                }),
+                paymentMethod,
+                redirectUrl: new URL('https://www.example.com'),
+                cancelUrl: new URL('https://www.example.com'),
+                totalPrice: groupPrice.price.price,
+            });
+        }
+
+        /**
+         * A group without a maximum, but with a limited and an unlimited price: only the limited price can sell out.
+         */
+        async function initGroupWithLimitedPrice({ organization, stock, price }: { organization: Organization; stock: number; price: number }) {
+            const group = await new GroupFactory({ organization, price, stock }).create();
+            group.settings.prices.push(GroupPrice.create({
+                name: new TranslatedString('Unlimited'),
+                price: ReduceablePrice.create({ price }),
+            }));
+            await group.save();
+            return { group, limitedPrice: group.settings.prices[0] };
+        }
+
+        test('A pending online payment reserves the spot for the next registration', async () => {
+            const { organization } = await initOrganization();
+            await initPayconiq({ organization });
+            const group = await new GroupFactory({ organization, price: 1500, maxMembers: 1 }).create();
+            const [first, second] = await initUsers({ organization, amount: 2 });
+
+            const response = await post(buildBody({ organization, group, member: first.member, paymentMethod: PaymentMethod.Payconiq }), organization, first.token);
+            expect(response.body.paymentUrl).toMatch(/payconiq-checkout\.test/);
+            expect(response.body.registrations[0].reservedUntil).toEqual(expect.any(Date));
+
+            // The first user did not pay yet, but their spot is taken until the reservation expires
+            await expect(post(buildBody({ organization, group, member: second.member, paymentMethod: PaymentMethod.Payconiq }), organization, second.token))
+                .rejects.toThrow(STExpect.errorWithCode('maximum_reached'));
+
+            await QueueHandler.awaitAll();
+            await group.refresh();
+            expect(group.settings.registeredMembers).toBe(0);
+            expect(group.settings.reservedMembers).toBe(1);
+        });
+
+        test('A pending online payment reserves the stock of a limited price', async () => {
+            const { organization } = await initOrganization();
+            await initPayconiq({ organization });
+            const { group, limitedPrice } = await initGroupWithLimitedPrice({ organization, stock: 1, price: 1500 });
+            const [first, second] = await initUsers({ organization, amount: 2 });
+
+            const response = await post(buildBody({ organization, group, groupPrice: limitedPrice, member: first.member, paymentMethod: PaymentMethod.Payconiq }), organization, first.token);
+            expect(response.body.paymentUrl).toMatch(/payconiq-checkout\.test/);
+            expect(response.body.registrations[0].reservedUntil).toEqual(expect.any(Date));
+
+            await expect(post(buildBody({ organization, group, groupPrice: limitedPrice, member: second.member, paymentMethod: PaymentMethod.Payconiq }), organization, second.token))
+                .rejects.toThrow(STExpect.errorWithCode('stock_empty'));
+
+            await QueueHandler.awaitAll();
+            await group.refresh();
+            expect(group.settings.reservedMembers).toBe(1);
+            expect(StockReservation.getAmount('GroupPrice', limitedPrice.id, group.stockReservations)).toBe(limitedPrice.stock);
+        });
+
+        test('A pending online payment reserves the stock of a limited option', async () => {
+            const { organization } = await initOrganization();
+            await initPayconiq({ organization });
+            const group = await new GroupFactory({ organization, price: 1500 }).create();
+            const option = GroupOption.create({ name: 'option 1', stock: 1, price: ReduceablePrice.create({ price: 0 }) });
+            const optionMenu = GroupOptionMenu.create({ name: 'option menu 1', multipleChoice: true, options: [option] });
+            group.settings.optionMenus = [optionMenu];
+            await group.save();
+            const [first, second] = await initUsers({ organization, amount: 2 });
+
+            const withOption = (member: MemberWithUsersRegistrationsAndGroups) => {
+                const body = buildBody({ organization, group, member, paymentMethod: PaymentMethod.Payconiq });
+                body.cart.items[0].options = [RegisterItemOption.create({ option, optionMenu, amount: 1 })];
+                return body;
+            };
+
+            const response = await post(withOption(first.member), organization, first.token);
+            expect(response.body.paymentUrl).toMatch(/payconiq-checkout\.test/);
+            expect(response.body.registrations[0].reservedUntil).toEqual(expect.any(Date));
+
+            await expect(post(withOption(second.member), organization, second.token))
+                .rejects.toThrow(STExpect.errorWithCode('stock_empty'));
+
+            await QueueHandler.awaitAll();
+            await group.refresh();
+            expect(group.settings.reservedMembers).toBe(1);
+            expect(StockReservation.getAmount('GroupOption', option.id, group.stockReservations)).toBe(1);
+        });
+
+        test('A pending online payment does not reserve a spot in a group without limits', async () => {
+            const { organization } = await initOrganization();
+            await initPayconiq({ organization });
+            const group = await new GroupFactory({ organization, price: 1500 }).create();
+            const [first] = await initUsers({ organization, amount: 1 });
+
+            const response = await post(buildBody({ organization, group, member: first.member, paymentMethod: PaymentMethod.Payconiq }), organization, first.token);
+            expect(response.body.paymentUrl).toMatch(/payconiq-checkout\.test/);
+            expect(response.body.registrations[0].reservedUntil).toBeNull();
+
+            await QueueHandler.awaitAll();
+            await group.refresh();
+            expect(group.settings.reservedMembers).toBe(0);
+            expect(group.stockReservations.length).toBe(0);
+        });
+
+        test('Concurrent free registrations never exceed the maximum', async () => {
+            const { organization } = await initOrganization();
+            const group = await new GroupFactory({ organization, price: 0, maxMembers: 2 }).create();
+            const users = await initUsers({ organization, amount: 6 });
+
+            const results = await Promise.allSettled(
+                users.map(({ member, token }) => post(buildBody({ organization, group, member, paymentMethod: PaymentMethod.PointOfSale }), organization, token)),
+            );
+
+            const fulfilled = results.filter(r => r.status === 'fulfilled');
+            const rejected = results.filter(r => r.status === 'rejected');
+            expect(fulfilled.length).toBe(2);
+            expect(rejected.length).toBe(4);
+            for (const result of rejected) {
+                expect(() => {
+                    throw result.reason;
+                }).toThrow(STExpect.errorWithCode('maximum_reached'));
+            }
+
+            await QueueHandler.awaitAll();
+
+            const registrations = await Registration.where({ groupId: group.id, registeredAt: { sign: '!=', value: null }, deactivatedAt: null });
+            expect(registrations.length).toBe(2);
+
+            await group.refresh();
+            expect(group.settings.registeredMembers).toBe(2);
+            expect(group.settings.reservedMembers).toBe(0);
+        });
+
+        test('Concurrent online payments never reserve more than the maximum', async () => {
+            const { organization } = await initOrganization();
+            await initPayconiq({ organization });
+            const group = await new GroupFactory({ organization, price: 1500, maxMembers: 2 }).create();
+            const users = await initUsers({ organization, amount: 6 });
+
+            const results = await Promise.allSettled(
+                users.map(({ member, token }) => post(buildBody({ organization, group, member, paymentMethod: PaymentMethod.Payconiq }), organization, token)),
+            );
+
+            const fulfilled = results.filter(r => r.status === 'fulfilled');
+            const rejected = results.filter(r => r.status === 'rejected');
+            expect(fulfilled.length).toBe(2);
+            expect(rejected.length).toBe(4);
+            for (const result of fulfilled) {
+                expect(result.value.body.paymentUrl).toMatch(/payconiq-checkout\.test/);
+            }
+            for (const result of rejected) {
+                expect(() => {
+                    throw result.reason;
+                }).toThrow(STExpect.errorWithCode('maximum_reached'));
+            }
+
+            await QueueHandler.awaitAll();
+
+            const reserved = await Registration.where({ groupId: group.id, registeredAt: null, reservedUntil: { sign: '>', value: new Date() } });
+            expect(reserved.length).toBe(2);
+
+            await group.refresh();
+            expect(group.settings.registeredMembers).toBe(0);
+            expect(group.settings.reservedMembers).toBe(2);
+        });
+
+        test('Concurrent free registrations never exceed the stock of a limited price', async () => {
+            const { organization } = await initOrganization();
+            const { group, limitedPrice } = await initGroupWithLimitedPrice({ organization, stock: 2, price: 0 });
+            const users = await initUsers({ organization, amount: 6 });
+
+            const results = await Promise.allSettled(
+                users.map(({ member, token }) => post(buildBody({ organization, group, groupPrice: limitedPrice, member, paymentMethod: PaymentMethod.PointOfSale }), organization, token)),
+            );
+
+            expect(results.filter(r => r.status === 'fulfilled').length).toBe(2);
+            const rejected = results.filter(r => r.status === 'rejected');
+            expect(rejected.length).toBe(4);
+            for (const result of rejected) {
+                expect(() => {
+                    throw result.reason;
+                }).toThrow(STExpect.errorWithCode('stock_empty'));
+            }
+
+            await QueueHandler.awaitAll();
+            await group.refresh();
+            expect(group.settings.registeredMembers).toBe(2);
+            expect(StockReservation.getAmount('GroupPrice', limitedPrice.id, group.stockReservations)).toBe(limitedPrice.stock);
+        });
+
+        test('Concurrent online payments never reserve more than the stock of a limited price', async () => {
+            const { organization } = await initOrganization();
+            await initPayconiq({ organization });
+            const { group, limitedPrice } = await initGroupWithLimitedPrice({ organization, stock: 2, price: 1500 });
+            const users = await initUsers({ organization, amount: 6 });
+
+            const results = await Promise.allSettled(
+                users.map(({ member, token }) => post(buildBody({ organization, group, groupPrice: limitedPrice, member, paymentMethod: PaymentMethod.Payconiq }), organization, token)),
+            );
+
+            expect(results.filter(r => r.status === 'fulfilled').length).toBe(2);
+            const rejected = results.filter(r => r.status === 'rejected');
+            expect(rejected.length).toBe(4);
+            for (const result of rejected) {
+                expect(() => {
+                    throw result.reason;
+                }).toThrow(STExpect.errorWithCode('stock_empty'));
+            }
+
+            await QueueHandler.awaitAll();
+
+            const reserved = await Registration.where({ groupId: group.id, registeredAt: null, reservedUntil: { sign: '>', value: new Date() } });
+            expect(reserved.length).toBe(2);
+
+            await group.refresh();
+            expect(group.settings.registeredMembers).toBe(0);
+            expect(group.settings.reservedMembers).toBe(2);
+            expect(StockReservation.getAmount('GroupPrice', limitedPrice.id, group.stockReservations)).toBe(limitedPrice.stock);
         });
     });
 });

--- a/backend/app/api/src/endpoints/global/registration/RegisterMembersEndpoint.ts
+++ b/backend/app/api/src/endpoints/global/registration/RegisterMembersEndpoint.ts
@@ -4,8 +4,9 @@ import type { DecodedRequest, Request } from '@simonbackx/simple-endpoints';
 import { Endpoint, Response } from '@simonbackx/simple-endpoints';
 import { SimpleError } from '@simonbackx/simple-errors';
 import { Email } from '@stamhoofd/email';
-import type { MemberWithUsersRegistrationsAndGroups, Organization, Payment } from '@stamhoofd/models';
+import type { MemberWithUsersRegistrationsAndGroups, Organization, Payment, User } from '@stamhoofd/models';
 import { BalanceItem, CachedBalance, Group, Member, Platform, RateLimiter, Registration, RegistrationPeriod } from '@stamhoofd/models';
+import { QueueHandler } from '@stamhoofd/queues';
 import type { BalanceItem as BalanceItemStruct, PlatformMember, RegisterItem } from '@stamhoofd/structures';
 import { BalanceItemRelation, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, IDRegisterCheckout, Payment as PaymentStruct, PermissionLevel, PlatformFamily, ReceivableBalanceType, RegisterResponse, TranslatedString } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
@@ -37,6 +38,12 @@ export const demoLimiter = new RateLimiter({
 });
 
 export type RegistrationWithMemberAndGroup = Registration & { member: Member } & { group: Group };
+
+function hasStockLimit(group: Group) {
+    return group.settings.maxMembers !== null
+        || group.settings.prices.some(p => p.stock !== null)
+        || group.settings.optionMenus.some(m => m.options.some(o => o.stock !== null));
+}
 
 /**
  * Allow to add, patch and delete multiple members simultaneously, which is needed in order to sync relational data that is saved encrypted in multiple members (e.g. parents)
@@ -126,6 +133,14 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             }
         }
 
+        // Checkouts of the same organization are handled one at a time, so the stock a cart is
+        // validated against already includes the registrations and reservations made just before it
+        return await QueueHandler.schedule('register-members-' + organization.id, async () => {
+            return await this.register(request, { organization, user, whoWillPayNow });
+        });
+    }
+
+    private async register(request: DecodedRequest<Params, Query, Body>, { organization, user, whoWillPayNow }: { organization: Organization; user: User; whoWillPayNow: 'member' | 'organization' | 'nobody' }) {
         // Update balances before we start
         await BalanceItemService.flushCaches(organization.id);
 
@@ -273,7 +288,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
 
         const registrations: RegistrationWithMemberAndGroup[] = [];
         const payRegistrations: { registration: RegistrationWithMemberAndGroup; item: RegisterItem }[] = [];
-        const deactivatedRegistrationGroupIds: string[] = [];
+        const deactivatedRegistrations: Registration[] = [];
 
         if (checkout.cart.isEmpty) {
             throw new SimpleError({
@@ -518,7 +533,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             const member = members.find(m => m.id === existingRegistration.memberId);
 
             await RegistrationService.deactivate(existingRegistration, group, member);
-            deactivatedRegistrationGroupIds.push(existingRegistration.groupId);
+            deactivatedRegistrations.push(existingRegistration);
         }
 
         // Cache the registration period relation per periodId, so we only load each period once.
@@ -597,7 +612,7 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             // Reserve registration for 30 minutes (if needed)
             const group = groups.find(g => g.id === registration.groupId);
 
-            if (group && group.settings.maxMembers !== null && whoWillPayNow !== 'nobody') {
+            if (group && hasStockLimit(group) && whoWillPayNow !== 'nobody') {
                 registration.reservedUntil = new Date(new Date().getTime() + 1000 * 60 * 30);
             }
 
@@ -901,9 +916,15 @@ export class RegisterMembersEndpoint extends Endpoint<Params, Query, Body, Respo
             }
         }
 
+        // Apply the stock changes before the next queued checkout is validated: the updates
+        // scheduled while activating or deactivating are asynchronous and would land too late
+        for (const registration of [...registrations, ...deactivatedRegistrations]) {
+            await RegistrationService.scheduleStockUpdateAsync(registration.id);
+        }
+
         // Update occupancy
         for (const group of groups) {
-            if (registrations.some(r => r.groupId === group.id) || deactivatedRegistrationGroupIds.some(id => id === group.id)) {
+            if ([...registrations, ...deactivatedRegistrations].some(r => r.groupId === group.id)) {
                 await group.updateOccupancy();
                 await group.save();
             }

--- a/backend/app/api/src/services/RegistrationService.ts
+++ b/backend/app/api/src/services/RegistrationService.ts
@@ -2,7 +2,7 @@ import { ManyToOneRelation } from '@simonbackx/simple-database';
 import { encodeObject } from '@simonbackx/simple-encoding';
 import { BalanceItem, Document, Group, Member, Organization, Platform, Registration, RegistrationInvitation } from '@stamhoofd/models';
 import { sendEmailTemplate } from '../helpers/EmailBuilder.js';
-import { QueueHandler } from '@stamhoofd/queues';
+import { isCanceledError, QueueHandler } from '@stamhoofd/queues';
 import { AppliedRegistrationDiscount, AuditLogSource, BalanceItemRelationType, BalanceItemStatus, BalanceItemType, EmailTemplateType, getAppHost, GroupType, Recipient, Replacement, StockReservation, Version } from '@stamhoofd/structures';
 import { Formatter } from '@stamhoofd/utility';
 import { AuditLogService } from './AuditLogService.js';
@@ -360,6 +360,11 @@ export const RegistrationService = {
 
                 await RegistrationService.unsafeStockUpdate(updated);
             });
-        }).catch(console.error);
+        }).catch((e) => {
+            // A newer update for the same registration replaced this one
+            if (!isCanceledError(e)) {
+                console.error(e);
+            }
+        });
     },
 };


### PR DESCRIPTION
Fixes STA-1408: with many users registering at once, more members could get in than a group's maximum (or a price / option stock) allowed.

Two causes:
- A registration waiting on an online payment got a `reservedUntil`, but its stock was never written to the group's `stockReservations`, which is what validation reads. So a user on the payment page did not take a spot. `reservedUntil` was also only set when the group had `maxMembers`, never for a limited price or option.
- Nothing serialized checkouts: every request read the group, validated, saved, and scheduled a fire-and-forget stock update, so concurrent requests all validated against the same stale stock.

Fix: the checkout runs in a `QueueHandler` queue per organization, the stock updates for created and deactivated registrations are awaited before the queued request finishes, and a reservation is made whenever the group has any stock limit.

Tests: pending online payments now block the next registration (group maximum, price stock, option stock), and six concurrent users for a group with room for two get exactly two successes, for free and online-paid registrations. All fail on `main`.

Notes from the self-review that were deliberately not applied:
- The UiTPAS social tariff lookup (an external call) now runs inside the queue. Moving it out means loading members twice; it only runs for members whose social tariff needs a refresh, so the cost stays limited.
- `hasStockLimit` stays a local helper in the endpoint rather than a getter on `GroupSettings`, to keep this change out of the shared structures package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
