### PR TITLE
Avoid CI when pull request is draft

### DIFF
--- a/.github/workflows/auto-ready.yml
+++ b/.github/workflows/auto-ready.yml
@@ -21,7 +21,7 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
         run: |
-          STATUS=$(gh api "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&status=completed&per_page=1" \
+          STATUS=$(gh api "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$SHA&status=success&per_page=1" \
             --jq '.workflow_runs[0].conclusion // empty')
 
           if [ "$STATUS" != "success" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
   push:
     branches: [ main, ci-test, 'renovate/**' ]
   pull_request:
-    branches: [ main ]
+    # re-evaluate when a PR stops being a draft, gets a label or is retargeted at main
+    types: [opened, synchronize, reopened, ready_for_review, labeled, edited]
 
 # Cancel superseded runs on the same ref. We only cancel on pull_request events so
 # that pushes to main always run to completion (and keep their full check history).
@@ -18,9 +19,24 @@ on:
 #   group: ci-${{ github.workflow }}-${{ github.ref }}
 #   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' && github.event.action != 'labeled' }}
+
+
 jobs:
   job_setup:
     runs-on: ubuntu-latest
+    # IF draft AND not targeting main AND no "ready if CI succeeds" label -> don't run
+    # e.g. middle PR in a stack of PRs (gh stack)
+    if: |
+      github.event_name != 'pull_request' || (
+        (github.event.action != 'edited' || github.event.changes.base.ref.from != '') && (
+          !github.event.pull_request.draft ||
+          github.event.pull_request.base.ref == 'main' ||
+          contains(github.event.pull_request.labels.*.name, 'ready if CI succeeds')
+        )
+      )
     permissions:
       contents: read
       actions: read
@@ -682,6 +698,7 @@ jobs:
     if: |
       !cancelled() &&
       github.event_name == 'pull_request' &&
+      needs.job_setup.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     permissions:


### PR DESCRIPTION
Skip CI on draft PRs unless they target main or have the "ready if CI succeeds" label.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/stamhoofd/codesmith/stamhoofd/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791712542&installation_model_id=423362&pr_number=879&repository=stamhoofd%2Fstamhoofd&return_to=https%3A%2F%2Fgithub.com%2Fstamhoofd%2Fstamhoofd%2Fpull%2F879&signature=3949d09964351f2b90b259aa91cbe7c171162b007cec85843d6b3c5f6876c466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->