### PR TITLE
🐛 Fix rotated session token being retired by a concurrent request

### DIFF
--- a/backend/app/api/src/services/SessionService.test.ts
+++ b/backend/app/api/src/services/SessionService.test.ts
@@ -1,3 +1,4 @@
+import { DatabaseInstance } from '@simonbackx/simple-database';
 import { Request } from '@simonbackx/simple-endpoints';
 import type { Organization, User } from '@stamhoofd/models';
 import { OrganizationFactory, Token, UserFactory, UserSession } from '@stamhoofd/models';
@@ -218,6 +219,97 @@ describe('SessionService', () => {
             expect(retryReplacement.sessionId).toBe(original.sessionId);
             expect(await Token.getByAccessToken(lostReplacement.accessToken)).toBeUndefined();
             expect(await Token.getByAccessToken(original.accessToken)).toBeDefined();
+        });
+
+        describe('concurrent activation', () => {
+            afterEach(() => {
+                vi.restoreAllMocks();
+            });
+
+            /**
+             * Pauses the first query of `method` that starts with `prefix`, so another database
+             * operation can be interleaved at exactly that point.
+             */
+            function pauseQueryOnce(method: 'update' | 'delete', prefix: string): { reached: Promise<void>; resume: () => void } {
+                let reached!: () => void;
+                let resume!: () => void;
+                const reachedPromise = new Promise<void>(resolve => reached = resolve);
+                const resumePromise = new Promise<void>(resolve => resume = resolve);
+                const original = DatabaseInstance.prototype[method];
+                let paused = false;
+
+                vi.spyOn(DatabaseInstance.prototype, method).mockImplementation(async function (this: DatabaseInstance, ...args: Parameters<DatabaseInstance['update']>) {
+                    if (!paused && args[0].startsWith(prefix)) {
+                        paused = true;
+                        reached();
+                        await resumePromise;
+                    }
+                    return await original.call(this, ...args);
+                });
+                return { reached: reachedPromise, resume };
+            }
+
+            async function createUsedToken(): Promise<Token & { user: User }> {
+                const admin = await createAdmin();
+                const original = await SessionService.createSession(admin, { loginMethod: SessionLoginMethod.Password });
+                return await SessionService.rotateSession(original);
+            }
+
+            async function expectActiveAndReplaced(used: Token, replacement: Token) {
+                expect(await Token.getByAccessToken(replacement.accessToken)).toBeDefined();
+                expect(await Token.getByAccessToken(used.accessToken)).toBeDefined();
+                const session = await getSession(used);
+                expect(session.lastActiveTokenId).toBe(used.id);
+                expect(session.lastUsedTokenId).toBe(replacement.id);
+            }
+
+            test('a renewal during the activation of the previous token keeps the replacement', async () => {
+                const used = await createUsedToken();
+
+                // The activating request has updated the session but not yet retired the other
+                // tokens when the client renews `used` in a parallel request.
+                const retire = pauseQueryOnce('delete', 'DELETE FROM `tokens`');
+                const activation = SessionService.activateToken(used);
+                await retire.reached;
+                const rotation = SessionService.rotateSession(used);
+                // The rotation either completes now, or has to wait for the activation.
+                await Promise.race([rotation, new Promise(resolve => setTimeout(resolve, 200))]);
+                retire.resume();
+
+                expect(await activation).toBe(true);
+                await expectActiveAndReplaced(used, await rotation);
+            });
+
+            test('an activation of the previous token during a renewal keeps the replacement', async () => {
+                const used = await createUsedToken();
+
+                // The renewal is halfway when a parallel request with `used` activates it.
+                const bookkeeping = pauseQueryOnce('update', 'UPDATE `user_sessions` SET `lastUsedTokenId`');
+                const rotation = SessionService.rotateSession(used);
+                await bookkeeping.reached;
+                expect(await SessionService.activateToken(used)).toBe(true);
+                bookkeeping.resume();
+
+                await expectActiveAndReplaced(used, await rotation);
+            });
+
+            test('an activation waits for a renewal that already holds the session', async () => {
+                const used = await createUsedToken();
+
+                // The renewal holds the session row when a parallel request with `used` arrives.
+                const retire = pauseQueryOnce('delete', 'DELETE FROM `tokens`');
+                const rotation = SessionService.rotateSession(used);
+                await retire.reached;
+                const activation = SessionService.activateToken(used);
+                await Promise.race([activation, new Promise(resolve => setTimeout(resolve, 200))]);
+                retire.resume();
+
+                const replacement = await rotation;
+                // `used` was never active, so the renewal retired it: that request retries with the replacement.
+                expect(await activation).toBe(false);
+                expect(await Token.getByAccessToken(replacement.accessToken)).toBeDefined();
+                expect(await Token.getByAccessToken(used.accessToken)).toBeUndefined();
+            });
         });
 
         test('renewal updates versions but keeps stable device metadata', async () => {

--- a/backend/app/api/src/services/SessionService.ts
+++ b/backend/app/api/src/services/SessionService.ts
@@ -127,25 +127,31 @@ export class SessionService {
         }
 
         const isSSOHandoff = this.isSSOHandoff(oldToken, session);
-        const token = await this.createToken(oldToken.user, { session });
+        const tokenId = uuidv4();
 
-        this.applyLimits({ token, session, user: oldToken.user });
-        await token.save();
+        // The session row is locked before the token is inserted, so a request that activates the
+        // previous token at the same time runs either completely before or completely after this.
+        // The insert has to come last: its foreign key check takes a shared lock on the session
+        // row, and upgrading that to the exclusive lock of the update deadlocks with a waiting activation.
+        return await Database.beginTransaction(async () => {
+            const didRotate = isSSOHandoff
+                ? await this.consumeSSOHandoff({ sessionId: session.id, handoffTokenId: oldToken.id, tokenId })
+                : await this.replaceLastUsedToken({ sessionId: session.id, previousTokenId: oldToken.id, tokenId });
+            if (!didRotate) {
+                throw this.invalidRefreshTokenError();
+            }
 
-        const didRotate = isSSOHandoff
-            ? await this.consumeSSOHandoff({ sessionId: session.id, handoffTokenId: oldToken.id, tokenId: token.id })
-            : await this.replaceLastUsedToken({ sessionId: session.id, previousTokenId: oldToken.id, tokenId: token.id });
-        if (!didRotate) {
-            await token.delete();
-            throw this.invalidRefreshTokenError();
-        }
+            const token = await this.createToken(oldToken.user, { session, tokenId });
+            this.applyLimits({ token, session, user: oldToken.user });
+            await token.save();
 
-        const metaData = this.getMetaData();
-        session.appVersion = metaData.appVersion ?? session.appVersion;
-        session.nativeAppVersion = metaData.nativeAppVersion ?? session.nativeAppVersion;
-        session.osVersion = metaData.osVersion ?? session.osVersion;
-        await session.save();
-        return token;
+            const metaData = this.getMetaData();
+            session.appVersion = metaData.appVersion ?? session.appVersion;
+            session.nativeAppVersion = metaData.nativeAppVersion ?? session.nativeAppVersion;
+            session.osVersion = metaData.osVersion ?? session.osVersion;
+            await session.save();
+            return token;
+        });
     }
 
     private static isSSOHandoff(token: Token, session: UserSession): boolean {
@@ -176,15 +182,27 @@ export class SessionService {
     }
 
     static async activateToken(token: Token): Promise<boolean> {
-        const [result] = await Database.update(
-            'UPDATE `user_sessions` SET `lastActiveTokenId` = ? WHERE `id` = ? AND `lastUsedTokenId` = ?',
-            [token.id, token.sessionId, token.id],
-        );
-        if (result.affectedRows > 0) {
-            await Database.delete('DELETE FROM `tokens` WHERE `sessionId` = ? AND `id` != ?', [token.sessionId, token.id]);
+        // Runs on every request: an active token never needs the transaction below.
+        if (await this.isActiveToken(token)) {
             return true;
         }
 
+        // Retiring the other tokens has to happen under the same session row lock as the
+        // activation, or a replacement rotated in between would be retired as well.
+        return await Database.beginTransaction(async () => {
+            const [result] = await Database.update(
+                'UPDATE `user_sessions` SET `lastActiveTokenId` = ? WHERE `id` = ? AND `lastUsedTokenId` = ?',
+                [token.id, token.sessionId, token.id],
+            );
+            if (result.affectedRows > 0) {
+                await Database.delete('DELETE FROM `tokens` WHERE `sessionId` = ? AND `id` != ?', [token.sessionId, token.id]);
+                return true;
+            }
+            return await this.isActiveToken(token);
+        });
+    }
+
+    private static async isActiveToken(token: Token): Promise<boolean> {
         const [sessions] = await Database.select('SELECT `id` FROM `user_sessions` WHERE `id` = ? AND `lastActiveTokenId` = ? LIMIT 1', [token.sessionId, token.id]);
         return sessions.length > 0;
     }


### PR DESCRIPTION
## What

A request that activates the previous token (`activateToken`, every authenticated request) could delete the token that a parallel refresh (`rotateSession`) had just inserted. The rotation still reported success, so the client got `401 invalid_access_token` on its new token and was logged out.

Both operations now lock the session row inside a transaction, so they run entirely before or entirely after each other. The rotation updates the session before inserting the new token; `activateToken` also skips the transaction when the token is already active, which replaces the update + delete it issued on every request with one read.

## Why

Root cause of the flaky `webshop-orders.spec.ts` "Order sync does not skip an order added in the second it last synced" CI failure (e.g. run 34271980490 and 34220696307). That test fast-forwards the browser clock by a day, but the in-process backend keeps the real clock, so the dashboard refreshes its token before every request and hits this race on almost every page load. In production the window is a request in flight during the 15-minute rotation.

## Gotchas

- `tokens.sessionId` has a FK to `user_sessions`. Inserting the token first would take a shared lock on the session row, and upgrading that to the exclusive lock of the update deadlocks with a waiting activation. Hence update, then insert.
- The new tests pause one statement by spying on `DatabaseInstance.prototype` and start the competing operation from the test body; starting it inside the spy would inherit the paused transaction's connection through AsyncLocalStorage.

Self-review remarks not applied: the reported typecheck failure in `CookieHelper` was a stale `node_modules` after rebasing on main, and the suggested rollback test for a failed rotation is moot because nothing is inserted before the rotation is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791528353&installation_model_id=423362&pr_number=873&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F873&signature=3533b4f555e61c946a869929b4ab2cfada6afc17a7753d9a9881df5d2ff19ae5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->